### PR TITLE
Encode Missouri SNAP individual household categories

### DIFF
--- a/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml",
+      "sha256": "fc5f0261775cd73ba3d0f5565fea648beeb176d79ea5e06389a5538c111275f5"
+    },
+    {
+      "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+      "sha256": "c9cf9fab0eaf4940145e3657fe9ec93788c571e821ff7ad34f7a044a7e61ec19"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9978ad8181914affdebcd6fb881291198c3bc839",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/trusted/axiom-encode-signer",
+    "version": "0.2.1200.3",
+    "version_commit": "9978ad8181914affdebcd6fb881291198c3bc839"
+  },
+  "axiom_encode_version": "0.2.1200.3",
+  "backend": "manual",
+  "citation": "us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-13T19:36:13.614749+00:00",
+  "generated_output_file": "/tmp/tmp87clgefk/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+  "generated_output_root": "/tmp/tmp87clgefk",
+  "generated_output_sha256": "c9cf9fab0eaf4940145e3657fe9ec93788c571e821ff7ad34f7a044a7e61ec19",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml",
-      "sha256": "6b54e74e59cfe4430d0afc77d009b6929283b5e045f5bfe6bf1fb91e5c76a237"
+      "sha256": "823d734b4a95f4d564a1c3b882149e34d5ead36889a4f276b9bd193218edb8b1"
     },
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-      "sha256": "ebe8f2fb61ec44bd0ee91f250e87db90dd9d9b3d18d1f878c336597f53ea0735"
+      "sha256": "f5897dd45ef6da2289c116cd6a1a6ce6e332a3ddfe05ff5a18666ba0d066dae8"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T20:38:04.176921+00:00",
-  "generated_output_file": "/tmp/tmp_j14cdsr/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-  "generated_output_root": "/tmp/tmp_j14cdsr",
-  "generated_output_sha256": "ebe8f2fb61ec44bd0ee91f250e87db90dd9d9b3d18d1f878c336597f53ea0735",
+  "generated_at": "2026-07-13T21:14:43.493154+00:00",
+  "generated_output_file": "/tmp/tmpvrmb2bom/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+  "generated_output_root": "/tmp/tmpvrmb2bom",
+  "generated_output_sha256": "f5897dd45ef6da2289c116cd6a1a6ce6e332a3ddfe05ff5a18666ba0d066dae8",
   "generation_prompt_sha256": null,
   "manual_exception": "repair",
   "model": "",
@@ -34,22 +34,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "8818d4741430937be6bc050e51c1e572300f3ce49660c5ae23252707d9be79e8"
+    "value": "6b311126991324148a39ffa343d0f38c3a8244700cded1c8fc808667a35932b3"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-13T20:21:38.957823+00:00",
+    "generated_at": "2026-07-13T20:38:04.176921+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "fb714c6eb9060d41db404797f251d077d36450b1723e788e8839d069af269313",
-    "prior_signature": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b",
+    "manifest_sha256": "00a528a284210c1789fe8f44c13310128ae8d31f255851810d4ba5df6ec97c0f",
+    "prior_signature": "8818d4741430937be6bc050e51c1e572300f3ce49660c5ae23252707d9be79e8",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-13T19:36:13.614749+00:00",
+      "generated_at": "2026-07-13T20:21:38.957823+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
-      "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+      "manifest_sha256": "fb714c6eb9060d41db404797f251d077d36450b1723e788e8839d069af269313",
+      "prior_signature": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-13T19:36:13.614749+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
+        "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml",
-      "sha256": "fc5f0261775cd73ba3d0f5565fea648beeb176d79ea5e06389a5538c111275f5"
+      "sha256": "14e769368bf68034805c98fbd77d3ded262c0ae9c0da33afc160ed1e28f59223"
     },
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-      "sha256": "c9cf9fab0eaf4940145e3657fe9ec93788c571e821ff7ad34f7a044a7e61ec19"
+      "sha256": "8a2f20cd7e2b97f9c158834edfb1b19a1f5ca7a872f0fc11c7ac2ece9b89254f"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T19:36:13.614749+00:00",
-  "generated_output_file": "/tmp/tmp87clgefk/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-  "generated_output_root": "/tmp/tmp87clgefk",
-  "generated_output_sha256": "c9cf9fab0eaf4940145e3657fe9ec93788c571e821ff7ad34f7a044a7e61ec19",
+  "generated_at": "2026-07-13T20:21:38.957823+00:00",
+  "generated_output_file": "/tmp/tmp6_q3yd2b/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+  "generated_output_root": "/tmp/tmp6_q3yd2b",
+  "generated_output_sha256": "8a2f20cd7e2b97f9c158834edfb1b19a1f5ca7a872f0fc11c7ac2ece9b89254f",
   "generation_prompt_sha256": null,
   "manual_exception": "repair",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b"
+    "value": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-13T19:36:13.614749+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
+    "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml",
-      "sha256": "823d734b4a95f4d564a1c3b882149e34d5ead36889a4f276b9bd193218edb8b1"
+      "sha256": "017e153f2cb9b775373644759a24f7b63f44555aae7291d229cc26d5a5a478eb"
     },
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-      "sha256": "f5897dd45ef6da2289c116cd6a1a6ce6e332a3ddfe05ff5a18666ba0d066dae8"
+      "sha256": "3944c23f44e0f376288d5bbc678ace3eeec1e23cb55327315b7e7d84698f80be"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T21:14:43.493154+00:00",
-  "generated_output_file": "/tmp/tmpvrmb2bom/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-  "generated_output_root": "/tmp/tmpvrmb2bom",
-  "generated_output_sha256": "f5897dd45ef6da2289c116cd6a1a6ce6e332a3ddfe05ff5a18666ba0d066dae8",
+  "generated_at": "2026-07-13T21:24:58.822186+00:00",
+  "generated_output_file": "/tmp/tmpy0lhzgk5/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+  "generated_output_root": "/tmp/tmpy0lhzgk5",
+  "generated_output_sha256": "3944c23f44e0f376288d5bbc678ace3eeec1e23cb55327315b7e7d84698f80be",
   "generation_prompt_sha256": null,
   "manual_exception": "repair",
   "model": "",
@@ -34,29 +34,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6b311126991324148a39ffa343d0f38c3a8244700cded1c8fc808667a35932b3"
+    "value": "5eff771941f70ce8295d0893a4a762d3ab6e1a254719cf683325fe788ad004d8"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-13T20:38:04.176921+00:00",
+    "generated_at": "2026-07-13T21:14:43.493154+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "00a528a284210c1789fe8f44c13310128ae8d31f255851810d4ba5df6ec97c0f",
-    "prior_signature": "8818d4741430937be6bc050e51c1e572300f3ce49660c5ae23252707d9be79e8",
+    "manifest_sha256": "45ae652c37845ce0f39cf47029c18bcbfa144c978b07da2c0f6509488ae3214a",
+    "prior_signature": "6b311126991324148a39ffa343d0f38c3a8244700cded1c8fc808667a35932b3",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-13T20:21:38.957823+00:00",
+      "generated_at": "2026-07-13T20:38:04.176921+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "fb714c6eb9060d41db404797f251d077d36450b1723e788e8839d069af269313",
-      "prior_signature": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b",
+      "manifest_sha256": "00a528a284210c1789fe8f44c13310128ae8d31f255851810d4ba5df6ec97c0f",
+      "prior_signature": "8818d4741430937be6bc050e51c1e572300f3ce49660c5ae23252707d9be79e8",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-13T19:36:13.614749+00:00",
+        "generated_at": "2026-07-13T20:21:38.957823+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
-        "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+        "manifest_sha256": "fb714c6eb9060d41db404797f251d077d36450b1723e788e8839d069af269313",
+        "prior_signature": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-13T19:36:13.614749+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
+          "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
+++ b/.axiom/encoding-manifests/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml",
-      "sha256": "14e769368bf68034805c98fbd77d3ded262c0ae9c0da33afc160ed1e28f59223"
+      "sha256": "6b54e74e59cfe4430d0afc77d009b6929283b5e045f5bfe6bf1fb91e5c76a237"
     },
     {
       "path": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-      "sha256": "8a2f20cd7e2b97f9c158834edfb1b19a1f5ca7a872f0fc11c7ac2ece9b89254f"
+      "sha256": "ebe8f2fb61ec44bd0ee91f250e87db90dd9d9b3d18d1f878c336597f53ea0735"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T20:21:38.957823+00:00",
-  "generated_output_file": "/tmp/tmp6_q3yd2b/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
-  "generated_output_root": "/tmp/tmp6_q3yd2b",
-  "generated_output_sha256": "8a2f20cd7e2b97f9c158834edfb1b19a1f5ca7a872f0fc11c7ac2ece9b89254f",
+  "generated_at": "2026-07-13T20:38:04.176921+00:00",
+  "generated_output_file": "/tmp/tmp_j14cdsr/sign-applied-files/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+  "generated_output_root": "/tmp/tmp_j14cdsr",
+  "generated_output_sha256": "ebe8f2fb61ec44bd0ee91f250e87db90dd9d9b3d18d1f878c336597f53ea0735",
   "generation_prompt_sha256": null,
   "manual_exception": "repair",
   "model": "",
@@ -34,15 +34,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b"
+    "value": "8818d4741430937be6bc050e51c1e572300f3ce49660c5ae23252707d9be79e8"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-13T19:36:13.614749+00:00",
+    "generated_at": "2026-07-13T20:21:38.957823+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
-    "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+    "manifest_sha256": "fb714c6eb9060d41db404797f251d077d36450b1723e788e8839d069af269313",
+    "prior_signature": "0c5134dc37a6219a2c6d59a8f21c8b27b47506aa09c2dc3da1c4c5a8db861d7b",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-13T19:36:13.614749+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "34f07bb077884cd3a8a564af98932739b61ea79dc610423c3d02b7d295d2cb9f",
+      "prior_signature": "81613e44972b616539a3ececf2ac21cc991d51cb21729aa54da3bbea3f5fee4b",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -13816,6 +13816,31 @@
         ]
       }
     ],
+    "us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1": [
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1": [
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mo/manual/dss/snap/1105-000-00/1105-015-00/block-1": [
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1": [
       {
         "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
@@ -30074,6 +30099,18 @@
     "us/statute/7/2012": [
       {
         "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/block-1.yaml",
         "via": [
           "proof_atom"
         ]

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -13807,6 +13807,15 @@
         ]
       }
     ],
+    "us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1": [
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/1115-035-25-05/block-1": [
       {
         "module": "us-mo/manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1.yaml",
@@ -24914,6 +24923,12 @@
       }
     ],
     "us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2": [
+      {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
       {
         "module": "us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml",
         "via": [

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -30073,6 +30073,12 @@
     ],
     "us/statute/7/2012": [
       {
+        "module": "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us/statutes/7/2012/j.yaml",
         "via": [
           "module"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -965,6 +965,24 @@ entries:
   - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
     source: manual
     since: 2026-07-12
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_considered_separate_from_resident_boarders_for_eligibility
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_may_participate_in_snap
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#cooperative_buying_club_manager_may_participate_as_part_of_eligibility_eu
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#fns_authorized_retail_store_owner_or_manager_may_participate_as_part_of_eligibility_eu
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#person_not_barred_from_eligibility_eu_by_residence
+    source: bulk
+    since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
     source: bulk
     since: 2026-07-13
@@ -1005,6 +1023,27 @@ entries:
     source: bulk
     since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_customarily_purchases_and_prepares_food_together_path
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_delivered_meals_or_communal_dining_path
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path_scalar_limit
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_residential_treatment_program_path
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_cohabiting_spouse_path
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#others_countable_income_poverty_level_limit_ratio
     source: bulk
     since: 2026-07-13
   - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
@@ -1907,45 +1946,6 @@ entries:
   - legal_id: us-wv:statutes/11-21-3#unincorporated_organization_subject_to_article_tax
     source: bulk
     since: 2026-07-08
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
-    source: migration
-    since: 2026-07-13
-  - legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
-    source: migration
-    since: 2026-07-13
   - legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
     source: bulk
     since: 2026-07-09

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 741
+ceiling: 742
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -985,6 +985,9 @@ entries:
     source: bulk
     since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
     source: bulk
     since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 728
+ceiling: 740
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -966,6 +966,42 @@ entries:
   - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
     source: manual
     since: 2026-07-12
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_minimum_age
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_additional_person
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income_table
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_table_maximum_size
+    source: bulk
+    since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    source: bulk
+    since: 2026-07-13
   - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
     source: bulk
     since: 2026-07-08

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -8,2229 +8,2229 @@
 version: 1
 ceiling: 742
 entries:
-  - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#blind_deaf_or_totally_disabled_person_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#current_income_distribution_trust_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#estate_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#estate_exemption_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#individual_personal_exemption_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#individual_personal_exemption_unit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#other_trust_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-54#trust_exemption_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_0_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#applicable_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#dependent_care_center
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#dependent_care_center_individual_count_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#dollar_limit_on_creditable_expenses
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#earned_income_limitation
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#half_of_household_cost
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#household_maintained
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#married_individual_living_apart_not_considered_married
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#married_taxpayer_joint_return_requirement_satisfied
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#multiple_qualifying_individual_expense_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#one_qualifying_individual_expense_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#percentage_of_creditable_expenses
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#refund_floor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#spouse_monthly_deemed_earned_income_for_limitation
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#spouse_multiple_qualifying_individual_monthly_deemed_earned_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/6#spouse_one_qualifying_individual_monthly_deemed_earned_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#adjusted_gross_income_credit_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#claim_deadline_months_after_taxable_year
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#credit_amount_per_qualified_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#qualified_exemption_count
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#qualified_exemption_state_residence_months_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#refundable_payment_minimum
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#rent_paid_credit_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#rental_unit_multiple_occupancy_minimum_individuals
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#renter_credit_before_tax_liability
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#renter_credit_claimant_eligible
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#renter_credit_income_and_rent_test_met
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#renter_credit_refundable_payment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/7#senior_double_credit_age_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#food_excise_adjusted_gross_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#non_single_return_food_excise_credit_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#non_single_return_food_excise_credit_per_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#person_disqualified_from_food_excise_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#person_food_excise_credit_available
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#single_return_food_excise_credit_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#single_return_food_excise_credit_per_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-hi:statutes/235-55/85#taxpayer_may_claim_food_excise_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#age_sixty_five_additional_exemption_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#blind_additional_exemption_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#dependent_personal_exemption_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#estate_trust_single_or_separate_return_personal_exemption_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#full_year_reserve_peace_officer_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#full_year_volunteer_firefighter_or_ems_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#head_of_household_or_joint_return_personal_exemption_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#months_in_tax_year_for_proration
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#reserve_peace_officer_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#tuition_credit_expense_cap_per_dependent
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#tuition_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12#volunteer_firefighter_or_ems_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12B#allocated_earned_income_credit_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12B#earned_income_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12B#earned_income_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12B#earned_income_credit_tax_reduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12B#refundable_earned_income_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_0_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_1_lower_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_1_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_2_lower_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_2_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_3_lower_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_3_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_4_lower_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_4_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_5_lower_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_5_upper_net_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_credit_before_residency_ratio
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#child_and_dependent_care_income_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#credit_applied_to_current_year_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#dependent_qualifies_for_early_childhood_development_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_before_residency_ratio
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_net_income_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_per_dependent
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#early_childhood_development_expense_cap_per_dependent
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#iowa_child_and_dependent_care_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#iowa_credit_residency_ratio
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#iowa_early_childhood_development_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#maximum_early_childhood_dependent_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#minimum_early_childhood_dependent_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ia:statutes/422/12C#refundable_excess_credit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
-    source: manual
-    since: 2026-07-09
-  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax
-    source: manual
-    since: 2026-07-09
-  - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income
-    source: manual
-    since: 2026-07-09
-  - legal_id: us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_carryforward_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:294#standard_deduction_joint_surviving_spouse_head_of_household_2025
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:294#standard_deduction_joint_surviving_spouse_head_of_household_multiplier
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:294#standard_deduction_single_individual_married_separate_2025
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:295#penalty_waiver_oversight_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit_carryforward
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#excess_credit_carryforward_year_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#high_income_credit_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#initial_low_income_unreduced_federal_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#low_income_federal_adjusted_gross_income_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#middle_income_claimed_federal_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#middle_income_federal_adjusted_gross_income_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#upper_income_claimed_federal_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/4#upper_middle_income_federal_adjusted_gross_income_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_base_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_temporary_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-la:statutes/47:297/8#louisiana_earned_income_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_maximum_grant
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_standard_of_need
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_maximum_grant
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_standard_of_need
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-me:statutes/36/5111#head_of_household_band_0_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_band_1_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_base_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_excess_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#head_of_household_tax_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_0_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_1_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_base_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_excess_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#joint_surviving_spouse_tax_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#nonresident_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_band_0_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_band_1_upper
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_base_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_excess_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5111#single_separate_tax_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction_before_phaseout
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5124-C#standard_deduction_computation_method
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#married_separate_phaseout_denominator
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#nonjoint_spouse_additional_personal_exemption_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#other_phaseout_denominator
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5213-A#tax_credit_allowed_under_this_section_is_refundable
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-S#eligible_without_qualifying_child_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-S#other_eligible_individual_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-SS#base_child_and_dependent_credit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-me:statutes/36/5219-SS#young_child_credit_multiplier
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/10#retirement_or_pension_benefits_deduction_under_subsection_10
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/10#subsection_10_full_subsection_1_f_treatment_indicator
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/10#subsection_10_phase_in_deduction_percentage
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/11#qualifying_public_safety_or_corrections_retirement_benefits
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/11#retirement_pension_deduction_without_additional_limitations
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/11#subsection_9_or_10_limitation_election_applies
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/11#unrestricted_subsection_1_f_retirement_pension_deduction_election_applies
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/2#personal_and_dependency_exemption_count
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/2#personal_exemption_base_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/2#personal_exemption_subtraction_before_exceptions
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/2#spouse_personal_exemption_may_be_claimed
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/3#listed_disability_additional_exemption_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/3#qualified_disabled_veteran_additional_exemption
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/3#qualified_disabled_veteran_additional_exemption_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/7#additional_personal_exemption_increase
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/7#adjusted_exemptions_allowed_under_subsection_3
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/7#adjusted_personal_exemption_allowed_under_subsection_2
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206.30/7#exemption_rounding_increment
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mi:statutes/206/272#additional_credit_percentage_for_tax_year
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:statutes/206/272#additional_earned_income_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:statutes/206/272#earned_income_tax_credit_refund
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mi:statutes/206/272#total_earned_income_tax_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#dependent_exemption_before_disallowance
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#inflation_rounding_multiple
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#married_filing_separately_phaseout_step_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#married_filing_separately_threshold_fraction_of_joint
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#maximum_applicable_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#phaseout_percentage_points_per_step
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#statutory_dependent_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#statutory_head_of_household_threshold_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#statutory_joint_return_or_surviving_spouse_threshold_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0121#statutory_single_threshold_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_blind_spouse
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_married_or_surviving_spouse_blind_taxpayer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_married_or_surviving_spouse_senior_taxpayer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_other_blind_taxpayer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_other_senior_taxpayer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#additional_amount_for_senior_spouse
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#dependent_earned_income_addition
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#dependent_standard_deduction_floor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#head_of_household_standard_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#inflation_adjustment_rounding_increment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#joint_or_surviving_spouse_standard_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_cap_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_first_agi_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_first_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_high_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_second_agi_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_second_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit_carryover_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit_carryover_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#bovine_testing_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#corporate_bovine_testing_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#corporation_franchise_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#corporation_franchise_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#film_production_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#film_production_credit_carryover_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#head_of_household_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#head_of_household_bracket_selector
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#joint_return_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#joint_return_bracket_selector
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#noncorporate_bovine_testing_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#pass_through_entity_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#section_529_credit_recapture_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#section_529_plan_recapture_additional_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#section_529_subtraction_recapture_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_carryover_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#transit_pass_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#transit_pass_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#unmarried_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/06#unmarried_bracket_selector
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#dependent_care_credit_after_income_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#dependent_care_credit_income_limit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#income_reduction_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#infant_deemed_expense_age_limit_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#licensed_parent_family_day_care_child_age_limit_years
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#one_qualifying_individual_income_limit_base_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#statutory_income_reduction_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_count
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_income_limit_base_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/067#younger_child_deemed_expense_age_limit_months
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#earned_income_credit_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#earned_income_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#no_qualifying_child_maximum_age_exclusive
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#no_qualifying_child_minimum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#older_child_no_section_290_0661_phaseout_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#one_qualifying_older_child_increase
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#qualifying_older_child_minimum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#three_or_more_qualifying_older_children_increase
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#two_qualifying_older_children_increase
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_income_share
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_homeless_standard_eligible
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_liheap_sua_threshold
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_amount
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_amount
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_selected_homeless_or_excess_shelter_deduction
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_shared_utility_household_receives_full_standard
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_amount
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_amount
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_entitled
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation
-    source: manual
-    since: 2026-07-13
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_standard_reassessment_required
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_shelter_costs_allowed
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard
-    source: manual
-    since: 2026-07-13
-  - legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
-    source: manual
-    since: 2026-07-12
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_considered_separate_from_resident_boarders_for_eligibility
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_may_participate_in_snap
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#cooperative_buying_club_manager_may_participate_as_part_of_eligibility_eu
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#fns_authorized_retail_store_owner_or_manager_may_participate_as_part_of_eligibility_eu
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#person_not_barred_from_eligibility_eu_by_residence
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_minimum_age
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_table
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_table_maximum_size
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_customarily_purchases_and_prepares_food_together_path
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_delivered_meals_or_communal_dining_path
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path_scalar_limit
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_residential_treatment_program_path
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_cohabiting_spouse_path
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#others_countable_income_poverty_level_limit_ratio
-    source: bulk
-    since: 2026-07-13
-  - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mt:statutes/15-30-2318#reduction_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-mt:statutes/15-30-2318#state_earned_income_tax_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income_of_lesser_earning_spouse
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nd:statutes/57/57-38-01/28#statutory_married_couple_credit_maximum
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#bracket_adjustment_rounding_increment
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_first
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_fourth
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_second
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_third
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#other_federal_taxes_nebraska_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_estates_trusts
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_head_of_household
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_joint
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_married_separate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_single
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_estates_trusts
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_head_of_household
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_joint
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_married_separate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_single
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/03#tax_table_maximum_difference_between_brackets
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#family_member_for_extremely_blighted_area_residence_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_minimum_gestation_weeks
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2007_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2018_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2007_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2018_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#inflation_adjusted_standard_deduction_rounding_multiple
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#married_filing_jointly_personal_exemption_additional_count
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#other_return_personal_exemption_additional_count
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1993
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1994
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1995
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1996
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1997
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1998
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_2018_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2007_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2018_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_married_filing_jointly_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_married_filing_separately_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2003_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2007_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2018_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#age_exception_exclusive_maximum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#age_exception_minimum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_refund
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#exemption_amount_per_federal_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_full_exemption_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_phaseout_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_phaseout_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#separate_return_full_exemption_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#separate_return_phaseout_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#separate_return_phaseout_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#single_full_exemption_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#single_phaseout_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-nm:statutes/7-2-5/8#single_phaseout_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability
-    source: manual
-    since: 2026-07-08
-  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax
-    source: manual
-    since: 2026-07-08
-  - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_income
-    source: manual
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#estate_low_income_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#estate_low_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#excess_exemptions_deductible_from_taxable_business_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#individual_income_tax_no_tax_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_base_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_excess_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/02#taxable_business_income_after_excess_exemptions
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#adjusted_personal_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2025
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_high_income_band_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_income_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_low_income_band_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_lower_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_upper_bound
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#personal_exemption_rounding_multiple
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/025#statutory_personal_exemption_amount_by_income_band
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/71#earned_income_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-oh:statutes/5747/71#federal_credit_percentage
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/264#applicable_percentage_at_110_percent_fpl
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/264#student_low_income_comparison_expense_base
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/264#student_low_income_credit_comparison_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/264#youngest_qualifying_individual_age_category
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#base_earned_income_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#earned_income_credit_applicable_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#refundable_credit_excess
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#young_dependent_age_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/315/266#young_dependent_earned_income_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/316/085#joint_surviving_spouse_head_of_household_federal_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/316/085#other_filer_federal_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/316/085#personal_exemption_credit_indexing_factor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#child_for_rebate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#child_maximum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_claim_penalty
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_penalty_per_dependent
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#joint_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#maximum_rebate_children
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#rebate_amount_per_child
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#rebate_child_count
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#rebate_payment_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_204_component_eligible
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_eligible
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_gross_income_eligible
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_payment_standard_amount
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_resources_eligible_output
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:programs/tanf/fy-2026#ut_fep_work_expense_allowance
-    source: bulk
-    since: 2026-07-12
-  - legal_id: us-ut:statutes/59-10-1018#applicable_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#credit_reduction_rate_per_excess_dollar
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#deduction_credit_component
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#head_of_household_filing_status
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#income_based_credit_reduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_head_of_household_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_joint_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_single_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_utah_personal_exemption_base_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#joint_filing_status
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#personal_exemption_credit_component
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#single_filing_status
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#state_or_local_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#statutory_head_of_household_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#statutory_joint_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#statutory_single_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#statutory_utah_personal_exemption_base_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#tax_credit_before_income_reduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#utah_itemized_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1018#utah_personal_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#eligible_claimant
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#head_of_household_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#joint_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#married_filing_separately_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#senior_credit_base_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#senior_credit_reduction_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-1019#single_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_applies
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#first_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#first_bracket_upper_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#individual_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#second_bracket_lower_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#second_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#second_bracket_upper_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#third_bracket_lower_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#third_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#third_bracket_upper_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#top_bracket_lower_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-320#top_bracket_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#armed_forces_service_compensation_not_liable_to_va_income_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#individual_and_spouse_no_tax_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#married_separate_threshold_fraction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#no_tax_or_return_required
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#single_individual_no_tax_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_boiler_minimum_fuel_utilization_rating
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_furnace_minimum_fuel_utilization_rating
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#advanced_water_heater_minimum_energy_factor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_married_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_minimum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_single_phaseout_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#blind_or_aged_additional_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#bone_marrow_donor_screening_fee_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_current
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_temporary
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#central_air_conditioner_minimum_cooling_seer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#charitable_mileage_state_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_annual_deduction_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_no_limit_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_cooling_seer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_heating_performance_factor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_capacity_kilowatts
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_efficiency
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_cooling_cop
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_heating_cop
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#heat_pump_water_heater_minimum_energy_factor
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_month_window
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#married_separate_standard_deduction_fraction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#permanent_foster_care_child_deduction_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#personal_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#ppp_loan_deduction_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_fagi_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_age
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_earned_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_general
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_temporary
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_general
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_temporary
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-322/03#tobacco_single_payment_gain_subtraction_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#disqualifying_subtraction_or_deduction_claimed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_nonrefundable_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_refundable_credit_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_amount_per_counted_person
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#low_income_nonrefundable_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-va:statutes/58.1/58/1-339/8#poverty_guideline_percentage_limit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_base_excise_tax_rate
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/060#statutory_combined_standard_deduction_limit_for_spouses_or_domestic_partners
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/060#statutory_standard_deduction_per_individual
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/080#nonprofit_organization
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/080#principally_directed_and_managed_within_washington
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/080#qualified_organization
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_maximum_charitable_donation_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_minimum_qualifying_charitable_donation_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_deduction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#earned_income_for_section
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#separate_return_earned_income_exclusion_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-10#temporary_initial_year_exclusion_fraction
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#resident_individual_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#separately_determined_spouse_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#surviving_spouse
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#credit_calculated_before_section_23_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#eligible_taxable_assessed_value_for_taxes_paid
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#homestead_exemption_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#homestead_property_tax_refundable_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#low_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#low_income_federal_poverty_guideline_multiplier
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#minimum_refundable_credit_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#post_2007_taxable_assessed_value_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#pre_2007_taxable_assessed_value_cap
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-21#refund_claim_deadline_years_after_return_due_date
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#gross_household_income
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#gross_household_income_percentage_threshold
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#low_income_homeowner
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#low_income_person
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#maximum_refundable_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#minimum_refundable_credit_refund
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_allowed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_preliminary
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_refund_amount
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-23#section_23_low_income_federal_poverty_guideline_multiplier
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#electing_pass_through_entity_west_virginia_taxable_income_tax_imposed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#estate_west_virginia_taxable_income_tax_imposed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#individual_west_virginia_taxable_income_tax_imposed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#pass_through_entity_subject_to_article_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#trust_west_virginia_taxable_income_tax_imposed
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us-wv:statutes/11-21-3#unincorporated_organization_subject_to_article_tax
-    source: bulk
-    since: 2026-07-08
-  - legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#certified_federal_program_adjunctive_income_eligible
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#maximum_csfp_household_income_limit_fpg_ratio
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#state_administered_program_adjunctive_income_eligible
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#state_agency_csfp_income_limit_complies
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:regulations/7-cfr/247/9/b#subject_to_prior_elderly_pilot_income_criteria
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/102#amount_excluded_from_gross_income_under_section_102
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#applicable_limitation_amount_after_calendar_year_2029
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#applicable_limitation_amount_annual_adjustment_factor
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2025
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2026
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#applicable_limitation_amount_phaseout_floor
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#married_separate_applicable_limitation_fraction
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_phaseout_rate
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_annual_adjustment_factor
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2025
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2026
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#personal_property_tax
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#purchaser_real_property_tax_treated_as_imposed
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/164#seller_real_property_tax_treated_as_imposed
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/212#section_212_deduction_allowed
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#catch_up_age_threshold
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#catch_up_applicable_amount_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#catch_up_cost_of_living_rounding_multiple
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#deductible_amount_before_compensation_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#deductible_amount_cost_of_living_rounding_multiple
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#maximum_general_deduction_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#maximum_plan_contribution_deduction_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#plan_contribution_compensation_limit_rate
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#plan_contribution_limit_amount
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#section_applies_to_contribution
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/b#statutory_deductible_amount_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#active_participant
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#active_participant_before_exceptions
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#adjusted_gross_income_for_subsection
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_joint_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_other_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#applicable_dollar_amount_separate_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#inflation_adjustment_start_year_threshold
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#inflation_rounding_multiple
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#minimum_limitation_before_complete_phaseout
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#phaseout_denominator_joint
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#phaseout_denominator_other
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#reduction_rounding_multiple
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#reserve_component_active_duty_exception_limit_days
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#reserve_component_participation_not_active_participant_solely_for_that_participation
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#spouse_not_active_participant_applicable_dollar_amount_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#spouses_filing_separately_living_apart_not_treated_as_married
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#subsection_applies_to_individual
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#volunteer_firefighter_accrued_benefit_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#volunteer_firefighter_annuity_commencement_age
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#statutory_student_loan_interest_deduction_cap
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_joint_return
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_other_return
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_joint_return
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_other_return
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_age_threshold
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_2
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_3
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_4
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_5
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_6
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#family_coverage_annual_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#individual_attained_additional_contribution_age
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#monthly_proration_denominator
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#self_only_coverage_annual_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#testing_period_additional_tax_rate
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/223/b#testing_period_month_count
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/61#enumerated_gross_income_items
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/61#gross_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#adjusted_gross_income
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator_expense_base_cap
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator_expense_cap_after_inflation_adjustment
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator_expense_cap_rounding_multiple
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator_expenses_allowable_above_the_line
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#eligible_educator_minimum_school_hours
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#qualified_performing_artist_agi_limit
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#qualified_performing_artist_expense_gross_income_rate
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#qualified_performing_artist_minimum_employer_count
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#qualified_performing_artist_nominal_employer_receipts_floor
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/62#unlawful_discrimination
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/64#ordinary_income_gain_inclusion_applies
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/65#ordinary_loss
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_base
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_denominator
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_numerator
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deduction_reduction_under_section_68
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#itemized_deductions_allowed_after_section_68
-    source: bulk
-    since: 2026-07-09
-  - legal_id: us:statutes/26/68#section_68_reduction_applies_to_individual
-    source: bulk
-    since: 2026-07-09
+- legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#blind_deaf_or_totally_disabled_person_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#current_income_distribution_trust_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#estate_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#estate_exemption_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#individual_personal_exemption_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#individual_personal_exemption_unit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#other_trust_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-54#trust_exemption_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_0_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_1_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_2_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_3_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_4_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#adjusted_gross_income_band_5_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#applicable_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#dependent_care_center
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#dependent_care_center_individual_count_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#dollar_limit_on_creditable_expenses
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#earned_income_limitation
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#half_of_household_cost
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#household_maintained
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#married_individual_living_apart_not_considered_married
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#married_taxpayer_joint_return_requirement_satisfied
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#multiple_qualifying_individual_expense_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#one_qualifying_individual_expense_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#percentage_of_creditable_expenses
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#refund_floor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#spouse_monthly_deemed_earned_income_for_limitation
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#spouse_multiple_qualifying_individual_monthly_deemed_earned_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/6#spouse_one_qualifying_individual_monthly_deemed_earned_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#adjusted_gross_income_credit_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#claim_deadline_months_after_taxable_year
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#credit_amount_per_qualified_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#qualified_exemption_count
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#qualified_exemption_state_residence_months_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#refundable_payment_minimum
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#rent_paid_credit_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#rental_unit_multiple_occupancy_minimum_individuals
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#renter_credit_before_tax_liability
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#renter_credit_claimant_eligible
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#renter_credit_income_and_rent_test_met
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#renter_credit_refundable_payment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/7#senior_double_credit_age_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#food_excise_adjusted_gross_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#non_single_return_food_excise_credit_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#non_single_return_food_excise_credit_per_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#person_disqualified_from_food_excise_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#person_food_excise_credit_available
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#single_return_food_excise_credit_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#single_return_food_excise_credit_per_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-hi:statutes/235-55/85#taxpayer_may_claim_food_excise_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#age_sixty_five_additional_exemption_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#blind_additional_exemption_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#dependent_personal_exemption_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#estate_trust_single_or_separate_return_personal_exemption_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#full_year_reserve_peace_officer_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#full_year_volunteer_firefighter_or_ems_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#head_of_household_or_joint_return_personal_exemption_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#months_in_tax_year_for_proration
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#reserve_peace_officer_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#tuition_credit_expense_cap_per_dependent
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#tuition_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#volunteer_and_reserve_service_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12#volunteer_firefighter_or_ems_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12B#allocated_earned_income_credit_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12B#earned_income_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12B#earned_income_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12B#earned_income_credit_tax_reduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12B#refundable_earned_income_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_0_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_1_lower_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_1_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_2_lower_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_2_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_3_lower_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_3_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_4_lower_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_4_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_5_lower_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_band_5_upper_net_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_credit_before_residency_ratio
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#child_and_dependent_care_income_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#credit_applied_to_current_year_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#dependent_qualifies_for_early_childhood_development_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_before_residency_ratio
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_net_income_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_per_dependent
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#early_childhood_development_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#early_childhood_development_expense_cap_per_dependent
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#iowa_child_and_dependent_care_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#iowa_credit_residency_ratio
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#iowa_early_childhood_development_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#maximum_early_childhood_dependent_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#minimum_early_childhood_dependent_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ia:statutes/422/12C#refundable_excess_credit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
+  source: manual
+  since: '2026-07-09'
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax
+  source: manual
+  since: '2026-07-09'
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income
+  source: manual
+  since: '2026-07-09'
+- legal_id: us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/067#household_and_dependent_care_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_carryforward_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ky:statutes/11/141/069#kentucky_education_tuition_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:294#standard_deduction_joint_surviving_spouse_head_of_household_2025
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:294#standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:294#standard_deduction_single_individual_married_separate_2025
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:295#penalty_waiver_oversight_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:295#penalty_waiver_subject_to_committee_oversight
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#child_care_expense_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#child_care_expense_credit_carryforward
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#child_care_expense_credit_refundable_overpayment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#excess_credit_carryforward_year_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#high_income_credit_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#initial_low_income_unreduced_federal_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#later_low_income_unreduced_federal_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#low_income_federal_adjusted_gross_income_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#middle_income_claimed_federal_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#middle_income_federal_adjusted_gross_income_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#upper_income_claimed_federal_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/4#upper_middle_income_federal_adjusted_gross_income_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_base_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_excess_overpayment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#earned_income_tax_credit_temporary_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-la:statutes/47:297/8#louisiana_earned_income_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_schedule_tax
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-me:policies/income_tax/pilot_liability_pipeline#me_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_maximum_grant
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-me:programs/tanf/fy-2026#me_tanf_adult_included_standard_of_need
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_maximum_grant
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-me:programs/tanf/fy-2026#me_tanf_child_only_standard_of_need
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-me:statutes/36/5111#head_of_household_band_0_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_band_1_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_base_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_excess_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#head_of_household_tax_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_0_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_band_1_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_base_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_excess_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#joint_surviving_spouse_tax_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#nonresident_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_band_0_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_band_1_upper
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_base_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_excess_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5111#single_separate_tax_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5124-C#resident_individual_standard_deduction_before_phaseout
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5124-C#standard_deduction_computation_method
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#base_personal_exemption_deduction_before_phaseout
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#joint_return_additional_personal_exemption_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#married_separate_phaseout_denominator
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#nonjoint_spouse_additional_personal_exemption_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#other_phaseout_denominator
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5126-A#personal_exemption_deduction_before_deferred_phaseout_and_nonjoint_spouse_branch
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5213-A#tax_credit_allowed_under_this_section_is_refundable
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-S#eligible_without_qualifying_child_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-S#maine_earned_income_credit_before_limitation
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-S#other_eligible_individual_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-SS#base_child_and_dependent_credit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-me:statutes/36/5219-SS#young_child_credit_multiplier
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_schedule_tax
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:policies/income_tax/pilot_liability_pipeline#mi_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/10#retirement_or_pension_benefits_deduction_under_subsection_10
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/10#subsection_10_full_subsection_1_f_treatment_indicator
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/10#subsection_10_phase_in_deduction_percentage
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/11#qualifying_public_safety_or_corrections_retirement_benefits
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/11#retirement_pension_deduction_without_additional_limitations
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/11#subsection_9_or_10_limitation_election_applies
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/11#unrestricted_subsection_1_f_retirement_pension_deduction_election_applies
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/2#personal_and_dependency_exemption_count
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/2#personal_exemption_base_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/2#personal_exemption_subtraction_before_exceptions
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/2#spouse_personal_exemption_may_be_claimed
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/3#listed_disability_additional_exemption_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/3#qualified_disabled_veteran_additional_exemption
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/3#qualified_disabled_veteran_additional_exemption_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/7#additional_personal_exemption_increase
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/7#adjusted_exemptions_allowed_under_subsection_3
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/7#adjusted_personal_exemption_allowed_under_subsection_2
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206.30/7#exemption_rounding_increment
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mi:statutes/206/272#additional_credit_percentage_for_tax_year
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:statutes/206/272#additional_earned_income_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:statutes/206/272#earned_income_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:statutes/206/272#earned_income_tax_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:statutes/206/272#earned_income_tax_credit_refund
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mi:statutes/206/272#total_earned_income_tax_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#dependent_exemption_before_disallowance
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#inflation_rounding_multiple
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#married_filing_separately_phaseout_step_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#married_filing_separately_threshold_fraction_of_joint
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#maximum_applicable_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#phaseout_percentage_points_per_step
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#statutory_dependent_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#statutory_head_of_household_threshold_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#statutory_joint_return_or_surviving_spouse_threshold_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0121#statutory_single_threshold_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_blind_spouse
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_married_or_surviving_spouse_blind_taxpayer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_married_or_surviving_spouse_senior_taxpayer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_other_blind_taxpayer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_other_senior_taxpayer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#additional_amount_for_senior_spouse
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#dependent_earned_income_addition
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#dependent_standard_deduction_floor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#head_of_household_standard_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#inflation_adjustment_rounding_increment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#joint_or_surviving_spouse_standard_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_cap_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_first_agi_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_first_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_high_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_second_agi_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0123#standard_deduction_reduction_second_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#beginning_farmer_incentive_credit_carryover_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#beginning_farmer_management_credit_carryover_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#bovine_testing_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#corporate_bovine_testing_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#corporation_franchise_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#corporation_franchise_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#film_production_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#film_production_credit_carryover_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#head_of_household_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#head_of_household_bracket_selector
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#joint_return_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#joint_return_bracket_selector
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#noncorporate_bovine_testing_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#pass_through_entity_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#section_529_credit_recapture_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#section_529_plan_recapture_additional_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#section_529_subtraction_recapture_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#seed_capital_investment_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_carryover_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#seed_capital_investment_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#transit_pass_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#transit_pass_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#unmarried_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/06#unmarried_bracket_selector
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#dependent_care_credit_after_income_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#dependent_care_credit_income_limit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#income_reduction_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#infant_deemed_expense_age_limit_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#licensed_parent_family_day_care_child_age_limit_years
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#nonresident_or_part_year_resident_earned_income_allocation_ratio
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#one_qualifying_individual_income_limit_base_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#statutory_income_reduction_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_count
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#two_or_more_qualifying_individuals_income_limit_base_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/067#younger_child_deemed_expense_age_limit_months
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#earned_income_credit_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#earned_income_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#earned_income_taxable_allocation_ratio
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#no_qualifying_child_maximum_age_exclusive
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#no_qualifying_child_minimum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#older_child_no_section_290_0661_phaseout_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#one_qualifying_older_child_increase
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#qualifying_older_child_minimum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#three_or_more_qualifying_older_children_increase
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#two_qualifying_older_children_increase
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_income_share
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_homeless_standard_eligible
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_liheap_sua_threshold
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_amount
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_amount
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_selected_homeless_or_excess_shelter_deduction
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_shared_utility_household_receives_full_standard
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_amount
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_amount
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_entitled
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation
+  source: manual
+  since: '2026-07-13'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_standard_reassessment_required
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_shelter_costs_allowed
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard
+  source: manual
+  since: '2026-07-13'
+- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
+  source: manual
+  since: '2026-07-12'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_considered_separate_from_resident_boarders_for_eligibility
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_may_participate_in_snap
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#cooperative_buying_club_manager_may_participate_as_part_of_eligibility_eu
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#fns_authorized_retail_store_owner_or_manager_may_participate_as_part_of_eligibility_eu
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#person_not_barred_from_eligibility_eu_by_residence
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_minimum_age
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_table
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_table_maximum_size
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_customarily_purchases_and_prepares_food_together_path
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_delivered_meals_or_communal_dining_path
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_disabled_age_60_unable_to_purchase_prepare_path_scalar_limit
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_residential_treatment_program_path
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_cohabiting_spouse_path
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#others_countable_income_poverty_level_limit_ratio
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit_refund
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mt:statutes/15-30-2318#reduction_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-mt:statutes/15-30-2318#state_earned_income_tax_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit_before_residency_adjustment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nd:statutes/57/57-38-01/28#qualifying_income_of_lesser_earning_spouse
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nd:statutes/57/57-38-01/28#statutory_married_couple_credit_maximum
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#bracket_adjustment_rounding_increment
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_first
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_fourth
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_second
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#bracket_rate_third
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#other_federal_taxes_nebraska_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_estates_trusts
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_head_of_household
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_joint
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_married_separate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_maximum_single
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_estates_trusts
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_head_of_household
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_joint
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_married_separate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#statutory_bracket_minimum_single
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/03#tax_table_maximum_difference_between_brackets
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#extremely_blighted_area_residence_credit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#family_member_for_extremely_blighted_area_residence_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_credit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2715/07#stillborn_child_minimum_gestation_weeks
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2007_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_married_2018_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2007_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#additional_standard_deduction_single_or_head_of_household_2018_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#inflation_adjusted_standard_deduction_rounding_multiple
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#married_filing_jointly_personal_exemption_additional_count
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#other_return_personal_exemption_additional_count
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1993
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1994
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1995
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1996
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1997
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_1998
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#personal_exemption_credit_amount_2018_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2007_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_head_of_household_2018_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_married_filing_jointly_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_married_filing_separately_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2003_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2007_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ne:statutes/77/77-2716/01#standard_deduction_single_2018_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#age_exception_exclusive_maximum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#age_exception_minimum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#taxpayer_qualifies_for_working_families_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-18/15#working_families_tax_credit_refund
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#exemption_amount_per_federal_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_full_exemption_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_phaseout_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#joint_surviving_spouse_head_phaseout_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#separate_return_full_exemption_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#separate_return_phaseout_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#separate_return_phaseout_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#single_full_exemption_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#single_phaseout_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-nm:statutes/7-2-5/8#single_phaseout_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability
+  source: manual
+  since: '2026-07-08'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax
+  source: manual
+  since: '2026-07-08'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_income
+  source: manual
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#estate_low_income_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#estate_low_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#excess_exemptions_deductible_from_taxable_business_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#individual_income_tax_no_tax_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_base_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_excess_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/02#taxable_business_income_after_excess_exemptions
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#adjusted_personal_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2025
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_high_income_band_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_income_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_low_income_band_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_lower_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_upper_bound
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#personal_exemption_rounding_multiple
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/025#statutory_personal_exemption_amount_by_income_band
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/71#earned_income_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-oh:statutes/5747/71#federal_credit_percentage
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/264#applicable_percentage_at_110_percent_fpl
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/264#student_low_income_comparison_expense_base
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/264#student_low_income_credit_comparison_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/264#youngest_qualifying_individual_age_category
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#base_earned_income_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#earned_income_credit_applicable_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#refundable_credit_excess
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#taxpayer_has_dependent_under_age_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#young_dependent_age_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/315/266#young_dependent_earned_income_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/316/085#indexed_personal_exemption_credit_dollar_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/316/085#joint_surviving_spouse_head_of_household_federal_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/316/085#other_filer_federal_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/316/085#personal_exemption_credit_indexing_factor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-or:statutes/316/085#statutory_personal_exemption_credit_base_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#child_for_rebate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#child_maximum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_claim_penalty
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#fraudulent_dependent_penalty_per_dependent
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#joint_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#maximum_rebate_children
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#rebate_amount_per_child
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#rebate_child_count
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#rebate_payment_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_204_component_eligible
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_eligible
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_gross_income_eligible
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_payment_standard_amount
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_resources_eligible_output
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:programs/tanf/fy-2026#ut_fep_work_expense_allowance
+  source: bulk
+  since: '2026-07-12'
+- legal_id: us-ut:statutes/59-10-1018#applicable_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#credit_reduction_rate_per_excess_dollar
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#deduction_credit_component
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#head_of_household_filing_status
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#income_based_credit_reduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_head_of_household_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_joint_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_single_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#inflation_adjusted_utah_personal_exemption_base_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#joint_filing_status
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#nonrefundable_tax_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#personal_exemption_credit_component
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#single_filing_status
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#state_or_local_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#statutory_head_of_household_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#statutory_joint_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#statutory_single_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#statutory_utah_personal_exemption_base_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#tax_credit_before_income_reduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#tax_credit_carryforward_or_carryback_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#utah_itemized_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1018#utah_personal_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#eligible_claimant
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#head_of_household_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#joint_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#married_filing_separately_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#senior_credit_base_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#senior_credit_reduction_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-1019#single_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_applies
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#first_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#first_bracket_upper_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#individual_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#second_bracket_lower_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#second_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#second_bracket_upper_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#third_bracket_lower_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#third_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#third_bracket_upper_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#top_bracket_lower_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-320#top_bracket_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#armed_forces_service_compensation_not_liable_to_va_income_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#eligible_veteran_loan_discharge_exclusion_from_va_adjusted_gross_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#individual_and_spouse_no_tax_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#married_separate_threshold_fraction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#no_tax_or_return_required
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#single_individual_no_tax_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-321#va_adjusted_gross_income_plus_subdivision_5_modification
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_boiler_minimum_fuel_utilization_rating
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#advanced_oil_furnace_minimum_fuel_utilization_rating
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#advanced_water_heater_minimum_energy_factor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_married_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_minimum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#age_deduction_single_phaseout_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#blind_or_aged_additional_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#bone_marrow_donor_screening_fee_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_current
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#business_interest_deduction_rate_temporary
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#central_air_conditioner_minimum_cooling_seer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#charitable_mileage_state_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_annual_deduction_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#college_savings_no_limit_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#continuing_teacher_education_deduction_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_cooling_seer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#electric_heat_pump_minimum_heating_performance_factor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#energy_efficient_property_deduction_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_capacity_kilowatts
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#fuel_cell_minimum_efficiency
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_cooling_cop
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#gas_heat_pump_minimum_heating_cop
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#heat_pump_water_heater_minimum_energy_factor
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_deduction_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#living_organ_donor_expense_month_window
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#married_separate_standard_deduction_fraction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#permanent_foster_care_child_deduction_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#personal_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#ppp_loan_deduction_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_fagi_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_age
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#senior_insurance_deduction_minimum_earned_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_general
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_married_temporary
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_general
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#standard_deduction_single_temporary
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-322/03#tobacco_single_payment_gain_subtraction_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#disqualifying_subtraction_or_deduction_claimed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_nonrefundable_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#earned_income_refundable_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_nonrefundable_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#federal_eitc_refundable_credit_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#low_income_credit_amount_per_counted_person
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#low_income_nonrefundable_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-va:statutes/58.1/58/1-339/8#poverty_guideline_percentage_limit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_additional_excise_tax_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/040#capital_gains_base_excise_tax_rate
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/040#washington_capital_gains_excise_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/060#statutory_combined_standard_deduction_limit_for_spouses_or_domestic_partners
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/060#statutory_standard_deduction_per_individual
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/080#nonprofit_organization
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/080#principally_directed_and_managed_within_washington
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/080#qualified_organization
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_maximum_charitable_donation_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wa:statutes/82/82.87/82/87/080#statutory_minimum_qualifying_charitable_donation_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#earned_income_exclusion_deduction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#earned_income_for_section
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#eligible_taxpayer
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#separate_return_earned_income_exclusion_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-10#temporary_initial_year_exclusion_fraction
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#resident_individual_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#separately_determined_spouse_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#surviving_spouse
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#surviving_spouse_additional_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#credit_calculated_before_section_23_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#eligible_taxable_assessed_value_for_taxes_paid
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#homestead_exemption_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#homestead_property_tax_refundable_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#low_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#low_income_federal_poverty_guideline_multiplier
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#minimum_refundable_credit_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#post_2007_taxable_assessed_value_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#pre_2007_taxable_assessed_value_cap
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-21#refund_claim_deadline_years_after_return_due_date
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#gross_household_income
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#gross_household_income_percentage_threshold
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#low_income_homeowner
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#low_income_person
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#maximum_refundable_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#minimum_refundable_credit_refund
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_allowed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_preliminary
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#refundable_homestead_property_tax_credit_refund_amount
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-23#section_23_low_income_federal_poverty_guideline_multiplier
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#electing_pass_through_entity_west_virginia_taxable_income_tax_imposed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#estate_west_virginia_taxable_income_tax_imposed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#individual_west_virginia_taxable_income_tax_imposed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#pass_through_entity_subject_to_article_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#trust_west_virginia_taxable_income_tax_imposed
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us-wv:statutes/11-21-3#unincorporated_organization_subject_to_article_tax
+  source: bulk
+  since: '2026-07-08'
+- legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#certified_federal_program_adjunctive_income_eligible
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#csfp_income_eligible_under_current_rule
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#maximum_csfp_household_income_limit_fpg_ratio
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#state_administered_program_adjunctive_income_eligible
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#state_agency_csfp_income_limit_complies
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:regulations/7-cfr/247/9/b#subject_to_prior_elderly_pilot_income_criteria
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/102#amount_excluded_from_gross_income_under_section_102
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#applicable_limitation_amount_after_calendar_year_2029
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#applicable_limitation_amount_annual_adjustment_factor
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2025
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#applicable_limitation_amount_for_taxable_year_beginning_in_calendar_year_2026
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#applicable_limitation_amount_phaseout_floor
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#married_separate_applicable_limitation_fraction
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#modified_adjusted_gross_income_phaseout_rate
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_annual_adjustment_factor
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2025
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#modified_adjusted_gross_income_threshold_for_taxable_year_beginning_in_calendar_year_2026
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#personal_property_tax
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#purchaser_real_property_tax_treated_as_imposed
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/164#seller_real_property_tax_treated_as_imposed
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/212#section_212_deduction_allowed
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#catch_up_age_threshold
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#catch_up_applicable_amount_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#catch_up_cost_of_living_rounding_multiple
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#deductible_amount_before_compensation_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#deductible_amount_cost_of_living_rounding_multiple
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#maximum_general_deduction_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#maximum_plan_contribution_deduction_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#plan_contribution_compensation_limit_rate
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#plan_contribution_limit_amount
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#section_applies_to_contribution
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/b#statutory_deductible_amount_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#active_participant
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#active_participant_before_exceptions
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#adjusted_gross_income_for_subsection
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#applicable_dollar_amount_joint_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#applicable_dollar_amount_other_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#applicable_dollar_amount_separate_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#inflation_adjustment_start_year_threshold
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#inflation_rounding_multiple
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#minimum_limitation_before_complete_phaseout
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#phaseout_denominator_joint
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#phaseout_denominator_other
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#reduction_rounding_multiple
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#reserve_component_active_duty_exception_limit_days
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#reserve_component_participation_not_active_participant_solely_for_that_participation
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#spouse_not_active_participant_applicable_dollar_amount_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#spouses_filing_separately_living_apart_not_treated_as_married
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#subsection_applies_to_individual
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#volunteer_firefighter_accrued_benefit_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#volunteer_firefighter_annuity_commencement_age
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/219/g#volunteer_firefighter_participation_not_active_participant_solely_for_that_participation
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#statutory_student_loan_interest_deduction_cap
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_joint_return
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#statutory_student_loan_interest_phaseout_threshold_other_return
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#student_loan_interest_deduction_before_income_phaseout
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_joint_return
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/221#student_loan_interest_phaseout_range_other_return
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_age_threshold
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_2
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_3
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_4
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_5
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#additional_contribution_amount_scalar_limit_6
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#family_coverage_annual_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#individual_attained_additional_contribution_age
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#monthly_proration_denominator
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#self_only_coverage_annual_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#testing_period_additional_tax_rate
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/223/b#testing_period_month_count
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/61#enumerated_gross_income_items
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/61#gross_income
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#adjusted_gross_income
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator_expense_base_cap
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator_expense_cap_after_inflation_adjustment
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator_expense_cap_rounding_multiple
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator_expenses_allowable_above_the_line
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#eligible_educator_minimum_school_hours
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#qualified_performing_artist_agi_limit
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#qualified_performing_artist_expense_gross_income_rate
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#qualified_performing_artist_minimum_employer_count
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#qualified_performing_artist_nominal_employer_receipts_floor
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/62#unlawful_discrimination
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/64#gain_treated_as_from_noncapital_non1231_property
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/64#ordinary_income_gain_from_sale_or_exchange
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/64#ordinary_income_gain_inclusion_applies
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/65#ordinary_loss
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#itemized_deduction_reduction_base
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#itemized_deduction_reduction_denominator
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#itemized_deduction_reduction_numerator
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#itemized_deduction_reduction_under_section_68
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#itemized_deductions_allowed_after_section_68
+  source: bulk
+  since: '2026-07-09'
+- legal_id: us:statutes/26/68#section_68_reduction_applies_to_individual
+  source: bulk
+  since: '2026-07-09'

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -7,7 +7,7 @@
 # unmapped (classified upstream) must be removed or the check fails.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 740
+ceiling: 741
 entries:
   - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
     source: bulk
@@ -975,6 +975,9 @@ entries:
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
     source: bulk
     since: 2026-07-13
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
+    source: bulk
+    since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
     source: bulk
     since: 2026-07-13
@@ -987,13 +990,13 @@ entries:
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
     source: bulk
     since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_additional_person
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
     source: bulk
     since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     source: bulk
     since: 2026-07-13
-  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income_table
+  - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_table
     source: bulk
     since: 2026-07-13
   - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_table_maximum_size

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -797,7 +797,7 @@
     : not_holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
     : not_holds
-- name: statutory noninstitution exception preserves otherwise qualifying household status
+- name: statutory exception overrides every residence and meal compensation bar
   period: 2026-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
@@ -840,9 +840,9 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
     : true
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
-    : false
+    : true
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
-    : false
+    : true
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
     : holds

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -24,9 +24,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -73,9 +73,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -124,9 +124,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -175,9 +175,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -224,9 +224,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -249,7 +249,7 @@
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
-- name: sixty year old with permanent SSA disability at income limit meets status
+- name: sixty year old with permanent SSA disability at nonspouse income limit meets status
   period: 2026-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
@@ -263,8 +263,8 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 2152
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
@@ -321,8 +321,8 @@
     : true
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : true
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 8
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 8
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 7446
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
@@ -359,8 +359,8 @@
     : true
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 1000
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
@@ -385,8 +385,8 @@
 - name: ninth other resident adds the stated increment
   period: 2026-01
   input:
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 9
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 9
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 8203
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
     : false
@@ -416,8 +416,8 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 1000
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
@@ -469,8 +469,8 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 2
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 2
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 2910
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
@@ -513,8 +513,8 @@
 - name: fy 2025 manual table remains available for its effective period
   period: 2025-01
   input:
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 2071
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
     : false
@@ -558,9 +558,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
@@ -595,8 +595,8 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 2152
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
@@ -664,9 +664,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -717,9 +717,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -770,9 +770,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
@@ -823,9 +823,9 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
     : false
-    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_countable_gross_income
     : 0
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_excluding_spouse_household_size: 0
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -1,0 +1,313 @@
+- name: individual with no qualifying circumstance does not meet status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+- name: individual living alone and purchasing and preparing food meets status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: individual living with others and purchasing and preparing separately meets
+    status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: delivered meals or communal dining eligibility meets status
+  period: 2026-01
+  input:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: fns authorized treatment resident receiving program meals meets status
+  period: 2026-01
+  input:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: sixty year old ssdi recipient at income limit meets status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 60
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 2071
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 2071
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: mrt disability determination qualifies
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 72
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 8
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 7249
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 7249
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : holds
+- name: ninth other resident adds the stated increment
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 9
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 7989
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 7989
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    : holds
+- name: age below sixty does not meet elderly disabled status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 59
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 1000
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+- name: income above table limit does not meet elderly disabled status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 60
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 2
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 2812
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 2811
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -35,6 +35,15 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : not_holds
@@ -75,13 +84,21 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
-- name: individual living with others and purchasing and preparing separately meets
-    status
+- name: individual living with others and purchasing and preparing separately meets status
   period: 2026-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
@@ -117,6 +134,15 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
     : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
@@ -160,6 +186,15 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
@@ -199,6 +234,15 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
     : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
@@ -242,6 +286,15 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 2152
@@ -275,6 +328,15 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 7446
@@ -304,6 +366,15 @@
     : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
     : holds
@@ -317,6 +388,15 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 9
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 8203
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 8203
@@ -358,6 +438,15 @@
     : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
     : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
@@ -403,6 +492,15 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 2909
@@ -418,13 +516,21 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 2071
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 2071
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
     : holds
-- name: co-resident spouse of qualifying elderly disabled individual meets separate
-    status
+- name: co-resident spouse of qualifying elderly disabled individual meets separate status
   period: 2026-01
   input:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
@@ -461,8 +567,286 @@
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
     : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+- name: otherwise qualifying disability without licensed physician certification does not qualify
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 60
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 2152
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 2152
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+- name: institution residence bars otherwise qualifying household status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
+    : not_holds
+- name: boarding house residence bars otherwise qualifying household status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
+    : not_holds
+- name: paying co-residents for meals bars otherwise qualifying household status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : true
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
+    : not_holds
+- name: statutory noninstitution exception preserves otherwise qualifying household status
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_certified_by_licensed_physician
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_institution: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_treated_as_noninstitution_resident_under_snap_exception
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_resides_in_boarding_house
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others_and_pays_compensation_for_meals
+    : false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
     : holds

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -175,7 +175,7 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
-    : 2071
+    : 2152
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
@@ -196,7 +196,7 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-    : 2071
+    : 2152
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
@@ -216,12 +216,12 @@
     : true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 8
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
-    : 7249
+    : 7446
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-    : 7249
+    : 7446
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
@@ -231,10 +231,10 @@
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 9
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
-    : 7989
+    : 8203
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-    : 7989
+    : 8203
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
     : holds
 - name: age below sixty does not meet elderly disabled status
@@ -283,7 +283,7 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 2
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
-    : 2812
+    : 2910
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
     : false
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
@@ -304,10 +304,18 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-    : 2811
+    : 2909
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
     : not_holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
     : not_holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : not_holds
+- name: fy 2025 manual table remains available for its effective period
+  period: 2025-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income: 2071
+  output:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income: 2071
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit: holds

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.test.yaml
@@ -27,6 +27,14 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 0
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : not_holds
@@ -59,6 +67,14 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 0
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
     : holds
@@ -94,6 +110,14 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 0
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_with_others_purchases_and_prepares_food_separately
     : holds
@@ -128,6 +152,14 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 0
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
@@ -160,12 +192,20 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 0
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
-- name: sixty year old ssdi recipient at income limit meets status
+- name: sixty year old with permanent SSA disability at income limit meets status
   period: 2026-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
@@ -173,6 +213,12 @@
     : true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 60
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 2152
@@ -194,6 +240,8 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
     : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 2152
@@ -205,7 +253,7 @@
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
     : holds
-- name: mrt disability determination qualifies
+- name: severe permanent nondisease disability qualifies
   period: 2026-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
@@ -214,11 +262,19 @@
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 72
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
     : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 8
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 7446
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 7446
@@ -226,6 +282,35 @@
     : holds
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
     : holds
+- name: nondisease permanent disability that is not severe does not qualify
+  period: 2026-01
+  input:
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 72
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 1000
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+    : not_holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : not_holds
 - name: ninth other resident adds the stated increment
   period: 2026-01
   input:
@@ -245,6 +330,12 @@
     : true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 59
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 1000
@@ -266,6 +357,8 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
     : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
     : holds
@@ -281,6 +374,12 @@
     : true
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 60
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : true
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 2
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
     : 2910
@@ -302,6 +401,8 @@
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
     : false
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : false
   output:
     ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
     : 2909
@@ -315,7 +416,53 @@
   period: 2025-01
   input:
     us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 1
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income: 2071
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 2071
   output:
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income: 2071
-    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit: holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
+    : 2071
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+    : holds
+- name: co-resident spouse of qualifying elderly disabled individual meets separate
+    status
+  period: 2026-01
+  input:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
+    : true
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_age: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_customarily_purchases_food_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_mrt_non_disease_related_permanent_disability_determination
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_is_eligible_for_delivered_meals_or_communal_dining_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_alone: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_in_fns_authorized_residential_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_lives_with_others: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_prepares_meals_separate_from_others
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_purchases_food_for_home_consumption
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_meals_through_treatment_program
+    : false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssdi: false
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_receives_ssi: false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_unable_to_purchase_and_prepare_meals_because_disabled
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_countable_gross_income
+    : 0
+    us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.other_residents_household_size: 0
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_disability_is_considered_permanent_under_social_security_act
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_has_nondisease_related_permanent_disability
+    : false
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#input.individual_nondisease_related_permanent_disability_is_severe
+    : false
+  output:
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
+    : holds
+    ? us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_meets_snap_food_purchase_and_preparation_status
+    : holds

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -7,19 +7,24 @@ module:
     corpus_citation_paths:
       - us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
       - us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
+      - us/statute/7/2012
     upstream_source_check:
       status: checked_higher_authority
       checked_paths:
+        - us:statutes/7/2012/m/3
         - us:statutes/7/2012/m/4
         - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
       rationale: |-
         7 U.S.C. 2012(m)(4) supplies controlling institution and boarding-house
-        restrictions, and USDA publishes the annually adjusted federal SNAP income
-        standards. This Missouri manual provision supplies the individual household
-        categories and its FY 2025 table; the USDA source supplies the controlling
-        FY 2026 replacement values effective October 1, 2025.
+        restrictions, while 7 U.S.C. 2012(m)(3) supplies the controlling permanent-
+        disability alternatives and includes the qualifying individual's co-resident
+        spouse in the separate household. USDA publishes the annually adjusted
+        federal SNAP income standards. This Missouri manual provision supplies
+        the individual household categories and its FY 2025 table; the USDA source
+        supplies the controlling FY 2026 replacement values effective October 1,
+        2025.
     values:
-      other_residents_165_percent_poverty_maximum_gross_income_table:
+      snap_gross_income_limit_165_percent_fpl_48_states_dc_table:
         1: 2152
         2: 2909
         3: 3665
@@ -28,7 +33,7 @@ module:
         6: 5934
         7: 6690
         8: 7446
-      other_residents_165_percent_poverty_additional_person: 757
+      snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member: 757
   summary: |-
     An individual meets this Missouri SNAP household-status provision when the
     individual lives alone and purchases and prepares food, lives with others but
@@ -36,9 +41,9 @@ module:
     meals or communal dining, or lives in an FNS-authorized residential treatment
     program and receives meals there. A person living with others who cannot
     purchase and prepare meals because of disability also meets the provision when
-    age 60 or older, receiving SSDI or SSI or determined by MRT to have a qualifying
-    permanent disability, and the other residents' countable gross income does not
-    exceed the applicable 165-percent poverty limit. The captured Missouri table
+    age 60 or older, meeting the governing permanent-disability standard, and when
+    the other residents' countable gross income does not exceed the applicable
+    165-percent poverty limit. The captured Missouri table
     applies for FY 2025; the federal FY 2026 table applies beginning October 1,
     2025.
 rules:
@@ -74,7 +79,7 @@ rules:
       - effective_from: '0001-01-01'
         formula: '8'
 
-  - name: other_residents_165_percent_poverty_maximum_gross_income_table
+  - name: snap_gross_income_limit_165_percent_fpl_48_states_dc_table
     kind: parameter
     dtype: Money
     unit: USD
@@ -95,7 +100,7 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
-              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
+              value_key: snap_gross_income_limit_165_percent_fpl_48_states_dc_table
               table:
                 header: Gross Monthly Income Limit Where Elderly/Disabled Members Are a Separate Household (165% of Federal Poverty Level)
                 row_key: household_size
@@ -122,7 +127,7 @@ rules:
           7: 6690
           8: 7446
 
-  - name: other_residents_165_percent_poverty_additional_person
+  - name: snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
     kind: parameter
     dtype: Money
     unit: USD
@@ -139,7 +144,7 @@ rules:
             kind: amount
             source:
               corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
-              value_key: other_residents_165_percent_poverty_additional_person
+              value_key: snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
     versions:
       - effective_from: '2024-10-01'
         formula: '740'
@@ -164,12 +169,12 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
-              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
+              value_key: snap_gross_income_limit_165_percent_fpl_48_states_dc_table
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          other_residents_165_percent_poverty_maximum_gross_income_table[max(min(other_residents_household_size, other_residents_165_percent_poverty_table_maximum_size), 1)]
-          + (max(other_residents_household_size - other_residents_165_percent_poverty_table_maximum_size, 0) * other_residents_165_percent_poverty_additional_person)
+          snap_gross_income_limit_165_percent_fpl_48_states_dc_table[max(min(other_residents_household_size, other_residents_165_percent_poverty_table_maximum_size), 1)]
+          + (max(other_residents_household_size - other_residents_165_percent_poverty_table_maximum_size, 0) * snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member)
 
   - name: other_residents_countable_gross_income_within_165_percent_poverty_limit
     kind: derived
@@ -257,7 +262,7 @@ rules:
           individual_lives_in_fns_authorized_residential_treatment_program
           and individual_receives_meals_through_treatment_program
 
-  - name: individual_has_qualifying_disability_basis
+  - name: individual_has_missouri_administrative_disability_evidence
     kind: derived
     entity: Person
     dtype: Judgment
@@ -278,6 +283,34 @@ rules:
           or individual_receives_ssi
           or individual_has_mrt_non_disease_related_permanent_disability_determination
 
+  - name: individual_has_qualifying_disability_basis
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 U.S.C. 2012(m)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "a disability which would be considered a permanent disability under section 221(i) of the Social Security Act"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "a severe, permanent, and disabling physical or mental infirmity which is not symptomatic of a disease"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_disability_is_considered_permanent_under_social_security_act
+          or (
+            individual_has_nondisease_related_permanent_disability
+            and individual_nondisease_related_permanent_disability_is_severe
+          )
+
   - name: elderly_disabled_individual_living_with_others_meets_separate_status
     kind: derived
     entity: Person
@@ -297,14 +330,22 @@ rules:
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
               excerpt: "cannot exceed 165 percent of the poverty level"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "shall be considered, together with any of the others who is the spouse of such individual, an individual household"
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          individual_lives_with_others
-          and individual_unable_to_purchase_and_prepare_meals_because_disabled
-          and individual_age >= elderly_disabled_individual_minimum_age
-          and individual_has_qualifying_disability_basis
-          and other_residents_countable_gross_income_within_165_percent_poverty_limit
+          (
+            individual_lives_with_others
+            and individual_unable_to_purchase_and_prepare_meals_because_disabled
+            and individual_age >= elderly_disabled_individual_minimum_age
+            and individual_has_qualifying_disability_basis
+            and other_residents_countable_gross_income_within_165_percent_poverty_limit
+          )
+          or individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
 
   - name: individual_meets_snap_food_purchase_and_preparation_status
     kind: derived

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -296,6 +296,11 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us/statute/7/2012
+              excerpt: "as certified by a licensed physician"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2012
               excerpt: "a disability which would be considered a permanent disability under section 221(i) of the Social Security Act"
           - path: versions[0].formula
             kind: condition
@@ -305,10 +310,13 @@ rules:
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          individual_disability_is_considered_permanent_under_social_security_act
-          or (
-            individual_has_nondisease_related_permanent_disability
-            and individual_nondisease_related_permanent_disability_is_severe
+          individual_disability_certified_by_licensed_physician
+          and (
+            individual_disability_is_considered_permanent_under_social_security_act
+            or (
+              individual_has_nondisease_related_permanent_disability
+              and individual_nondisease_related_permanent_disability_is_severe
+            )
           )
 
   - name: elderly_disabled_individual_living_with_others_meets_separate_status
@@ -347,6 +355,35 @@ rules:
           )
           or individual_is_co_resident_spouse_of_person_who_meets_elderly_disabled_separate_household_conditions
 
+  - name: individual_not_barred_by_snap_household_residence_or_meal_compensation
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 U.S.C. 2012(m)(4)-(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "In no event shall any individual or group of individuals constitute a household if they reside in an institution or boarding house, or else live with others and pay compensation to the others for meals"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "shall not be considered to be residents of institutions and shall be considered to be individual households"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            not individual_resides_in_institution
+            or individual_is_treated_as_noninstitution_resident_under_snap_exception
+          )
+          and not individual_resides_in_boarding_house
+          and not individual_lives_with_others_and_pays_compensation_for_meals
+
   - name: individual_meets_snap_food_purchase_and_preparation_status
     kind: derived
     entity: Person
@@ -360,11 +397,20 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_not_barred_by_snap_household_residence_or_meal_compensation
+              output: individual_not_barred_by_snap_household_residence_or_meal_compensation
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          individual_living_alone_purchases_and_prepares_food
-          or individual_living_with_others_purchases_and_prepares_food_separately
-          or individual_is_eligible_for_delivered_meals_or_communal_dining_program
-          or individual_receives_meals_in_fns_authorized_residential_treatment_program
-          or elderly_disabled_individual_living_with_others_meets_separate_status
+          (
+            individual_living_alone_purchases_and_prepares_food
+            or individual_living_with_others_purchases_and_prepares_food_separately
+            or individual_is_eligible_for_delivered_meals_or_communal_dining_program
+            or individual_receives_meals_in_fns_authorized_residential_treatment_program
+            or elderly_disabled_individual_living_with_others_meets_separate_status
+          )
+          and individual_not_barred_by_snap_household_residence_or_meal_compensation

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -18,11 +18,12 @@ module:
         7 U.S.C. 2012(m)(4) supplies controlling institution and boarding-house
         restrictions, while 7 U.S.C. 2012(m)(3) supplies the controlling permanent-
         disability alternatives and includes the qualifying individual's co-resident
-        spouse in the separate household. USDA publishes the annually adjusted
-        federal SNAP income standards. This Missouri manual provision supplies
-        the individual household categories and its FY 2025 table; the USDA source
-        supplies the controlling FY 2026 replacement values effective October 1,
-        2025.
+        spouse in the separate household while excluding that spouse from both the
+        co-resident income and household-size inputs to the 165-percent test. USDA
+        publishes the annually adjusted federal SNAP income standards. This Missouri
+        manual provision supplies the individual household categories and its FY 2025
+        table; the USDA source supplies the controlling FY 2026 replacement values
+        effective October 1, 2025.
     values:
       snap_gross_income_limit_165_percent_fpl_48_states_dc_table:
         1: 2152
@@ -42,8 +43,8 @@ module:
     program and receives meals there. A person living with others who cannot
     purchase and prepare meals because of disability also meets the provision when
     age 60 or older, meeting the governing permanent-disability standard, and when
-    the other residents' countable gross income does not exceed the applicable
-    165-percent poverty limit. The captured Missouri table
+    the non-spouse co-residents' countable gross income does not exceed the applicable
+    165-percent poverty limit for the number of non-spouse co-residents. The captured Missouri table
     applies for FY 2025; the federal FY 2026 table applies beginning October 1,
     2025.
 rules:
@@ -83,7 +84,7 @@ rules:
     kind: parameter
     dtype: Money
     unit: USD
-    indexed_by: other_residents_household_size
+    indexed_by: other_residents_excluding_spouse_household_size
     source: Missouri SNAP Manual 1105.015.04.05
     metadata:
       proof:
@@ -173,8 +174,8 @@ rules:
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          snap_gross_income_limit_165_percent_fpl_48_states_dc_table[max(min(other_residents_household_size, other_residents_165_percent_poverty_table_maximum_size), 1)]
-          + (max(other_residents_household_size - other_residents_165_percent_poverty_table_maximum_size, 0) * snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member)
+          snap_gross_income_limit_165_percent_fpl_48_states_dc_table[max(min(other_residents_excluding_spouse_household_size, other_residents_165_percent_poverty_table_maximum_size), 1)]
+          + (max(other_residents_excluding_spouse_household_size - other_residents_165_percent_poverty_table_maximum_size, 0) * snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member)
 
   - name: other_residents_countable_gross_income_within_165_percent_poverty_limit
     kind: derived
@@ -195,10 +196,15 @@ rules:
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
               excerpt: "is the gross income of the others with whom the individual resides determined as if they were applying to participate in the SNAP Program"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/7/2012
+              excerpt: "of the others, excluding the spouse, does not exceed the poverty line"
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          other_residents_countable_gross_income <= other_residents_165_percent_poverty_maximum_gross_income
+          other_residents_excluding_spouse_countable_gross_income <= other_residents_165_percent_poverty_maximum_gross_income
 
   - name: individual_living_alone_purchases_and_prepares_food
     kind: derived

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -1,0 +1,295 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:statutes/7/2012/m/4
+        - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
+      rationale: |-
+        7 U.S.C. 2012(m)(4) supplies controlling institution and boarding-house
+        restrictions, and USDA publishes the annually adjusted federal SNAP income
+        standards. This Missouri manual provision supplies the individual household
+        categories and the 165-percent table stated in the captured manual text.
+    values:
+      other_residents_165_percent_poverty_maximum_gross_income_table:
+        1: 2071
+        2: 2811
+        3: 3551
+        4: 4290
+        5: 5030
+        6: 5770
+        7: 6510
+        8: 7249
+      other_residents_165_percent_poverty_additional_person: 740
+  summary: |-
+    An individual meets this Missouri SNAP household-status provision when the
+    individual lives alone and purchases and prepares food, lives with others but
+    customarily purchases and prepares food separately, is eligible for delivered
+    meals or communal dining, or lives in an FNS-authorized residential treatment
+    program and receives meals there. A person living with others who cannot
+    purchase and prepare meals because of disability also meets the provision when
+    age 60 or older, receiving SSDI or SSI or determined by MRT to have a qualifying
+    permanent disability, and the other residents' countable gross income does not
+    exceed the stated 165-percent poverty limit.
+rules:
+  - name: elderly_disabled_individual_minimum_age
+    kind: parameter
+    dtype: Count
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "the individual must be 60 years of age or older"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: '60'
+
+  - name: other_residents_165_percent_poverty_table_maximum_size
+    kind: parameter
+    dtype: Count
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "8 $7,249 Each additional person +$740"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: '8'
+
+  - name: other_residents_165_percent_poverty_maximum_gross_income_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: other_residents_household_size
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
+              table:
+                header: 165% of Poverty Level
+                row_key: household_size
+                column_key: maximum_gross_income
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 2071
+          2: 2811
+          3: 3551
+          4: 4290
+          5: 5030
+          6: 5770
+          7: 6510
+          8: 7249
+
+  - name: other_residents_165_percent_poverty_additional_person
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              value_key: other_residents_165_percent_poverty_additional_person
+              excerpt: "Each additional person +$740"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: '740'
+
+  - name: other_residents_165_percent_poverty_maximum_gross_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          other_residents_165_percent_poverty_maximum_gross_income_table[max(min(other_residents_household_size, other_residents_165_percent_poverty_table_maximum_size), 1)]
+          + (max(other_residents_household_size - other_residents_165_percent_poverty_table_maximum_size, 0) * other_residents_165_percent_poverty_additional_person)
+
+  - name: other_residents_countable_gross_income_within_165_percent_poverty_limit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "cannot exceed 165 percent of the poverty level"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "is the gross income of the others with whom the individual resides determined as if they were applying to participate in the SNAP Program"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          other_residents_countable_gross_income <= other_residents_165_percent_poverty_maximum_gross_income
+
+  - name: individual_living_alone_purchases_and_prepares_food
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "lives alone and purchases and prepares food for home consumption"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_lives_alone
+          and individual_purchases_food_for_home_consumption
+          and individual_prepares_food_for_home_consumption
+
+  - name: individual_living_with_others_purchases_and_prepares_food_separately
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "lives with others but customarily purchases food and prepares meals for home consumption separate and apart from the others"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_lives_with_others
+          and individual_customarily_purchases_food_separate_from_others
+          and individual_prepares_meals_separate_from_others
+
+  - name: individual_receives_meals_in_fns_authorized_residential_treatment_program
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "lives in a residential treatment program authorized by the Food and Nutrition Service (FNS) and receives meals through the program"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_lives_in_fns_authorized_residential_treatment_program
+          and individual_receives_meals_through_treatment_program
+
+  - name: individual_has_qualifying_disability_basis
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "receiving Social Security Disability Insurance (SSDI) or Supplemental Security Income (SSI), or determined by the Medical Review Team (MRT) to have a non-disease-related permanent disability"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_receives_ssdi
+          or individual_receives_ssi
+          or individual_has_mrt_non_disease_related_permanent_disability_determination
+
+  - name: elderly_disabled_individual_living_with_others_meets_separate_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "lives with others but is unable to purchase and prepare meals because he/she is disabled; the individual must be 60 years of age or older"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+              excerpt: "cannot exceed 165 percent of the poverty level"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_lives_with_others
+          and individual_unable_to_purchase_and_prepare_meals_because_disabled
+          and individual_age >= elderly_disabled_individual_minimum_age
+          and individual_has_qualifying_disability_basis
+          and other_residents_countable_gross_income_within_165_percent_poverty_limit
+
+  - name: individual_meets_snap_food_purchase_and_preparation_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: Missouri SNAP Manual 1105.015.04.05
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_living_alone_purchases_and_prepares_food
+          or individual_living_with_others_purchases_and_prepares_food_separately
+          or individual_is_eligible_for_delivered_meals_or_communal_dining_program
+          or individual_receives_meals_in_fns_authorized_residential_treatment_program
+          or elderly_disabled_individual_living_with_others_meets_separate_status

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -383,12 +383,12 @@ rules:
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          (
+          individual_is_treated_as_noninstitution_resident_under_snap_exception
+          or (
             not individual_resides_in_institution
-            or individual_is_treated_as_noninstitution_resident_under_snap_exception
+            and not individual_resides_in_boarding_house
+            and not individual_lives_with_others_and_pays_compensation_for_meals
           )
-          and not individual_resides_in_boarding_house
-          and not individual_lives_with_others_and_pays_compensation_for_meals
 
   - name: individual_meets_snap_food_purchase_and_preparation_status
     kind: derived

--- a/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
+++ b/us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml
@@ -4,6 +4,9 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+    corpus_citation_paths:
+      - us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+      - us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
     upstream_source_check:
       status: checked_higher_authority
       checked_paths:
@@ -13,18 +16,19 @@ module:
         7 U.S.C. 2012(m)(4) supplies controlling institution and boarding-house
         restrictions, and USDA publishes the annually adjusted federal SNAP income
         standards. This Missouri manual provision supplies the individual household
-        categories and the 165-percent table stated in the captured manual text.
+        categories and its FY 2025 table; the USDA source supplies the controlling
+        FY 2026 replacement values effective October 1, 2025.
     values:
       other_residents_165_percent_poverty_maximum_gross_income_table:
-        1: 2071
-        2: 2811
-        3: 3551
-        4: 4290
-        5: 5030
-        6: 5770
-        7: 6510
-        8: 7249
-      other_residents_165_percent_poverty_additional_person: 740
+        1: 2152
+        2: 2909
+        3: 3665
+        4: 4421
+        5: 5177
+        6: 5934
+        7: 6690
+        8: 7446
+      other_residents_165_percent_poverty_additional_person: 757
   summary: |-
     An individual meets this Missouri SNAP household-status provision when the
     individual lives alone and purchases and prepares food, lives with others but
@@ -34,7 +38,9 @@ module:
     purchase and prepare meals because of disability also meets the provision when
     age 60 or older, receiving SSDI or SSI or determined by MRT to have a qualifying
     permanent disability, and the other residents' countable gross income does not
-    exceed the stated 165-percent poverty limit.
+    exceed the applicable 165-percent poverty limit. The captured Missouri table
+    applies for FY 2025; the federal FY 2026 table applies beginning October 1,
+    2025.
 rules:
   - name: elderly_disabled_individual_minimum_age
     kind: parameter
@@ -81,13 +87,21 @@ rules:
             kind: parameter_table
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
-              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
               table:
                 header: 165% of Poverty Level
                 row_key: household_size
                 column_key: maximum_gross_income
+          - path: versions[1].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
+              value_key: other_residents_165_percent_poverty_maximum_gross_income_table
+              table:
+                header: Gross Monthly Income Limit Where Elderly/Disabled Members Are a Separate Household (165% of Federal Poverty Level)
+                row_key: household_size
+                column_key: 48_states_dc_guam_virgin_islands
     versions:
-      - effective_from: '0001-01-01'
+      - effective_from: '2024-10-01'
         values:
           1: 2071
           2: 2811
@@ -97,6 +111,16 @@ rules:
           6: 5770
           7: 6510
           8: 7249
+      - effective_from: '2025-10-01'
+        values:
+          1: 2152
+          2: 2909
+          3: 3665
+          4: 4421
+          5: 5177
+          6: 5934
+          7: 6690
+          8: 7446
 
   - name: other_residents_165_percent_poverty_additional_person
     kind: parameter
@@ -110,11 +134,17 @@ rules:
             kind: amount
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
-              value_key: other_residents_165_percent_poverty_additional_person
               excerpt: "Each additional person +$740"
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
+              value_key: other_residents_165_percent_poverty_additional_person
     versions:
-      - effective_from: '0001-01-01'
+      - effective_from: '2024-10-01'
         formula: '740'
+      - effective_from: '2025-10-01'
+        formula: '757'
 
   - name: other_residents_165_percent_poverty_maximum_gross_income
     kind: derived
@@ -130,6 +160,10 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-mo/manual/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-income-eligibility-standards/page-2
               value_key: other_residents_165_percent_poverty_maximum_gross_income_table
     versions:
       - effective_from: '0001-01-01'


### PR DESCRIPTION
## Scope

Encodes Missouri SNAP Manual 1105.015.04.05 individual household-category rules, including separate purchase/preparation paths and the elderly/disabled 165%-of-poverty path. Adds FY2025 manual income limits and current FY2026 USDA limits with date-bounded versions, 11 companion cases, reverse-index coverage, and oracle-pending classification.

## Generation and review

- Three model generation attempts failed closed at compile because the generated table parameter lacked a valid formula. The source text was then encoded deterministically from the resolved corpus provision rather than accepting uncompilable output.
- Independent review found an unbounded FY2025 table, missing current values, missing reverse index, and missing signed apply provenance.
- Fixed the effective-date boundary, added the FY2026 USDA table and tests, regenerated the index, and attested the reviewed files with the pinned signer.
- Focused checks pass: `validate --skip-reviewers`, `proof-validate` (17 atoms), companion tests (11 cases), pending ratchet, reverse-index freshness, and `git diff --check`.

A final post-attestation independent review is running; merge remains gated on that cycle and green CI.