### PR TITLE
Queue South Carolina SNAP utility encoder runs safely

### DIFF
--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -15,9 +15,10 @@ Usage:
   # Read one field (used by the runner to look up backend/model per entry):
   python bulk/compute_matrix.py --get us-ny/statute/TAX/673 --field model
 
-The matrix shape is {"include": [{"citation", "repo", "backend", "model",
-"acceptance_criteria", "slug"}, ...]}. `slug` is the branch-safe citation slug used for
-`bulk/<slug>` branches and the PR title.
+The matrix shape preserves the reviewed execution metadata needed by local
+jobs, in addition to the citation/backend/model fields used by cloud jobs.
+`slug` is the branch-safe citation slug used for `bulk/<slug>` branches and the
+PR title.
 
 Status writes are intentionally NOT done here: the workflow updates statuses by
 committing to the worklist through a dedicated follow-up (so status changes are
@@ -37,7 +38,7 @@ import yaml
 
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
-SELECTABLE_STATUSES = {"pending"}
+SELECTABLE_STATUSES = {"pending", "pending-local"}
 
 
 def citation_slug(citation: str) -> str:
@@ -73,6 +74,19 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
             continue
         if batch and str(entry.get("batch", "")).upper() != batch.upper():
             continue
+        dependencies = entry.get("requires_merged_citations", [])
+        if not isinstance(dependencies, list) or not all(
+            isinstance(value, str) and value for value in dependencies
+        ):
+            raise ValueError(
+                f"{entry.get('citation')}: requires_merged_citations must be "
+                "a list of non-empty strings"
+            )
+        program_scope_sync = entry.get("program_scope_sync")
+        if program_scope_sync is not None and not isinstance(program_scope_sync, dict):
+            raise ValueError(
+                f"{entry.get('citation')}: program_scope_sync must be a mapping"
+            )
         out.append(
             {
                 "citation": entry["citation"],
@@ -81,6 +95,8 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                 "model": entry_model(data, entry),
                 "acceptance_criteria": entry.get("note", ""),
                 "slug": citation_slug(entry["citation"]),
+                "requires_merged_citations": dependencies,
+                "program_scope_sync": program_scope_sync,
             }
         )
     if limit is not None:
@@ -109,6 +125,12 @@ def main() -> int:
         help="LOCAL ONLY: set an entry's status in place.",
     )
     args = ap.parse_args()
+
+    if args.status not in SELECTABLE_STATUSES | {"any"}:
+        raise SystemExit(
+            f"unsupported selectable status: {args.status}; expected one of "
+            f"{', '.join(sorted(SELECTABLE_STATUSES | {'any'}))}"
+        )
 
     data = load()
 

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -17,8 +17,8 @@ Two decisions matter and are baked in here so PRs go green:
   *coverage/sync* tool below, not to generation.
 * **Coverage declaration uses an immutable current-CI encoder ref.** Before any
   mutation, the runner requires that exact ref to remain the head of the remote
-  ``main`` branch consumed by CI. The pinned 1200 generator has the older
-  workspace/repo sync interface, not the exact-checkout contract used here.
+  ``main`` branch consumed by CI. This keeps the coverage classifier aligned
+  with the exact-checkout contract used by required CI.
 
 Everything runs foreground. The loop is chunked (``--max-seconds``,
 ``--max-entries``) and every unit of durable state (pushed branch, opened PR,
@@ -30,7 +30,7 @@ Toolchain layout (override via env): a sibling ``_bulk_drain`` workspace holds
 pinned checkouts + venvs built once by the operator:
 
     _bulk_drain/
-      axiom-encode/            # worktree @ pinned axiom_encode_ref (1200)
+      axiom-encode/            # worktree @ pinned axiom_encode_ref
       .venv/                   # pinned encoder venv  -> generation
       axiom-encode-cov/        # worktree @ COV_ENCODER_REF below
       .venv-cov/               # coverage/sync venv   -> oracle-coverage-pending
@@ -39,7 +39,8 @@ pinned checkouts + venvs built once by the operator:
       wt/<slug>/rulespec-us/   # per-entry generation worktrees (leaf MUST be rulespec-us)
 
 Usage:
-    python bulk/local_drain.py drain   [--limit N] [--batch A] [--concurrency 3]
+    python bulk/local_drain.py drain   [--status pending-local] [--limit N]
+                                       [--batch A] [--concurrency 3]
                                        [--max-entries N] [--max-seconds 540]
     python bulk/local_drain.py unstick [--pr N ...] [--all] [--wait]
     python bulk/local_drain.py doctor  # verify toolchain + auth + signing key
@@ -67,7 +68,7 @@ from applied_artifacts import discover_applied_artifacts
 
 REPO = "TheAxiomFoundation/rulespec-us"
 REPO_NAME = "rulespec-us"
-COV_ENCODER_REF = "c83416309a4331d225bcde16907e3b4eb79e26f1"
+COV_ENCODER_REF = "f2b7e2393447deecbadf398c86d2b5f07ec5bfdd"
 COV_ENCODER_REMOTE = "https://github.com/TheAxiomFoundation/axiom-encode.git"
 COV_ORACLES_REF = "9901e2479ac39bba865b8232e1c7d879ba447d8d"
 HERE = Path(__file__).resolve().parent           # <checkout>/bulk
@@ -358,6 +359,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
         run(["git", "-C", str(leaf), "fetch", "origin", branch, "--quiet"])
         _, diff = run(["git", "-C", str(leaf), "diff", "--name-only",
                        "origin/main...FETCH_HEAD"])
+        program_specs = [f for f in diff.splitlines() if PROGRAM_SPEC_RE.match(f)]
         artifacts = [f for f in diff.splitlines()
                      if (MODULE_RE.match(f) or f.endswith(".test.yaml")
                          or is_encoding_manifest_path(f))]
@@ -365,10 +367,23 @@ def unstick_pr(branch: str, wait: bool) -> str:
             return f"{branch}: no module artifacts in diff (already merged?)"
         run(["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],
             check=True)
+        composition_files = []
+        if program_specs:
+            item = worklist_item_for_slug(leaf, slug)
+            configured_spec = (item.get("program_scope_sync") or {}).get(
+                "program_spec")
+            if program_specs != [configured_spec]:
+                raise RuntimeError(
+                    f"{branch}: changed ProgramSpecs {program_specs} do not match "
+                    f"the queue configuration {configured_spec!r}"
+                )
+            composition_files = apply_program_scope_sync(leaf, item, {})
         summary = sync_pending(leaf)
         keep_pending = finalize_pending(leaf)
         regen_index(leaf)
-        add_files = [*artifacts, ".axiom/index/provisions_to_rules.json"]
+        add_files = [
+            *artifacts, *composition_files, ".axiom/index/provisions_to_rules.json"
+        ]
         if keep_pending:
             add_files.append("oracle-coverage-pending.yaml")
         run(["git", "-C", str(leaf), "add", "--", *add_files])
@@ -440,6 +455,8 @@ def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
 # ---------------------------------------------------------------------------
 MODULE_RE = re.compile(
     r"^[a-z]{2}(-[a-z0-9-]+)?/(manual|statutes|regulations|policies)/.*\.yaml$")
+PROGRAM_SPEC_RE = re.compile(
+    r"^programs/[a-z]{2}(?:-[a-z0-9]+)*/.+\.yaml$")
 
 
 def already_handled(slug: str) -> bool:
@@ -461,12 +478,91 @@ def handled_slugs() -> set:
             if p.get("headRefName", "").startswith("bulk/")}
 
 
+def worklist_item_for_slug(leaf: Path, slug: str) -> dict:
+    process = subprocess.run(
+        [str(COV_PY), str(leaf / "bulk/compute_matrix.py"),
+         "--status", "any", "--format", "matrix"],
+        capture_output=True, text=True, cwd=leaf,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"could not read worklist metadata for {slug}: {process.stderr.strip()}"
+        )
+    try:
+        entries = json.loads(process.stdout)["include"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise RuntimeError(f"invalid worklist matrix while resolving {slug}") from exc
+    matches = [entry for entry in entries if entry.get("slug") == slug]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one worklist entry for {slug}; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def merged_dependency(citation: str) -> bool:
+    branch = f"bulk/{citation_slug(citation)}"
+    prs = gh_json([
+        "pr", "list", "--repo", REPO, "--state", "merged", "--head", branch,
+        "--json", "number",
+    ])
+    if prs is None:
+        raise RuntimeError(f"could not determine merged state for {branch}")
+    return bool(prs)
+
+
+def apply_program_scope_sync(leaf: Path, item: dict, env: dict) -> list[str]:
+    spec = item.get("program_scope_sync")
+    if spec is None:
+        return []
+    if not isinstance(spec, dict):
+        raise ValueError("program_scope_sync must be a mapping")
+    program_spec = spec.get("program_spec")
+    scope = spec.get("scope")
+    add = spec.get("add", [])
+    remove = spec.get("remove", [])
+    if not isinstance(program_spec, str) or not program_spec:
+        raise ValueError("program_scope_sync.program_spec must be a non-empty string")
+    if scope not in {"federal", "state", "local"}:
+        raise ValueError("program_scope_sync.scope must be federal, state, or local")
+    if not isinstance(add, list) or not all(isinstance(v, str) for v in add):
+        raise ValueError("program_scope_sync.add must be a string list")
+    if not isinstance(remove, list) or not all(isinstance(v, str) for v in remove):
+        raise ValueError("program_scope_sync.remove must be a string list")
+    if not add and not remove:
+        raise ValueError("program_scope_sync must add or remove at least one module")
+    command = [
+        str(COV_AE), "program-scope-sync", "--repo", str(leaf),
+        "--program-spec", program_spec, "--scope", scope,
+    ]
+    for value in add:
+        command.extend(["--add", value])
+    for value in remove:
+        command.extend(["--remove", value])
+    rc, out = run(command, cwd=leaf, env=env)
+    if rc != 0:
+        raise RuntimeError(f"program-scope-sync failed:\n{out}")
+    return [program_spec]
+
+
 def encode_entry(item: dict) -> dict:
     """Full local mirror of bulk-encode.yml for one entry. Returns a result dict."""
     citation, slug = item["citation"], item["slug"]
     res = {"citation": citation, "slug": slug, "status": "failed", "detail": ""}
     if _PAUSE.is_set():
         res["detail"] = "paused"
+        return res
+    try:
+        unmet = [
+            dependency
+            for dependency in item.get("requires_merged_citations", [])
+            if not merged_dependency(dependency)
+        ]
+    except RuntimeError as exc:
+        return pause_for_retry(res, f"{exc}; retry drain")
+    if unmet:
+        res["status"] = "blocked"
+        res["detail"] = "waiting for merged dependencies: " + ", ".join(unmet)
         return res
     try:
         handled = already_handled(slug)
@@ -509,11 +605,16 @@ def encode_entry(item: dict) -> dict:
         except ValueError as exc:
             res["detail"] = f"applied artifact discovery failed: {exc}"
             return res
+        try:
+            composition_files = apply_program_scope_sync(leaf, item, env)
+        except (RuntimeError, ValueError) as exc:
+            res["detail"] = str(exc)
+            return res
         regen_index(leaf)
 
         # gate battery (fail-closed pre-check, PR-CI order)
         run(["git", "-C", str(leaf), "add", "--", module, test_file, manifest,
-             ".axiom/index/provisions_to_rules.json"])
+             *composition_files, ".axiom/index/provisions_to_rules.json"])
         run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
              "-c", "user.name=bulk-encode", "commit", "-q", "-m", f"wip: {citation}"])
         roots = subprocess.run([str(COV_PY), str(leaf / "bulk/roots_for.py"), module],
@@ -542,7 +643,7 @@ def encode_entry(item: dict) -> dict:
         title = f"Encode {citation} (bulk)"
         if gate_status == "needs-fixtures":
             title = f"Encode {citation} (bulk, needs-fixtures)"
-        add_files = [".axiom/index/provisions_to_rules.json"]
+        add_files = [*composition_files, ".axiom/index/provisions_to_rules.json"]
         if keep_pending:
             add_files.append("oracle-coverage-pending.yaml")
         run(["git", "-C", str(leaf), "add", "--", *add_files])
@@ -576,6 +677,7 @@ def encode_entry(item: dict) -> dict:
         body = (f"## Locally bulk-encoded module\n\n- Citation: `{citation}`\n"
                 f"- Module: `{module}`\n- Encoder: `{BACKEND}:{MODEL}` "
                 f"(toolchain-pinned axiom-encode)\n- Local gate: **{gate_status}**\n"
+                f"- ProgramSpec sync: `{', '.join(composition_files) or 'none'}`\n"
                 f"- {sync_summary}\n\nProduced by `bulk/local_drain.py` "
                 "(local Codex mirror of the bulk-encode dispatcher). The "
                 "authoritative gate is the required `validate / validate` check.\n\n"
@@ -762,14 +864,25 @@ def cmd_doctor(_args) -> int:
     tc = pinned_toolchain()
     print(f"DRAIN_BASE           : {DRAIN_BASE}")
     command_ok = True
-    for label, ae, require_pending in (("gen encoder (pin)", GEN_AE, False),
-                                       ("cov encoder (pin)", COV_AE, True)):
+    for label, ae, required_commands in (
+        ("gen encoder (pin)", GEN_AE, ("encode",)),
+        ("current encoder", COV_AE,
+         ("oracle-coverage-pending", "program-scope-sync")),
+    ):
         has_pending = ae.exists() and run(
             [str(ae), "oracle-coverage-pending", "--help"])[0] == 0
-        ok = ae.exists() and (has_pending or not require_pending)
+        has_scope_sync = ae.exists() and run(
+            [str(ae), "program-scope-sync", "--help"])[0] == 0
+        available = {
+            "encode": ae.exists() and run([str(ae), "encode", "--help"])[0] == 0,
+            "oracle-coverage-pending": has_pending,
+            "program-scope-sync": has_scope_sync,
+        }
+        ok = ae.exists() and all(available[command]
+                                 for command in required_commands)
         command_ok = command_ok and ok
         print(f"{label:20s}: {'OK' if ok else 'CHECK'} "
-              f"(oracle-coverage-pending {'present' if has_pending else 'absent'})")
+              f"(commands: {', '.join(command for command in required_commands if available[command])})")
     try:
         actual_cov_ref = require_coverage_ref()
         cov_ref_ok = True
@@ -822,7 +935,7 @@ def cmd_drain(args) -> int:
     require_coverage_ref()
     matrix = json.loads(subprocess.run(
         [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
-         "--status", "pending", "--format", "matrix",
+         "--status", args.status, "--format", "matrix",
          *(["--batch", args.batch] if args.batch else []),
          *(["--limit", str(args.limit)] if args.limit else [])],
         capture_output=True, text=True, cwd=CHECKOUT).stdout)["include"]
@@ -868,7 +981,7 @@ def cmd_drain(args) -> int:
                         inflight.add(ex.submit(encode_entry, item))
     remaining = int(subprocess.run(
         [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
-         "--status", "pending", "--format", "count"],
+         "--status", args.status, "--format", "count"],
         capture_output=True, text=True, cwd=CHECKOUT).stdout or 0)
     write_progress(results, remaining, _PAUSE.is_set())
     # Persist flips durably to a file and batch them into ONE worklist PR later
@@ -908,7 +1021,9 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
-    d = sub.add_parser("drain", help="Encode pending worklist entries via local Codex.")
+    d = sub.add_parser("drain", help="Encode worklist entries via local Codex.")
+    d.add_argument("--status", choices=("pending", "pending-local"),
+                   default="pending")
     d.add_argument("--limit", type=int)
     d.add_argument("--batch")
     d.add_argument("--concurrency", type=int, default=3)

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1564,21 +1564,10 @@ entries:
   class: deduction
   note: Self-contained itemized-deduction allowance for expenses of producing income;
     zero external Section refs.
-- citation: us-sc/manual/dss/snap-policy-manual/page-159
-  repo: rulespec-us
-  batch: SNAP-SC-UTIL
-  status: pending
-  backend: openai
-  model: gpt-5.5
-  heading: South Carolina SNAP utility allowance amounts
-  class: parameter
-  note: Encode the current MUA, BUA, and telephone amounts from page 159 through
-    the canonical encode --apply path. Review must verify integration with pages
-    163-165, mutual exclusivity, FY2026 composition, and current-source precedence.
 - citation: us-sc/manual/dss/snap-policy-manual/page-163
   repo: rulespec-us
-  batch: SNAP-SC-UTIL
-  status: pending
+  batch: SNAP-SC-UTIL-PREREQ
+  status: pending-local
   backend: openai
   model: gpt-5.5
   heading: South Carolina SNAP utility allowance assignment
@@ -1588,8 +1577,8 @@ entries:
     MUA-entitled household cannot simultaneously receive BUA.
 - citation: us-sc/manual/dss/snap-policy-manual/page-165
   repo: rulespec-us
-  batch: SNAP-SC-UTIL
-  status: pending
+  batch: SNAP-SC-UTIL-PREREQ
+  status: pending-local
   backend: openai
   model: gpt-5.5
   heading: South Carolina SNAP utility allowance exclusions and telephone standard
@@ -1597,3 +1586,24 @@ entries:
   note: Re-encode through canonical encode --apply. Regression review must cover
     a coherent telephone-only household and require an anticipated ongoing state
     telephone-standard charge without contradictory utility-count predicates.
+- citation: us-sc/manual/dss/snap-policy-manual/page-159
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL-AMOUNTS
+  status: pending-local
+  backend: openai
+  model: gpt-5.5
+  heading: South Carolina SNAP utility allowance amounts
+  class: parameter
+  note: Encode the current MUA, BUA, and telephone amounts from page 159 through
+    the canonical encode --apply path. Review must verify integration with pages
+    163-165, mutual exclusivity, FY2026 composition, and current-source precedence.
+  requires_merged_citations:
+  - us-sc/manual/dss/snap-policy-manual/page-163
+  - us-sc/manual/dss/snap-policy-manual/page-165
+  program_scope_sync:
+    program_spec: programs/us-sc/snap/fy-2026.yaml
+    scope: state
+    add:
+    - policies/dss/snap-policy-manual/page-159
+    remove:
+    - policies/dss/snap-policy-manual/page-369

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1568,7 +1568,7 @@ entries:
   repo: rulespec-us
   batch: SNAP-SC-UTIL
   status: pending
-  backend: codex
+  backend: openai
   model: gpt-5.5
   heading: South Carolina SNAP utility allowance amounts
   class: parameter
@@ -1579,7 +1579,7 @@ entries:
   repo: rulespec-us
   batch: SNAP-SC-UTIL
   status: pending
-  backend: codex
+  backend: openai
   model: gpt-5.5
   heading: South Carolina SNAP utility allowance assignment
   class: eligibility
@@ -1590,7 +1590,7 @@ entries:
   repo: rulespec-us
   batch: SNAP-SC-UTIL
   status: pending
-  backend: codex
+  backend: openai
   model: gpt-5.5
   heading: South Carolina SNAP utility allowance exclusions and telephone standard
   class: eligibility

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1564,3 +1564,36 @@ entries:
   class: deduction
   note: Self-contained itemized-deduction allowance for expenses of producing income;
     zero external Section refs.
+- citation: us-sc/manual/dss/snap-policy-manual/page-159
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL
+  status: pending
+  backend: codex
+  model: gpt-5.5
+  heading: South Carolina SNAP utility allowance amounts
+  class: parameter
+  note: Encode the current MUA, BUA, and telephone amounts from page 159 through
+    the canonical encode --apply path. Review must verify integration with pages
+    163-165, mutual exclusivity, FY2026 composition, and current-source precedence.
+- citation: us-sc/manual/dss/snap-policy-manual/page-163
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL
+  status: pending
+  backend: codex
+  model: gpt-5.5
+  heading: South Carolina SNAP utility allowance assignment
+  class: eligibility
+  note: Re-encode through canonical encode --apply. Regression review must verify
+    that page-164 BUA eligibility replaces unresolved generic inputs and that an
+    MUA-entitled household cannot simultaneously receive BUA.
+- citation: us-sc/manual/dss/snap-policy-manual/page-165
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL
+  status: pending
+  backend: codex
+  model: gpt-5.5
+  heading: South Carolina SNAP utility allowance exclusions and telephone standard
+  class: eligibility
+  note: Re-encode through canonical encode --apply. Regression review must cover
+    a coherent telephone-only household and require an anticipated ongoing state
+    telephone-standard charge without contradictory utility-count predicates.

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -372,6 +372,13 @@ def test_matrix_preserves_acceptance_criteria() -> None:
                 "status": "pending",
                 "batch": "SNAP-SC-UTIL",
                 "note": "Verify mutual exclusivity.",
+                "requires_merged_citations": ["us-sc/manual/page-163"],
+                "program_scope_sync": {
+                    "program_spec": "programs/us-sc/snap/fy-2026.yaml",
+                    "scope": "state",
+                    "add": ["policies/dss/snap-policy-manual/page-159"],
+                    "remove": ["policies/dss/snap-policy-manual/page-369"],
+                },
             }
         ],
     }
@@ -379,6 +386,96 @@ def test_matrix_preserves_acceptance_criteria() -> None:
     selected = select(data, "pending", "SNAP-SC-UTIL", None)
 
     assert selected[0]["acceptance_criteria"] == "Verify mutual exclusivity."
+    assert selected[0]["requires_merged_citations"] == ["us-sc/manual/page-163"]
+    assert selected[0]["program_scope_sync"]["scope"] == "state"
+
+
+def test_program_scope_sync_uses_pinned_encoder(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return 0, "updated\n"
+
+    monkeypatch.setattr(_local_drain, "run", fake_run)
+    item = {
+        "program_scope_sync": {
+            "program_spec": "programs/us-sc/snap/fy-2026.yaml",
+            "scope": "state",
+            "add": ["policies/dss/snap-policy-manual/page-159"],
+            "remove": ["policies/dss/snap-policy-manual/page-369"],
+        }
+    }
+
+    changed = _local_drain.apply_program_scope_sync(tmp_path, item, {})
+
+    assert changed == ["programs/us-sc/snap/fy-2026.yaml"]
+    assert calls == [[
+        str(_local_drain.COV_AE), "program-scope-sync", "--repo", str(tmp_path),
+        "--program-spec", "programs/us-sc/snap/fy-2026.yaml", "--scope", "state",
+        "--add", "policies/dss/snap-policy-manual/page-159",
+        "--remove", "policies/dss/snap-policy-manual/page-369",
+    ]]
+
+
+def test_program_scope_sync_rejects_empty_mapping(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="program_spec"):
+        _local_drain.apply_program_scope_sync(
+            tmp_path, {"program_scope_sync": {}}, {}
+        )
+
+
+def test_matrix_rejects_scalar_dependency_metadata() -> None:
+    data = {
+        "entries": [{
+            "citation": "us-sc/manual/page-159",
+            "status": "pending-local",
+            "requires_merged_citations": "us-sc/manual/page-163",
+        }]
+    }
+
+    with pytest.raises(ValueError, match="requires_merged_citations"):
+        select(data, "pending-local", None, None)
+
+
+def test_sc_local_queue_schedules_prerequisites_before_dependent() -> None:
+    selected = select(_compute_matrix.load(), "pending-local", None, None)
+
+    citations = [item["citation"] for item in selected]
+    assert citations.index("us-sc/manual/dss/snap-policy-manual/page-163") < (
+        citations.index("us-sc/manual/dss/snap-policy-manual/page-159")
+    )
+    assert citations.index("us-sc/manual/dss/snap-policy-manual/page-165") < (
+        citations.index("us-sc/manual/dss/snap-policy-manual/page-159")
+    )
+
+
+def test_unstick_recognizes_program_specs() -> None:
+    assert _local_drain.PROGRAM_SPEC_RE.match("programs/us-sc/snap/fy-2026.yaml")
+    assert not _local_drain.PROGRAM_SPEC_RE.match("us-sc/policies/dss/snap/page.yaml")
+
+
+def test_worklist_item_for_slug_reads_all_statuses(monkeypatch, tmp_path: Path) -> None:
+    item = {
+        "citation": "us-sc/manual/page-159",
+        "slug": "us-sc-manual-page-159",
+        "program_scope_sync": {"program_spec": "programs/us-sc/snap/fy-2026.yaml"},
+    }
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps({"include": [item]}), stderr=""
+        )
+
+    monkeypatch.setattr(_local_drain.subprocess, "run", fake_run)
+
+    assert _local_drain.worklist_item_for_slug(
+        tmp_path, "us-sc-manual-page-159"
+    ) == item
+    assert "--status" in calls[0][0]
+    assert "any" in calls[0][0]
 
 
 def test_local_runner_requires_review_before_merge() -> None:
@@ -398,6 +495,7 @@ def test_local_runner_requires_review_before_merge() -> None:
     assert 'return "checks complete; draft review required"' in local_drain
     assert "could not determine PR state" in local_drain
     assert "before push" in local_drain
-    assert "COV_ENCODER_REF = \"c83416309a4331d225bcde16907e3b4eb79e26f1\"" in local_drain
+    assert "COV_ENCODER_REF = \"f2b7e2393447deecbadf398c86d2b5f07ec5bfdd\"" in local_drain
+    assert '"program-scope-sync", "--help"' in local_drain
     assert "COV_ORACLES_REF = \"9901e2479ac39bba865b8232e1c7d879ba447d8d\"" in local_drain
     assert local_drain.count("require_coverage_ref()") >= 5


### PR DESCRIPTION
## Summary\n- queue South Carolina SNAP utility provisions as local-only encoder jobs, isolated from the scheduled cloud dispatcher\n- enforce page 163 and page 165 merge dependencies before page 159 can run\n- apply the FY2026 ProgramSpec replacement through axiom-encode 0.2.1245 program-scope-sync, adding page 159 and removing page 369\n- preserve ProgramSpec composition safely when a generated PR is rebuilt on current main\n\n## Safety\n- atomic RuleSpec YAML and companion tests remain generated only by the toolchain-pinned axiom-encode encode --apply path\n- ProgramSpec changes use the exact current encoder ref f2b7e2393447deecbadf398c86d2b5f07ec5bfdd\n- generated PRs remain drafts with auto-merge disabled until independent review and current CI complete\n- malformed sync metadata and unmet dependencies fail closed\n\n## Review Cycle\nThree independent review-fix iterations completed.\n\nFindings fixed:\n- prevent the cloud dispatcher from racing local dependency-ordered jobs\n- ensure page 159 updates FY2026 composition and waits for pages 163 and 165\n- preserve composition during unstick without overwriting newer changes from main\n- reject empty sync metadata\n- verify required latest-encoder commands in doctor\n- order prerequisites before the blocked dependent\n\nFinal independent review: no actionable correctness issues.\n\n## Checks\n- uv run ruff check bulk/compute_matrix.py bulk/local_drain.py tests/test_bulk_applied_artifacts.py\n- python -m compileall -q bulk/compute_matrix.py bulk/local_drain.py\n- uv run pytest -q: 46 passed, 1 existing warning