### PR TITLE
Bump the pinned axiom-corpus ref for full C.R.S. title 39 coverage

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "be0fa40d962e1e3dda29bd5348aed6b682318ec1"
+axiom_corpus_ref = "c3a7a15c5bb6c6a6e39bbff22edf671e83d67bf1"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Corpus pin → current corpus main (axiom-corpus#323, Sol-reviewed through three adversarial rounds: ranged repealed articles, pre-range annex attachment, caption-leak fixes, all with regression tests). Makes all of title 39 encodable ground: ~660 new substantive sections across property tax (incl. senior homestead exemption), sales/use, PTC rebate, severance, fuel, and tobacco articles. Full-repository revalidation by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)