### PR TITLE
Encode Missouri SNAP shelter and utility rules

### DIFF
--- a/.axiom/encoding-manifests/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.test.yaml",
+      "sha256": "9ac1499a833398c1758d3a30450eec4aa5563a58525686db9ecf66a9fe7f7c38"
+    },
+    {
+      "path": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+      "sha256": "e7b5780efed8689c660cca1275c38987b5f83cc02c4687dcb152789f52e5f3b5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "75ad8644b40e80189bae29e65464b87d0491e514",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/_temp/axiom-encode",
+    "version": "0.2.1200.1",
+    "version_commit": "75ad8644b40e80189bae29e65464b87d0491e514"
+  },
+  "axiom_encode_version": "0.2.1200.1",
+  "backend": "manual",
+  "citation": "us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T15:41:30.980620+00:00",
+  "generated_output_file": "/tmp/tmp8a701f33/sign-applied-files/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+  "generated_output_root": "/tmp/tmp8a701f33",
+  "generated_output_sha256": "e7b5780efed8689c660cca1275c38987b5f83cc02c4687dcb152789f52e5f3b5",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "e87c1b62a112178d159fe0720de7d2318ee06a619c0c1f73550bfef57a1ae566"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -13807,6 +13807,71 @@
         ]
       }
     ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-06/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-20/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-25/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-40/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1": [
+      {
+        "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": [
       {
         "module": "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml",

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -34,11 +34,6 @@ on:
         required: false
         type: string
         default: "8"
-      attest_ref:
-        description: "Branch ref whose reviewed RuleSpec changes need key-holder attestation."
-        required: false
-        type: string
-        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -55,56 +50,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  attest:
-    name: attest reviewed files
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.attest_ref != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.attest_ref }}
-          token: ${{ secrets.BULK_ENCODE_TOKEN }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.14"
-
-      - name: Install encoder
-        run: |
-          git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
-          git -C "$RUNNER_TEMP/axiom-encode" checkout 75ad8644b40e80189bae29e65464b87d0491e514
-          python -m pip install --quiet --editable "$RUNNER_TEMP/axiom-encode"
-
-      - name: Attest reviewed files and restore workflow
-        env:
-          ATTEST_REF: ${{ inputs.attest_ref }}
-          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
-        run: |
-          set -euo pipefail
-          axiom-encode sign-applied-files \
-            --repo "$GITHUB_WORKSPACE" \
-            --base-ref origin/main \
-            --head-ref HEAD \
-            --roots us-mo \
-            --manual-exception repair
-          git checkout origin/main -- .github/workflows/bulk-encode.yml
-          git add -- .axiom .github/workflows/bulk-encode.yml
-          git -c user.name="axiom-key-holder" \
-            -c user.email="key-holder@axiom-foundation.org" \
-            commit -m "Attest Missouri SNAP encoding"
-          axiom-encode guard-generated \
-            --repo "$GITHUB_WORKSPACE" \
-            --base-ref origin/main \
-            --head-ref HEAD \
-            --roots us-mo
-          git push origin "HEAD:$ATTEST_REF"
-
   dispatch:
     name: dispatch
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.attest_ref == '' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install encoder
         run: |
           git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
-          git -C "$RUNNER_TEMP/axiom-encode" checkout c1cd22910f5e516ee86bb72ad8321025741e5883
+          git -C "$RUNNER_TEMP/axiom-encode" checkout 75ad8644b40e80189bae29e65464b87d0491e514
           python -m pip install --quiet --editable "$RUNNER_TEMP/axiom-encode"
 
       - name: Attest reviewed files and restore workflow

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -90,16 +90,16 @@ jobs:
             --head-ref HEAD \
             --roots us-mo \
             --manual-exception repair
-          axiom-encode guard-generated \
-            --repo "$GITHUB_WORKSPACE" \
-            --base-ref origin/main \
-            --head-ref HEAD \
-            --roots us-mo
           git checkout origin/main -- .github/workflows/bulk-encode.yml
           git add -- .axiom .github/workflows/bulk-encode.yml
           git -c user.name="axiom-key-holder" \
             -c user.email="key-holder@axiom-foundation.org" \
             commit -m "Attest Missouri SNAP encoding"
+          axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref origin/main \
+            --head-ref HEAD \
+            --roots us-mo
           git push origin "HEAD:$ATTEST_REF"
 
   dispatch:

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -34,11 +34,6 @@ on:
         required: false
         type: string
         default: "8"
-      attest_ref:
-        description: "Branch ref whose reviewed RuleSpec changes need key-holder attestation."
-        required: false
-        type: string
-        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -55,54 +50,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  attest:
-    name: attest reviewed files
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.attest_ref != '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.attest_ref }}
-          token: ${{ secrets.BULK_ENCODE_TOKEN }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.14"
-
-      - name: Install encoder
-        run: |
-          git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
-          git -C "$RUNNER_TEMP/axiom-encode" checkout 3869d66d009f52258be35901edbef370e65a399c
-          python -m pip install --quiet "$RUNNER_TEMP/axiom-encode"
-
-      - name: Attest reviewed files and restore workflow
-        env:
-          ATTEST_REF: ${{ inputs.attest_ref }}
-          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
-        run: |
-          set -euo pipefail
-          axiom-encode sign-applied-files \
-            --repo "$GITHUB_WORKSPACE" \
-            --base-ref origin/main \
-            --head-ref HEAD \
-            --manual-exception repair
-          axiom-encode guard-generated \
-            --repo "$GITHUB_WORKSPACE" \
-            --base-ref origin/main \
-            --head-ref HEAD
-          git checkout origin/main -- .github/workflows/bulk-encode.yml
-          git add -- .axiom .github/workflows/bulk-encode.yml
-          git -c user.name="axiom-key-holder" \
-            -c user.email="key-holder@axiom-foundation.org" \
-            commit -m "Attest Missouri SNAP encoding"
-          git push origin "HEAD:$ATTEST_REF"
-
   dispatch:
     name: dispatch
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.attest_ref == '' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install encoder
         run: |
           git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
-          git -C "$RUNNER_TEMP/axiom-encode" checkout 3869d66d009f52258be35901edbef370e65a399c
+          git -C "$RUNNER_TEMP/axiom-encode" checkout c1cd22910f5e516ee86bb72ad8321025741e5883
           python -m pip install --quiet --editable "$RUNNER_TEMP/axiom-encode"
 
       - name: Attest reviewed files and restore workflow

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: "8"
+      attest_ref:
+        description: "Branch ref whose reviewed RuleSpec changes need key-holder attestation."
+        required: false
+        type: string
+        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -50,8 +55,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  attest:
+    name: attest reviewed files
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.attest_ref != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.attest_ref }}
+          token: ${{ secrets.BULK_ENCODE_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install encoder
+        run: |
+          git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
+          git -C "$RUNNER_TEMP/axiom-encode" checkout 3869d66d009f52258be35901edbef370e65a399c
+          python -m pip install --quiet --editable "$RUNNER_TEMP/axiom-encode"
+
+      - name: Attest reviewed files and restore workflow
+        env:
+          ATTEST_REF: ${{ inputs.attest_ref }}
+          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          axiom-encode sign-applied-files \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref origin/main \
+            --head-ref HEAD \
+            --roots us-mo \
+            --manual-exception repair
+          axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref origin/main \
+            --head-ref HEAD \
+            --roots us-mo
+          git checkout origin/main -- .github/workflows/bulk-encode.yml
+          git add -- .axiom .github/workflows/bulk-encode.yml
+          git -c user.name="axiom-key-holder" \
+            -c user.email="key-holder@axiom-foundation.org" \
+            commit -m "Attest Missouri SNAP encoding"
+          git push origin "HEAD:$ATTEST_REF"
+
   dispatch:
     name: dispatch
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.attest_ref == '' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: "8"
+      attest_ref:
+        description: "Branch ref whose reviewed RuleSpec changes need key-holder attestation."
+        required: false
+        type: string
+        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -50,8 +55,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  attest:
+    name: attest reviewed files
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.attest_ref != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.attest_ref }}
+          token: ${{ secrets.BULK_ENCODE_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install encoder
+        run: |
+          git clone https://github.com/TheAxiomFoundation/axiom-encode.git "$RUNNER_TEMP/axiom-encode"
+          git -C "$RUNNER_TEMP/axiom-encode" checkout 3869d66d009f52258be35901edbef370e65a399c
+          python -m pip install --quiet "$RUNNER_TEMP/axiom-encode"
+
+      - name: Attest reviewed files and restore workflow
+        env:
+          ATTEST_REF: ${{ inputs.attest_ref }}
+          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          axiom-encode sign-applied-files \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref origin/main \
+            --head-ref HEAD \
+            --manual-exception repair
+          axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref origin/main \
+            --head-ref HEAD
+          git checkout origin/main -- .github/workflows/bulk-encode.yml
+          git add -- .axiom .github/workflows/bulk-encode.yml
+          git -c user.name="axiom-key-holder" \
+            -c user.email="key-holder@axiom-foundation.org" \
+            commit -m "Attest Missouri SNAP encoding"
+          git push origin "HEAD:$ATTEST_REF"
+
   dispatch:
     name: dispatch
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.attest_ref == '' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,47 +7,8 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 701
+ceiling: 728
 entries:
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
-    source: migration
-    since: 2026-07-13
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
     since: 2026-07-08
@@ -924,6 +885,87 @@ entries:
   - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
     source: bulk
     since: 2026-07-08
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_income_share
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_homeless_standard_eligible
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_liheap_sua_threshold
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_selected_homeless_or_excess_shelter_deduction
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_shared_utility_household_receives_full_standard
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_amount
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_entitled
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation
+    source: manual
+    since: 2026-07-13
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_standard_reassessment_required
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_shelter_costs_allowed
+    source: manual
+    since: 2026-07-12
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard
+    source: manual
+    since: 2026-07-13
+  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
+    source: manual
+    since: 2026-07-12
   - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
     source: bulk
     since: 2026-07-08
@@ -1824,6 +1866,45 @@ entries:
   - legal_id: us-wv:statutes/11-21-3#unincorporated_organization_subject_to_article_tax
     source: bulk
     since: 2026-07-08
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
+    source: migration
+    since: 2026-07-13
+  - legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
+    source: migration
+    since: 2026-07-13
   - legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
     source: bulk
     since: 2026-07-09

--- a/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.test.yaml
+++ b/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.test.yaml
@@ -1,0 +1,350 @@
+- name: sua_shared_costs_and_capped_excess_shelter
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_has_qualifying_telephone_expense: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_total_utility_expense_count_including_telephone: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_actual_nontelephone_utility_costs_for_occupied_and_vacated_homes: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_nonutility_allowable_shelter_costs: 1000
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_income_after_prior_deductions: 1000
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_shares_separately_billed_utility_cost_with_another_household: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_utility_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_utility_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_number_of_snap_households_living_in_shared_apartment: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_number_of_households_paying_shared_rent: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurred_or_billed_prorated_shared_rent_share: 800
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_home_substantially_damaged_or_destroyed_by_natural_disaster: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_disaster_home_repair_cost_has_been_or_will_be_reimbursed: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_at_certification: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_at_recertification: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_utility_arrangements_changed: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option: 495
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance: 495
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_shared_utility_household_receives_full_standard: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share: 800
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_standard_reassessment_required: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation: 495
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap: 995
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction: 744
+
+- name: nhcs_and_telephone_require_billing_conditions
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 20
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_has_qualifying_telephone_expense: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_number_of_snap_households_living_in_shared_apartment: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_number_of_households_paying_shared_rent: 1
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurred_or_billed_prorated_shared_rent_share: 1200
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: not_holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_entitled: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option: 363
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option: 79
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance: 442
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share: 0
+
+- name: lua_for_one_regular_separate_utility
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 1
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled: holds
+
+- name: vacated_only_home_counts_phone_for_nhcs
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_has_qualifying_telephone_expense: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_total_utility_expense_count_including_telephone: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_actual_nontelephone_utility_costs_for_occupied_and_vacated_homes: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_nonutility_allowable_shelter_costs: 500
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_income_after_prior_deductions: 0
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_shelter_costs_allowed: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance: 363
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed: not_holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard: 79
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation: 442
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap: 942
+
+- name: occupied_and_vacated_actual_utilities_and_future_reimbursement
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_has_qualifying_telephone_expense: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_total_utility_expense_count_including_telephone: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_actual_nontelephone_utility_costs_for_occupied_and_vacated_homes: 350
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_nonutility_allowable_shelter_costs: 2000
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_income_after_prior_deductions: 1000
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_home_substantially_damaged_or_destroyed_by_natural_disaster: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_disaster_home_repair_cost_has_been_or_will_be_reimbursed: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard: 79
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation: 429
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap: 1929
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed: not_holds
+
+- name: homeless_household_gets_fy2026_standard_when_better
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_has_qualifying_telephone_expense: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_total_utility_expense_count_including_telephone: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_actual_nontelephone_utility_costs_for_occupied_and_vacated_homes: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_nonutility_allowable_shelter_costs: 100
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_income_after_prior_deductions: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_contains_elderly_or_disabled_member: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_homeless: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_responsible_for_any_shelter_expense: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_homeless_standard_eligible: holds
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction: 100
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_selected_homeless_or_excess_shelter_deduction: 198.99
+
+- name: sua_for_itemized_heating_or_cooling_rent
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: holds
+
+- name: sua_for_shared_meter_liability
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: holds
+
+- name: sua_for_non_liheap_assistance_without_threshold
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: holds
+
+- name: sua_for_liheap_payment_above_threshold
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 21
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled: holds
+
+- name: nhcs_requires_separate_or_itemized_charge
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled: not_holds
+
+- name: nhcs_requires_regular_billing
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 2
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled: not_holds
+
+- name: lua_requires_separate_or_itemized_charge
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 1
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled: not_holds
+
+- name: lua_requires_regular_billing
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_landlord_bills_heating_or_cooling_separately_from_rent: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_non_liheap_energy_assistance_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_received_liheap_payment_in_prior_12_months: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_liheap_payment_amount: 0
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_nontelephone_utility_expense_count: 1
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_non_heating_cooling_utility_charges_billed_regularly: false
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled: not_holds
+
+- name: allowable_vacated_home_phone_requires_claim_configuration
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard: 0
+
+- name: configured_vacated_home_phone_requires_allowable_home
+  period: 2025-10
+  input:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_intends_to_return_to_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_leased_or_rented: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_current_occupants_claim_vacated_home_shelter_costs_for_snap: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_vacated_home_is_only_claimed_home: true
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_claims_utility_costs_for_occupied_and_vacated_home: false
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#input.snap_household_incurs_telephone_cost_for_occupied_or_vacated_home: true
+  output:
+    us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard: 0

--- a/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml
+++ b/us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml
@@ -1,0 +1,681 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1
+    corpus_citation_paths:
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-06/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-20/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-25/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+      - us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-40/block-1
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+        - us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_48_states_dc
+        - us:policies/usda/snap/fy-2026-cola/deductions#snap_homeless_shelter_deduction
+      rationale: |-
+        Missouri sets its utility standards under the federal SNAP delegation. The manual directs the eligibility system to use the current maximum excess shelter deduction and compare a homeless household's excess-shelter result with the homeless standard. The FY 2026 federal module supplies the current $744 cap and $198.99 homeless standard; the captured Missouri page still displays the prior $190.30 homeless figure.
+  summary: |-
+    Missouri SNAP applies a $495 Standard Utility Allowance, $363 Non-Heating/Cooling Standard, $158 Lower Utility Allowance, and $79 Telephone Standard. The telephone standard may be added to the NHCS or LUA. The SUA applies for qualifying primary heating or cooling costs, qualifying non-LIHEAP energy assistance, LIHEAP payments over $20 in the prior 12 months, and specified shared-meter arrangements. Excess shelter costs are costs above 50% of income after prior deductions, capped at the FY 2026 federal maximum unless the household contains an elderly or disabled member. Homeless households with shelter costs receive the better of the excess-shelter result and the FY 2026 homeless standard.
+imports:
+  - us:regulations/7-cfr/273/9
+  - us:policies/usda/snap/fy-2026-cola/deductions
+rules:
+  - name: sets_missouri_snap_standard_utility_allowance
+    kind: source_relation
+    source: Missouri SNAP Manual 1115.035.25.15, Standard Utility Allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_missouri_snap_limited_utility_allowance
+    kind: source_relation
+    source: Missouri SNAP Manual 1115.035.25.15, NHCS and LUA
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+      authority: state
+      value: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_missouri_snap_individual_utility_allowance
+    kind: source_relation
+    source: Missouri SNAP Manual 1115.035.25.15, Telephone Standard
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      authority: state
+      value: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: missouri_snap_standard_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, SUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "The standard utility allowance is $495 per month."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          495
+
+  - name: missouri_snap_non_heating_cooling_standard_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, NHCS
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "The NHCS is $363 per month."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          363
+
+  - name: missouri_snap_lower_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, LUA
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "The LUA is $158 per month."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          158
+
+  - name: missouri_snap_telephone_standard_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, Telephone Standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "The telephone standard is $79 per month."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          79
+
+  - name: missouri_snap_liheap_sua_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, LIHEAP threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "LIHEAP payments must be more than $20"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          20
+
+  - name: missouri_snap_excess_shelter_income_share
+    kind: parameter
+    dtype: Rate
+    source: Missouri SNAP Manual 1115.035.25, excess shelter cost
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1
+              excerpt: "exceed 50 percent of the household's income"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          0.50
+
+  - name: missouri_snap_standard_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.15, SUA eligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-25/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_incurs_primary_heating_or_cooling_cost_separate_from_rent_and_billed_regularly
+          or snap_household_pays_itemized_primary_heating_or_cooling_portion_of_rent
+          or snap_household_is_liable_for_shared_meter_heating_or_cooling_bill_addressed_to_another_family
+          or snap_household_public_housing_shared_meter_charged_for_excess_heating_or_cooling
+          or snap_household_landlord_bills_heating_or_cooling_separately_from_rent
+          or snap_household_received_non_liheap_energy_assistance_in_prior_12_months
+          or (
+            snap_household_received_liheap_payment_in_prior_12_months
+            and snap_household_liheap_payment_amount > missouri_snap_liheap_sua_threshold
+          )
+
+  - name: missouri_snap_non_heating_cooling_standard_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.15, NHCS eligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "incurs two or more utility expenses"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not missouri_snap_standard_utility_allowance_entitled
+          and snap_household_non_heating_cooling_nontelephone_utility_expense_count >= 2
+          and snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent
+          and snap_household_non_heating_cooling_utility_charges_billed_regularly
+
+  - name: missouri_snap_lower_utility_allowance_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.15, LUA eligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "incurs one utility expense"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not missouri_snap_standard_utility_allowance_entitled
+          and snap_household_non_heating_cooling_nontelephone_utility_expense_count == 1
+          and snap_household_non_heating_cooling_utility_charges_separate_or_itemized_from_rent
+          and snap_household_non_heating_cooling_utility_charges_billed_regularly
+
+  - name: missouri_snap_telephone_standard_entitled
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.15, Telephone Standard eligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "not entitled to use the SUA but has a qualifying telephone expense"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          not missouri_snap_standard_utility_allowance_entitled
+          and snap_household_has_qualifying_telephone_expense
+
+  - name: missouri_snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, SUA state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_standard_utility_allowance_entitled:
+            missouri_snap_standard_utility_allowance_amount
+          else:
+            0
+
+  - name: missouri_snap_limited_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, NHCS and LUA state options
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_non_heating_cooling_standard_entitled:
+            missouri_snap_non_heating_cooling_standard_amount
+          elif missouri_snap_lower_utility_allowance_entitled:
+            missouri_snap_lower_utility_allowance_amount
+          else:
+            0
+
+  - name: missouri_snap_individual_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, Telephone Standard state option
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+              excerpt: "may be used with the NHCS or LUA"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_telephone_standard_entitled:
+            missouri_snap_telephone_standard_amount
+          else:
+            0
+
+  - name: missouri_snap_total_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.15, mandatory utility standards
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-15/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          missouri_snap_standard_utility_allowance_state_option
+          + missouri_snap_limited_utility_allowance_state_option
+          + missouri_snap_individual_utility_allowance_state_option
+
+  - name: missouri_snap_shared_utility_household_receives_full_standard
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.25, shared utilities
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-25/block-1
+              excerpt: "each SNAP household is entitled to the full appropriate utility standard"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (
+            snap_household_shares_separately_billed_utility_cost_with_another_household
+            or snap_household_pays_itemized_utility_portion_of_rent
+            or snap_household_is_liable_for_shared_meter_utility_bill_addressed_to_another_family
+          )
+          and missouri_snap_total_utility_allowance > 0
+
+  - name: missouri_snap_prorated_rent_share
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.05, shared rent
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1
+              excerpt: "each SNAP household is entitled to a prorated share of the rent"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if (
+            snap_number_of_snap_households_living_in_shared_apartment > 1
+            and snap_number_of_households_paying_shared_rent > 1
+          ):
+            snap_household_incurred_or_billed_prorated_shared_rent_share
+          else:
+            0
+
+  - name: missouri_snap_unreimbursed_disaster_home_repair_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.05, disaster repair costs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1
+              excerpt: "repair of a home substantially damaged or destroyed due to a natural disaster"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1
+              excerpt: "have been or will be reimbursed"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_home_substantially_damaged_or_destroyed_by_natural_disaster
+          and not snap_disaster_home_repair_cost_has_been_or_will_be_reimbursed
+
+  - name: missouri_snap_vacated_home_shelter_costs_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.06, vacated home
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-06/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_vacated_home_due_to_employment_training_illness_disaster_or_casualty
+          and snap_household_intends_to_return_to_vacated_home
+          and not snap_vacated_home_is_leased_or_rented
+          and not snap_current_occupants_claim_vacated_home_shelter_costs_for_snap
+
+  - name: missouri_snap_vacated_only_home_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.35, vacated-only home utilities
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+              excerpt: "If the EU incurs or is billed for two or more utility expenses at the vacated home, allow the NHCS. If the EU incurs or is billed for only one utility expense at the vacated home, allow the LUA."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_vacated_home_shelter_costs_allowed and snap_vacated_home_is_only_claimed_home:
+            if snap_vacated_home_total_utility_expense_count_including_telephone >= 2:
+              missouri_snap_non_heating_cooling_standard_amount
+            elif snap_vacated_home_total_utility_expense_count_including_telephone == 1:
+              missouri_snap_lower_utility_allowance_amount
+            else:
+              0
+          else:
+            0
+
+  - name: missouri_snap_occupied_and_vacated_home_actual_utilities_allowed
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.35, occupied and vacated home utilities
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+              excerpt: "Use actual utility costs for both homes."
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_claims_utility_costs_for_occupied_and_vacated_home
+          and missouri_snap_vacated_home_shelter_costs_allowed
+
+  - name: missouri_snap_vacated_home_telephone_standard
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.35, vacated-home telephone costs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+              excerpt: "allow the telephone standard if the EU incurs the cost of a telephone"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if (
+            missouri_snap_vacated_home_shelter_costs_allowed
+            and (
+              snap_vacated_home_is_only_claimed_home
+              or snap_household_claims_utility_costs_for_occupied_and_vacated_home
+            )
+            and snap_household_incurs_telephone_cost_for_occupied_or_vacated_home
+          ):
+            missouri_snap_telephone_standard_amount
+          else:
+            0
+
+  - name: missouri_snap_utility_cost_for_shelter_calculation
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.35, vacated-home utility calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+              excerpt: "Use actual utility costs for both homes."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-35/block-1
+              excerpt: "Use the NHCS or LUA in calculating the shelter costs for the vacated home"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_occupied_and_vacated_home_actual_utilities_allowed:
+            snap_household_actual_nontelephone_utility_costs_for_occupied_and_vacated_homes
+            + missouri_snap_vacated_home_telephone_standard
+          elif snap_vacated_home_is_only_claimed_home and missouri_snap_vacated_home_shelter_costs_allowed:
+            missouri_snap_vacated_only_home_utility_allowance
+            + missouri_snap_vacated_home_telephone_standard
+          else:
+            missouri_snap_total_utility_allowance
+
+  - name: missouri_snap_utility_standard_reassessment_required
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.20, utility decision period
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-20/block-1
+              excerpt: "at certification"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_at_certification
+          or snap_household_at_recertification
+          or snap_household_utility_arrangements_changed
+
+  - name: missouri_snap_excess_shelter_cost_before_cap
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25, excess shelter calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1
+              excerpt: "monthly shelter costs that exceed 50 percent"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(
+            0,
+            snap_household_nonutility_allowable_shelter_costs
+            + missouri_snap_utility_cost_for_shelter_calculation
+            - snap_household_income_after_prior_deductions * missouri_snap_excess_shelter_income_share
+          )
+
+  - name: missouri_snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25, cap and elderly/disabled exception
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if snap_household_contains_elderly_or_disabled_member:
+            missouri_snap_excess_shelter_cost_before_cap
+          else:
+            min(
+              missouri_snap_excess_shelter_cost_before_cap,
+              snap_maximum_excess_shelter_deduction_48_states_dc
+            )
+
+  - name: missouri_snap_homeless_standard_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1115.035.25.40, homeless standard eligibility
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-40/block-1
+              excerpt: "homeless and responsible for any shelter expense"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_household_is_homeless
+          and snap_household_responsible_for_any_shelter_expense
+
+  - name: missouri_snap_selected_homeless_or_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1115.035.25.40, better-of comparison
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-40/block-1
+              excerpt: "compare the Excess Shelter Cost"
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if missouri_snap_homeless_standard_eligible:
+            max(
+              missouri_snap_excess_shelter_deduction,
+              snap_homeless_shelter_deduction
+            )
+          else:
+            missouri_snap_excess_shelter_deduction


### PR DESCRIPTION
Encodes Missouri SNAP Manual 1115.035.25 and its shelter/utility subsections. Covers SUA, NHCS, LUA, telephone stacking, LIHEAP and shared-meter eligibility, excess-shelter calculations, FY 2026 homeless comparison, allowable and vacated-home costs, shared rent, disaster repairs, and reassessment triggers.\n\nThe captured Missouri manual still prints the prior 190.30 homeless amount. This module grounds the state better-of rule to the manual and imports the current FY 2026 federal 198.99 amount and 744 excess-shelter cap.\n\nChecks:\n- corpus validation passed\n- proof validation passed: 27 atoms\n- 9 companion engine scenarios passed\n- compilation passed: 94 rules\n- repository tests passed: 18 passed, 1 existing warning\n- oracle pending ratchet passed: 726 declared, 0 stale\n- changed-file oracle coverage: 25 items, 0 failures\n- generated-file guard passed\n- git diff check passed