### PR TITLE
Expose South Carolina SNAP telephone entitlement

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.test.yaml",
+      "sha256": "2ccd4061ea2ac30ad9728450af6ebfc1ec6002b2ffe67f1763b6bdbce2e33b63"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+      "sha256": "e10a8a8dd8723e249a6b20b701143059eee50dd71d9ed525ed2b0de77161c49e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "9978ad8181914affdebcd6fb881291198c3bc839",
+    "dirty_tracked": false,
+    "root": "/home/runner/work/rulespec-us/rulespec-us/trusted/axiom-encode-signer",
+    "version": "0.2.1200.3",
+    "version_commit": "9978ad8181914affdebcd6fb881291198c3bc839"
+  },
+  "axiom_encode_version": "0.2.1200.3",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-165",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-14T12:15:33.681455+00:00",
+  "generated_output_file": "/tmp/tmpxeggm9xm/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+  "generated_output_root": "/tmp/tmpxeggm9xm",
+  "generated_output_sha256": "e10a8a8dd8723e249a6b20b701143059eee50dd71d9ed525ed2b0de77161c49e",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "104b317875881260ea7b0ffbd72e99b1b35f2b1fb535874ac292aeec5037b291"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -47,7 +47,7 @@
     : false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
@@ -62,7 +62,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
     ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
@@ -76,6 +76,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#telephone_standard_allowance_entitlement: holds
     us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
 - name: utilities-in-rent-blocks-bua-and-agreed-households-satisfy-same-residence-rule

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -7,7 +7,7 @@
     : false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
@@ -62,7 +62,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
     ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
@@ -76,9 +76,49 @@
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#telephone_standard_allowance_entitlement: holds
     us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
+- name: telephone-only-household-is-entitled-to-telephone-standard
+  period: 2026-05
+  input:
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_liheap: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_energy_assistance_under_state_law: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#telephone_standard_allowance_entitlement: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: not_holds
 - name: utilities-in-rent-blocks-bua-and-agreed-households-satisfy-same-residence-rule
   period: 2026-05
   input:

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -134,6 +134,33 @@ rules:
           or claimed_utility_is_utility_installation_fee
           or claimed_utility_is_state_standard_for_telephone)
 
+  - name: telephone_standard_allowance_entitlement
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: SNAP Manual p. 165, actual utility cost deduction categories
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+              excerpt: "State Standard for Telephone"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed
+              output: actual_utility_costs_allowed
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          actual_utility_costs_allowed
+          and agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+          and claimed_utility_is_state_standard_for_telephone
+
   - name: same_residence_utility_allowance_agreement_requirement_satisfied
     kind: derived
     entity: Household


### PR DESCRIPTION
## Summary
- expose the page 165 telephone-standard entitlement as a distinct executable output
- require actual utility costs to be allowed, anticipated to continue, and claimed as the state telephone standard
- exercise the positive telephone branch in the page 165 companion suite

## Checks
- focused validate, proof validation, and money-atom validation pass
- companion tests: 4 passed
- repository structural suite: 18 passed
- independent review cycle pending