### PR TITLE
Wire South Carolina SNAP BUA verification

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.test.yaml",
+      "sha256": "df75d610f468ce3a8b3211274d9c318524da9ab6683746e9665ba1310900ca59"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+      "sha256": "9df3abfa9f7f1c70581f1434ece4c191dc881a0cb96304da2851d847c4dd1a15"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9978ad8181914affdebcd6fb881291198c3bc839",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/trusted/axiom-encode-signer",
+    "version": "0.2.1200.3",
+    "version_commit": "9978ad8181914affdebcd6fb881291198c3bc839"
+  },
+  "axiom_encode_version": "0.2.1200.3",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-163",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-14T12:13:21.080218+00:00",
+  "generated_output_file": "/tmp/tmpidd5erxx/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+  "generated_output_root": "/tmp/tmpidd5erxx",
+  "generated_output_sha256": "9df3abfa9f7f1c70581f1434ece4c191dc881a0cb96304da2851d847c4dd1a15",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1c08fdcc3a57b17c4cc962b2d9e942a9cb6f3f63dba8b7271fca0faf51e7f1da"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -10,7 +10,8 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
@@ -28,7 +29,8 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua: 20
@@ -47,7 +49,8 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
@@ -65,7 +68,8 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -29,14 +29,15 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua: 20
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
 - name: actual_verified_cost_applies_only_without_mua_or_bua
   period: 2026-05
   input:

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -6,6 +6,8 @@ module:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
   summary: |-
     At initial certification, a household will be assigned one utility allowance based on utility cost: actual verified utility cost if not entitled to MUA or BUA, MUA if entitled, BUA if entitled, or no utility deduction. To be entitled to the MUA, the household must incur and be billed for, or expect to incur during the next heating or cooling season, heating or cooling costs; or must have received a LIHEAP payment greater than $20 within the past 12 months.
+imports:
+  - us-sc:policies/dss/snap-policy-manual/page-164
 rules:
   - name: liheap_payment_threshold_for_mua
     kind: parameter
@@ -123,12 +125,18 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
               hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
+              output: household_may_receive_bua
+              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           household_has_actual_verified_utility_cost
           and not household_entitled_to_mandatory_utility_allowance
-          and not household_entitled_to_basic_utility_allowance
+          and not household_may_receive_bua
 
   - name: household_basic_utility_allowance_deduction_allowed
     kind: derived
@@ -143,8 +151,14 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
+              output: household_may_receive_bua
+              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          household_entitled_to_basic_utility_allowance
+          household_may_receive_bua
           and household_submitted_utility_verification

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -157,8 +157,15 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
               output: household_may_receive_bua
               hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           household_may_receive_bua
           and household_submitted_utility_verification
+          and not household_entitled_to_mandatory_utility_allowance


### PR DESCRIPTION
## Summary
- replace page 163 generic BUA entitlement input with the encoded page 164 two-utility eligibility rule
- use the same grounded BUA entitlement when determining whether actual verified utility costs apply
- update four page 163 behavior cases for the cross-page rule

## Checks
- focused validate, proof validation, and money-atom validation pass
- companion tests: 4 passed
- repository structural suite: 18 passed
- independent review cycle pending