### PR TITLE
Bump the pinned axiom-corpus ref for the Colorado session-law companion ingest

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "f5a491849befe1abfcc23af6d3561c8cfed884bf"
+axiom_corpus_ref = "be0fa40d962e1e3dda29bd5348aed6b682318ec1"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Corpus pin f5a49184 → be0fa40d (axiom-corpus#319: HB 24-1134 + HB 24-1311 signed acts as single_block whole-act provisions). Unblocks real rules for the deferred 39-22-130 / 39-22-123 scaffolds. Toolchain change → full-repository revalidation by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)