### PR TITLE
Add the federal SNAP state-plan composition module; migrate five states onto it

### DIFF
--- a/.axiom/encoding-manifests/programs/us-az/snap/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-az/snap/fy-2026.json
@@ -2,7 +2,7 @@
  "applied_files": [
   {
    "path": "programs/us-az/snap/fy-2026.yaml",
-   "sha256": "49e8d5d3dd8895babb5114882f74ceee715414d075c4d6b89bca8b785bb6e73b"
+   "sha256": "f43d70872cb210f192c1f2791712295a734c11c8a2a82fc2984b223de0dfdbdf"
   }
  ],
  "axiom_encode_git": {
@@ -17,12 +17,12 @@
  "citation": "programs/us-az/snap/fy-2026",
  "context_manifest_file": null,
  "context_manifest_sha256": null,
- "generated_at": "2026-07-12T18:30:00+00:00",
+ "generated_at": "2026-07-13T01:43:41.396029+00:00",
  "generated_output_file": null,
  "generated_output_root": null,
  "generated_output_sha256": "49e8d5d3dd8895babb5114882f74ceee715414d075c4d6b89bca8b785bb6e73b",
  "generation_prompt_sha256": null,
- "manual_exception": "#842",
+ "manual_exception": "#875",
  "model": "",
  "run_id": null,
  "runner": "manual-attestation",
@@ -30,7 +30,7 @@
  "signature": {
   "algorithm": "hmac-sha256",
   "key_id": "axiom-encode-apply-v1",
-  "value": "a025e6537f7c2392726129afab4d2725e5b10bb204533b724ffd3bbceac3255c"
+  "value": "4666271189864ad37c9eac4bf0320e724cb326eac3da112608acac94013c373d"
  },
  "tool": "axiom-encode sign-applied-files",
  "trace_file": null,

--- a/.axiom/encoding-manifests/programs/us-ca/snap/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-ca/snap/fy-2026.json
@@ -1,8 +1,8 @@
 {
  "applied_files": [
   {
-   "path": "programs/us-ny/snap/fy-2026.yaml",
-   "sha256": "16dce85301be3d36e0c25c09a0011a5bea2dd3eea77c112ff6bd193eab293358"
+   "path": "programs/us-ca/snap/fy-2026.yaml",
+   "sha256": "9ad0cd9b24c1b43db13300a7691e3af8bea2cf78c9dd9a8589a38121bf3d8dfa"
   }
  ],
  "axiom_encode_git": {
@@ -14,10 +14,10 @@
  },
  "axiom_encode_version": "0.2.1201",
  "backend": "manual",
- "citation": "programs/us-ny/snap/fy-2026",
+ "citation": "us-ca:programs/snap/fy-2026",
  "context_manifest_file": null,
  "context_manifest_sha256": null,
- "generated_at": "2026-07-13T02:37:36.420344+00:00",
+ "generated_at": "2026-07-13T01:43:41.393199+00:00",
  "generated_output_file": null,
  "generated_output_root": null,
  "generated_output_sha256": "3d8271c624d5e90a732ca76e0f08f14924c873612a61315f7c350fba21de85b5",
@@ -30,7 +30,7 @@
  "signature": {
   "algorithm": "hmac-sha256",
   "key_id": "axiom-encode-apply-v1",
-  "value": "e9aec91b0b77ab56ccef0ecea7454a09f28ce508527dda54ec5d510c4a778397"
+  "value": "99a9c714d3ce94ec5299284aed6d2cbf67d10ba1fd3ee29c0bdcd15c238ef875"
  },
  "tool": "axiom-encode sign-applied-files",
  "trace_file": null,

--- a/.axiom/encoding-manifests/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "b5ef66a0807ffa51159a411c2120f9b66f74c535724e89e9ec242a1121ace2c4"
+      "sha256": "9ab04c189887c20aa4ee501696d5f84bddcbffb7248d78eb2f57986417347139"
     },
     {
       "path": "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
-      "sha256": "ce458bc1faca995600011dd72fe674464c573b3e12e2256062a536fd593c89cc"
+      "sha256": "2c33d205e07d544ecb41c7a1d4452c6023e280cf0f2d8b800319616d3ffe82d4"
     }
   ],
   "axiom_encode_git": {
@@ -21,12 +21,12 @@
   "citation": "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-12T22:27:29.383021+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdvgpfk37/sign-applied-files/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdvgpfk37",
-  "generated_output_sha256": "ce458bc1faca995600011dd72fe674464c573b3e12e2256062a536fd593c89cc",
+  "generated_at": "2026-07-13T01:40:07.727128+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3ycjiv46/sign-applied-files/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3ycjiv46",
+  "generated_output_sha256": "2c33d205e07d544ecb41c7a1d4452c6023e280cf0f2d8b800319616d3ffe82d4",
   "generation_prompt_sha256": null,
-  "manual_exception": "#842",
+  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,43 +34,52 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "af1c8c1a5a369da603e4cb664d48fd5626b8348e89715ac4e17168e23cfd4d0e"
+    "value": "41ee013b89735c17af42cfb2d17598bab0b0d2ae64037bfef316b574ac87728d"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-12T21:14:40.310992+00:00",
+    "generated_at": "2026-07-12T22:27:29.383021+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "0e7ed6d0cbaaaf8068388e22c154b4a01abb540c2d592a181de9fcf7ed75f233",
-    "prior_signature": "c3a5f26a904cdfd779e145bdc1c63fc3636ccd920a7149de710af973feda336e",
+    "manifest_sha256": "ce635d0f5248f28518a8ff549002cfc36ae764cb583f5c7c43f8bc21107494c9",
+    "prior_signature": "af1c8c1a5a369da603e4cb664d48fd5626b8348e89715ac4e17168e23cfd4d0e",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-12T19:08:20.672085+00:00",
+      "generated_at": "2026-07-12T21:14:40.310992+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "6e9a43077378da7073a8080303d326b50770cfc04ea4463a1956dc42b19b3248",
-      "prior_signature": "499d4165203aeda7eaa830b3219fcbc2935a86ce557beaaed0d9c6cd8d7bc1f3",
+      "manifest_sha256": "0e7ed6d0cbaaaf8068388e22c154b4a01abb540c2d592a181de9fcf7ed75f233",
+      "prior_signature": "c3a5f26a904cdfd779e145bdc1c63fc3636ccd920a7149de710af973feda336e",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-12T18:16:52.046953+00:00",
+        "generated_at": "2026-07-12T19:08:20.672085+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "214ee7b5db08d43b892335ba3f79b92a29acc8dfac7ed32049a0f1c013b4fb8e",
-        "prior_signature": "e506809eeed292a2f7dbc2c1942b0d5f42aed0983f55c8df4a13bd7909751538",
+        "manifest_sha256": "6e9a43077378da7073a8080303d326b50770cfc04ea4463a1956dc42b19b3248",
+        "prior_signature": "499d4165203aeda7eaa830b3219fcbc2935a86ce557beaaed0d9c6cd8d7bc1f3",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-12T18:10:10.421477+00:00",
+          "generated_at": "2026-07-12T18:16:52.046953+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "3631fd1225e0d6fed489f6bd00eaf388a7fdbcff8d4a0cec076044f38aa66745",
-          "prior_signature": "70080975253f4d16740167e8a45c241a0befefa21f2e9b873707bc4fdfcf8e91",
+          "manifest_sha256": "214ee7b5db08d43b892335ba3f79b92a29acc8dfac7ed32049a0f1c013b4fb8e",
+          "prior_signature": "e506809eeed292a2f7dbc2c1942b0d5f42aed0983f55c8df4a13bd7909751538",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-12T18:09:28.228823+00:00",
+            "generated_at": "2026-07-12T18:10:10.421477+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "843d60db600a8011e312d2bc351d69353b53b16d603cd437949613a6118c01ad",
-            "prior_signature": "f198f1317eb5057e3d7f622980bfc60667f6145275001d96ff631c40fa320233",
+            "manifest_sha256": "3631fd1225e0d6fed489f6bd00eaf388a7fdbcff8d4a0cec076044f38aa66745",
+            "prior_signature": "70080975253f4d16740167e8a45c241a0befefa21f2e9b873707bc4fdfcf8e91",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-12T18:09:28.228823+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "843d60db600a8011e312d2bc351d69353b53b16d603cd437949613a6118c01ad",
+              "prior_signature": "f198f1317eb5057e3d7f622980bfc60667f6145275001d96ff631c40fa320233",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml",
+      "sha256": "f412fb345613e47e156d1da55f45eb17f07791f126f36f2cc7b46ee016f4c8fe"
+    },
+    {
+      "path": "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml",
+      "sha256": "6ab626f72b387915181fe62dca4977914f9f0086d6886c14e10085ae4bcd221d"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "adff58d1032d26be07644c181f5c4f6b1bf1b706",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us-ca:policies/cdss/snap/fy-2026-benefit-calculation",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T01:40:08.170379+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpp4uwyd8c/sign-applied-files/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpp4uwyd8c",
+  "generated_output_sha256": "6ab626f72b387915181fe62dca4977914f9f0086d6886c14e10085ae4bcd221d",
+  "generation_prompt_sha256": null,
+  "manual_exception": "#875",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3eac90c6d96dc619d20330e26bf70d8f6a88b18c0c2d6b12a09c2fde8bd656f8"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "f19d0c5b9b74bcabc7f81ad1dd00d00c82dc671b0e5effe7c25516b4e15273d2"
+      "sha256": "50a38c65fb073523cdc0c17e8deeafc8f1691b2eb2eaadda6cc77f3f38285f79"
     },
     {
       "path": "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
-      "sha256": "dc04758cc72db315f4bd91b318de4270359f0083a5f3d86a5afab5ca179dcc07"
+      "sha256": "a942c33104ad4acab8fd510f09cf5446c23df73f9ba9c2ae64b31c3a5faea432"
     }
   ],
   "axiom_encode_git": {
@@ -21,12 +21,12 @@
   "citation": "us-ga:policies/dfcs/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-12T22:27:29.792204+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpl8ciladw/sign-applied-files/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpl8ciladw",
-  "generated_output_sha256": "dc04758cc72db315f4bd91b318de4270359f0083a5f3d86a5afab5ca179dcc07",
+  "generated_at": "2026-07-13T01:40:08.607542+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9xk5npen/sign-applied-files/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9xk5npen",
+  "generated_output_sha256": "a942c33104ad4acab8fd510f09cf5446c23df73f9ba9c2ae64b31c3a5faea432",
   "generation_prompt_sha256": null,
-  "manual_exception": "#842",
+  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +34,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "698a98ea15b6e839d099faef93675303d92790f5c30865fb1f45610ab871337b"
+    "value": "a6e7e5bed1601c1c937265706e28cf2e7659c6bb7f3de2928c87911c44c3eafe"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-12T21:14:40.913392+00:00",
+    "generated_at": "2026-07-12T22:27:29.792204+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "78954e25155eabee2d824b17fb4b6c06f47c9bc0a09d0deb289bd0669bfcf852",
-    "prior_signature": "e18908909f42c02a0f5f82c27859a4339196a21ce7b81906d4461fff172e5d40",
+    "manifest_sha256": "fd31aa817d0557ff60e8a37bef67396dfd1cc9164bd11a2c7a03519361d4a62d",
+    "prior_signature": "698a98ea15b6e839d099faef93675303d92790f5c30865fb1f45610ab871337b",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-12T19:08:21.179427+00:00",
+      "generated_at": "2026-07-12T21:14:40.913392+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "30961e8878ae7d8f02a074e655eb427e3e3bdc1f27a0084aabba99b86bba5b86",
-      "prior_signature": "3d284429600457c341698efcb332e4bd19a391f3612e39205ff55355d635ef58",
+      "manifest_sha256": "78954e25155eabee2d824b17fb4b6c06f47c9bc0a09d0deb289bd0669bfcf852",
+      "prior_signature": "e18908909f42c02a0f5f82c27859a4339196a21ce7b81906d4461fff172e5d40",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-12T18:10:10.907077+00:00",
+        "generated_at": "2026-07-12T19:08:21.179427+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "8af41adc70fe05c103734195f97ea62dbda90b9544d2eae8d2afa972abb4b313",
-        "prior_signature": "29a1d76eb7fdcac444a90b24e902348d67520f2cc0f3f2e04217e28d2bdae816",
+        "manifest_sha256": "30961e8878ae7d8f02a074e655eb427e3e3bdc1f27a0084aabba99b86bba5b86",
+        "prior_signature": "3d284429600457c341698efcb332e4bd19a391f3612e39205ff55355d635ef58",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-12T18:09:28.742756+00:00",
+          "generated_at": "2026-07-12T18:10:10.907077+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "864dd420ffe6515fab8217139d71ba908d93415487d559ed837082504c1f3e56",
-          "prior_signature": "6ca90b8461ef28a666d9838d29096c7296d9cf7a88ccfebebb167eb6a9316fe1",
+          "manifest_sha256": "8af41adc70fe05c103734195f97ea62dbda90b9544d2eae8d2afa972abb4b313",
+          "prior_signature": "29a1d76eb7fdcac444a90b24e902348d67520f2cc0f3f2e04217e28d2bdae816",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-12T18:09:28.742756+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "864dd420ffe6515fab8217139d71ba908d93415487d559ed837082504c1f3e56",
+            "prior_signature": "6ca90b8461ef28a666d9838d29096c7296d9cf7a88ccfebebb167eb6a9316fe1",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "5f6316b106e9e8e6ed945483a9536a6ce55684c2de02cbac70f035f5dccb5363"
+      "sha256": "f276f5fdfa4e0c27223a9971fb6798f974114aef2fdaf059f2e07c8afc487092"
     },
     {
       "path": "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
-      "sha256": "14ef83880ef8b8b39a5397f8a22992b384d7ef6446374492a9dec3d6839c97e7"
+      "sha256": "c090e2c1a5c4806d2f82e5a56fa6ae7b16de46169871111b950723bf938b925f"
     }
   ],
   "axiom_encode_git": {
@@ -21,12 +21,12 @@
   "citation": "us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-12T22:27:30.232528+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpk4fx3a_u/sign-applied-files/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpk4fx3a_u",
-  "generated_output_sha256": "14ef83880ef8b8b39a5397f8a22992b384d7ef6446374492a9dec3d6839c97e7",
+  "generated_at": "2026-07-13T01:40:09.040048+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb_gx_kbl/sign-applied-files/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb_gx_kbl",
+  "generated_output_sha256": "c090e2c1a5c4806d2f82e5a56fa6ae7b16de46169871111b950723bf938b925f",
   "generation_prompt_sha256": null,
-  "manual_exception": "#842",
+  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,29 +34,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "95719a75242225e0d8a2ec9a1a5605890d0e2cfca4f17c6443e2bc9150cce38d"
+    "value": "a8057393822d6a2dc83fdee2a4297e2322082348e854f766a92b0ae4ff82c9fb"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-12T21:14:41.399388+00:00",
+    "generated_at": "2026-07-12T22:27:30.232528+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "ac7998da07c06f8e111ced17cfd6b18f88d57c0b9dcac68aa582cfc22c944e70",
-    "prior_signature": "a7c5ad4f57e28a77537b7301a456a5cdc12a74eaa003da98466b22fbb0f4edbd",
+    "manifest_sha256": "f935a67986d7e56cbd13e12b9e4f12113e2c287188d7bdc26e74bf291fe3a059",
+    "prior_signature": "95719a75242225e0d8a2ec9a1a5605890d0e2cfca4f17c6443e2bc9150cce38d",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-12T18:10:11.412621+00:00",
+      "generated_at": "2026-07-12T21:14:41.399388+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "0e783e45dd2b3cbb2ac554bc630a894e143ace55fa2398b23928713a9533a574",
-      "prior_signature": "008ffd7d401f61f50132317a9b5c00cc3cb6b26105f58ee5c54ec5e67d66564d",
+      "manifest_sha256": "ac7998da07c06f8e111ced17cfd6b18f88d57c0b9dcac68aa582cfc22c944e70",
+      "prior_signature": "a7c5ad4f57e28a77537b7301a456a5cdc12a74eaa003da98466b22fbb0f4edbd",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-12T18:09:29.239837+00:00",
+        "generated_at": "2026-07-12T18:10:11.412621+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "1f9f2ee86f415d5f189d9adfe8264505cc57b052414994072e3dee357323cc3b",
-        "prior_signature": "3457ea05439477d947ea0365d70ede9082943f20d798850ae4c20bc471614406",
+        "manifest_sha256": "0e783e45dd2b3cbb2ac554bc630a894e143ace55fa2398b23928713a9533a574",
+        "prior_signature": "008ffd7d401f61f50132317a9b5c00cc3cb6b26105f58ee5c54ec5e67d66564d",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-12T18:09:29.239837+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "1f9f2ee86f415d5f189d9adfe8264505cc57b052414994072e3dee357323cc3b",
+          "prior_signature": "3457ea05439477d947ea0365d70ede9082943f20d798850ae4c20bc471614406",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ny/policies/otda/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ny/policies/otda/snap/fy-2026-benefit-calculation.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "22c1955a492ca8231f6465777d34b3b696f8f38769368d9a11144bed3b71f3e5"
+      "sha256": "e168b707a7823b0b2d66e01e04899b5b22df8fdfccae153cdd5b91c3423ab53e"
     },
     {
       "path": "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
-      "sha256": "b067e9f1d52fccc86e6a1075857a5cbda9809bcb253cd456c120ac1c859de619"
+      "sha256": "ea73222f65e01e0ffb412b3f2cf418050ef1e39109b377b5e3f9c6896c520aa9"
     }
   ],
   "axiom_encode_git": {
@@ -21,11 +21,12 @@
   "citation": "us-ny:policies/otda/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-12T15:13:06.543377+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp7grdi_nu/sign-applied-files/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp7grdi_nu",
-  "generated_output_sha256": "b067e9f1d52fccc86e6a1075857a5cbda9809bcb253cd456c120ac1c859de619",
+  "generated_at": "2026-07-13T02:36:32.706355+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo9firzv_/sign-applied-files/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo9firzv_",
+  "generated_output_sha256": "ea73222f65e01e0ffb412b3f2cf418050ef1e39109b377b5e3f9c6896c520aa9",
   "generation_prompt_sha256": null,
+  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -33,7 +34,43 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "74e6b03a8b5d309b8dc993048418c7b2adb6646d8e5672ae4ff3a338a4e10d68"
+    "value": "ce574180bfce89557364e44197d8179abf012dfd23d78367edc417defec6398a"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-13T02:17:21.885943+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "399dab4520705f67e1054befce07b673c548b72e6cbdd6e2ce129722f54737d4",
+    "prior_signature": "ebfe6f015ecc6047fc9155ae9dba5d6ff2cbc674fa3dfd677d60d88355d48122",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-13T01:40:41.194329+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "d2456f91b915c8af611be2c0ab83fd08de2195cf4d23b3527a4fb5b62c188153",
+      "prior_signature": "f5055702f40f55340fb2788d68cbc92157310c18bbc4357ddeaa281500bd5541",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-13T01:40:09.481674+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "97b324a350815aaec2155e6e7019496335d47081e966e69e76b1af28580dd580",
+        "prior_signature": "0048ac64bc5828dc5b4af1900956c8cbeb338be5358bea04c43825d7b9cff336",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-12T15:13:06.543377+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "4abacb3c753f8a27969aa68faa030e6991c69d4fa50475b18593f314cb28e3ba",
+          "prior_signature": "74e6b03a8b5d309b8dc993048418c7b2adb6646d8e5672ae4ff3a338a4e10d68",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/policies/usda/snap/state-plan-composition.json
+++ b/.axiom/encoding-manifests/us/policies/usda/snap/state-plan-composition.json
@@ -1,0 +1,69 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/usda/snap/state-plan-composition.test.yaml",
+      "sha256": "fd5cd0633252bddb7278c62cb5b49390f935a0e2e251b06947c9b3f0ac908645"
+    },
+    {
+      "path": "us/policies/usda/snap/state-plan-composition.yaml",
+      "sha256": "4da6365679735248c7d89416236db9cc5681fd5871bd81426faa32b81e22af07"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "adff58d1032d26be07644c181f5c4f6b1bf1b706",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
+    "version": "0.2.1201",
+    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+  },
+  "axiom_encode_version": "0.2.1201",
+  "backend": "manual",
+  "citation": "us:policies/usda/snap/state-plan-composition",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T02:36:32.293624+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmprjmqsehu/sign-applied-files/us/policies/usda/snap/state-plan-composition.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmprjmqsehu",
+  "generated_output_sha256": "4da6365679735248c7d89416236db9cc5681fd5871bd81426faa32b81e22af07",
+  "generation_prompt_sha256": null,
+  "manual_exception": "#875",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e53b8c4b214b1e667d45d5eaed1f202363d050586e8a01e6b5d6040d728dbb93"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-13T02:17:21.487077+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "92de486ef90587549c827231012eab25061e9d75ce2b27a177c8ea277a5e4c48",
+    "prior_signature": "21bc5cf405bcad662db958a0455051aaeca2ee43a43a2a15f6cefa9f036827b2",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-13T01:40:41.639509+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "e78e4a984965844f8b26e0d39de8dd0d8d20ab4ff9a70934c77c34869c39c48e",
+      "prior_signature": "a56ef8a1ad9e391b1e123e8d2bca3e94ecc09ae51c21045a797bb14234d265a6",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-13T01:40:07.289038+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "15ce04f84ca96c088e72a75e57314fb2add8e04c3ba701f7cf4d2a224e9686b2",
+        "prior_signature": "d28cc840361753181b78c84e0c7155b3514dda5f3edd73a9610ff3e3ee5c2deb",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -24822,6 +24822,13 @@
           "module",
           "proof_atom"
         ]
+      },
+      {
+        "module": "us/policies/usda/snap/state-plan-composition.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
       }
     ],
     "us/guidance/usda/fns/snap-fy2026-cola/page-2": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -20,7 +20,6 @@ missing_companion_tests:
 shape_issues:
   - us-ca/regulations/mpp/63-406/1.yaml
 uncovered_derived_rules:
-  - us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml#calfresh_income_and_resource_eligible
   # Social Security Title II AIME/PIA/COLA derived outputs (42 USC 415) reach AIME
   # through the engine's sum_top_n_over_periods over-periods reduction, valid only
   # under lifetime execution; the per-period companion-test harness cannot assert

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,8 +7,47 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 688
+ceiling: 701
 entries:
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
+    source: migration
+    since: 2026-07-13
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
     since: 2026-07-08

--- a/programs/us-az/snap/fy-2026.yaml
+++ b/programs/us-az/snap/fy-2026.yaml
@@ -22,6 +22,7 @@ auto_gate_outputs:
 
 scope:
   federal:
+    - policies/usda/snap/state-plan-composition
     - policies/usda/snap/fy-2026-cola/maximum-allotments
     - policies/usda/snap/fy-2026-cola/deductions
     - policies/usda/snap/fy-2026-cola/income-eligibility-standards

--- a/programs/us-ca/snap/fy-2026.yaml
+++ b/programs/us-ca/snap/fy-2026.yaml
@@ -30,6 +30,7 @@ auto_gate_outputs:
 
 scope:
   federal:
+    - policies/usda/snap/state-plan-composition
     - regulations/7-cfr/273/3
     - regulations/7-cfr/273/4
     - regulations/7-cfr/273/5

--- a/programs/us-ny/snap/fy-2026.yaml
+++ b/programs/us-ny/snap/fy-2026.yaml
@@ -21,6 +21,7 @@ auto_gate_outputs:
 
 scope:
   federal:
+    - policies/usda/snap/state-plan-composition
     - regulations/7-cfr/273/3
     - regulations/7-cfr/273/4
     - regulations/7-cfr/273/5
@@ -84,7 +85,11 @@ transformations:
   # composition policies/otda/snap/fy-2026-benefit-calculation in scope now
   # produces them (with NY's own member-eligibility predicates and the
   # 387/12 excess-shelter chain); keeping the inline copies would create
-  # duplicate derived rules. The inline snap_total_allowable_shelter_expenses
+  # duplicate derived rules. The single-term
+  # snap_countable_earned_income / snap_countable_unearned_income sum_terms
+  # bridges were removed the same way (rulespec-us#875): the federal
+  # state-plan composition derives them from the raw income inputs.
+  # The inline snap_total_allowable_shelter_expenses
   # and snap_benefit bridges were removed the same way (rulespec-us#830): the
   # composition now binds the 273.10 shelter input from New York's
   # 387.12(f)(3)(vi) allowable shelter costs — which, unlike the removed
@@ -101,25 +106,3 @@ transformations:
     conditions:
       - snap_income_limit_exemption_for_categorically_eligible_household
       - snap_standard_income_eligible
-
-  - pattern: sum_terms
-    name: snap_countable_earned_income
-    effective_from: '2026-01-01'
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: axiom-programs/us-ny/snap/fy-2026 income composition
-    terms:
-      - snap_gross_monthly_earned_income
-
-  - pattern: sum_terms
-    name: snap_countable_unearned_income
-    effective_from: '2026-01-01'
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: axiom-programs/us-ny/snap/fy-2026 income composition
-    terms:
-      - snap_total_monthly_unearned_income

--- a/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml
+++ b/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml
@@ -16,9 +16,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 1003
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 500
@@ -89,9 +90,9 @@
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 594
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 526
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 68
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 277
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 277
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#na_regular_month_allotment: 277.6
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_gross_monthly_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1003
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#shelter_costs: 823
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#na_net_income: 68
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 526
@@ -113,9 +114,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 2000
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 800
@@ -185,7 +187,7 @@
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 1377
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 550
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 827
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 745
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 745
 - name: telephone_only_household_receives_the_tua
   period: 2026-01
   input:
@@ -204,9 +206,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 1003
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 500
@@ -274,7 +277,7 @@
     : 544
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 247
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 347
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 193
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 193
 - name: one_person_low_benefit_rounds_up_to_the_minimum_on_both_surfaces
   period: 2026-01
   input:
@@ -293,9 +296,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 1450
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 0
@@ -360,7 +364,7 @@
   output:
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#az_applied_utility_allowance: 0
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 951
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 24
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 24
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#na_regular_month_allotment: 24
 - name: ineligible_unit_receives_zero_on_both_surfaces
   period: 2026-01
@@ -380,9 +384,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 1003
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 500
@@ -446,7 +451,7 @@
       us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible: not_holds
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 0
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
     us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#na_regular_month_allotment: 0
 
 # Sol-gate divergent case: disqualified participants are excluded from the
@@ -472,9 +477,10 @@
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    ? us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income
     : 2000
-    ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income
+    ? us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income
     : 0
     ? us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.household_shelter_costs_incurred
     : 800
@@ -544,4 +550,4 @@
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 1391
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 543
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 848
-    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_benefit: 530
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 530

--- a/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml
+++ b/us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml
@@ -15,39 +15,11 @@ module:
     eligibility determination remains an input bridge until the full Arizona
     NA eligibility chain is wired.
 imports:
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:policies/usda/snap/fy-2026-cola/deductions
-  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
-  - us:regulations/7-cfr/273/3
-  - us:regulations/7-cfr/273/4
-  - us:regulations/7-cfr/273/5
-  - us:regulations/7-cfr/273/6
-  - us:regulations/7-cfr/273/7
-  - us:regulations/7-cfr/273/8
-  - us:regulations/7-cfr/273/9
-  - us:regulations/7-cfr/273/10
-  - us:regulations/7-cfr/273/24
-  - us:statutes/7/2012/j
-  - us:statutes/7/2017/a
+  - us:policies/usda/snap/state-plan-composition
   - us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility
   - us-az:policies/des/faa6/utility-allowance-current-amount
   - us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount
 rules:
-  - name: snap_gross_monthly_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          max(0, snap_gross_monthly_earned_income + snap_total_monthly_unearned_income)
-
-  # The applied utility allowance: Arizona awards exactly one allowance per
-  # budgetary unit — the SUA, else the LUA, else the TUA — per the FAA5
-  # eligibility judgments, at the FAA6.J.09 participant-bracket amounts.
   - name: az_applied_utility_allowance
     kind: derived
     entity: Household
@@ -81,23 +53,6 @@ rules:
         formula: |-
           household_shelter_costs_incurred + az_applied_utility_allowance
 
-  # Binds the 7 CFR 273.10(e) shelter input to Arizona's shelter costs with
-  # the applied utility allowance — the California composition's binding.
-  - name: snap_total_allowable_shelter_expenses
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          shelter_costs
-
-  # Binds the FAA5 benefit-amount module's net-income bridge input to the
-  # 273.10 whole-dollar net income, so Arizona's manual-literal benefit rule
-  # computes over the same net income as the federal chain.
   - name: na_net_income
     kind: derived
     entity: Household
@@ -110,16 +65,17 @@ rules:
         formula: |-
           snap_net_monthly_income
 
-  - name: snap_eligible
+  - name: snap_total_allowable_shelter_expenses
     kind: derived
     entity: Household
-    dtype: Judgment
+    dtype: Money
     period: Month
+    unit: USD
     source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          na_budgetary_unit_is_eligible
+          shelter_costs
 
   - name: snap_excess_shelter_deduction
     kind: derived
@@ -133,28 +89,17 @@ rules:
         formula: |-
           max(0, snap_excess_shelter_deduction_for_net_income)
 
-  # The issued monthly benefit on the 7 CFR 273.10(e)(1)-(2) whole-dollar
-  # chain (earned-income deduction cents dropped, excess shelter rounded to
-  # the nearest dollar, minimum-benefit floor), the computation FNS applies
-  # in the SNAP quality control database and AZTECS applies in issuance.
-  - name: snap_benefit
+  - name: snap_eligible
     kind: derived
     entity: Household
-    dtype: Money
+    dtype: Judgment
     period: Month
-    unit: USD
-    source: 7 CFR 273.10(e)(2)(ii) via Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
     versions:
       - effective_from: '2025-10-01'
         formula: |-
-          if na_budgetary_unit_is_eligible:
-              snap_monthly_allotment
-          else:
-              0
+          na_budgetary_unit_is_eligible
 
-  # Arizona's manual-literal benefit rule (FAA5 block 9), retained as its own
-  # surface; renamed from snap_regular_month_allotment because the composed
-  # 7 USC 2017(a) module owns that name.
   - name: na_regular_month_allotment
     kind: derived
     entity: Household

--- a/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml
+++ b/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml
@@ -11,68 +11,23 @@ module:
     provisions. It composes those sources into CalFresh eligibility and monthly
     benefit calculations.
 imports:
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:policies/usda/snap/fy-2026-cola/deductions
-  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
-  - us:regulations/7-cfr/273/3
-  - us:regulations/7-cfr/273/4
-  - us:regulations/7-cfr/273/5
-  - us:regulations/7-cfr/273/6
-  - us:regulations/7-cfr/273/7
+  - us:policies/usda/snap/state-plan-composition
   - us:regulations/7-cfr/273/8
   - us:regulations/7-cfr/273/9
-  - us:regulations/7-cfr/273/10
-  - us:regulations/7-cfr/273/24
-  - us:statutes/7/2012/j
-  - us:statutes/7/2014/e/2
-  - us:statutes/7/2014/e/6/A
-  - us:statutes/7/2017/a
   - us-ca:policies/cdss/snap/standard-utility-allowance
   - us-ca:regulations/mpp/63-503/324
 rules:
-  - name: snap_countable_earned_income
+  - name: snap_total_allowable_shelter_expenses
     kind: derived
     entity: Household
     dtype: Money
     period: Month
     unit: USD
-    source: California CalFresh FY 2026 benefit calculation composition
+    source: California CalFresh shelter utility allowance composition bridge
     versions:
       - effective_from: '2025-10-01'
-        formula: max(0, snap_gross_monthly_earned_income)
-
-  - name: snap_countable_unearned_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: California CalFresh FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, snap_total_monthly_unearned_income)
-
-  - name: snap_gross_monthly_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: California CalFresh FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, snap_countable_earned_income + snap_countable_unearned_income)
-
-  - name: snap_monthly_household_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: California CalFresh FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, snap_countable_earned_income + snap_countable_unearned_income)
+        formula: |-
+          shelter_costs
 
   - name: snap_excess_shelter_deduction
     kind: derived
@@ -85,39 +40,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: snap_excess_shelter_deduction_for_net_income
 
-  - name: snap_member_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: California CalFresh SNAP eligibility member composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_member_citizenship_or_alien_status_eligible
-          and snap_member_ssn_requirement_eligible
-          and snap_member_work_requirement_eligible
-          and snap_member_student_eligible
-  - name: snap_residency_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: California CalFresh SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_household_residency_eligible
-  - name: snap_household_member_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: California CalFresh SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          count_where(member_of_household, snap_member_eligible) > 0
   - name: snap_eligible
     kind: derived
     entity: Household
@@ -130,29 +52,6 @@ rules:
           snap_residency_eligible
           and snap_household_member_eligible
           and calfresh_income_and_resource_eligible
-  - name: snap_benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 63-503.324 and 7 CFR 273.10(e)(2)(ii)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_eligible:
-              snap_monthly_allotment
-          else:
-              0
-  - name: member_of_household
-    kind: data_relation
-    data_relation:
-      predicate: member_of_household
-      arity: 2
-      arguments:
-        - Person
-        - Household
-
   - name: shelter_costs
     kind: derived
     entity: Household
@@ -164,17 +63,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           household_shelter_costs_incurred + snap_standard_utility_allowance
-  - name: snap_total_allowable_shelter_expenses
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: California CalFresh shelter utility allowance composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          shelter_costs
   - name: calfresh_income_and_resource_eligible
     kind: derived
     entity: Household

--- a/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml
@@ -22,11 +22,8 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 300
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -66,15 +63,15 @@
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 594
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 408
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 186
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_benefit: 242
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_countable_earned_income: 1003
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_countable_unearned_income: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 1003
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_monthly_household_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 242
+    us:policies/usda/snap/state-plan-composition#snap_countable_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 1003
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 408
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#shelter_costs: 705
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_residency_eligible: holds
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_household_member_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_residency_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_household_member_eligible: holds
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_eligible: holds
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_snap_eligible: holds
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_income_and_resource_eligible: holds
@@ -102,11 +99,8 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -144,7 +138,7 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 858
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 561
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 33
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_benefit: 288
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 288
 - name: telephone_standard_household
   period: 2026-01
   input:
@@ -169,11 +163,8 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -211,7 +202,7 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 547
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 250
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 344
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_benefit: 194
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 194
 - name: no_utility_standard_household
   period: 2026-01
   input:
@@ -236,11 +227,8 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -276,7 +264,7 @@
   output:
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_applied_utility_allowance: 0
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 500
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_benefit: 180
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 180
 - name: eligible_member_passes_the_member_composition_bridge
   period: 2026-01
   input:
@@ -309,7 +297,7 @@
     us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_member_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_member_eligible: holds
 - name: over_resource_household_without_categorical_eligibility_receives_zero
   period: 2026-01
   input:
@@ -334,11 +322,8 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 300
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -375,4 +360,4 @@
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_income_and_resource_eligible: not_holds
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
     us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#ga_snap_eligible: not_holds
-    us-ga:policies/dfcs/snap/fy-2026-benefit-calculation#snap_benefit: 0
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0

--- a/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml
+++ b/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml
@@ -12,67 +12,22 @@ module:
     eligibility and monthly benefit calculations on the 7 CFR 273.10
     whole-dollar chain.
 imports:
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:policies/usda/snap/fy-2026-cola/deductions
-  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
-  - us:regulations/7-cfr/273/3
-  - us:regulations/7-cfr/273/4
-  - us:regulations/7-cfr/273/5
-  - us:regulations/7-cfr/273/6
-  - us:regulations/7-cfr/273/7
+  - us:policies/usda/snap/state-plan-composition
   - us:regulations/7-cfr/273/8
   - us:regulations/7-cfr/273/9
-  - us:regulations/7-cfr/273/10
-  - us:regulations/7-cfr/273/24
-  - us:statutes/7/2012/j
-  - us:statutes/7/2014/e/2
-  - us:statutes/7/2014/e/6/A
-  - us:statutes/7/2017/a
   - us-ga:policies/dfcs/snap/standard-utility-allowances
 rules:
-  - name: ga_countable_earned_income
+  - name: snap_total_allowable_shelter_expenses
     kind: derived
     entity: Household
     dtype: Money
     period: Month
     unit: USD
-    source: Georgia SNAP FY 2026 benefit calculation composition
+    source: Georgia SNAP shelter utility allowance composition bridge
     versions:
       - effective_from: '2025-10-01'
-        formula: max(0, snap_gross_monthly_earned_income)
-
-  - name: ga_countable_unearned_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Georgia SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, snap_total_monthly_unearned_income)
-
-  - name: snap_gross_monthly_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Georgia SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, ga_countable_earned_income + ga_countable_unearned_income)
-
-  - name: snap_monthly_household_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Georgia SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, ga_countable_earned_income + ga_countable_unearned_income)
+        formula: |-
+          shelter_costs
 
   - name: snap_excess_shelter_deduction
     kind: derived
@@ -85,39 +40,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: snap_excess_shelter_deduction_for_net_income
 
-  - name: ga_member_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: Georgia SNAP eligibility member composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_member_citizenship_or_alien_status_eligible
-          and snap_member_ssn_requirement_eligible
-          and snap_member_work_requirement_eligible
-          and snap_member_student_eligible
-  - name: snap_residency_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: Georgia SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_household_residency_eligible
-  - name: snap_household_member_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: Georgia SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          count_where(member_of_household, ga_member_eligible) > 0
   - name: ga_snap_eligible
     kind: derived
     entity: Household
@@ -140,34 +62,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           ga_snap_eligible
-  - name: snap_benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 CFR 273.10(e)(2)(ii) via Georgia SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if ga_snap_eligible:
-              snap_monthly_allotment
-          else:
-              0
-  - name: member_of_household
-    kind: data_relation
-    data_relation:
-      predicate: member_of_household
-      arity: 2
-      arguments:
-        - Person
-        - Household
-
-  # The applied standard utility allowance: exactly one of Georgia's three
-  # section 3617 standards per assistance unit — the H/C SUA, else the LSUA,
-  # else the telephone standard. Qualification facts are inputs; the replay
-  # and downstream consumers adjudicate them from the household's own
-  # utility circumstances.
   - name: ga_applied_utility_allowance
     kind: derived
     entity: Household
@@ -200,17 +94,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           household_shelter_costs_incurred + ga_applied_utility_allowance
-  - name: snap_total_allowable_shelter_expenses
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Georgia SNAP shelter utility allowance composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          shelter_costs
   - name: ga_income_and_resource_eligible
     kind: derived
     entity: Household

--- a/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml
@@ -22,11 +22,8 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 300
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -65,15 +62,15 @@
     us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 594
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 575
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 19
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_benefit: 292
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_countable_earned_income: 1003
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_countable_unearned_income: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 1003
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_monthly_household_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 292
+    us:policies/usda/snap/state-plan-composition#snap_countable_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 1003
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 575
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#shelter_costs: 872
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_residency_eligible: holds
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_household_member_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_residency_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_household_member_eligible: holds
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_eligible: holds
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_snap_eligible: holds
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_income_and_resource_eligible: holds
@@ -101,11 +98,8 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -142,7 +136,7 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 850
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 553
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 41
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_benefit: 285
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 285
 - name: telephone_allowance_household
   period: 2026-01
   input:
@@ -167,11 +161,8 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -208,7 +199,7 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 540
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 243
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 351
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_benefit: 192
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 192
 - name: no_utility_allowance_household
   period: 2026-01
   input:
@@ -233,11 +224,8 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -272,7 +260,7 @@
   output:
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_applied_utility_allowance: 0
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 500
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_benefit: 180
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 180
 - name: eligible_member_passes_the_member_composition_bridge
   period: 2026-01
   input:
@@ -305,7 +293,7 @@
     us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_member_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_member_eligible: holds
 - name: over_resource_household_without_categorical_eligibility_receives_zero
   period: 2026-01
   input:
@@ -330,11 +318,8 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 300
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
-    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
-    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
-    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
@@ -370,4 +355,4 @@
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_income_and_resource_eligible: not_holds
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
     us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#md_snap_eligible: not_holds
-    us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation#snap_benefit: 0
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0

--- a/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml
+++ b/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml
@@ -12,67 +12,22 @@ module:
     eligibility and monthly benefit calculations on the 7 CFR 273.10
     whole-dollar chain.
 imports:
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:policies/usda/snap/fy-2026-cola/deductions
-  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
-  - us:regulations/7-cfr/273/3
-  - us:regulations/7-cfr/273/4
-  - us:regulations/7-cfr/273/5
-  - us:regulations/7-cfr/273/6
-  - us:regulations/7-cfr/273/7
+  - us:policies/usda/snap/state-plan-composition
   - us:regulations/7-cfr/273/8
   - us:regulations/7-cfr/273/9
-  - us:regulations/7-cfr/273/10
-  - us:regulations/7-cfr/273/24
-  - us:statutes/7/2012/j
-  - us:statutes/7/2014/e/2
-  - us:statutes/7/2014/e/6/A
-  - us:statutes/7/2017/a
   - us-md:policies/dhs/fia/snap/standard-utility-allowances
 rules:
-  - name: md_countable_earned_income
+  - name: snap_total_allowable_shelter_expenses
     kind: derived
     entity: Household
     dtype: Money
     period: Month
     unit: USD
-    source: Maryland SNAP FY 2026 benefit calculation composition
+    source: Maryland SNAP shelter utility allowance composition bridge
     versions:
       - effective_from: '2025-10-01'
-        formula: max(0, snap_gross_monthly_earned_income)
-
-  - name: md_countable_unearned_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Maryland SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, snap_total_monthly_unearned_income)
-
-  - name: snap_gross_monthly_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Maryland SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, md_countable_earned_income + md_countable_unearned_income)
-
-  - name: snap_monthly_household_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Maryland SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: max(0, md_countable_earned_income + md_countable_unearned_income)
+        formula: |-
+          shelter_costs
 
   - name: snap_excess_shelter_deduction
     kind: derived
@@ -85,39 +40,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: snap_excess_shelter_deduction_for_net_income
 
-  - name: md_member_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: Maryland SNAP eligibility member composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_member_citizenship_or_alien_status_eligible
-          and snap_member_ssn_requirement_eligible
-          and snap_member_work_requirement_eligible
-          and snap_member_student_eligible
-  - name: snap_residency_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: Maryland SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_household_residency_eligible
-  - name: snap_household_member_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: Maryland SNAP eligibility composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          count_where(member_of_household, md_member_eligible) > 0
   - name: md_snap_eligible
     kind: derived
     entity: Household
@@ -140,34 +62,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           md_snap_eligible
-  - name: snap_benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 CFR 273.10(e)(2)(ii) via Maryland SNAP FY 2026 benefit calculation composition
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if md_snap_eligible:
-              snap_monthly_allotment
-          else:
-              0
-  - name: member_of_household
-    kind: data_relation
-    data_relation:
-      predicate: member_of_household
-      arity: 2
-      arguments:
-        - Person
-        - Household
-
-  # The applied standard utility allowance: exactly one of Maryland's three
-  # AT 26-05 standards per household — the SUA, else the LUA, else the
-  # telephone allowance. Qualification facts are inputs; the replay
-  # and downstream consumers adjudicate them from the household's own
-  # utility circumstances.
   - name: md_applied_utility_allowance
     kind: derived
     entity: Household
@@ -200,17 +94,6 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           household_shelter_costs_incurred + md_applied_utility_allowance
-  - name: snap_total_allowable_shelter_expenses
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: Maryland SNAP shelter utility allowance composition bridge
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          shelter_costs
   - name: md_income_and_resource_eligible
     kind: derived
     entity: Household

--- a/us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml
@@ -5,10 +5,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 1000
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1000
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1000
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -45,7 +44,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : true
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -54,7 +53,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -78,14 +77,14 @@
       snap_utility_allowance_type: SUA
       snap_utility_region_str: NY_NYC
   output:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 1000
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_monthly_household_income: 1000
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1000
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 1000
     us:regulations/7-cfr/273/9#snap_standard_income_eligible: holds
     us:regulations/7-cfr/273/8#snap_resource_eligible: holds
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_ssn_eligible: holds
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_work_requirement_eligible: holds
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_student_eligible: holds
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_residency_citizenship_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_ssn_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_student_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible: holds
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible: holds
     us:policies/usda/snap/fy-2026-cola/deductions#snap_standard_deduction: 209
     us:statutes/7/2014/e/2#snap_earned_income_deduction: 200
@@ -103,10 +102,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 0
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 0
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -131,7 +129,7 @@
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
     us:statutes/7/2012/j#relation.member_of_household: *id001
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : true
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -140,7 +138,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -171,10 +169,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 10000
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 10000
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 10000
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 10000
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -199,7 +196,7 @@
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
     us:statutes/7/2012/j#relation.member_of_household: *id001
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -208,7 +205,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -228,8 +225,8 @@
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_size: 1
   output:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 10000
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_monthly_household_income: 10000
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 10000
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 10000
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
     us:statutes/7/2017/a#snap_regular_month_allotment: 0
 - name: additional_household_member_uses_usda_additional_member_amount
@@ -239,10 +236,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 9
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 9
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 9
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 0
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 0
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -267,7 +263,7 @@
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
     us:statutes/7/2012/j#relation.member_of_household: *id001
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -276,7 +272,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -296,7 +292,7 @@
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_size: 9
   output:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_monthly_household_income: 0
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 0
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible: holds
     us:statutes/7/2014/e/6/A#snap_net_income: 0
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 2007
@@ -308,10 +304,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 0
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 0
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -348,7 +343,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : true
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -357,7 +352,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id002
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id002
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -377,7 +372,7 @@
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_size: 1
   output:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_ssn_eligible: not_holds
+    us:policies/usda/snap/state-plan-composition#snap_ssn_eligible: not_holds
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
     us:statutes/7/2017/a#snap_regular_month_allotment: 0
 - name: categorical_eligibility_exempts_new_york_household_from_resource_limit
@@ -387,10 +382,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 2600
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 2600
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 2600
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 2600
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -427,7 +421,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : true
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -436,7 +430,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id003
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id003
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -466,10 +460,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 1000
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1000
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1000
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -494,7 +487,7 @@
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
     us:statutes/7/2012/j#relation.member_of_household: *id001
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -503,7 +496,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: true
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -535,10 +528,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 0
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 0
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -563,7 +555,7 @@
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
     us:statutes/7/2012/j#relation.member_of_household: *id001
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 153
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 153
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -572,7 +564,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household: &id004
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: false
@@ -595,12 +587,12 @@
     us:statutes/7/2014/e/6/A#snap_net_income: 0
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 298
     us:statutes/7/2017/a#snap_allotment_before_minimum: 298
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_initial_month_allotment_after_minimum_issuance: 153
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_benefit: 153
+    us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment: 153
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 153
 - name: initial_month_prorated_allotment_below_minimum_gets_zero_issuance
   period: 2026-01
   input:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 5
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 5
     us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
     us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
@@ -612,10 +604,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 0
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 0
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -648,11 +639,11 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: true
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household: *id001
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household: *id001
     us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household: *id004
   output:
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_initial_month_allotment_after_minimum_issuance: 0
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_benefit: 0
+    us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment: 0
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
 - name: issued_benefit_drops_earned_income_deduction_cents_per_273_10
   period: 2026-01
   input:
@@ -660,10 +651,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 1003
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -700,7 +690,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -709,7 +699,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
@@ -751,7 +741,7 @@
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 203
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 391
     us:regulations/7-cfr/273/10#snap_monthly_allotment: 180
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_benefit: 180
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 180
 - name: issued_benefit_rounds_excess_shelter_to_nearest_dollar_per_273_10
   period: 2026-01
   input:
@@ -759,10 +749,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 1005
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1005
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1005
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1005
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -799,7 +788,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 622
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -808,7 +797,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
@@ -850,7 +839,7 @@
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 325
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 270
     us:regulations/7-cfr/273/10#snap_monthly_allotment: 217
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_benefit: 217
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 217
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#ny_snap_excess_shelter_cost: 324.5
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 324.5
     us:statutes/7/2014/e/6/A#snap_net_income: 270.5 # the statutory chain's half-dollar the 273.10 election rounds away
@@ -862,10 +851,9 @@
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
     us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income: 1003
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
     us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_countable_unearned_income: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
@@ -902,7 +890,7 @@
       us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_incurred_or_anticipated_heating_or_cooling_costs_separate_from_rent_or_mortgage
     : false
     ? us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_in_central_meter_housing_charged_only_for_excess_heating_or_cooling
@@ -911,7 +899,7 @@
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_new_york_city: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#input.household_resides_in_nassau_or_suffolk_county: false
     us-ny:regulations/18-nycrr/387/12/f/3/v/b#input.household_billed_separately_for_non_telephone_standard_utility: false
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation.member_of_household:
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
@@ -954,5 +942,5 @@
     us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 0
     us:regulations/7-cfr/273/10#snap_net_monthly_income: 594
     us:regulations/7-cfr/273/10#snap_monthly_allotment: 119
-    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_benefit: 119
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 119
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_claimed_homeless_shelter_deduction: 0

--- a/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml
+++ b/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml
@@ -14,19 +14,9 @@ module:
   source_verification:
     corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
 imports:
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
-  - us:policies/usda/snap/fy-2026-cola/deductions
-  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
-  - us:regulations/7-cfr/273/3
-  - us:regulations/7-cfr/273/4
-  - us:regulations/7-cfr/273/5
-  - us:regulations/7-cfr/273/6
-  - us:regulations/7-cfr/273/7
+  - us:policies/usda/snap/state-plan-composition
   - us:regulations/7-cfr/273/8
   - us:regulations/7-cfr/273/9
-  - us:regulations/7-cfr/273/10
-  - us:regulations/7-cfr/273/24
-  - us:statutes/7/2012/j
   - us:statutes/7/2014/e/2
   - us:statutes/7/2014/e/6/A
   - us:statutes/7/2017/a
@@ -43,15 +33,6 @@ imports:
   - us-ny:regulations/18-nycrr/387/12/f/3/v/b
   - us-ny:regulations/18-nycrr/387/12/f/3/v/c
 rules:
-  - name: member_of_household
-    kind: data_relation
-    data_relation:
-      predicate: member_of_household
-      arity: 2
-      arguments:
-        - Person
-        - Household
-
   - name: shelter_costs
     kind: derived
     entity: Household
@@ -74,52 +55,6 @@ rules:
           + snap_standard_utility_allowance
           + snap_limited_utility_allowance
           + snap_individual_utility_allowance
-  - name: snap_gross_monthly_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          max(
-              0,
-              snap_countable_earned_income
-              + snap_countable_unearned_income
-          )
-  - name: snap_monthly_household_income
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          max(
-              0,
-              snap_countable_earned_income
-              + snap_countable_unearned_income
-          )
   - name: ny_snap_excess_shelter_cost
     kind: derived
     entity: Household
@@ -143,6 +78,26 @@ rules:
               snap_allowable_shelter_costs
               - (snap_net_income_pre_shelter * snap_excess_shelter_income_share)
           )
+  - name: snap_total_allowable_shelter_expenses
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: New York SNAP FY 2026 benefit calculation composition
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+              span: 'New York SNAP FY 2026 benefit calculation composition'
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_allowable_shelter_costs
+
   - name: snap_excess_shelter_deduction
     kind: derived
     entity: Household
@@ -165,99 +120,6 @@ rules:
               ny_snap_excess_shelter_cost
           else:
               min(ny_snap_excess_shelter_cost, snap_maximum_excess_shelter_deduction_48_states_dc)
-  - name: snap_initial_month_allotment_after_minimum_issuance
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_initial_month_prorated_allotment < snap_initial_month_minimum_issuance:
-              0
-          else:
-              snap_initial_month_prorated_allotment
-  - name: snap_ssn_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0
-  - name: snap_residency_citizenship_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_household_residency_eligible
-          and count_where(member_of_household, snap_member_citizenship_or_alien_status_eligible) > 0
-  - name: snap_work_requirement_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          count_where(member_of_household, snap_member_work_requirement_ineligible) == 0
-  - name: snap_student_eligible
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: count_where(member_of_household, snap_member_student_ineligible) == 0
   - name: snap_eligible
     kind: derived
     entity: Household
@@ -283,7 +145,7 @@ rules:
           and snap_ssn_eligible
           and snap_work_requirement_eligible
           and snap_student_eligible
-          and snap_residency_citizenship_eligible
+          and snap_household_residency_and_citizenship_eligible
 
   # Binds the 7 CFR 273.10(e) shelter input to New York's allowable shelter
   # costs (18 NYCRR 387.12(f)(3)(vi)), so the regulation's whole-dollar
@@ -293,38 +155,6 @@ rules:
   # allowance as a shelter expense, so the federal pre-shelter homeless
   # deduction stays off (the snap_claimed_homeless_shelter_deduction binding
   # below).
-  - name: snap_total_allowable_shelter_expenses
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 18 NYCRR 387.12(f)(3)(vi)
-    metadata:
-      proof:
-        atoms:
-          # The proof validator requires composition atoms to cite the
-          # module's own verification source; the operative shelter-expense
-          # substitution is proven in the imported
-          # us-ny:regulations/18-nycrr/387/12/f/3/vi module's own atoms.
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_allowable_shelter_costs
-
-  # New York administers homeless shelter costs as a shelter expense through
-  # the excess-shelter computation (18 NYCRR 387.12(f)(3)(vi), which restates
-  # the federal homeless deduction into snap_allowable_shelter_costs above),
-  # not as the separate 273.10(e) pre-shelter homeless deduction. Binding the
-  # federal claimed amount to zero keeps exactly one homeless path live: a
-  # positive claimed amount would zero the federal excess-shelter cost while
-  # the vi substitution simultaneously carries the allowance as a shelter
-  # cost.
   - name: snap_claimed_homeless_shelter_deduction
     kind: derived
     entity: Household
@@ -359,31 +189,3 @@ rules:
   # snap_initial_month_allotment_after_minimum_issuance. The composed
   # 2014(e)/2017(a) statutory chain above stays pure (it carries cents) and
   # is not the issued amount.
-  - name: snap_benefit
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 CFR 273.10(e)(2)(ii) via New York SNAP FY 2026 benefit calculation composition
-    metadata:
-      proof:
-        atoms:
-          # Composition-source atom (validator constraint, as above); the
-          # whole-dollar allotment computation is proven in the imported
-          # us:regulations/7-cfr/273/10 module's own atoms.
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              span: 'New York SNAP FY 2026 benefit calculation composition'
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          if snap_eligible:
-              if household_initial_month:
-                  snap_initial_month_allotment_after_minimum_issuance
-              else:
-                  snap_monthly_allotment
-          else:
-              0

--- a/us/policies/usda/snap/state-plan-composition.test.yaml
+++ b/us/policies/usda/snap/state-plan-composition.test.yaml
@@ -1,4 +1,4 @@
-- name: low_income_one_person_household_receives_maximum_allotment
+- name: eligible_household_rides_the_whole_dollar_chain
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
@@ -9,9 +9,7 @@
     us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
     us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
     us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
-    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false
-    us:regulations/7-cfr/273/8#input.snap_countable_financial_resources: 0
-    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
     us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
@@ -19,10 +17,12 @@
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
     us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
     us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage: false
     us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
     us:regulations/7-cfr/273/10#input.household_initial_month: false
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: true
     us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
     us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
@@ -53,261 +53,23 @@
       us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
       us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
-    us:policies/usda/snap/state-plan-composition#snap_countable_earned_income: 0
+    us:policies/usda/snap/state-plan-composition#snap_countable_earned_income: 1003
     us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income: 0
-    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 0
+    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1003
+    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 1003
+    us:regulations/7-cfr/273/10#snap_earned_income_deduction_for_net_income: 200
+    us:regulations/7-cfr/273/10#snap_net_income_before_shelter: 594
+    us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income: 408
+    us:regulations/7-cfr/273/10#snap_net_monthly_income: 186
     us:policies/usda/snap/state-plan-composition#snap_residency_eligible: holds
     us:policies/usda/snap/state-plan-composition#snap_household_member_eligible: holds
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 0
-    us:policies/usda/snap/state-plan-composition#snap_monthly_household_income: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: holds
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#calfresh_income_and_resource_eligible: holds
-    us:regulations/7-cfr/273/10#snap_monthly_allotment: 298
-    us:policies/usda/snap/state-plan-composition#snap_benefit: 298
+    us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 242
+    us:policies/usda/snap/state-plan-composition#snap_ssn_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_student_eligible: holds
 
-- name: earned_income_reduces_benefit
-  period: 2026-01
-  input:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/10#input.household_size: 1
-    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
-    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
-    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
-    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
-    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false
-    us:regulations/7-cfr/273/8#input.snap_countable_financial_resources: 0
-    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1000
-    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
-    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
-    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
-    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
-    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage: false
-    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
-    us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
-    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
-    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-      us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
-      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
-      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
-      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
-      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
-      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
-      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
-      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
-      us:regulations/7-cfr/273/7#input.member_age: 60
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-      us:regulations/7-cfr/273/4#input.member_is_refugee: false
-      us:regulations/7-cfr/273/4#input.member_is_asylee: false
-      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
-      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
-      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
-  output:
-    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 1000
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: holds
-    us:policies/usda/snap/state-plan-composition#snap_benefit: 120
-
-- name: high_income_household_is_ineligible_and_receives_zero
-  period: 2026-01
-  input:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/10#input.household_size: 1
-    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
-    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
-    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
-    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
-    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false
-    us:regulations/7-cfr/273/8#input.snap_countable_financial_resources: 0
-    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 10000
-    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
-    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
-    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
-    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
-    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage: false
-    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
-    us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
-    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
-    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-      us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
-      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
-      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
-      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
-      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
-      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
-      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
-      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
-      us:regulations/7-cfr/273/7#input.member_age: 60
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-      us:regulations/7-cfr/273/4#input.member_is_refugee: false
-      us:regulations/7-cfr/273/4#input.member_is_asylee: false
-      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
-      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
-      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
-  output:
-    us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income: 10000
-    us:regulations/7-cfr/273/9#snap_standard_income_eligible: not_holds
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#calfresh_income_and_resource_eligible: not_holds
-    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
-
-- name: shelter_costs_raise_benefit_when_income_is_positive
-  period: 2026-01
-  input:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/10#input.household_size: 1
-    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
-    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
-    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
-    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
-    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false
-    us:regulations/7-cfr/273/8#input.snap_countable_financial_resources: 0
-    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1000
-    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
-    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
-    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
-    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
-    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
-    us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage: true
-    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
-    us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
-    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
-    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-      us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
-      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
-      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
-      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
-      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
-      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
-      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
-      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
-      us:regulations/7-cfr/273/7#input.member_age: 60
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-      us:regulations/7-cfr/273/4#input.member_is_refugee: false
-      us:regulations/7-cfr/273/4#input.member_is_asylee: false
-      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
-      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
-      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
-  output:
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: holds
-    us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance: 663
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 1163
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744
-    us:policies/usda/snap/state-plan-composition#snap_benefit: 298
-
-- name: ineligible_member_receives_zero
-  period: 2026-01
-  input:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
-    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
-    us:regulations/7-cfr/273/10#input.household_size: 1
-    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
-    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
-    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
-    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
-    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false
-    us:regulations/7-cfr/273/8#input.snap_countable_financial_resources: 0
-    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 0
-    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
-    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
-    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
-    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
-    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
-    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0
-    us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage: false
-    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
-    us:regulations/7-cfr/273/10#input.household_initial_month: false
-    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
-    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
-    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-      us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
-      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
-      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
-      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
-      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
-      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
-      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
-      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
-      us:regulations/7-cfr/273/7#input.member_age: 60
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-      us:regulations/7-cfr/273/4#input.member_is_refugee: false
-      us:regulations/7-cfr/273/4#input.member_is_asylee: false
-      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
-      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
-      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
-  output:
-    us:policies/usda/snap/state-plan-composition#snap_household_member_eligible: not_holds
-    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
-    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
-
-- name: member_eligibility_bridge_holds_for_basic_eligible_member
+- name: eligible_member_passes_the_member_composition_bridge
   period: 2026-01
   input:
     us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
@@ -339,3 +101,223 @@
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
     us:policies/usda/snap/state-plan-composition#snap_member_eligible: holds
+
+- name: ineligible_household_receives_zero
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
+    us:regulations/7-cfr/273/10#input.household_initial_month: false
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: false
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+  output:
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
+
+- name: initial_month_below_minimum_issuance_zeroes
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
+    us:regulations/7-cfr/273/10#input.household_initial_month: true
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: true
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 5
+  output:
+    us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment: 0
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 0
+
+- name: initial_month_at_or_above_minimum_issuance_pays_prorated
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
+    us:regulations/7-cfr/273/10#input.household_initial_month: true
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: true
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 100
+  output:
+    us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment: 100
+    us:policies/usda/snap/state-plan-composition#snap_benefit: 100
+
+- name: ineligible_student_member_fails_the_student_wrapper
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.household_size: 1
+    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
+    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
+    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
+    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
+    us:regulations/7-cfr/273/10#input.household_initial_month: false
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: true
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
+    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+      us:regulations/7-cfr/273/5#input.assigned_or_placed_in_higher_education_through_qualifying_employment_training_program: false
+      us:regulations/7-cfr/273/5#input.single_parent_enrolled_full_time_in_higher_education: false
+      us:regulations/7-cfr/273/5#input.responsible_for_care_of_dependent_household_member_age_six_to_under_twelve: false
+      us:regulations/7-cfr/273/5#input.responsible_for_care_of_dependent_household_member_under_age_six: false
+      us:regulations/7-cfr/273/5#input.student_participating_in_on_the_job_training_program: false
+      us:regulations/7-cfr/273/5#input.student_participating_in_state_or_federally_financed_work_study: false
+      us:regulations/7-cfr/273/5#input.state_agency_averaged_student_work_hours_meet_twenty_per_week: false
+      us:regulations/7-cfr/273/5#input.student_self_employment_hours_per_week: 0
+      us:regulations/7-cfr/273/5#input.student_paid_employment_hours_per_week: 0
+      us:regulations/7-cfr/273/5#input.enrolled_through_jobs_or_successor_program: false
+      us:regulations/7-cfr/273/5#input.student_receives_tanf: false
+      us:regulations/7-cfr/273/5#input.student_physically_or_mentally_unfit: false
+      us:regulations/7-cfr/273/5#input.student_age: 25
+      us:regulations/7-cfr/273/5#input.enrolled_in_college_or_university_degree_program: true
+      us:regulations/7-cfr/273/5#input.enrolled_in_business_technical_trade_or_vocational_school_requiring_high_school_diploma: false
+      us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: true
+      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
+      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
+      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
+      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
+      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
+      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
+      us:regulations/7-cfr/273/7#input.member_age: 25
+      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
+      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
+      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+      us:regulations/7-cfr/273/4#input.member_is_refugee: false
+      us:regulations/7-cfr/273/4#input.member_is_asylee: false
+      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us:policies/usda/snap/state-plan-composition#snap_student_eligible: not_holds
+
+- name: work_requirement_failing_member_fails_the_work_wrapper
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/deductions#input.household_size: 1
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.household_size: 1
+    us:regulations/7-cfr/273/3#input.household_lives_in_application_state: true
+    us:regulations/7-cfr/273/3#input.household_in_project_area_solely_for_vacation: false
+    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false
+    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1003
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:regulations/7-cfr/273/10#input.snap_total_medical_expenses: 0
+    us:regulations/7-cfr/273/10#input.household_entitled_to_excess_medical_deduction: false
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_dependent_care_expenses: 0
+    us:regulations/7-cfr/273/10#input.snap_allowable_monthly_child_support_payments: 0
+    us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction: 0
+    us:regulations/7-cfr/273/10#input.state_agency_rounds_thirty_percent_net_income_up: true
+    us:regulations/7-cfr/273/10#input.household_initial_month: false
+    us:policies/usda/snap/state-plan-composition#input.snap_gross_monthly_earned_income: 1003
+    us:policies/usda/snap/state-plan-composition#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 705
+    us:policies/usda/snap/state-plan-composition#input.snap_eligible: true
+    us:policies/usda/snap/state-plan-composition#input.snap_initial_month_prorated_allotment: 0
+    us:policies/usda/snap/state-plan-composition#relation.member_of_household:
+    - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+      us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: false
+      us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+      us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+      us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
+      us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
+      us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
+      us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
+      us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
+      us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
+      us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
+      us:regulations/7-cfr/273/7#input.member_age: 25
+      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
+      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
+      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+      us:regulations/7-cfr/273/4#input.member_is_refugee: false
+      us:regulations/7-cfr/273/4#input.member_is_asylee: false
+      us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+      us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+      us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+      us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+      us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+      us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+      us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+      us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+      us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+      us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible: not_holds

--- a/us/policies/usda/snap/state-plan-composition.yaml
+++ b/us/policies/usda/snap/state-plan-composition.yaml
@@ -1,0 +1,228 @@
+format: rulespec/v1
+module:
+  kind: composition
+  source_verification:
+    corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us/regulation/7/273/10
+        - us/regulation/7/273/4
+        - us/regulation/7/273/5
+        - us/regulation/7/273/6
+        - us/regulation/7/273/7
+        - us/regulation/7/273/3
+      rationale: |-
+        This module defines no policy values of its own. It composes the
+        already-encoded 7 CFR 273.3-273.7 eligibility rules and the 7 CFR
+        273.10 whole-dollar benefit computation into the generic surfaces
+        every state SNAP composition needs, gated on state-bound inputs
+        (snap_eligible, shelter_costs). The FY 2026 cost-of-living
+        adjustment memorandum is the composition-source convention used by
+        the merged state compositions this module deduplicates; the
+        operative authority for every formula lives in the imported
+        regulation modules' own proofs.
+  summary: |-
+    Federal SNAP state-plan composition support. This module owns the generic
+    rules every state SNAP composition otherwise re-authors: countable-income
+    aggregation, the member-eligibility conjunction over the composed 7 CFR
+    273.4/.5/.6/.7 rules, the residency and household-member wrappers, and
+    the issued monthly benefit on the 273.10 whole-dollar chain with the
+    initial-month proration branch. State compositions import this module and
+    bind snap_eligible (the state's eligibility determination) and their own
+    snap_total_allowable_shelter_expenses / snap_excess_shelter_deduction
+    shelter bindings into 7 CFR 273.10. States with their own variants of any rule here define theirs
+    under a state-prefixed name and expose identities as needed.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+  - us:policies/usda/snap/fy-2026-cola/deductions
+  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
+  - us:regulations/7-cfr/273/3
+  - us:regulations/7-cfr/273/4
+  - us:regulations/7-cfr/273/5
+  - us:regulations/7-cfr/273/6
+  - us:regulations/7-cfr/273/7
+  - us:regulations/7-cfr/273/10
+  - us:regulations/7-cfr/273/24
+  - us:statutes/7/2012/j
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
+
+  - name: snap_countable_earned_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_gross_monthly_earned_income)
+
+  - name: snap_countable_unearned_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_total_monthly_unearned_income)
+
+  - name: snap_gross_monthly_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_countable_earned_income + snap_countable_unearned_income)
+
+  - name: snap_monthly_household_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_countable_earned_income + snap_countable_unearned_income)
+
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP member eligibility composition bridge
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+              span: 'Federal SNAP state-plan composition support'
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_member_citizenship_or_alien_status_eligible
+          and snap_member_ssn_requirement_eligible
+          and snap_member_work_requirement_eligible
+          and snap_member_student_eligible
+
+  - name: snap_residency_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_residency_eligible
+
+  - name: snap_household_member_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          count_where(member_of_household, snap_member_eligible) > 0
+
+  - name: snap_household_residency_and_citizenship_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_residency_eligible
+          and count_where(member_of_household, snap_member_citizenship_or_alien_status_eligible) > 0
+
+  - name: snap_ssn_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0
+
+  - name: snap_work_requirement_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          count_where(member_of_household, snap_member_work_requirement_ineligible) == 0
+
+  - name: snap_student_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Federal SNAP eligibility composition bridge
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          count_where(member_of_household, snap_member_student_ineligible) == 0
+
+  - name: snap_initial_month_issued_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_initial_month_prorated_allotment < snap_initial_month_minimum_issuance:
+              0
+          else:
+              snap_initial_month_prorated_allotment
+
+  # The issued monthly benefit on the 7 CFR 273.10(e)(1)-(2) whole-dollar
+  # chain (earned-income deduction cents dropped, excess shelter rounded to
+  # the nearest dollar, minimum-benefit floor), gated on the state's
+  # eligibility determination (snap_eligible is a state-bound input). Initial
+  # months ride the 273.10(a) proration through
+  # snap_initial_month_allotment_after_minimum_issuance.
+  - name: snap_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.10(e)(2)(ii) via federal SNAP state-plan composition support
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_eligible:
+              if household_initial_month:
+                  snap_initial_month_issued_allotment
+              else:
+                  snap_monthly_allotment
+          else:
+              0


### PR DESCRIPTION
Fixes #875.

Every state SNAP composition re-authored the same federal chain, and the copied-executable placement check correctly taxes each new clone against the incumbents — which made every new state in the encoding sweep (#807–#867) start with a namespacing fight. This adds the shared federal module and migrates all five composed states onto it in one change, so no incumbent ever flags against it.

## The module

`us/policies/usda/snap/state-plan-composition.yaml` owns the generic rules: countable-income aggregation, the 7 CFR 273.4/.5/.6/.7 member-eligibility conjunction and its household wrappers (member, residency, residency+citizenship, SSN, work-requirement, student), the initial-month minimum-issuance floor, and the issued benefit on the 273.10 whole-dollar chain with the initial-month proration branch — gated on a state-bound `snap_eligible` input. The `member_of_household` relation lives here. Companion test: seven cases including both initial-month branches, a person-scoped member case, an ineligible-zero case, and negative member cases for the student and work-requirement wrappers (each enumerating the full 273.5/273.7 exemption input surface).

CA, NY, AZ, GA, and MD now import it and keep only state law: their eligibility determinations, applied utility allowances, `shelter_costs`, and their own 273.10 shelter bindings. California's composition is down to 3 rules; the others hold 4–7.

## Two invariants the oracle forced (the contract for future states)

1. **Absorb computation, never bindings.** `snap_total_allowable_shelter_expenses` and `snap_excess_shelter_deduction` stay per-state: New York binds the statutory 2014(e) chain unrounded with the homeless shelter-expense substitution (18 NYCRR 387.12(f)(3)(vi)) — a shared identity fed the *rounded* value into the statutory chain, and NY's own companion contrast case caught the corruption (statutory net 270.5 vs 270).
2. **Counts live where the relation lives.** A `count_where` in a state module bound an empty relation instance while federal-module counts over the same predicate saw the members — three eligibility wrappers held *vacuously* while a fourth failed every row. All member-count wrappers now live in the federal module; zero `count_where` remains in any importing state composition, and the negative companion cases prove non-vacuity directly.

Also resolved in passing: the federal initial-month rule is named `snap_initial_month_issued_allotment` because Colorado's merged 10-CCR restatement carries a byte-identical formula under the old name; and the latent NY↔CO `snap_residency_citizenship_eligible` signature pair is dissolved (NY's copy deleted, Colorado untouched).

**Program specs**: the three composed SNAP programs gain the module in scope; New York's two single-term countable-income `sum_terms` bridges are removed per the #830/#585 duplicate-rule precedent. All three compose and compile on the CI-pinned composer (AZ 182 rules, CA 305, NY 173).

## Oracle evidence (frozen pair: this branch @ 04d9d7cc + axiom-oracles `snap-qc-federal-composition`)

All six SNAP QC suites replay exactly through the new architecture, every stage comparison at zero tolerance:

| Suite | Cases | Exact |
|---|---|---|
| co-snap-qc | 856 | 856/856 |
| ny-snap-qc | 847 | 847/847 |
| ca-snap-qc | 883 | 883/883 |
| az-snap-qc | 922 | 922/922 |
| ga-snap-qc | 945 | 945/945 |
| md-snap-qc | 722 | 722/722 |

**5,175/5,175.** The companion axiom-oracles PR re-points the suites at the federal surfaces and carries the regenerated dashboards.

## Review

Cross-model gated on frozen pushed refs (verdicts in comments): Sol r1 REQUEST-CHANGES (the three NY member-count wrappers were still state-local and silently vacuous — the one failure class the QC replay structurally cannot see, since in-scope rows never carry an ineligible member) → fixed with the relocation + negative cases → Sol r2 APPROVE with reproduction ledger. Fable clean-room r1 REQUEST-CHANGES on review-target integrity (the commits were amended mid-review; its substance verdict: "sound and fully reproduces") → branch pair frozen → Fable r2 APPROVE after independently re-running all six validates, **all six QC replays at zero tolerance**, the worktree-wide collision scan (zero pairs touching this change), the coverage census, and the manifest census against the frozen hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
