### PR TITLE
Enable durable bulk encoding for state SNAP manuals

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -239,27 +239,30 @@ jobs:
           ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-corpus" "$GITHUB_WORKSPACE/../axiom-corpus"
 
       # The oracle-coverage-pending lane (the fix for new-state bulk PRs failing
-      # the changed-file PolicyEngine oracle-coverage gate) is a *newer* encoder
-      # feature than the pinned validate toolchain: the pinned axiom-encode has
-      # no `oracle-coverage-pending` subcommand, and the CI coverage classifier
-      # deliberately runs axiom-encode@main so new mappings unblock generated PRs
-      # (validate-rulespec.yml `oracle-coverage-axiom-encode-ref`, default main).
-      # Install that same classifier in an isolated venv so the sync step below
-      # declares a new module's unmapped outputs exactly as the CI gate reads
-      # them. Without this, every new-state module opens a PR that fails the
+      # the changed-file PolicyEngine oracle-coverage gate) requires a reviewed
+      # `sync` writer aligned with the current oracle registry. Install that
+      # immutable classifier in an isolated venv so the sync step below declares
+      # a new module's unmapped outputs. Without this, every new-state module
+      # opens a PR that fails the
       # required validate check on `... : unmapped` and auto-merge hangs forever
       # (rulespec-us #614-616, #619-636 etc.).
-      - name: Checkout oracle-coverage classifier (axiom-encode main)
+      - name: Checkout oracle-coverage classifier (pinned sync writer)
         uses: actions/checkout@v6.0.2
         with:
           repository: TheAxiomFoundation/axiom-encode
-          ref: main
+          ref: d052eabfaa2e209654aa979638672b28d71b3957
           path: _axiom/axiom-encode-oracle-coverage
 
       - name: Install oracle-coverage classifier (isolated venv)
         shell: bash
         run: |
           set -euo pipefail
+          expected="d052eabfaa2e209654aa979638672b28d71b3957"
+          actual="$(git -C _axiom/axiom-encode-oracle-coverage rev-parse HEAD)"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Oracle-coverage classifier resolved to $actual, expected $expected." >&2
+            exit 1
+          fi
           python -m venv "$RUNNER_TEMP/cov-venv"
           "$RUNNER_TEMP/cov-venv/bin/pip" install --quiet --upgrade pip
           "$RUNNER_TEMP/cov-venv/bin/pip" install --quiet -e _axiom/axiom-encode-oracle-coverage
@@ -328,8 +331,8 @@ jobs:
           fi
 
           # Declare the module's unmapped executable outputs in the
-          # oracle-coverage pending lane, using the axiom-encode@main classifier
-          # installed above. The changed-file oracle-coverage gate reclassifies
+          # oracle-coverage pending lane, using the pinned current-registry
+          # classifier installed above. The changed-file oracle-coverage gate reclassifies
           # declared outputs from `unmapped` to `pending_classification`, so this
           # is what lets a new-state module's PR pass the required validate check
           # instead of hanging on `... : unmapped`. `sync` rewrites
@@ -340,7 +343,6 @@ jobs:
           # Keep the key scoped to the legacy encode/apply process above.
           env -u AXIOM_ENCODE_APPLY_SIGNING_KEY "$COV_AE" oracle-coverage-pending sync \
             --root "$GITHUB_WORKSPACE/.." \
-            --repo rulespec-us \
             --source bulk || {
               echo "::error::oracle-coverage-pending sync failed for $CITATION." >&2
               exit 1

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -180,7 +180,7 @@ jobs:
         env:
           EXPECTED_ENCODER_REF: ${{ matrix.item.encoder_ref || steps.toolchain.outputs.axiom_encode_ref }}
           OVERRIDE_ENCODER_REF: ${{ matrix.item.encoder_ref }}
-          APPROVED_OVERRIDE_ENCODER_REF: fed5f3df343cd7548809d1c944a17f96c7c52a68
+          APPROVED_OVERRIDE_ENCODER_REF: 9978ad8181914affdebcd6fb881291198c3bc839
         run: |
           set -euo pipefail
           if [ -n "$OVERRIDE_ENCODER_REF" ] \
@@ -336,7 +336,9 @@ jobs:
           # oracle-coverage-pending.yaml to exactly the repo's current unmapped
           # set; it is a no-op when the module's outputs are already mapped.
           pending_file="oracle-coverage-pending.yaml"
-          "$COV_AE" oracle-coverage-pending sync \
+          # The modern classifier rejects private signing material by design.
+          # Keep the key scoped to the legacy encode/apply process above.
+          env -u AXIOM_ENCODE_APPLY_SIGNING_KEY "$COV_AE" oracle-coverage-pending sync \
             --root "$GITHUB_WORKSPACE/.." \
             --repo rulespec-us \
             --source bulk || {

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -118,6 +118,17 @@ jobs:
           # validate CI (the default GITHUB_TOKEN would not).
           token: ${{ secrets.BULK_ENCODE_TOKEN }}
 
+      - name: Prepare clean default-branch base
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          cp bulk/applied_artifacts.py "$RUNNER_TEMP/applied_artifacts.py"
+          git switch --detach "origin/$DEFAULT_BRANCH"
+          install -m 0755 "$RUNNER_TEMP/applied_artifacts.py" bulk/applied_artifacts.py
+          echo "Generating from $(git rev-parse HEAD) on origin/$DEFAULT_BRANCH."
+
       - name: Guard - workspace must be named rulespec-us
         shell: bash
         run: |
@@ -161,8 +172,27 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           repository: TheAxiomFoundation/axiom-encode
-          ref: ${{ steps.toolchain.outputs.axiom_encode_ref }}
+          ref: ${{ matrix.item.encoder_ref || steps.toolchain.outputs.axiom_encode_ref }}
           path: _axiom/axiom-encode
+
+      - name: Verify selected encoder commit
+        shell: bash
+        env:
+          EXPECTED_ENCODER_REF: ${{ matrix.item.encoder_ref || steps.toolchain.outputs.axiom_encode_ref }}
+          OVERRIDE_ENCODER_REF: ${{ matrix.item.encoder_ref }}
+          APPROVED_OVERRIDE_ENCODER_REF: 75ad8644b40e80189bae29e65464b87d0491e514
+        run: |
+          set -euo pipefail
+          if [ -n "$OVERRIDE_ENCODER_REF" ] \
+             && [ "$OVERRIDE_ENCODER_REF" != "$APPROVED_OVERRIDE_ENCODER_REF" ]; then
+            echo "::error::Encoder override is not in the reviewed compatibility allowlist." >&2
+            exit 1
+          fi
+          actual="$(git -C _axiom/axiom-encode rev-parse HEAD)"
+          if [ "$actual" != "$EXPECTED_ENCODER_REF" ]; then
+            echo "::error::Selected encoder resolved to $actual, expected $EXPECTED_ENCODER_REF." >&2
+            exit 1
+          fi
 
       - name: Checkout axiom-rules-engine (pinned)
         uses: actions/checkout@v6.0.2
@@ -186,11 +216,14 @@ jobs:
         with:
           workspaces: _axiom/axiom-rules-engine
 
-      - name: Install pinned axiom-encode
+      - name: Install selected axiom-encode
+        id: encoder
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pyyaml
           python -m pip install -e _axiom/axiom-encode
+          echo "version=$(python -c 'import axiom_encode; print(axiom_encode.__version__)')" >> "$GITHUB_OUTPUT"
+          echo "ref=$(git -C _axiom/axiom-encode rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build axiom-rules-engine
         working-directory: _axiom/axiom-rules-engine
@@ -267,43 +300,21 @@ jobs:
           echo "wall_seconds=$((end - start))" >> "$GITHUB_OUTPUT"
           echo "Encode wall time: $((end - start))s"
 
-          # Locate the applied module path from the git worktree. Restrict to
-          # jurisdiction directories (two-letter code, optional -suffix) so the
-          # sibling checkouts under _axiom/ and any build artifacts are never
-          # picked up.
-          slug='${{ matrix.item.slug }}'
-          # -uall (untracked-files=all): a brand-new module path creates a new
-          # nested untracked dir; without -uall, `git status --porcelain`
-          # COLLAPSES it to the bare dir entry (e.g. `?? us-ca/statutes/rtc/17053/`),
-          # which the *.yaml regex misses -> the applied module is not detected
-          # even though --apply wrote it (fail-closed false negative). Mirrors the
-          # rulespec-be/rulespec-gh fix.
-          mapfile -t applied < <(git -C "$GITHUB_WORKSPACE" status --porcelain -uall \
-            | sed 's/^...//' \
-            | grep -E '^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$' \
-            | grep -v '\.test\.yaml$' || true)
-
-          if [ "$apply_status" -ne 0 ] || [ "${#applied[@]}" -eq 0 ]; then
+          if [ "$apply_status" -ne 0 ]; then
             echo "status=failed" >> "$GITHUB_OUTPUT"
             echo "::error::Encode/apply failed for $CITATION (exit $apply_status). See encode.log; a *.repair.json was written under $RUNNER_TEMP/encode-out." >&2
             exit 1
           fi
 
-          module="${applied[0]}"
-          test_file="${module%.yaml}.test.yaml"
-          juris="${module%%/*}"
-          # The apply manifest mirrors the module's path under the jurisdiction's
-          # .axiom/encoding-manifests/ -- e.g. us-il/statutes/35/5/306.yaml ->
-          # us-il/.axiom/encoding-manifests/statutes/35/5/306.json. Strip only
-          # the jurisdiction prefix (keep the statutes/regulations/policies bucket).
-          rest="${module#"$juris"/}"
-          manifest_rel="$juris/.axiom/encoding-manifests/${rest%.yaml}.json"
-          # Fall back to a basename search if the direct manifest path guess misses.
-          if [ ! -f "$GITHUB_WORKSPACE/$manifest_rel" ]; then
-            manifest_rel="$(cd "$GITHUB_WORKSPACE" && find "$juris/.axiom/encoding-manifests" -name "$(basename "${module%.yaml}").json" 2>/dev/null | head -1)"
-          fi
+          artifact_output="$(python bulk/applied_artifacts.py \
+            --repo "$GITHUB_WORKSPACE" --citation "$CITATION")"
+          mapfile -t applied_artifacts <<< "$artifact_output"
+          module="${applied_artifacts[0]}"
+          test_file="${applied_artifacts[1]}"
+          manifest_rel="${applied_artifacts[2]}"
           echo "module=$module" >> "$GITHUB_OUTPUT"
           echo "test_file=$test_file" >> "$GITHUB_OUTPUT"
+          echo "manifest_rel=$manifest_rel" >> "$GITHUB_OUTPUT"
           echo "Applied module: $module"
           echo "Applied manifest: $manifest_rel"
 
@@ -404,6 +415,7 @@ jobs:
           CITATION: ${{ matrix.item.citation }}
           MODULE: ${{ steps.encode.outputs.module }}
           TEST_FILE: ${{ steps.encode.outputs.test_file }}
+          MANIFEST_REL: ${{ steps.encode.outputs.manifest_rel }}
           ENC_STATUS: ${{ steps.encode.outputs.status }}
           WALL: ${{ steps.encode.outputs.wall_seconds }}
           MODEL: ${{ matrix.item.model }}
@@ -416,7 +428,7 @@ jobs:
             echo
             echo "- Citation: \`$CITATION\`"
             echo "- Module: \`$MODULE\`"
-            echo "- Encoder: \`$BACKEND:$MODEL\` (toolchain-pinned axiom-encode ${{ steps.toolchain.outputs.axiom_encode_version }})"
+            echo "- Encoder: \`$BACKEND:$MODEL\` (axiom-encode ${{ steps.encoder.outputs.version }} at ${{ steps.encoder.outputs.ref }})"
             echo "- Encode wall time: ${WALL}s"
             echo "- Local gate status: **$ENC_STATUS**"
             echo
@@ -425,12 +437,7 @@ jobs:
             echo
             echo "### Manifest summary"
             echo '```json'
-            # The apply manifest mirrors the module path under the jurisdiction's
-            # .axiom/encoding-manifests/. Locate it by basename (robust to the
-            # statutes/regulations/policies split).
-            manifest=""
-            mf="$(find "$GITHUB_WORKSPACE" -path '*/.axiom/encoding-manifests/*' -name "$(basename "${MODULE%.yaml}").json" 2>/dev/null | head -1)"
-            [ -n "$mf" ] && manifest="$(cat "$mf")"
+            manifest="$(cat "$GITHUB_WORKSPACE/$MANIFEST_REL")"
             echo "$manifest" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(json.dumps({k:d.get(k) for k in ["citation","model","backend","run_id","axiom_encode_version","applied_files"]}, indent=2))' 2>/dev/null || echo "$manifest"
             echo '```'
             echo

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -180,7 +180,7 @@ jobs:
         env:
           EXPECTED_ENCODER_REF: ${{ matrix.item.encoder_ref || steps.toolchain.outputs.axiom_encode_ref }}
           OVERRIDE_ENCODER_REF: ${{ matrix.item.encoder_ref }}
-          APPROVED_OVERRIDE_ENCODER_REF: 75ad8644b40e80189bae29e65464b87d0491e514
+          APPROVED_OVERRIDE_ENCODER_REF: fed5f3df343cd7548809d1c944a17f96c7c52a68
         run: |
           set -euo pipefail
           if [ -n "$OVERRIDE_ENCODER_REF" ] \

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -535,7 +535,7 @@ jobs:
             -m "Produced by axiom-encode encode $CITATION --apply (backend ${{ matrix.item.backend }}, model ${{ matrix.item.model }})." \
             -m "" \
             -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
-          git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:$branch"
+          git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:refs/heads/$branch"
 
           if [ -z "$pr_state" ]; then
             retry gh pr create --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -636,7 +636,12 @@ jobs:
             --head-ref HEAD \
             --roots "$roots" \
             --manual-exception repair
-          git -C "$target" add -- .axiom "$jurisdiction/.axiom"
+          generated_paths=(.axiom)
+          if [ -d "$target/$jurisdiction/.axiom" ] || \
+             git -C "$target" ls-files -- "$jurisdiction/.axiom" | grep -q .; then
+            generated_paths+=("$jurisdiction/.axiom")
+          fi
+          git -C "$target" add -A -- "${generated_paths[@]}"
           if git -C "$target" diff --cached --quiet; then
             echo "::error::Signer did not update an apply manifest" >&2
             exit 1

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: "8"
+      attest_ref:
+        description: "Existing bulk/* branch to re-attest after review fixes. Empty = encode queue."
+        required: false
+        type: string
+        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -52,6 +57,7 @@ concurrency:
 jobs:
   dispatch:
     name: dispatch
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.attest_ref == '' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
@@ -556,3 +562,85 @@ jobs:
           retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto --squash
 
           echo "PR ready for $CITATION on branch $branch (status: $ENC_STATUS, auto-merge on green)."
+
+  attest-review-fix:
+    name: attest review fix
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.attest_ref != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate repair branch name
+        shell: bash
+        env:
+          ATTEST_REF: ${{ inputs.attest_ref }}
+        run: |
+          set -euo pipefail
+          case "$ATTEST_REF" in
+            bulk/*) ;;
+            *) echo "::error::attest_ref must name a bulk/* branch" >&2; exit 1 ;;
+          esac
+          git check-ref-format "refs/heads/$ATTEST_REF"
+
+      - name: Checkout reviewed repair branch
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.attest_ref }}
+          token: ${{ secrets.BULK_ENCODE_TOKEN }}
+          path: target/rulespec-us
+
+      - name: Set up trusted Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Checkout reviewed manifest signer
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: 9978ad8181914affdebcd6fb881291198c3bc839
+          path: trusted/axiom-encode-signer
+
+      - name: Install reviewed manifest signer
+        working-directory: trusted/axiom-encode-signer
+        run: python -m pip install --quiet -e .
+
+      - name: Attest reviewed RuleSpec edits
+        shell: bash
+        working-directory: trusted/axiom-encode-signer
+        env:
+          ATTEST_REF: ${{ inputs.attest_ref }}
+          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          target="$GITHUB_WORKSPACE/target/rulespec-us"
+          git -C "$target" fetch origin main
+          mapfile -t modules < <(
+            git -C "$target" diff --name-only --diff-filter=AM origin/main...HEAD -- '*.yaml' |
+              awk '/^us(-[a-z0-9_]+)?\/(policies|manual|regulations|statutes)\// && $0 !~ /\.test\.yaml$/'
+          )
+          if [ "${#modules[@]}" -ne 1 ]; then
+            printf '::error::Expected exactly one changed RuleSpec module, found %s\n' "${#modules[@]}" >&2
+            printf '  %s\n' "${modules[@]}" >&2
+            exit 1
+          fi
+          jurisdiction="${modules[0]%%/*}"
+          roots="us"
+          if [ "$jurisdiction" != "us" ]; then
+            roots="us $jurisdiction"
+          fi
+          axiom-encode sign-applied-files \
+            --repo "$target" \
+            --base-ref origin/main \
+            --head-ref HEAD \
+            --roots "$roots" \
+            --manual-exception repair
+          git -C "$target" add -- .axiom "$jurisdiction/.axiom"
+          if git -C "$target" diff --cached --quiet; then
+            echo "::error::Signer did not update an apply manifest" >&2
+            exit 1
+          fi
+          git -C "$target" -c user.email=bulk-encode@axiom -c user.name="bulk-encode" \
+            commit -m "Attest reviewed encoder fixes"
+          git -C "$target" push origin "HEAD:refs/heads/$ATTEST_REF"

--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,6 +19,7 @@ jobs:
     secrets: inherit
     with:
       validate-roots: auto
+      oracle-coverage-axiom-encode-ref: d052eabfaa2e209654aa979638672b28d71b3957
 
   drift-alarm:
     # Red-main alarm. A full validation runs on every push to main and on the

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -14,7 +14,7 @@ provisions to queue.
 
 | File | Role |
 | --- | --- |
-| `bulk/worklist.yaml` | The durable queue. One entry per module. Committed. |
+| `bulk/worklist.yaml` | The durable queue. One entry per module. Committed. Entries may pin `encoder_ref` for a reviewed compatibility build. |
 | `bulk/compute_matrix.py` | Turns the worklist into the CI job matrix; single source of truth for status selection. |
 | `bulk/roots_for.py` | Maps an applied module path to `guard-generated --roots`. |
 | `.github/workflows/bulk-encode.yml` | The runner: dispatch → matrix → encode `--apply` → gate battery → PR + auto-merge. |
@@ -51,10 +51,17 @@ so two runs never fight over the same `bulk/<slug>` branches.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.
+   - Switches the worktree to the current default-branch commit before
+     generation. A dispatch from a reviewed workflow branch can therefore
+     carry queue plumbing without leaking that branch's infrastructure diff
+     into each per-module PR.
    - Reads `.axiom/toolchain.toml` and checks out **the pinned** `axiom-encode`,
      `axiom-rules-engine`, and `axiom-corpus`, then builds the engine. Using the
      pinned encoder means generation and the downstream PR CI validate with the
-     identical version — no version-skew surprises.
+     identical version. An entry-level `encoder_ref` is restricted to an
+     explicit allowlist of reviewed, immutable compatibility builds needed by a source layout such as
+     consolidated state manuals; the actual version and commit are recorded in
+     the signed manifest and PR body.
    - Runs `axiom-encode encode <citation> --apply`. `--apply` validates the main
      file, companion test, and direct dependents in a temporary overlay and
      writes nothing on failure (fail-closed), then installs the three artifacts:
@@ -115,8 +122,10 @@ to `pr-open`, then `merged`.
 
 Append entries to `bulk/worklist.yaml` in the existing shape. `citation` is the
 corpus citation path the encoder resolves (`<jurisdiction>/statute/<path>`).
-Pick self-contained rate/credit/deduction/exemption sections; **skip**
-cross-reference-heavy ones (encode#1058) and any known gate-held sections.
+Prefer self-contained rate/credit/deduction/exemption sections. Complete-manual
+batches may also queue cross-reference-heavy provisions, but each remains an
+independent fail-closed PR and any encode#1058 blocker is triaged rather than
+merged around.
 
 To find candidates mechanically, enumerate un-encoded provisions from the public
 corpus view and cross-reference the encoded YAML on main:

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Locate and validate the artifacts written by one bulk encode apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
+JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
+
+
+def changed_paths(repo: Path) -> list[str]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    paths: list[str] = []
+    for record in completed.stdout.split(b"\0"):
+        if not record:
+            continue
+        decoded = record.decode("utf-8", errors="strict")
+        if len(decoded) >= 4:
+            paths.append(decoded[3:])
+    return paths
+
+
+def _is_module(path: PurePosixPath) -> bool:
+    return (
+        len(path.parts) >= 3
+        and bool(JURISDICTION_RE.fullmatch(path.parts[0]))
+        and path.parts[1] in MODULE_BUCKETS
+        and path.suffix == ".yaml"
+        and not path.name.endswith(".test.yaml")
+    )
+
+
+def _is_manifest(path: PurePosixPath) -> bool:
+    parts = path.parts
+    return (
+        bool(parts)
+        and parts[0] != "_axiom"
+        and path.suffix == ".json"
+        and any(
+            parts[index : index + 2] == (".axiom", "encoding-manifests")
+            for index in range(len(parts) - 1)
+        )
+    )
+
+
+def discover_applied_artifacts(
+    repo: Path,
+    *,
+    citation: str,
+    paths: list[str] | None = None,
+) -> tuple[str, str, str]:
+    repo = Path(repo)
+    candidates = paths if paths is not None else changed_paths(repo)
+    modules = sorted(path for path in candidates if _is_module(PurePosixPath(path)))
+    manifests = sorted(
+        path for path in candidates if _is_manifest(PurePosixPath(path))
+    )
+    if len(modules) != 1:
+        raise ValueError(f"expected one applied module; found {len(modules)}: {modules}")
+    if len(manifests) != 1:
+        raise ValueError(
+            f"expected one applied manifest; found {len(manifests)}: {manifests}"
+        )
+
+    module = modules[0]
+    test_file = f"{module[:-len('.yaml')]}.test.yaml"
+    if not (repo / module).is_file():
+        raise ValueError(f"applied module does not exist: {module}")
+    if not (repo / test_file).is_file():
+        raise ValueError(f"companion test does not exist: {test_file}")
+
+    manifest_rel = manifests[0]
+    try:
+        manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
+    if manifest.get("citation") != citation:
+        raise ValueError(
+            f"manifest citation {manifest.get('citation')!r} does not match {citation!r}"
+        )
+
+    applied_files = manifest.get("applied_files")
+    if not isinstance(applied_files, list):
+        raise ValueError(f"manifest {manifest_rel} has no applied_files list")
+    actual_paths = {
+        item.get("path")
+        for item in applied_files
+        if isinstance(item, dict)
+        and item.get("deleted") is not True
+        and isinstance(item.get("path"), str)
+    }
+    expected_full = {module, test_file}
+    expected_local = {
+        path.split("/", 1)[1] if "/" in path else path for path in expected_full
+    }
+    if actual_paths not in (expected_full, expected_local):
+        raise ValueError(
+            f"manifest {manifest_rel} covers {sorted(actual_paths)}; expected "
+            f"{sorted(expected_full)} or {sorted(expected_local)}"
+        )
+    return module, test_file, manifest_rel
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--citation", required=True)
+    args = parser.parse_args()
+    try:
+        artifacts = discover_applied_artifacts(args.repo, citation=args.citation)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        parser.error(str(exc))
+    print("\n".join(artifacts))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -38,7 +38,7 @@ import yaml
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
 SELECTABLE_STATUSES = {"pending"}
-APPROVED_ENCODER_REFS = {"fed5f3df343cd7548809d1c944a17f96c7c52a68"}
+APPROVED_ENCODER_REFS = {"9978ad8181914affdebcd6fb881291198c3bc839"}
 
 
 def citation_slug(citation: str) -> str:

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -16,7 +16,7 @@ Usage:
   python bulk/compute_matrix.py --get us-ny/statute/TAX/673 --field model
 
 The matrix shape is {"include": [{"citation", "repo", "backend", "model",
-"slug"}, ...]}. `slug` is the branch-safe citation slug used for
+"encoder_ref", "slug"}, ...]}. `slug` is the branch-safe citation slug used for
 `bulk/<slug>` branches and the PR title.
 
 Status writes are intentionally NOT done here: the workflow updates statuses by
@@ -38,6 +38,7 @@ import yaml
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
 SELECTABLE_STATUSES = {"pending"}
+APPROVED_ENCODER_REFS = {"75ad8644b40e80189bae29e65464b87d0491e514"}
 
 
 def citation_slug(citation: str) -> str:
@@ -66,6 +67,23 @@ def entry_model(data: dict, entry: dict) -> str:
     return entry.get("model") or data.get("defaults", {}).get("model", "gpt-5.5")
 
 
+def entry_encoder_ref(data: dict, entry: dict) -> str:
+    encoder_ref = entry.get("encoder_ref") or data.get("defaults", {}).get(
+        "encoder_ref", ""
+    )
+    if encoder_ref and not re.fullmatch(r"[0-9a-f]{40}", str(encoder_ref)):
+        raise ValueError(
+            f"encoder_ref for {entry.get('citation', '<unknown>')} must be a full "
+            "40-character lowercase commit SHA"
+        )
+    if encoder_ref and str(encoder_ref) not in APPROVED_ENCODER_REFS:
+        raise ValueError(
+            f"encoder_ref for {entry.get('citation', '<unknown>')} is not in the "
+            "reviewed compatibility allowlist"
+        )
+    return str(encoder_ref)
+
+
 def select(data: dict, status: str, batch: str | None, limit: int | None) -> list[dict]:
     out: list[dict] = []
     for entry in data["entries"]:
@@ -79,6 +97,7 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                 "repo": entry.get("repo", "rulespec-us"),
                 "backend": entry_backend(data, entry),
                 "model": entry_model(data, entry),
+                "encoder_ref": entry_encoder_ref(data, entry),
                 "slug": citation_slug(entry["citation"]),
             }
         )
@@ -134,6 +153,8 @@ def main() -> int:
                     print(entry_model(data, entry))
                 elif args.field == "backend":
                     print(entry_backend(data, entry))
+                elif args.field == "encoder_ref":
+                    print(entry_encoder_ref(data, entry))
                 elif args.field:
                     print(entry.get(args.field, ""))
                 else:

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -38,7 +38,7 @@ import yaml
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
 SELECTABLE_STATUSES = {"pending"}
-APPROVED_ENCODER_REFS = {"75ad8644b40e80189bae29e65464b87d0491e514"}
+APPROVED_ENCODER_REFS = {"fed5f3df343cd7548809d1c944a17f96c7c52a68"}
 
 
 def citation_slug(citation: str) -> str:

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -5,10 +5,7 @@ Drains ``bulk/worklist.yaml`` on the operator's machine using the local Codex
 CLI (ChatGPT subscription, ``gpt-5.5``) instead of the cloud ``bulk-encode.yml``
 dispatcher, opening the identical one-PR-per-module with auto-merge. It is a
 faithful local mirror of ``.github/workflows/bulk-encode.yml`` plus the
-oracle-coverage-pending declaration step the cloud dispatcher is missing (that
-missing step is why every new-state bulk PR fails the changed-file oracle
-coverage gate; see ``unstick`` below and the workflow fix in the same PR as this
-script).
+oracle-coverage-pending declaration step used by the cloud dispatcher.
 
 Two decisions matter and are baked in here so PRs go green:
 
@@ -18,11 +15,9 @@ Two decisions matter and are baked in here so PRs go green:
   newer risks schema/manifest skew. Do NOT "upgrade" the generation encoder to
   match a brief that says ">=0.2.1190" -- that number refers only to the
   *coverage/sync* tool below, not to generation.
-* **Coverage declaration uses axiom-encode main (>=0.2.1190)**, because the CI
-  changed-file coverage classifier (``oracle-coverage-axiom-encode-ref``,
-  default ``main``) is what reclassifies declared-pending outputs from
-  ``unmapped`` to ``pending_classification``. The pinned 1184 encoder does not
-  even have the ``oracle-coverage-pending`` subcommand.
+* **Coverage declaration uses the reviewed current-registry sync writer**, the
+  same immutable encoder revision pinned by the cloud workflow. The generation
+  encoder does not have the required exact-checkout sync command.
 
 Everything runs foreground. The loop is chunked (``--max-seconds``,
 ``--max-entries``) and every unit of durable state (pushed branch, opened PR,
@@ -36,11 +31,11 @@ pinned checkouts + venvs built once by the operator:
     _bulk_drain/
       axiom-encode/            # worktree @ pinned axiom_encode_ref (1184)
       .venv/                   # pinned encoder venv  -> generation
-      axiom-encode-cov/        # worktree @ axiom-encode main (>=1190)
+      axiom-encode-cov/        # worktree @ reviewed current-registry sync writer
       .venv-cov/               # coverage/sync venv   -> oracle-coverage-pending
       axiom-rules-engine/      # worktree @ pinned engine ref, cargo build
       axiom-corpus/            # worktree @ pinned corpus ref
-      wt/<slug>/rulespec-us/   # per-entry generation worktrees (leaf MUST be rulespec-us)
+      wt/<slug>/rulespec-us/rulespec-us/  # same-named wrapper + generation worktree
 
 Usage:
     python bulk/local_drain.py drain   [--limit N] [--batch A] [--concurrency 3]
@@ -61,11 +56,17 @@ import sys
 import threading
 import time
 import tomllib
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO = "TheAxiomFoundation/rulespec-us"
 REPO_NAME = "rulespec-us"
+APPROVED_CLASSIFIER_REF = "d052eabfaa2e209654aa979638672b28d71b3957"
+APPROVED_ORACLES_REF = "f2d2df36deb9c96b9fac4af15eab69c11d899e51"
+APPROVED_GENERATION_REFS = {
+    "3869d66d009f52258be35901edbef370e65a399c": "0.2.1200",
+    "9978ad8181914affdebcd6fb881291198c3bc839": "0.2.1200.3",
+}
 HERE = Path(__file__).resolve().parent           # <checkout>/bulk
 CHECKOUT = HERE.parent                            # this checkout root
 
@@ -74,8 +75,14 @@ DRAIN_BASE = Path(
     os.environ.get("DRAIN_BASE", Path.home() / "TheAxiomFoundation" / "_bulk_drain")
 ).resolve()
 GEN_AE = Path(os.environ.get("DRAIN_GEN_AE", DRAIN_BASE / ".venv/bin/axiom-encode"))
-COV_AE = Path(os.environ.get("DRAIN_COV_AE", DRAIN_BASE / ".venv-cov/bin/axiom-encode"))
+GEN_PY = Path(os.environ.get("DRAIN_GEN_PY", DRAIN_BASE / ".venv/bin/python"))
+GEN_CHECKOUT = Path(
+    os.environ.get("DRAIN_GEN_CHECKOUT", DRAIN_BASE / "axiom-encode")
+)
 COV_PY = Path(os.environ.get("DRAIN_COV_PY", DRAIN_BASE / ".venv-cov/bin/python"))
+COV_CHECKOUT = Path(
+    os.environ.get("DRAIN_COV_CHECKOUT", DRAIN_BASE / "axiom-encode-cov")
+)
 ENGINE = Path(os.environ.get("DRAIN_ENGINE", DRAIN_BASE / "axiom-rules-engine"))
 CORPUS = Path(os.environ.get("DRAIN_CORPUS", DRAIN_BASE / "axiom-corpus"))
 ENGINE_BIN = ENGINE / "target" / "debug"
@@ -101,11 +108,21 @@ def log(msg: str) -> None:
         print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
 
 
-def run(cmd, cwd=None, env=None, capture=True, check=False, timeout=None):
+def run(
+    cmd,
+    cwd=None,
+    env=None,
+    capture=True,
+    check=False,
+    timeout=None,
+    unset_env=(),
+):
     """Run a subprocess, returning (rc, combined_output)."""
     full = dict(os.environ)
     if env:
         full.update(env)
+    for name in unset_env:
+        full.pop(name, None)
     proc = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd else None,
@@ -163,17 +180,18 @@ def gh_json(args):
 # --- worktree helpers -------------------------------------------------------
 def make_worktree(slug: str, ref: str) -> Path:
     """Fresh generation worktree whose leaf dir is exactly ``rulespec-us``
-    (the --apply resolver requirement) with sibling engine/corpus symlinks."""
-    parent = WT_ROOT / slug
-    leaf = parent / REPO_NAME
+    inside the same-named wrapper required by the canonical path resolver."""
+    container = WT_ROOT / slug
+    wrapper = container / REPO_NAME
+    leaf = wrapper / REPO_NAME
     with _wt_lock:
         if leaf.exists():
             run(["git", "-C", str(CHECKOUT), "worktree", "remove", "--force", str(leaf)])
-        parent.mkdir(parents=True, exist_ok=True)
+        wrapper.mkdir(parents=True, exist_ok=True)
         run(["git", "-C", str(CHECKOUT), "fetch", "origin", "main", "--quiet"])
         run(["git", "-C", str(CHECKOUT), "worktree", "add", "--detach", str(leaf), ref])
     for name, target in (("axiom-rules-engine", ENGINE), ("axiom-corpus", CORPUS)):
-        link = parent / name
+        link = wrapper / name
         if link.is_symlink() or link.exists():
             link.unlink()
         link.symlink_to(target)
@@ -192,11 +210,13 @@ def regen_index(leaf: Path) -> None:
 
 
 def sync_pending(leaf: Path) -> str:
-    """Write oracle-coverage-pending.yaml for REPO_NAME using the >=1190 tool.
+    """Write oracle-coverage-pending.yaml using the reviewed sync writer.
     Returns the sync summary line."""
-    rc, out = run([str(COV_AE), "oracle-coverage-pending", "sync",
-                   "--root", str(leaf.parent), "--repo", REPO_NAME, "--source", "bulk"],
-                  env={"PATH": f"{ENGINE_BIN}:{os.environ['PATH']}"})
+    rc, out = run([str(COV_PY), "-m", "axiom_encode.entrypoint",
+                   "oracle-coverage-pending", "sync",
+                   "--root", str(leaf.parent), "--source", "bulk"],
+                  env={"PATH": f"{ENGINE_BIN}:{os.environ['PATH']}"},
+                  unset_env=("AXIOM_ENCODE_APPLY_SIGNING_KEY",))
     if rc != 0:
         raise RuntimeError(f"oracle-coverage-pending sync failed:\n{out}")
     return out.strip().splitlines()[-1] if out.strip() else "(no output)"
@@ -254,7 +274,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
         run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
         run(["git", "-C", str(leaf), "fetch", "origin", branch, "--quiet"])
         _, diff = run(["git", "-C", str(leaf), "diff", "--name-only",
-                       f"origin/main...FETCH_HEAD"])
+                       "origin/main...FETCH_HEAD"])
         artifacts = [f for f in diff.splitlines()
                      if (MODULE_RE.match(f) or f.endswith(".test.yaml")
                          or "/.axiom/encoding-manifests/" in f)]
@@ -340,6 +360,19 @@ def encode_entry(item: dict) -> dict:
     if already_handled(slug):
         res["status"] = "skipped"
         res["detail"] = "bulk/<slug> PR already exists"
+        return res
+    expected_encoder_ref = item.get("encoder_ref") or pinned_toolchain().get(
+        "axiom_encode_ref"
+    )
+    rc, active_encoder_ref = run(
+        ["git", "-C", str(GEN_CHECKOUT), "rev-parse", "HEAD"]
+    )
+    if rc != 0 or active_encoder_ref.strip() != expected_encoder_ref:
+        res["status"] = "config-mismatch"
+        res["detail"] = (
+            "generation encoder revision mismatch: "
+            f"expected {expected_encoder_ref}, got {active_encoder_ref.strip() or 'unresolved'}"
+        )
         return res
     leaf = make_worktree(slug, "origin/main")
     tmp = WT_ROOT / slug / "encode-out"
@@ -494,16 +527,112 @@ def write_progress(results: list, remaining: int, paused: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
+def coverage_sync_writer_status() -> tuple[bool, str]:
+    """Verify the local coverage interpreter imports the clean pinned checkout."""
+    if not COV_PY.exists():
+        return False, f"missing interpreter {COV_PY}"
+    if not COV_CHECKOUT.is_dir():
+        return False, f"missing checkout {COV_CHECKOUT}"
+
+    rc, head = run(["git", "-C", str(COV_CHECKOUT), "rev-parse", "HEAD"])
+    if rc != 0 or head.strip() != APPROVED_CLASSIFIER_REF:
+        actual = head.strip() or "unresolved"
+        return False, f"checkout {actual}, expected {APPROVED_CLASSIFIER_REF}"
+
+    rc, dirty = run(
+        ["git", "-C", str(COV_CHECKOUT), "status", "--porcelain"],
+    )
+    if rc != 0 or dirty.strip():
+        return False, "approved checkout is dirty or unreadable"
+
+    rc, source = run(
+        [
+            str(COV_PY),
+            "-c",
+            "import pathlib, axiom_encode; print(pathlib.Path(axiom_encode.__file__).resolve())",
+        ],
+        unset_env=("AXIOM_ENCODE_APPLY_SIGNING_KEY",),
+    )
+    expected_source = (COV_CHECKOUT / "src/axiom_encode/__init__.py").resolve()
+    if rc != 0 or source.strip() != str(expected_source):
+        return False, "coverage interpreter is not bound to approved checkout"
+
+    rc, oracle_ref = run(
+        [
+            str(COV_PY),
+            "-c",
+            (
+                "import json; from importlib.metadata import distribution; "
+                "payload=json.loads(distribution('axiom-oracles').read_text("
+                "'direct_url.json') or '{}'); "
+                "print(payload.get('vcs_info', {}).get('commit_id', ''))"
+            ),
+        ],
+        unset_env=("AXIOM_ENCODE_APPLY_SIGNING_KEY",),
+    )
+    if rc != 0 or oracle_ref.strip() != APPROVED_ORACLES_REF:
+        return False, "coverage interpreter has the wrong axiom-oracles revision"
+
+    rc, help_text = run(
+        [
+            str(COV_PY),
+            "-m",
+            "axiom_encode.entrypoint",
+            "oracle-coverage-pending",
+            "sync",
+            "--help",
+        ],
+        unset_env=("AXIOM_ENCODE_APPLY_SIGNING_KEY",),
+    )
+    if rc != 0 or "--root" not in help_text or "--repo" in help_text:
+        return False, "executable lacks exact-checkout sync contract"
+    return True, APPROVED_CLASSIFIER_REF
+
+
+def generation_encoder_status() -> tuple[bool, str]:
+    """Verify the local generation executable imports one approved clean checkout."""
+    if not GEN_AE.exists() or not GEN_PY.exists():
+        return False, "generation executable or interpreter is missing"
+    if not GEN_CHECKOUT.is_dir():
+        return False, f"missing checkout {GEN_CHECKOUT}"
+
+    rc, head = run(["git", "-C", str(GEN_CHECKOUT), "rev-parse", "HEAD"])
+    ref = head.strip()
+    if rc != 0 or ref not in APPROVED_GENERATION_REFS:
+        return False, f"unapproved generation checkout {ref or 'unresolved'}"
+    rc, dirty = run(["git", "-C", str(GEN_CHECKOUT), "status", "--porcelain"])
+    if rc != 0 or dirty.strip():
+        return False, "generation checkout is dirty or unreadable"
+
+    rc, identity = run(
+        [
+            str(GEN_PY),
+            "-c",
+            (
+                "import pathlib, axiom_encode; "
+                "print(pathlib.Path(axiom_encode.__file__).resolve()); "
+                "print(axiom_encode.__version__)"
+            ),
+        ],
+        unset_env=("AXIOM_ENCODE_APPLY_SIGNING_KEY",),
+    )
+    lines = identity.strip().splitlines()
+    expected_source = (GEN_CHECKOUT / "src/axiom_encode/__init__.py").resolve()
+    expected_version = APPROVED_GENERATION_REFS[ref]
+    if rc != 0 or lines != [str(expected_source), expected_version]:
+        return False, "generation interpreter is not bound to approved checkout/version"
+    if GEN_AE.parent.resolve() != GEN_PY.parent.resolve():
+        return False, "generation executable and interpreter use different environments"
+    return True, f"{ref} ({expected_version})"
+
+
 def cmd_doctor(_args) -> int:
     tc = pinned_toolchain()
     print(f"DRAIN_BASE           : {DRAIN_BASE}")
-    for label, ae, want_pending in (("gen encoder (pin)", GEN_AE, False),
-                                    ("cov encoder (main)", COV_AE, True)):
-        has_pending = ae.exists() and run(
-            [str(ae), "oracle-coverage-pending", "--help"])[0] == 0
-        ok = ae.exists() and (has_pending == want_pending)
-        print(f"{label:20s}: {'OK' if ok else 'CHECK'} "
-              f"(oracle-coverage-pending {'present' if has_pending else 'absent'})")
+    gen_ok, gen_detail = generation_encoder_status()
+    print(f"{'gen encoder (pin)':20s}: {'OK' if gen_ok else 'CHECK'} ({gen_detail})")
+    cov_ok, cov_detail = coverage_sync_writer_status()
+    print(f"{'cov sync writer':20s}: {'OK' if cov_ok else 'CHECK'} ({cov_detail})")
     print(f"pinned encoder ver   : {tc.get('axiom_encode_version')}")
     print(f"engine bin           : {'OK' if ENGINE_BIN.exists() else 'MISSING'} {ENGINE_BIN}")
     print(f"corpus               : {'OK' if CORPUS.exists() else 'MISSING'} {CORPUS}")
@@ -513,7 +642,7 @@ def cmd_doctor(_args) -> int:
         print(f"signing key          : {e}")
     rc, out = run(["codex", "--version"])
     print(f"codex CLI            : {'OK ' + out.strip() if rc == 0 else 'MISSING'}")
-    return 0
+    return 0 if gen_ok and cov_ok else 1
 
 
 def cmd_unstick(args) -> int:

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -343,7 +343,7 @@ def wait_for_merge(branch: str, timeout_s: int = 1500) -> str:
 # PART B: generate + PR one pending worklist entry via local Codex.
 # ---------------------------------------------------------------------------
 MODULE_RE = re.compile(
-    r"^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$")
+    r"^[a-z]{2}(-[a-z0-9-]+)?/(manual|statutes|regulations|policies)/.*\.yaml$")
 
 
 def already_handled(slug: str) -> bool:

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -212,6 +212,9 @@ def regen_index(leaf: Path) -> None:
 def sync_pending(leaf: Path) -> str:
     """Write oracle-coverage-pending.yaml using the reviewed sync writer.
     Returns the sync summary line."""
+    cov_ok, cov_detail = coverage_sync_writer_status()
+    if not cov_ok:
+        raise RuntimeError(f"coverage sync writer provenance failed: {cov_detail}")
     rc, out = run([str(COV_PY), "-m", "axiom_encode.entrypoint",
                    "oracle-coverage-pending", "sync",
                    "--root", str(leaf.parent), "--source", "bulk"],
@@ -238,6 +241,13 @@ def finalize_pending(leaf: Path) -> bool:
         pf.unlink()
         return False
     return True
+
+
+def is_encoding_manifest_path(path: str) -> bool:
+    """Return whether a changed path is a root or jurisdiction apply manifest."""
+    return path.startswith(".axiom/encoding-manifests/") or (
+        "/.axiom/encoding-manifests/" in path
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +278,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
     and never conflicts on the shared oracle-coverage-pending.yaml as siblings
     merge one after another.
     """
+    require_local_mutation_provenance()
     slug = branch.split("/", 1)[1]
     leaf = make_worktree(f"unstick-{slug}", "origin/main")
     try:
@@ -277,7 +288,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
                        "origin/main...FETCH_HEAD"])
         artifacts = [f for f in diff.splitlines()
                      if (MODULE_RE.match(f) or f.endswith(".test.yaml")
-                         or "/.axiom/encoding-manifests/" in f)]
+                         or is_encoding_manifest_path(f))]
         if not artifacts:
             return f"{branch}: no module artifacts in diff (already merged?)"
         run(["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],
@@ -360,6 +371,17 @@ def encode_entry(item: dict) -> dict:
     if already_handled(slug):
         res["status"] = "skipped"
         res["detail"] = "bulk/<slug> PR already exists"
+        return res
+    gen_ok, gen_detail = generation_encoder_status()
+    cov_ok, cov_detail = coverage_sync_writer_status()
+    if not gen_ok or not cov_ok:
+        failures = []
+        if not gen_ok:
+            failures.append(f"generation encoder: {gen_detail}")
+        if not cov_ok:
+            failures.append(f"coverage sync writer: {cov_detail}")
+        res["status"] = "config-mismatch"
+        res["detail"] = "local provenance check failed: " + "; ".join(failures)
         return res
     expected_encoder_ref = item.get("encoder_ref") or pinned_toolchain().get(
         "axiom_encode_ref"
@@ -626,6 +648,19 @@ def generation_encoder_status() -> tuple[bool, str]:
     return True, f"{ref} ({expected_version})"
 
 
+def require_local_mutation_provenance() -> None:
+    """Fail before local drain or unstick can mutate a worktree or branch."""
+    gen_ok, gen_detail = generation_encoder_status()
+    cov_ok, cov_detail = coverage_sync_writer_status()
+    failures = []
+    if not gen_ok:
+        failures.append(f"generation encoder: {gen_detail}")
+    if not cov_ok:
+        failures.append(f"coverage sync writer: {cov_detail}")
+    if failures:
+        raise RuntimeError("local mutation provenance failed: " + "; ".join(failures))
+
+
 def cmd_doctor(_args) -> int:
     tc = pinned_toolchain()
     print(f"DRAIN_BASE           : {DRAIN_BASE}")
@@ -646,6 +681,7 @@ def cmd_doctor(_args) -> int:
 
 
 def cmd_unstick(args) -> int:
+    require_local_mutation_provenance()
     prs = open_bulk_prs()
     if args.pr:
         targets = [p for p in prs if p["number"] in set(args.pr)]
@@ -666,6 +702,7 @@ def cmd_unstick(args) -> int:
 
 
 def cmd_drain(args) -> int:
+    require_local_mutation_provenance()
     matrix = json.loads(subprocess.run(
         [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
          "--status", "pending", "--format", "matrix",

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -9,7 +9,7 @@ entries:
   status: pending
   heading: 1105.015.00 SNAP Household Determination
   class: snap-household-composition
-  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
+  encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
   note: First durable Missouri full-manual wave; reviewed manual-monorepo compatibility build.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1
   repo: rulespec-us
@@ -17,7 +17,7 @@ entries:
   status: pending
   heading: 1105.015.04 Eligibility Unit Members
   class: snap-household-composition
-  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
+  encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
   note: First durable Missouri full-manual wave; child of household determination.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
   repo: rulespec-us
@@ -25,7 +25,7 @@ entries:
   status: pending
   heading: 1105.015.04.05 Individuals
   class: snap-household-composition
-  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
+  encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
   note: First durable Missouri full-manual wave; individual membership rules.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1
   repo: rulespec-us
@@ -33,7 +33,7 @@ entries:
   status: pending
   heading: 1105.015.04.10 Eligibility Unit Groups
   class: snap-household-composition
-  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
+  encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
   note: First durable Missouri full-manual wave; grouped membership rules.
 - citation: us-il/statute/35/5/402
   repo: rulespec-us

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -3,6 +3,38 @@ defaults:
   backend: openai
   model: gpt-5.5
 entries:
+- citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/block-1
+  repo: rulespec-us
+  batch: SNAP-MO-1
+  status: pending
+  heading: 1105.015.00 SNAP Household Determination
+  class: snap-household-composition
+  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  note: First durable Missouri full-manual wave; reviewed manual-monorepo compatibility build.
+- citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1
+  repo: rulespec-us
+  batch: SNAP-MO-1
+  status: pending
+  heading: 1105.015.04 Eligibility Unit Members
+  class: snap-household-composition
+  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  note: First durable Missouri full-manual wave; child of household determination.
+- citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+  repo: rulespec-us
+  batch: SNAP-MO-1
+  status: pending
+  heading: 1105.015.04.05 Individuals
+  class: snap-household-composition
+  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  note: First durable Missouri full-manual wave; individual membership rules.
+- citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1
+  repo: rulespec-us
+  batch: SNAP-MO-1
+  status: pending
+  heading: 1105.015.04.10 Eligibility Unit Groups
+  class: snap-household-composition
+  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  note: First durable Missouri full-manual wave; grouped membership rules.
 - citation: us-il/statute/35/5/402
   repo: rulespec-us
   batch: A

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -6,7 +6,7 @@ entries:
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/block-1
   repo: rulespec-us
   batch: SNAP-MO-1
-  status: pending
+  status: pr-open
   heading: 1105.015.00 SNAP Household Determination
   class: snap-household-composition
   encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
@@ -14,7 +14,7 @@ entries:
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1
   repo: rulespec-us
   batch: SNAP-MO-1
-  status: pending
+  status: pr-open
   heading: 1105.015.04 Eligibility Unit Members
   class: snap-household-composition
   encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
@@ -22,7 +22,7 @@ entries:
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
   repo: rulespec-us
   batch: SNAP-MO-1
-  status: pending
+  status: pr-open
   heading: 1105.015.04.05 Individuals
   class: snap-household-composition
   encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839
@@ -30,7 +30,7 @@ entries:
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1
   repo: rulespec-us
   batch: SNAP-MO-1
-  status: pending
+  status: pr-open
   heading: 1105.015.04.10 Eligibility Unit Groups
   class: snap-household-composition
   encoder_ref: 9978ad8181914affdebcd6fb881291198c3bc839

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -9,7 +9,7 @@ entries:
   status: pending
   heading: 1105.015.00 SNAP Household Determination
   class: snap-household-composition
-  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
   note: First durable Missouri full-manual wave; reviewed manual-monorepo compatibility build.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1
   repo: rulespec-us
@@ -17,7 +17,7 @@ entries:
   status: pending
   heading: 1105.015.04 Eligibility Unit Members
   class: snap-household-composition
-  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
   note: First durable Missouri full-manual wave; child of household determination.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
   repo: rulespec-us
@@ -25,7 +25,7 @@ entries:
   status: pending
   heading: 1105.015.04.05 Individuals
   class: snap-household-composition
-  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
   note: First durable Missouri full-manual wave; individual membership rules.
 - citation: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1
   repo: rulespec-us
@@ -33,7 +33,7 @@ entries:
   status: pending
   heading: 1105.015.04.10 Eligibility Unit Groups
   class: snap-household-composition
-  encoder_ref: 75ad8644b40e80189bae29e65464b87d0491e514
+  encoder_ref: fed5f3df343cd7548809d1c944a17f96c7c52a68
   note: First durable Missouri full-manual wave; grouped membership rules.
 - citation: us-il/statute/35/5/402
   repo: rulespec-us

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,0 +1,110 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bulk.applied_artifacts import discover_applied_artifacts
+
+
+def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "citation": citation,
+                "applied_files": [
+                    {"path": applied_path, "sha256": "0" * 64}
+                    for applied_path in sorted(applied_paths)
+                ],
+            }
+        )
+    )
+
+
+def test_discovers_repo_root_manifest_for_manual_module(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+    ) == (module, test_file, manifest)
+
+
+def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> None:
+    citation = "us-oh/statute/5747.71"
+    module = "us-oh/statutes/5747/71.yaml"
+    test_file = "us-oh/statutes/5747/71.test.yaml"
+    manifest = "us-oh/.axiom/encoding-manifests/statutes/5747/71.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        citation,
+        {"statutes/5747/71.yaml", "statutes/5747/71.test.yaml"},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+@pytest.mark.parametrize(
+    ("extra_path", "message"),
+    [
+        ("us-mo/manual/dss/snap/1105/other.yaml", "expected one applied module"),
+        (
+            ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/other.json",
+            "expected one applied manifest",
+        ),
+    ],
+)
+def test_rejects_ambiguous_artifacts(
+    tmp_path: Path, extra_path: str, message: str
+) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    if extra_path.endswith(".json"):
+        _write_manifest(tmp_path / extra_path, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match=message):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest, extra_path],
+        )
+
+
+def test_rejects_manifest_for_different_citation(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, "us-mo/manual/different", {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -130,6 +130,11 @@ def test_unstick_preserves_root_and_jurisdiction_manifests() -> None:
     assert not local_drain.is_encoding_manifest_path(".axiom/index/example.json")
 
 
+def test_local_drain_recognizes_manual_rulespec_modules() -> None:
+    assert local_drain.MODULE_RE.match("us-mo/manual/dss/snap/1105/block-1.yaml")
+    assert local_drain.MODULE_RE.match("us-mo/policies/dss/snap/block-1.yaml")
+
+
 def test_local_worktree_uses_same_named_wrapper(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(local_drain, "WT_ROOT", tmp_path / "wt")
     monkeypatch.setattr(local_drain, "CHECKOUT", tmp_path / "checkout")

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -30,6 +30,30 @@ def test_bulk_branch_push_uses_full_destination_ref() -> None:
     assert 'push -f origin "HEAD:$branch"' not in workflow
 
 
+def test_review_fix_attestation_is_isolated_and_pinned() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert (
+        "if: ${{ github.event_name != 'workflow_dispatch' || "
+        "inputs.attest_ref == '' }}" in workflow
+    )
+    assert (
+        "if: ${{ github.event_name == 'workflow_dispatch' && "
+        "inputs.attest_ref != '' }}" in workflow
+    )
+    assert 'bulk/*) ;;' in workflow
+    assert "ref: 9978ad8181914affdebcd6fb881291198c3bc839" in workflow
+    assert 'python-version: "3.14"' in workflow
+    assert "path: target/rulespec-us" in workflow
+    assert "working-directory: trusted/axiom-encode-signer" in workflow
+    assert "--roots \"$roots\"" in workflow
+    assert 'git -C "$target" add -- .axiom "$jurisdiction/.axiom"' in workflow
+    assert "AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}" in workflow
+    assert "axiom-encode sign-applied-files" in workflow
+    assert "--manual-exception repair" in workflow
+    assert 'git -C "$target" push origin "HEAD:refs/heads/$ATTEST_REF"' in workflow
+
+
 def test_oracle_classifier_uses_reviewed_sync_writer() -> None:
     workflow = WORKFLOW.read_text()
 

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -1,8 +1,20 @@
+from pathlib import Path
+
 import pytest
 
 from bulk.compute_matrix import APPROVED_ENCODER_REFS, select
 
 APPROVED_ENCODER_REF = next(iter(APPROVED_ENCODER_REFS))
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "bulk-encode.yml"
+
+
+def test_oracle_classifier_does_not_receive_apply_signing_key() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert (
+        'env -u AXIOM_ENCODE_APPLY_SIGNING_KEY "$COV_AE" '
+        "oracle-coverage-pending sync"
+    ) in workflow
 
 
 def test_select_carries_entry_encoder_ref_into_matrix() -> None:

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -2,10 +2,16 @@ from pathlib import Path
 
 import pytest
 
+from bulk import local_drain
 from bulk.compute_matrix import APPROVED_ENCODER_REFS, select
 
 APPROVED_ENCODER_REF = next(iter(APPROVED_ENCODER_REFS))
+APPROVED_CLASSIFIER_REF = "d052eabfaa2e209654aa979638672b28d71b3957"
 WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "bulk-encode.yml"
+REPOSITORY_CHECKS = (
+    Path(__file__).parents[1] / ".github" / "workflows" / "repository-checks.yml"
+)
+LOCAL_DRAIN = Path(__file__).parents[1] / "bulk" / "local_drain.py"
 
 
 def test_oracle_classifier_does_not_receive_apply_signing_key() -> None:
@@ -15,6 +21,113 @@ def test_oracle_classifier_does_not_receive_apply_signing_key() -> None:
         'env -u AXIOM_ENCODE_APPLY_SIGNING_KEY "$COV_AE" '
         "oracle-coverage-pending sync"
     ) in workflow
+
+
+def test_oracle_classifier_uses_reviewed_sync_writer() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert (
+        "Checkout oracle-coverage classifier (pinned sync writer)" in workflow
+    )
+    assert f"ref: {APPROVED_CLASSIFIER_REF}" in workflow
+    assert f'expected="{APPROVED_CLASSIFIER_REF}"' in workflow
+    assert 'actual="$(git -C _axiom/axiom-encode-oracle-coverage rev-parse HEAD)"' in workflow
+    assert '--root "$GITHUB_WORKSPACE/.."' in workflow
+    assert "--repo rulespec-us" not in workflow
+    assert (
+        f"oracle-coverage-axiom-encode-ref: {APPROVED_CLASSIFIER_REF}"
+        in REPOSITORY_CHECKS.read_text()
+    )
+
+
+def test_local_drain_uses_exact_checkout_sync_contract() -> None:
+    local_drain = LOCAL_DRAIN.read_text()
+
+    assert '"--root", str(leaf.parent), "--source", "bulk"' in local_drain
+    assert '"--root", str(leaf.parent), "--repo"' not in local_drain
+
+
+def test_local_pending_sync_strips_apply_signing_key(monkeypatch, tmp_path) -> None:
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        return 0, "synced"
+
+    monkeypatch.setattr(local_drain, "run", fake_run)
+
+    assert local_drain.sync_pending(tmp_path) == "synced"
+    assert captured["unset_env"] == ("AXIOM_ENCODE_APPLY_SIGNING_KEY",)
+    assert captured["cmd"][-4:] == [
+        "--root",
+        str(tmp_path.parent),
+        "--source",
+        "bulk",
+    ]
+
+
+def test_local_worktree_uses_same_named_wrapper(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(local_drain, "WT_ROOT", tmp_path / "wt")
+    monkeypatch.setattr(local_drain, "CHECKOUT", tmp_path / "checkout")
+    monkeypatch.setattr(local_drain, "ENGINE", tmp_path / "engine")
+    monkeypatch.setattr(local_drain, "CORPUS", tmp_path / "corpus")
+    monkeypatch.setattr(local_drain, "run", lambda *_args, **_kwargs: (0, ""))
+
+    leaf = local_drain.make_worktree("example", "origin/main")
+
+    assert leaf == tmp_path / "wt/example/rulespec-us/rulespec-us"
+    assert (leaf.parent / "axiom-rules-engine").is_symlink()
+    assert (leaf.parent / "axiom-corpus").is_symlink()
+
+
+def test_local_encoder_mismatch_is_resumable(monkeypatch) -> None:
+    monkeypatch.setattr(local_drain, "already_handled", lambda _slug: False)
+    monkeypatch.setattr(
+        local_drain,
+        "run",
+        lambda *_args, **_kwargs: (0, "3869d66d009f52258be35901edbef370e65a399c\n"),
+    )
+
+    result = local_drain.encode_entry(
+        {
+            "citation": "us-mo/manual/example/block-1",
+            "slug": "us-mo-manual-example-block-1",
+            "encoder_ref": APPROVED_ENCODER_REF,
+        }
+    )
+
+    assert result["status"] == "config-mismatch"
+    assert "generation encoder revision mismatch" in result["detail"]
+
+
+def test_local_doctor_rejects_obsolete_sync_contract(monkeypatch, tmp_path) -> None:
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    checkout = tmp_path / "axiom-encode-cov"
+    package = checkout / "src/axiom_encode"
+    package.mkdir(parents=True)
+    source = package / "__init__.py"
+    source.touch()
+    monkeypatch.setattr(local_drain, "COV_PY", interpreter)
+    monkeypatch.setattr(local_drain, "COV_CHECKOUT", checkout)
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "git":
+            if cmd[-2:] == ["rev-parse", "HEAD"]:
+                return 0, f"{APPROVED_CLASSIFIER_REF}\n"
+            return 0, ""
+        if "-c" in cmd:
+            if "direct_url.json" in cmd[-1]:
+                return 0, f"{local_drain.APPROVED_ORACLES_REF}\n"
+            return 0, f"{source.resolve()}\n"
+        return 0, "usage: sync --root ROOT --repo REPO"
+
+    monkeypatch.setattr(local_drain, "run", fake_run)
+
+    ok, detail = local_drain.coverage_sync_writer_status()
+    assert not ok
+    assert detail == "executable lacks exact-checkout sync contract"
 
 
 def test_select_carries_entry_encoder_ref_into_matrix() -> None:

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -23,6 +23,13 @@ def test_oracle_classifier_does_not_receive_apply_signing_key() -> None:
     ) in workflow
 
 
+def test_bulk_branch_push_uses_full_destination_ref() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert 'push -f origin "HEAD:refs/heads/$branch"' in workflow
+    assert 'push -f origin "HEAD:$branch"' not in workflow
+
+
 def test_oracle_classifier_uses_reviewed_sync_writer() -> None:
     workflow = WORKFLOW.read_text()
 

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -47,7 +47,10 @@ def test_review_fix_attestation_is_isolated_and_pinned() -> None:
     assert "path: target/rulespec-us" in workflow
     assert "working-directory: trusted/axiom-encode-signer" in workflow
     assert "--roots \"$roots\"" in workflow
-    assert 'git -C "$target" add -- .axiom "$jurisdiction/.axiom"' in workflow
+    assert "generated_paths=(.axiom)" in workflow
+    assert 'if [ -d "$target/$jurisdiction/.axiom" ]' in workflow
+    assert 'generated_paths+=("$jurisdiction/.axiom")' in workflow
+    assert 'git -C "$target" add -A -- "${generated_paths[@]}"' in workflow
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}" in workflow
     assert "axiom-encode sign-applied-files" in workflow
     assert "--manual-exception repair" in workflow

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -1,0 +1,98 @@
+import pytest
+
+from bulk.compute_matrix import APPROVED_ENCODER_REFS, select
+
+APPROVED_ENCODER_REF = next(iter(APPROVED_ENCODER_REFS))
+
+
+def test_select_carries_entry_encoder_ref_into_matrix() -> None:
+    data = {
+        "defaults": {
+            "backend": "openai",
+            "model": "gpt-5.5",
+                "encoder_ref": APPROVED_ENCODER_REF,
+        },
+        "entries": [
+            {
+                "citation": "us-mo/manual/dss/snap/1105/block-1",
+                "repo": "rulespec-us",
+                "batch": "SNAP-MO-1",
+                "status": "pending",
+                "encoder_ref": APPROVED_ENCODER_REF,
+            },
+            {
+                "citation": "us-il/statute/35/5/402",
+                "status": "pending",
+            },
+        ],
+    }
+
+    selected = select(data, "pending", "snap-mo-1", 1)
+
+    assert selected == [
+        {
+            "citation": "us-mo/manual/dss/snap/1105/block-1",
+            "repo": "rulespec-us",
+            "backend": "openai",
+            "model": "gpt-5.5",
+            "encoder_ref": APPROVED_ENCODER_REF,
+            "slug": "us-mo-manual-dss-snap-1105-block-1",
+        }
+    ]
+
+
+def test_select_uses_default_encoder_ref() -> None:
+    data = {
+        "defaults": {"encoder_ref": APPROVED_ENCODER_REF},
+        "entries": [
+            {
+                "citation": "us-il/statute/35/5/402",
+                "status": "pending",
+            }
+        ],
+    }
+
+    assert select(data, "pending", None, None)[0]["encoder_ref"] == APPROVED_ENCODER_REF
+
+
+def test_select_rejects_mutable_encoder_ref() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-mo/manual/dss/snap/1105/block-1",
+                "status": "pending",
+                "encoder_ref": "compat/manual-signing",
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="full 40-character lowercase commit SHA"):
+        select(data, "pending", None, None)
+
+
+def test_select_without_override_keeps_toolchain_fallback() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-il/statute/35/5/402",
+                "status": "pending",
+            }
+        ]
+    }
+
+    assert select(data, "pending", None, None)[0]["encoder_ref"] == ""
+
+
+def test_select_rejects_unapproved_immutable_encoder_ref() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-mo/manual/dss/snap/1105/block-1",
+                "status": "pending",
+                "encoder_ref": "f" * 40,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="reviewed compatibility allowlist"):
+        select(data, "pending", None, None)

--- a/tests/test_bulk_compute_matrix.py
+++ b/tests/test_bulk_compute_matrix.py
@@ -90,6 +90,9 @@ def test_local_pending_sync_strips_apply_signing_key(monkeypatch, tmp_path) -> N
         return 0, "synced"
 
     monkeypatch.setattr(local_drain, "run", fake_run)
+    monkeypatch.setattr(
+        local_drain, "coverage_sync_writer_status", lambda: (True, "reviewed")
+    )
 
     assert local_drain.sync_pending(tmp_path) == "synced"
     assert captured["unset_env"] == ("AXIOM_ENCODE_APPLY_SIGNING_KEY",)
@@ -99,6 +102,32 @@ def test_local_pending_sync_strips_apply_signing_key(monkeypatch, tmp_path) -> N
         "--source",
         "bulk",
     ]
+
+
+def test_local_pending_sync_fails_closed_on_provenance(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        local_drain,
+        "coverage_sync_writer_status",
+        lambda: (False, "wrong checkout"),
+    )
+    monkeypatch.setattr(
+        local_drain,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("sync command must not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="wrong checkout"):
+        local_drain.sync_pending(tmp_path)
+
+
+def test_unstick_preserves_root_and_jurisdiction_manifests() -> None:
+    assert local_drain.is_encoding_manifest_path(
+        ".axiom/encoding-manifests/us-mo/manual/example.json"
+    )
+    assert local_drain.is_encoding_manifest_path(
+        "us-oh/.axiom/encoding-manifests/statutes/example.json"
+    )
+    assert not local_drain.is_encoding_manifest_path(".axiom/index/example.json")
 
 
 def test_local_worktree_uses_same_named_wrapper(monkeypatch, tmp_path) -> None:
@@ -118,6 +147,12 @@ def test_local_worktree_uses_same_named_wrapper(monkeypatch, tmp_path) -> None:
 def test_local_encoder_mismatch_is_resumable(monkeypatch) -> None:
     monkeypatch.setattr(local_drain, "already_handled", lambda _slug: False)
     monkeypatch.setattr(
+        local_drain, "generation_encoder_status", lambda: (True, "reviewed")
+    )
+    monkeypatch.setattr(
+        local_drain, "coverage_sync_writer_status", lambda: (True, "reviewed")
+    )
+    monkeypatch.setattr(
         local_drain,
         "run",
         lambda *_args, **_kwargs: (0, "3869d66d009f52258be35901edbef370e65a399c\n"),
@@ -133,6 +168,34 @@ def test_local_encoder_mismatch_is_resumable(monkeypatch) -> None:
 
     assert result["status"] == "config-mismatch"
     assert "generation encoder revision mismatch" in result["detail"]
+
+
+def test_local_encoder_fails_closed_before_generation(monkeypatch) -> None:
+    monkeypatch.setattr(local_drain, "already_handled", lambda _slug: False)
+    monkeypatch.setattr(
+        local_drain,
+        "generation_encoder_status",
+        lambda: (False, "dirty checkout"),
+    )
+    monkeypatch.setattr(
+        local_drain, "coverage_sync_writer_status", lambda: (True, "reviewed")
+    )
+    monkeypatch.setattr(
+        local_drain,
+        "make_worktree",
+        lambda *_args, **_kwargs: pytest.fail("worktree must not be created"),
+    )
+
+    result = local_drain.encode_entry(
+        {
+            "citation": "us-mo/manual/example/block-1",
+            "slug": "us-mo-manual-example-block-1",
+            "encoder_ref": APPROVED_ENCODER_REF,
+        }
+    )
+
+    assert result["status"] == "config-mismatch"
+    assert "dirty checkout" in result["detail"]
 
 
 def test_local_doctor_rejects_obsolete_sync_contract(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- allow immutable per-entry encoder compatibility refs and verify the resolved checkout
- discover and validate exactly one applied module, companion test, and signed manifest across consolidated manual and legacy layouts
- queue the first four Missouri SNAP household-composition provisions as independent bulk PRs

## Checks

- `python -m pytest -q tests/test_bulk_compute_matrix.py tests/test_bulk_applied_artifacts.py` (9 passed)
- `uv run ruff check bulk/compute_matrix.py bulk/applied_artifacts.py tests/test_bulk_compute_matrix.py tests/test_bulk_applied_artifacts.py`
- `python -m compileall -q bulk/compute_matrix.py bulk/applied_artifacts.py tests/test_bulk_compute_matrix.py tests/test_bulk_applied_artifacts.py`
- workflow and worklist YAML parse
- SNAP-MO-1 matrix selects 4 pinned-corpus citations

## Review cycle

Independent review found mutable-ref, ambiguous-artifact, basename-manifest, and test-coverage gaps. All were fixed. The repeated independent review reported no actionable findings.