### PR TITLE
Require review for encoder-generated PRs

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -477,6 +477,25 @@ jobs:
             done
           }
 
+          ensure_draft() {
+            local pr_json
+            pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft,autoMergeRequest)"
+            if [ "$(jq -r '.autoMergeRequest == null' <<< "$pr_json")" != "true" ]; then
+              retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto
+            fi
+            if [ "$(jq -r '.isDraft' <<< "$pr_json")" != "true" ]; then
+              retry gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo
+            fi
+            pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft,autoMergeRequest)"
+            if ! jq -e '.isDraft == true and .autoMergeRequest == null' \
+              <<< "$pr_json" >/dev/null; then
+              echo "::error::Refusing to continue: $branch is not a draft with auto-merge disabled." >&2
+              return 1
+            fi
+          }
+
           # Ensure the bulk-encode label exists.
           gh label create bulk-encode --repo "$GITHUB_REPOSITORY" \
             --color 1f6feb --description "Opened by the bulk-encode dispatcher" 2>/dev/null || true
@@ -506,6 +525,12 @@ jobs:
             fi
           fi
 
+          # A legacy PR may still be ready with auto-merge armed. Normalize it
+          # before replacing its head so the new commit cannot merge in the gap.
+          if [ -n "$pr_state" ]; then
+            ensure_draft
+          fi
+
           # Push the applied commit onto the bulk branch. This updates the open or
           # just-reopened PR, or stages the branch for a fresh PR below.
           git -C "$GITHUB_WORKSPACE" -c user.email=bulk-encode@axiom \
@@ -529,19 +554,5 @@ jobs:
               --add-label bulk-encode
           fi
 
-          pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
-            --json isDraft,autoMergeRequest)"
-          if [ "$(jq -r '.autoMergeRequest == null' <<< "$pr_json")" != "true" ]; then
-            retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto
-          fi
-          if [ "$(jq -r '.isDraft' <<< "$pr_json")" != "true" ]; then
-            retry gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo
-          fi
-          pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
-            --json isDraft,autoMergeRequest)"
-          if ! jq -e '.isDraft == true and .autoMergeRequest == null' \
-            <<< "$pr_json" >/dev/null; then
-            echo "::error::Refusing to continue: $branch is not a draft with auto-merge disabled." >&2
-            exit 1
-          fi
+          ensure_draft
           echo "Draft PR opened for $CITATION on branch $branch (status: $ENC_STATUS; independent review required)."

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -515,14 +515,23 @@ jobs:
           # time. If the branch was already orphaned by an earlier failed run,
           # reopen is impossible; open a fresh PR instead -- GitHub permits a new
           # PR from a branch whose prior PR is closed.
-          pr_state="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json state -q .state 2>/dev/null || true)"
+          pr_json="$(retry gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head "$branch" --state all --limit 1 --json state)"
+          pr_state="$(jq -r '.[0].state // empty' <<< "$pr_json")"
           if [ "$pr_state" = "CLOSED" ]; then
             if gh pr reopen "$branch" --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
               echo "Reopened closed PR for $branch."
+              pr_state="OPEN"
             else
               echo "::warning::Closed PR for $branch cannot be reopened (head orphaned by a prior force-push); opening a fresh PR." >&2
               pr_state=""
             fi
+          elif [ "$pr_state" = "MERGED" ]; then
+            echo "::error::$branch already has a merged PR; fix the stale worklist entry instead of replacing its branch." >&2
+            exit 1
+          elif [ -n "$pr_state" ] && [ "$pr_state" != "OPEN" ]; then
+            echo "::error::Unexpected PR state for $branch: $pr_state" >&2
+            exit 1
           fi
 
           # A legacy PR may still be ready with auto-merge armed. Normalize it

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -12,9 +12,9 @@ name: Bulk encode
 #   * The job runs the same gate battery the PR CI runs (guard-generated is
 #     satisfied by the signed apply manifest; validate + companion test +
 #     proof-validate run locally as a fast fail-closed pre-check), opens a PR
-#     per module on branch `bulk/<slug>` labelled `bulk-encode`, and sets the
-#     PR to auto-merge on green (`gh pr merge --auto --squash`).
-#   * The job NEVER bypasses red. It never admin-merges. The authoritative gate
+#     per module on branch `bulk/<slug>` labelled `bulk-encode`, as a draft for
+#     the required independent review-fix cycle.
+#   * The job NEVER bypasses red or merges. The authoritative gate
 #     is the repository's required `validate / validate` check on the PR; this
 #     workflow only queues work and pre-checks it.
 #
@@ -118,6 +118,19 @@ jobs:
           # validate CI (the default GITHUB_TOKEN would not).
           token: ${{ secrets.BULK_ENCODE_TOKEN }}
 
+      - name: Prepare clean default-branch base
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          # Keep the dispatcher helper available while ensuring generated PRs
+          # contain no queue or workflow changes from the dispatch branch.
+          cp bulk/applied_artifacts.py "$RUNNER_TEMP/applied_artifacts.py"
+          git switch --detach "origin/$DEFAULT_BRANCH"
+          install -m 0755 "$RUNNER_TEMP/applied_artifacts.py" bulk/applied_artifacts.py
+          echo "Encoding from $(git rev-parse --short HEAD) (origin/$DEFAULT_BRANCH)"
+
       - name: Guard - workspace must be named rulespec-us
         shell: bash
         run: |
@@ -214,7 +227,7 @@ jobs:
       # Install that same classifier in an isolated venv so the sync step below
       # declares a new module's unmapped outputs exactly as the CI gate reads
       # them. Without this, every new-state module opens a PR that fails the
-      # required validate check on `... : unmapped` and auto-merge hangs forever
+      # required validate check on `... : unmapped`
       # (rulespec-us #614-616, #619-636 etc.).
       - name: Checkout oracle-coverage classifier (axiom-encode main)
         uses: actions/checkout@v6.0.2
@@ -267,43 +280,21 @@ jobs:
           echo "wall_seconds=$((end - start))" >> "$GITHUB_OUTPUT"
           echo "Encode wall time: $((end - start))s"
 
-          # Locate the applied module path from the git worktree. Restrict to
-          # jurisdiction directories (two-letter code, optional -suffix) so the
-          # sibling checkouts under _axiom/ and any build artifacts are never
-          # picked up.
-          slug='${{ matrix.item.slug }}'
-          # -uall (untracked-files=all): a brand-new module path creates a new
-          # nested untracked dir; without -uall, `git status --porcelain`
-          # COLLAPSES it to the bare dir entry (e.g. `?? us-ca/statutes/rtc/17053/`),
-          # which the *.yaml regex misses -> the applied module is not detected
-          # even though --apply wrote it (fail-closed false negative). Mirrors the
-          # rulespec-be/rulespec-gh fix.
-          mapfile -t applied < <(git -C "$GITHUB_WORKSPACE" status --porcelain -uall \
-            | sed 's/^...//' \
-            | grep -E '^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$' \
-            | grep -v '\.test\.yaml$' || true)
-
-          if [ "$apply_status" -ne 0 ] || [ "${#applied[@]}" -eq 0 ]; then
+          if [ "$apply_status" -ne 0 ]; then
             echo "status=failed" >> "$GITHUB_OUTPUT"
             echo "::error::Encode/apply failed for $CITATION (exit $apply_status). See encode.log; a *.repair.json was written under $RUNNER_TEMP/encode-out." >&2
             exit 1
           fi
 
-          module="${applied[0]}"
-          test_file="${module%.yaml}.test.yaml"
-          juris="${module%%/*}"
-          # The apply manifest mirrors the module's path under the jurisdiction's
-          # .axiom/encoding-manifests/ -- e.g. us-il/statutes/35/5/306.yaml ->
-          # us-il/.axiom/encoding-manifests/statutes/35/5/306.json. Strip only
-          # the jurisdiction prefix (keep the statutes/regulations/policies bucket).
-          rest="${module#"$juris"/}"
-          manifest_rel="$juris/.axiom/encoding-manifests/${rest%.yaml}.json"
-          # Fall back to a basename search if the direct manifest path guess misses.
-          if [ ! -f "$GITHUB_WORKSPACE/$manifest_rel" ]; then
-            manifest_rel="$(cd "$GITHUB_WORKSPACE" && find "$juris/.axiom/encoding-manifests" -name "$(basename "${module%.yaml}").json" 2>/dev/null | head -1)"
-          fi
+          artifact_output="$(python bulk/applied_artifacts.py \
+            --repo "$GITHUB_WORKSPACE" --citation "$CITATION")"
+          mapfile -t applied_artifacts <<< "$artifact_output"
+          module="${applied_artifacts[0]}"
+          test_file="${applied_artifacts[1]}"
+          manifest_rel="${applied_artifacts[2]}"
           echo "module=$module" >> "$GITHUB_OUTPUT"
           echo "test_file=$test_file" >> "$GITHUB_OUTPUT"
+          echo "manifest_rel=$manifest_rel" >> "$GITHUB_OUTPUT"
           echo "Applied module: $module"
           echo "Applied manifest: $manifest_rel"
 
@@ -368,8 +359,7 @@ jobs:
 
           # 4. companion test. A #1060 fixture-ceiling failure here is NOT a hard
           #    fail: mark the module needs-fixtures so a follow-up fixture pass
-          #    writes them, but still open the PR (auto-merge will hold on the
-          #    red required check until fixtures land).
+          #    writes them, but still open the draft PR so fixtures can land.
           set +e
           test_out="$RUNNER_TEMP/companion.log"
           axiom-encode test \
@@ -404,6 +394,8 @@ jobs:
           CITATION: ${{ matrix.item.citation }}
           MODULE: ${{ steps.encode.outputs.module }}
           TEST_FILE: ${{ steps.encode.outputs.test_file }}
+          MANIFEST_REL: ${{ steps.encode.outputs.manifest_rel }}
+          ACCEPTANCE_CRITERIA: ${{ matrix.item.acceptance_criteria }}
           ENC_STATUS: ${{ steps.encode.outputs.status }}
           WALL: ${{ steps.encode.outputs.wall_seconds }}
           MODEL: ${{ matrix.item.model }}
@@ -423,14 +415,13 @@ jobs:
             echo "Produced by \`axiom-encode encode $CITATION --apply\` in the bulk-encode dispatcher"
             echo "(\`.github/workflows/bulk-encode.yml\`). Values are the encoder's; this PR is plumbing."
             echo
+            echo "### Acceptance criteria"
+            echo
+            echo "$ACCEPTANCE_CRITERIA"
+            echo
             echo "### Manifest summary"
             echo '```json'
-            # The apply manifest mirrors the module path under the jurisdiction's
-            # .axiom/encoding-manifests/. Locate it by basename (robust to the
-            # statutes/regulations/policies split).
-            manifest=""
-            mf="$(find "$GITHUB_WORKSPACE" -path '*/.axiom/encoding-manifests/*' -name "$(basename "${MODULE%.yaml}").json" 2>/dev/null | head -1)"
-            [ -n "$mf" ] && manifest="$(cat "$mf")"
+            manifest="$(cat "$GITHUB_WORKSPACE/$MANIFEST_REL")"
             echo "$manifest" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(json.dumps({k:d.get(k) for k in ["citation","model","backend","run_id","axiom_encode_version","applied_files"]}, indent=2))' 2>/dev/null || echo "$manifest"
             echo '```'
             echo
@@ -450,12 +441,12 @@ jobs:
           } > "$body"
           echo "path=$body" >> "$GITHUB_OUTPUT"
 
-      - name: Open PR and enable auto-merge
+      - name: Open draft PR for independent review
         # Same gate-battery guard as "Assemble PR body": never force-push the
-        # bulk branch, open a PR, or arm auto-merge for an encode whose gate
-        # battery did not pass. Under the old `always() && module != ''` guard a
+        # bulk branch or open a PR for an encode whose gate battery did not pass.
+        # Under the old `always() && module != ''` guard a
         # guard/validate/proof failure (which sets `module` but leaves `status`
-        # unwritten) still force-pushed the broken commit and armed auto-merge
+        # unwritten) still force-pushed the broken commit
         # (rulespec-uk#104 D2 / rulespec-us#605).
         if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
         shell: bash
@@ -496,8 +487,8 @@ jobs:
           fi
 
           # Reconcile the PR for this branch BEFORE touching the branch. A prior
-          # run may have left a CLOSED PR for bulk/<slug>. auto-merge cannot be
-          # enabled on a closed PR, so it must be reopened -- but GitHub pins a
+          # run may have left a CLOSED PR for bulk/<slug>. It must be reopened
+          # before updating -- but GitHub pins a
           # closed PR to its head SHA and refuses to reopen once that head has
           # been force-updated (`reopenPullRequest` returns "Could not open the
           # pull request"). The force-push therefore MUST happen after the reopen,
@@ -531,17 +522,12 @@ jobs:
               --base "$DEFAULT_BRANCH" --head "$branch" \
               --title "$title" \
               --body-file "${{ steps.prbody.outputs.path }}" \
-              --label bulk-encode
+              --label bulk-encode --draft
           else
             retry gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" \
               --title "$title" --body-file "${{ steps.prbody.outputs.path }}" \
               --add-label bulk-encode
           fi
 
-          # Enable auto-merge on green. Never admin, never bypass red. If the
-          # module is needs-fixtures, auto-merge is still enabled but the red
-          # companion-test-derived required check holds the merge until a
-          # follow-up fixture pass turns it green.
-          retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto --squash
-
-          echo "PR ready for $CITATION on branch $branch (status: $ENC_STATUS, auto-merge on green)."
+          gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo >/dev/null 2>&1 || true
+          echo "Draft PR opened for $CITATION on branch $branch (status: $ENC_STATUS; independent review required)."

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -358,8 +358,8 @@ jobs:
           axiom-encode proof-validate "$GITHUB_WORKSPACE/$module"
 
           # 4. companion test. A #1060 fixture-ceiling failure here is NOT a hard
-          #    fail: mark the module needs-fixtures so a follow-up fixture pass
-          #    writes them, but still open the draft PR so fixtures can land.
+          #    fail: mark the module needs-fixtures and open the draft PR so the
+          #    encoder can be fixed and rerun without hand-editing generated files.
           set +e
           test_out="$RUNNER_TEMP/companion.log"
           axiom-encode test \
@@ -374,7 +374,7 @@ jobs:
             echo "Companion tests passed."
           else
             echo "status=needs-fixtures" >> "$GITHUB_OUTPUT"
-            echo "::warning::Companion fixtures failed for $CITATION (#1060 ceiling). Marking needs-fixtures; PR opens but will not merge until fixtures land." >&2
+            echo "::warning::Companion fixtures failed for $CITATION (#1060 ceiling). Marking needs-fixtures; fix the encoder and re-encode before review." >&2
           fi
 
       - name: Assemble PR body
@@ -433,7 +433,7 @@ jobs:
             if [ "$ENC_STATUS" = "green" ]; then
               echo "companion test:  pass"
             else
-              echo "companion test:  needs-fixtures (#1060 ceiling) - follow-up fixture pass required"
+              echo "companion test:  needs-fixtures (#1060 ceiling) - encoder fix and re-encode required"
             fi
             echo '```'
             echo

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -529,5 +529,19 @@ jobs:
               --add-label bulk-encode
           fi
 
-          gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo >/dev/null 2>&1 || true
+          pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,autoMergeRequest)"
+          if [ "$(jq -r '.autoMergeRequest == null' <<< "$pr_json")" != "true" ]; then
+            retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto
+          fi
+          if [ "$(jq -r '.isDraft' <<< "$pr_json")" != "true" ]; then
+            retry gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo
+          fi
+          pr_json="$(retry gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,autoMergeRequest)"
+          if ! jq -e '.isDraft == true and .autoMergeRequest == null' \
+            <<< "$pr_json" >/dev/null; then
+            echo "::error::Refusing to continue: $branch is not a draft with auto-merge disabled." >&2
+            exit 1
+          fi
           echo "Draft PR opened for $CITATION on branch $branch (status: $ENC_STATUS; independent review required)."

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -3,8 +3,9 @@
 A durable queue → runner → PR loop for bulk RuleSpec encoding, independent of
 any local session. It encodes already-ingested provisions with
 `axiom-encode encode <citation> --apply`, pre-checks them with the same gate
-battery the PR CI runs, opens one PR per module, and lets each PR auto-merge on
-green.
+battery the PR CI runs, and opens one draft PR per module for the required
+independent review/fix cycle. A PR is merged only after that cycle is complete
+and current CI is green.
 
 The encoder and the CI gates own correctness. This system is **plumbing**: it
 never edits or invents generated values. Its only judgement is *which*
@@ -17,7 +18,7 @@ provisions to queue.
 | `bulk/worklist.yaml` | The durable queue. One entry per module. Committed. |
 | `bulk/compute_matrix.py` | Turns the worklist into the CI job matrix; single source of truth for status selection. |
 | `bulk/roots_for.py` | Maps an applied module path to `guard-generated --roots`. |
-| `.github/workflows/bulk-encode.yml` | The runner: dispatch → matrix → encode `--apply` → gate battery → PR + auto-merge. |
+| `.github/workflows/bulk-encode.yml` | The runner: dispatch → matrix → encode `--apply` → gate battery → draft PR. |
 
 ## Running it
 
@@ -42,7 +43,7 @@ so two runs never fight over the same `bulk/<slug>` branches.
 | --- | --- |
 | `OPENAI_API_KEY` | Headless `--backend openai` generation. |
 | `AXIOM_ENCODE_APPLY_SIGNING_KEY` | Signs the apply manifest so `guard-generated` accepts the new files. Must match the key that signs manifests elsewhere. |
-| `BULK_ENCODE_TOKEN` | A `repo`+`workflow`-scoped token used to push the branch and open the PR. **Required**: PRs opened by the default `GITHUB_TOKEN` do **not** trigger the `pull_request` event, so the required `validate / validate` check would never run and auto-merge would hang forever. This token makes the PR a real event that triggers CI. |
+| `BULK_ENCODE_TOKEN` | A `repo`+`workflow`-scoped token used to push the branch and open the PR. **Required**: PRs opened by the default `GITHUB_TOKEN` do **not** trigger the `pull_request` event, so the required `validate / validate` check would never run. This token makes the PR a real event that triggers CI. |
 
 ## What each job does
 
@@ -62,12 +63,15 @@ so two runs never fight over the same `bulk/<slug>` branches.
      `.axiom/encoding-manifests/**/<sec>.json`.
    - Runs the gate battery in PR-CI order: `guard-generated` (manifest present),
      `validate --skip-reviewers`, `proof-validate`, then the companion `test`.
-   - Opens `bulk/<slug>` with the manifest summary + gate output as the PR body,
-     labels it `bulk-encode`, and runs `gh pr merge --auto --squash`.
+   - Opens `bulk/<slug>` as a draft with the manifest summary, acceptance
+     criteria, and gate output in the PR body, labels it `bulk-encode`, and
+     verifies that auto-merge is disabled.
 
-The job **never** uses `--admin`, never bypasses a red check, and never merges
-directly. The authoritative gate is the repository's required
-`validate / validate` check on the PR.
+The job **never** merges generated output. Each draft goes through an
+independent review, actionable findings are fixed by improving inputs or the
+encoder and re-encoding, and focused checks are rerun until there are no
+actionable findings. The authoritative automated gate is the repository's
+required `validate / validate` check on the PR.
 
 ## Statuses
 
@@ -77,8 +81,8 @@ Set in `worklist.yaml`. The runner reads `pending`; humans/follow-ups own the re
 | --- | --- |
 | `pending` | Queued. The next dispatch may pick it up. |
 | `in-progress` | A run is encoding it (transient). |
-| `needs-fixtures` | Encoded + applied, but the gpt-5.5 companion fixtures hit the #1060 ceiling. The PR opens; auto-merge holds on the red required check until fixtures land. |
-| `pr-open` | A PR exists and is set to auto-merge on green. |
+| `needs-fixtures` | Encoded + applied, but the gpt-5.5 companion fixtures hit the #1060 ceiling. The draft PR remains blocked while the encoder is fixed and rerun. |
+| `pr-open` | A draft PR exists and awaits the review/fix cycle and green CI. |
 | `merged` | The PR merged to main. Terminal success. |
 | `failed` | Encode or a non-fixture gate failed. Needs human triage. Never auto-retried, never merged. |
 
@@ -91,14 +95,14 @@ local convenience.
 `--apply` succeeds when the module compiles, validates, and its proof tree
 checks. The **companion test fixtures** are a separate quality tier: the #1060
 ceiling means gpt-5.5-authored fixtures sometimes fail. When that happens the
-runner marks the module `needs-fixtures` and still opens the PR, so the encoded
-module is reviewable and its auto-merge simply waits.
+runner marks the module `needs-fixtures` and still opens the draft PR, so the
+failure is durable and reviewable.
 
-A follow-up agent pass then writes correct fixtures — honestly split, i.e. the
-fixture values come from re-deriving expected outputs against the engine, never
-back-filled to make a test pass. Once fixtures are committed to the PR branch,
-the required check goes green and auto-merge completes. Update the worklist entry
-to `pr-open`, then `merged`.
+A follow-up pass fixes the encoder prompt, harness, source material, or other
+root cause and then reruns `encode --apply`. Generated RuleSpec and companion
+fixtures are not hand-edited. Once the re-encoded artifacts pass review and CI,
+the PR can be marked ready and merged. Update the worklist entry to `pr-open`,
+then `merged`.
 
 ## Failure taxonomy
 
@@ -158,6 +162,6 @@ already lives org-wide in
 country adopts bulk encoding, lift `bulk-encode.yml` into the org `.github`
 repo as a `workflow_call` reusable workflow parameterised by repo + worklist
 path, and keep a thin per-repo `bulk/worklist.yaml` + caller. The gate battery,
-toolchain-pin resolution, and PR/auto-merge logic are already repo-agnostic
+toolchain-pin resolution, and draft-PR/review logic are already repo-agnostic
 except for the hard-coded `rulespec-us` leaf-dir guard, which would become an
 input.

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -110,7 +110,7 @@ then `merged`.
 | --- | --- | --- |
 | `Generated RuleSpec failed CI validation` at apply | apply-blocked | Read `*.repair.json` under the run's `encode-out`; usually a bad generated formula or unresolved import. Re-encode (a new run), do not hand-edit. |
 | `points to a RuleSpec file that could not be resolved: rulespec-us-<state>/...` | resolver/layout | The checkout leaf dir was not `rulespec-us`, or a sibling checkout was missing. The workflow guards the leaf-dir name; check the sibling symlink step. |
-| companion test red only | fixtures (#1060) | `needs-fixtures`; run the follow-up fixture pass. |
+| companion test red only | fixtures (#1060) | `needs-fixtures`; fix the encoder or its inputs and re-encode. |
 | self-import / same-section subsection import error | encode#1058 | The section is too cross-reference-heavy for a clean atomic encode. Drop it from the worklist or split the citation to the self-contained fragment. |
 | `oracle coverage ... unmapped` on the PR | oracle mapping | The output needs a PolicyEngine oracle mapping entry (`axiom-encode classify`). Out of scope for the encode job; handle as a mapping follow-up. |
 | 429 from OpenAI | rate limit | Lower `limit`/`max-parallel` or re-dispatch later. The concurrency group prevents overlapping runs. |

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -27,13 +27,22 @@ def changed_paths(repo: Path) -> list[str]:
         check=True,
         capture_output=True,
     )
+    records = completed.stdout.split(b"\0")
     paths: list[str] = []
-    for record in completed.stdout.split(b"\0"):
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
         if not record:
             continue
-        decoded = record.decode("utf-8", errors="strict")
-        if len(decoded) >= 4:
-            paths.append(decoded[3:])
+        if len(record) < 4 or record[2:3] != b" ":
+            raise ValueError("malformed git status --porcelain=v1 -z output")
+        status = record[:2]
+        paths.append(record[3:].decode("utf-8", errors="strict"))
+        if b"R" in status or b"C" in status:
+            if index >= len(records) or not records[index]:
+                raise ValueError("git rename/copy status is missing its source path")
+            index += 1
     return paths
 
 

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Locate and validate the artifacts written by one bulk encode apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
+JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
+
+
+def changed_paths(repo: Path) -> list[str]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    paths: list[str] = []
+    for record in completed.stdout.split(b"\0"):
+        if not record:
+            continue
+        decoded = record.decode("utf-8", errors="strict")
+        if len(decoded) >= 4:
+            paths.append(decoded[3:])
+    return paths
+
+
+def _is_module(path: PurePosixPath) -> bool:
+    return (
+        len(path.parts) >= 3
+        and bool(JURISDICTION_RE.fullmatch(path.parts[0]))
+        and path.parts[1] in MODULE_BUCKETS
+        and path.suffix == ".yaml"
+        and not path.name.endswith(".test.yaml")
+    )
+
+
+def _is_manifest(path: PurePosixPath) -> bool:
+    parts = path.parts
+    return (
+        bool(parts)
+        and parts[0] != "_axiom"
+        and path.suffix == ".json"
+        and any(
+            parts[index : index + 2] == (".axiom", "encoding-manifests")
+            for index in range(len(parts) - 1)
+        )
+    )
+
+
+def discover_applied_artifacts(
+    repo: Path,
+    *,
+    citation: str,
+    paths: list[str] | None = None,
+) -> tuple[str, str, str]:
+    repo = Path(repo)
+    candidates = paths if paths is not None else changed_paths(repo)
+    modules = sorted(path for path in candidates if _is_module(PurePosixPath(path)))
+    manifests = sorted(
+        path for path in candidates if _is_manifest(PurePosixPath(path))
+    )
+    if len(modules) != 1:
+        raise ValueError(f"expected one applied module; found {len(modules)}: {modules}")
+    if len(manifests) != 1:
+        raise ValueError(
+            f"expected one applied manifest; found {len(manifests)}: {manifests}"
+        )
+
+    module = modules[0]
+    test_file = f"{module[:-len('.yaml')]}.test.yaml"
+    if not (repo / module).is_file():
+        raise ValueError(f"applied module does not exist: {module}")
+    if not (repo / test_file).is_file():
+        raise ValueError(f"companion test does not exist: {test_file}")
+
+    manifest_rel = manifests[0]
+    try:
+        manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
+    if manifest.get("citation") != citation:
+        raise ValueError(
+            f"manifest citation {manifest.get('citation')!r} does not match {citation!r}"
+        )
+
+    applied_files = manifest.get("applied_files")
+    if not isinstance(applied_files, list):
+        raise ValueError(f"manifest {manifest_rel} has no applied_files list")
+    actual_paths = {
+        item.get("path")
+        for item in applied_files
+        if isinstance(item, dict)
+        and item.get("deleted") is not True
+        and isinstance(item.get("path"), str)
+    }
+    expected_full = {module, test_file}
+    expected_local = {
+        path.split("/", 1)[1] if "/" in path else path for path in expected_full
+    }
+    if actual_paths not in (expected_full, expected_local):
+        raise ValueError(
+            f"manifest {manifest_rel} covers {sorted(actual_paths)}; expected "
+            f"{sorted(expected_full)} or {sorted(expected_local)}"
+        )
+    return module, test_file, manifest_rel
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--citation", required=True)
+    args = parser.parse_args()
+    try:
+        artifacts = discover_applied_artifacts(args.repo, citation=args.citation)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        parser.error(str(exc))
+    print("\n".join(artifacts))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -128,10 +128,16 @@ def discover_applied_artifacts(
     expected_local = {
         path.split("/", 1)[1] if "/" in path else path for path in expected_full
     }
-    if actual_paths not in (expected_full, expected_local):
+    local_module = module.split("/", 1)[1]
+    covers_changed_module = (
+        actual_paths <= expected_full and module in actual_paths
+    ) or (
+        actual_paths <= expected_local and local_module in actual_paths
+    )
+    if not covers_changed_module:
         raise ValueError(
-            f"manifest {manifest_rel} covers {sorted(actual_paths)}; expected "
-            f"{sorted(expected_full)} or {sorted(expected_local)}"
+            f"manifest {manifest_rel} covers {sorted(actual_paths)}; expected the "
+            f"changed module in {sorted(expected_full)} or {sorted(expected_local)}"
         )
     return module, test_file, manifest_rel
 

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -60,6 +60,12 @@ def _is_manifest(path: PurePosixPath) -> bool:
     )
 
 
+def _canonical_module_citation(module: str) -> str:
+    path = PurePosixPath(module)
+    relative = path.with_suffix("").parts
+    return f"{relative[0]}:{'/'.join(relative[1:])}"
+
+
 def discover_applied_artifacts(
     repo: Path,
     *,
@@ -91,9 +97,12 @@ def discover_applied_artifacts(
         manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
-    if manifest.get("citation") != citation:
+    manifest_citation = manifest.get("citation")
+    accepted_citations = {citation, _canonical_module_citation(module)}
+    if manifest_citation not in accepted_citations:
         raise ValueError(
-            f"manifest citation {manifest.get('citation')!r} does not match {citation!r}"
+            f"manifest citation {manifest_citation!r} does not match input "
+            f"{citation!r} or generated module {module!r}"
         )
 
     applied_files = manifest.get("applied_files")

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -101,11 +101,16 @@ def _module_matches_request(citation: str, module: str) -> bool:
     expected_buckets = SOURCE_BUCKETS.get(source_bucket.lower())
     if expected_buckets is None:
         return False
+    request_tokens = _legal_path_tokens(tuple(request_tail))
+    output_tokens = _legal_path_tokens(output.parts[2:])
+    if source_bucket.lower() in {"regulation", "regulations"}:
+        # Federal regulation modules canonicalize a numeric title as ``N-cfr``.
+        if len(output_tokens) >= 2 and output_tokens[1] == "cfr":
+            output_tokens = (output_tokens[0], *output_tokens[2:])
     return (
         output.parts[0].lower() == jurisdiction.lower()
         and output.parts[1].lower() in expected_buckets
-        and _legal_path_tokens(tuple(request_tail))
-        == _legal_path_tokens(output.parts[2:])
+        and request_tokens == output_tokens
     )
 
 

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -12,13 +12,13 @@ from pathlib import Path, PurePosixPath
 MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
 JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
 SOURCE_BUCKETS = {
-    "manual": "policies",
-    "policy": "policies",
-    "policies": "policies",
-    "regulation": "regulations",
-    "regulations": "regulations",
-    "statute": "statutes",
-    "statutes": "statutes",
+    "manual": frozenset({"manual", "policies"}),
+    "policy": frozenset({"policies"}),
+    "policies": frozenset({"policies"}),
+    "regulation": frozenset({"regulations"}),
+    "regulations": frozenset({"regulations"}),
+    "statute": frozenset({"statutes"}),
+    "statutes": frozenset({"statutes"}),
 }
 
 
@@ -98,12 +98,12 @@ def _module_matches_request(citation: str, module: str) -> bool:
     if len(request.parts) < 3 or len(output.parts) < 3:
         return False
     jurisdiction, source_bucket, *request_tail = request.parts
-    expected_bucket = SOURCE_BUCKETS.get(source_bucket.lower())
-    if expected_bucket is None:
+    expected_buckets = SOURCE_BUCKETS.get(source_bucket.lower())
+    if expected_buckets is None:
         return False
     return (
         output.parts[0].lower() == jurisdiction.lower()
-        and output.parts[1].lower() == expected_bucket
+        and output.parts[1].lower() in expected_buckets
         and _legal_path_tokens(tuple(request_tail))
         == _legal_path_tokens(output.parts[2:])
     )
@@ -140,10 +140,12 @@ def discover_applied_artifacts(
         manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
+    if not _module_matches_request(citation, module):
+        raise ValueError(
+            f"applied module {module!r} does not match requested citation {citation!r}"
+        )
     manifest_citation = manifest.get("citation")
-    accepted_citations = {citation}
-    if _module_matches_request(citation, module):
-        accepted_citations.add(_canonical_module_citation(module))
+    accepted_citations = {citation, _canonical_module_citation(module)}
     if manifest_citation not in accepted_citations:
         raise ValueError(
             f"manifest citation {manifest_citation!r} does not match input "

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -145,6 +145,8 @@ def discover_applied_artifacts(
         manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(f"applied manifest {manifest_rel} must contain a JSON object")
     if not _module_matches_request(citation, module):
         raise ValueError(
             f"applied module {module!r} does not match requested citation {citation!r}"

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -11,6 +11,15 @@ from pathlib import Path, PurePosixPath
 
 MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
 JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
+SOURCE_BUCKETS = {
+    "manual": "policies",
+    "policy": "policies",
+    "policies": "policies",
+    "regulation": "regulations",
+    "regulations": "regulations",
+    "statute": "statutes",
+    "statutes": "statutes",
+}
 
 
 def changed_paths(repo: Path) -> list[str]:
@@ -75,6 +84,31 @@ def _canonical_module_citation(module: str) -> str:
     return f"{relative[0]}:{'/'.join(relative[1:])}"
 
 
+def _legal_path_tokens(parts: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        token.lower()
+        for part in parts
+        for token in re.findall(r"[a-z0-9]+", part.lower())
+    )
+
+
+def _module_matches_request(citation: str, module: str) -> bool:
+    request = PurePosixPath(citation)
+    output = PurePosixPath(module).with_suffix("")
+    if len(request.parts) < 3 or len(output.parts) < 3:
+        return False
+    jurisdiction, source_bucket, *request_tail = request.parts
+    expected_bucket = SOURCE_BUCKETS.get(source_bucket.lower())
+    if expected_bucket is None:
+        return False
+    return (
+        output.parts[0].lower() == jurisdiction.lower()
+        and output.parts[1].lower() == expected_bucket
+        and _legal_path_tokens(tuple(request_tail))
+        == _legal_path_tokens(output.parts[2:])
+    )
+
+
 def discover_applied_artifacts(
     repo: Path,
     *,
@@ -107,7 +141,9 @@ def discover_applied_artifacts(
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not read applied manifest {manifest_rel}: {exc}") from exc
     manifest_citation = manifest.get("citation")
-    accepted_citations = {citation, _canonical_module_citation(module)}
+    accepted_citations = {citation}
+    if _module_matches_request(citation, module):
+        accepted_citations.add(_canonical_module_citation(module))
     if manifest_citation not in accepted_citations:
         raise ValueError(
             f"manifest citation {manifest_citation!r} does not match input "

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -16,7 +16,7 @@ Usage:
   python bulk/compute_matrix.py --get us-ny/statute/TAX/673 --field model
 
 The matrix shape is {"include": [{"citation", "repo", "backend", "model",
-"slug"}, ...]}. `slug` is the branch-safe citation slug used for
+"acceptance_criteria", "slug"}, ...]}. `slug` is the branch-safe citation slug used for
 `bulk/<slug>` branches and the PR title.
 
 Status writes are intentionally NOT done here: the workflow updates statuses by
@@ -79,6 +79,7 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                 "repo": entry.get("repo", "rulespec-us"),
                 "backend": entry_backend(data, entry),
                 "model": entry_model(data, entry),
+                "acceptance_criteria": entry.get("note", ""),
                 "slug": citation_slug(entry["citation"]),
             }
         )

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -314,28 +314,38 @@ def unstick_pr(branch: str, wait: bool) -> str:
         ensure_draft_pr(branch)
         result = f"rebuilt+pushed draft {branch}: {summary}"
         if wait:
-            result += "; " + wait_for_merge(branch)
+            result += "; " + wait_for_checks(branch)
         return result
     finally:
         drop_worktree(leaf)
 
 
-def wait_for_merge(branch: str, timeout_s: int = 1500) -> str:
+def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
         pr = gh_json(["pr", "view", branch, "--repo", REPO,
-                      "--json", "state,mergeStateStatus,statusCheckRollup"])
+                      "--json", "state,isDraft,statusCheckRollup"])
         if not pr:
             return "poll-error"
-        if pr["state"] == "MERGED":
-            return "MERGED"
-        vv = next((c.get("conclusion") or c.get("state")
-                   for c in pr.get("statusCheckRollup") or []
-                   if c.get("name") == "validate / validate"), None)
-        if vv in ("FAILURE", "ERROR"):
-            return f"validate={vv} (needs triage)"
+        if pr["state"] != "OPEN":
+            return pr["state"]
+        checks = pr.get("statusCheckRollup") or []
+        failures = {
+            str(check.get("conclusion") or check.get("state") or "").upper()
+            for check in checks
+        } & {"ACTION_REQUIRED", "CANCELLED", "ERROR", "FAILURE", "TIMED_OUT"}
+        if failures:
+            return f"checks={','.join(sorted(failures))} (needs triage)"
+        pending = any(
+            str(check.get("status") or "").upper()
+            not in {"", "COMPLETED"}
+            or str(check.get("state") or "").upper() in {"EXPECTED", "PENDING"}
+            for check in checks
+        )
+        if checks and not pending:
+            return "checks complete; draft review required"
         time.sleep(30)
-    return "timeout-waiting-merge"
+    return "timeout-waiting-checks"
 
 
 # ---------------------------------------------------------------------------
@@ -700,7 +710,7 @@ def main() -> int:
     u = sub.add_parser("unstick", help="Sync-declare + rebase open new-state bulk PRs.")
     u.add_argument("--pr", type=int, nargs="*", default=[])
     u.add_argument("--all", action="store_true")
-    u.add_argument("--wait", action="store_true", help="Poll each PR until merged.")
+    u.add_argument("--wait", action="store_true", help="Poll each PR until CI finishes.")
     u.set_defaults(func=cmd_unstick)
     doc = sub.add_parser("doctor", help="Verify toolchain, auth, signing key.")
     doc.set_defaults(func=cmd_doctor)

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -3,7 +3,7 @@
 
 Drains ``bulk/worklist.yaml`` on the operator's machine using the local Codex
 CLI (ChatGPT subscription, ``gpt-5.5``) instead of the cloud ``bulk-encode.yml``
-dispatcher, opening the identical one-PR-per-module with auto-merge. It is a
+dispatcher, opening the identical one-draft-PR-per-module review queue. It is a
 faithful local mirror of ``.github/workflows/bulk-encode.yml`` plus the
 oracle-coverage-pending declaration step the cloud dispatcher is missing (that
 missing step is why every new-state bulk PR fails the changed-file oracle
@@ -61,8 +61,10 @@ import sys
 import threading
 import time
 import tomllib
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
+
+from applied_artifacts import discover_applied_artifacts
 
 REPO = "TheAxiomFoundation/rulespec-us"
 REPO_NAME = "rulespec-us"
@@ -254,7 +256,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
         run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
         run(["git", "-C", str(leaf), "fetch", "origin", branch, "--quiet"])
         _, diff = run(["git", "-C", str(leaf), "diff", "--name-only",
-                       f"origin/main...FETCH_HEAD"])
+                       "origin/main...FETCH_HEAD"])
         artifacts = [f for f in diff.splitlines()
                      if (MODULE_RE.match(f) or f.endswith(".test.yaml")
                          or "/.axiom/encoding-manifests/" in f)]
@@ -281,8 +283,8 @@ def unstick_pr(branch: str, wait: bool) -> str:
              "-c", "user.name=bulk-encode", "commit", "-q", "-m", msg])
         run(["git", "-C", str(leaf), "push", "-f", "origin",
              f"HEAD:refs/heads/{branch}"], check=True)
-        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
-        result = f"rebuilt+pushed {branch}: {summary}"
+        run(["gh", "pr", "ready", branch, "--repo", REPO, "--undo"])
+        result = f"rebuilt+pushed draft {branch}: {summary}"
         if wait:
             result += "; " + wait_for_merge(branch)
         return result
@@ -312,7 +314,7 @@ def wait_for_merge(branch: str, timeout_s: int = 1500) -> str:
 # PART B: generate + PR one pending worklist entry via local Codex.
 # ---------------------------------------------------------------------------
 MODULE_RE = re.compile(
-    r"^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$")
+    r"^[a-z]{2}(-[a-z0-9-]+)?/(manual|statutes|regulations|policies)/.*\.yaml$")
 
 
 def already_handled(slug: str) -> bool:
@@ -364,21 +366,16 @@ def encode_entry(item: dict) -> dict:
             _PAUSE.set()
             res["status"], res["detail"] = "paused", "codex subscription-limit signal"
             return res
-        _, st = run(["git", "-C", str(leaf), "status", "--porcelain", "-uall"])
-        applied = [ln[3:] for ln in st.splitlines()
-                   if MODULE_RE.match(ln[3:]) and not ln[3:].endswith(".test.yaml")]
-        if rc != 0 or not applied:
+        if rc != 0:
             res["detail"] = f"encode/apply failed (rc={rc}); see {tmp}"
             return res
-        module = applied[0]
-        test_file = module[:-5] + ".test.yaml"
-        juris = module.split("/", 1)[0]
-        rest = module[len(juris) + 1:]
-        manifest = f"{juris}/.axiom/encoding-manifests/{rest[:-5]}.json"
-        if not (leaf / manifest).exists():
-            hits = list((leaf / juris / ".axiom/encoding-manifests").rglob(
-                Path(module).stem + ".json"))
-            manifest = str(hits[0].relative_to(leaf)) if hits else manifest
+        try:
+            module, test_file, manifest = discover_applied_artifacts(
+                leaf, citation=citation
+            )
+        except ValueError as exc:
+            res["detail"] = f"applied artifact discovery failed: {exc}"
+            return res
         regen_index(leaf)
 
         # gate battery (fail-closed pre-check, PR-CI order)
@@ -427,19 +424,21 @@ def encode_entry(item: dict) -> dict:
              f"HEAD:refs/heads/{branch}"], check=True)
         run(["gh", "label", "create", "bulk-encode", "--repo", REPO,
              "--color", "1f6feb", "-d", "Opened by the bulk-encode dispatcher"])
+        acceptance_criteria = item.get("acceptance_criteria", "")
         body = (f"## Locally bulk-encoded module\n\n- Citation: `{citation}`\n"
                 f"- Module: `{module}`\n- Encoder: `{BACKEND}:{MODEL}` "
                 f"(toolchain-pinned axiom-encode)\n- Local gate: **{gate_status}**\n"
                 f"- {sync_summary}\n\nProduced by `bulk/local_drain.py` "
                 "(local Codex mirror of the bulk-encode dispatcher). The "
-                "authoritative gate is the required `validate / validate` check.")
+                "authoritative gate is the required `validate / validate` check.\n\n"
+                f"### Acceptance criteria\n\n{acceptance_criteria}\n")
         bf = WT_ROOT / slug / "pr-body.md"
         bf.write_text(body)
         run(["gh", "pr", "create", "--repo", REPO, "--base", "main", "--head", branch,
-             "--title", title, "--body-file", str(bf), "--label", "bulk-encode"])
-        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
+             "--title", title, "--body-file", str(bf), "--label", "bulk-encode",
+             "--draft"])
         res["status"] = gate_status
-        res["detail"] = f"PR opened on {branch}; {sync_summary}"
+        res["detail"] = f"draft PR opened on {branch}; {sync_summary}"
         return res
     except subprocess.TimeoutExpired:
         res["detail"] = "encode timed out (>3600s)"
@@ -469,9 +468,8 @@ def flip_statuses(updates: dict) -> None:
         run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
              "--head", "bulk/worklist-status-flip", "--title",
              "Flip drained worklist statuses (bulk)", "--body",
-             "Status flips for locally-drained entries.", "--label", "bulk-encode"])
-        run(["gh", "pr", "merge", "bulk/worklist-status-flip", "--repo", REPO,
-             "--auto", "--squash"])
+             "Status flips for locally-drained entries.", "--label", "bulk-encode",
+             "--draft"])
     finally:
         drop_worktree(leaf)
 

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -162,6 +162,33 @@ def gh_json(args):
         return None
 
 
+def ensure_draft_pr(branch: str) -> None:
+    pr = gh_json(
+        ["pr", "view", branch, "--repo", REPO, "--json", "isDraft,autoMergeRequest"]
+    )
+    if pr is None:
+        raise RuntimeError(f"could not read PR state for {branch}")
+    if pr.get("autoMergeRequest") is not None:
+        run(
+            ["gh", "pr", "merge", branch, "--repo", REPO, "--disable-auto"],
+            check=True,
+        )
+    if pr.get("isDraft") is not True:
+        run(["gh", "pr", "ready", branch, "--repo", REPO, "--undo"], check=True)
+
+    verified = gh_json(
+        ["pr", "view", branch, "--repo", REPO, "--json", "isDraft,autoMergeRequest"]
+    )
+    if (
+        verified is None
+        or verified.get("isDraft") is not True
+        or verified.get("autoMergeRequest") is not None
+    ):
+        raise RuntimeError(
+            f"refusing to continue: {branch} is not a draft with auto-merge disabled"
+        )
+
+
 # --- worktree helpers -------------------------------------------------------
 def make_worktree(slug: str, ref: str) -> Path:
     """Fresh generation worktree whose leaf dir is exactly ``rulespec-us``
@@ -283,7 +310,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
              "-c", "user.name=bulk-encode", "commit", "-q", "-m", msg])
         run(["git", "-C", str(leaf), "push", "-f", "origin",
              f"HEAD:refs/heads/{branch}"], check=True)
-        run(["gh", "pr", "ready", branch, "--repo", REPO, "--undo"])
+        ensure_draft_pr(branch)
         result = f"rebuilt+pushed draft {branch}: {summary}"
         if wait:
             result += "; " + wait_for_merge(branch)

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -290,19 +290,52 @@ def finalize_pending(leaf: Path) -> bool:
     return True
 
 
+def is_encoding_manifest_path(path: str) -> bool:
+    return path.startswith(".axiom/encoding-manifests/") or bool(
+        re.match(
+            r"^[a-z]{2}(?:-[a-z0-9-]+)?/\.axiom/encoding-manifests/",
+            path,
+        )
+    )
+
+
+def aggregate_validation_state(checks: list[dict]) -> str | None:
+    states = [
+        str(check.get("conclusion") or check.get("state") or "").upper()
+        for check in checks
+        if str(check.get("name") or "").startswith("validate / validate")
+    ]
+    if not states:
+        return None
+    failed = {
+        "ACTION_REQUIRED",
+        "CANCELLED",
+        "ERROR",
+        "FAILURE",
+        "STALE",
+        "TIMED_OUT",
+    }
+    if any(state in failed for state in states):
+        return "FAILURE"
+    complete = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+    if any(state not in complete for state in states):
+        return "PENDING"
+    return "SUCCESS"
+
+
 # ---------------------------------------------------------------------------
 # PART A: unstick already-open new-state bulk PRs (priority).
 # ---------------------------------------------------------------------------
 def open_bulk_prs():
     data = gh_json(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "200",
                     "--json", "number,headRefName,mergeStateStatus,statusCheckRollup"])
+    if data is None:
+        raise RuntimeError("could not list open bulk PRs")
     prs = []
-    for pr in data or []:
+    for pr in data:
         if not pr["headRefName"].startswith("bulk/"):
             continue
-        vv = next((c.get("conclusion") or c.get("state")
-                   for c in pr.get("statusCheckRollup") or []
-                   if str(c.get("name") or "").startswith("validate / validate")), None)
+        vv = aggregate_validation_state(pr.get("statusCheckRollup") or [])
         prs.append({"number": pr["number"], "branch": pr["headRefName"],
                     "merge": pr["mergeStateStatus"], "validate": vv})
     return sorted(prs, key=lambda p: p["number"])
@@ -327,7 +360,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
                        "origin/main...FETCH_HEAD"])
         artifacts = [f for f in diff.splitlines()
                      if (MODULE_RE.match(f) or f.endswith(".test.yaml")
-                         or "/.axiom/encoding-manifests/" in f)]
+                         or is_encoding_manifest_path(f))]
         if not artifacts:
             return f"{branch}: no module artifacts in diff (already merged?)"
         run(["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -484,24 +484,58 @@ def flip_statuses(updates: dict) -> None:
     """updates: {citation: status}. Commits to worklist on a small branch + PR."""
     if not updates:
         return
+    branch = "bulk/worklist-status-flip"
+    open_prs = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "open",
+            "--head",
+            branch,
+            "--json",
+            "number",
+        ]
+    )
+    if open_prs is None:
+        raise RuntimeError(f"could not determine whether {branch} already has a PR")
+    existing_pr = bool(open_prs)
+    if existing_pr:
+        ensure_draft_pr(branch)
+
     leaf = make_worktree("worklist-flip", "origin/main")
     try:
-        run(["git", "-C", str(leaf), "checkout", "-B", "bulk/worklist-status-flip"])
+        if existing_pr:
+            run(["git", "-C", str(leaf), "fetch", "origin", branch], check=True)
+            run(["git", "-C", str(leaf), "checkout", "-B", branch, "FETCH_HEAD"], check=True)
+            run(["git", "-C", str(leaf), "rebase", "origin/main"], check=True)
+        else:
+            run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
         for citation, status in updates.items():
             run([str(COV_PY), str(leaf / "bulk/compute_matrix.py"),
-                 "--set-status", citation, status], cwd=leaf)
-        run(["git", "-C", str(leaf), "add", "bulk/worklist.yaml"])
-        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
-             "-c", "user.name=bulk-encode", "commit", "-q", "-m",
-             "Flip drained worklist statuses (bulk)\n\n"
-             "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"])
+                 "--set-status", citation, status], cwd=leaf, check=True)
+        _, worklist_diff = run(
+            ["git", "-C", str(leaf), "status", "--porcelain", "--", "bulk/worklist.yaml"]
+        )
+        if worklist_diff:
+            run(["git", "-C", str(leaf), "add", "bulk/worklist.yaml"])
+            run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
+                 "-c", "user.name=bulk-encode", "commit", "-q", "-m",
+                 "Flip drained worklist statuses (bulk)\n\n"
+                 "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"], check=True)
+        elif not existing_pr:
+            return
+        if existing_pr:
+            ensure_draft_pr(branch)
         run(["git", "-C", str(leaf), "push", "-f", "origin",
-             "HEAD:refs/heads/bulk/worklist-status-flip"], check=True)
-        branch = "bulk/worklist-status-flip"
-        run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
-             "--head", branch, "--title", "Flip drained worklist statuses (bulk)",
-             "--body", "Status flips for locally-drained entries.", "--label",
-             "bulk-encode", "--draft"], check=True)
+             f"HEAD:refs/heads/{branch}"], check=True)
+        if not existing_pr:
+            run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
+                 "--head", branch, "--title", "Flip drained worklist statuses (bulk)",
+                 "--body", "Status flips for locally-drained entries.", "--label",
+                 "bulk-encode", "--draft"], check=True)
         ensure_draft_pr(branch)
     finally:
         drop_worktree(leaf)

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -219,6 +219,13 @@ def ensure_draft_pr(branch: str) -> None:
         )
 
 
+def pause_for_retry(result: dict, detail: str) -> dict:
+    _PAUSE.set()
+    result["status"] = "paused"
+    result["detail"] = detail
+    return result
+
+
 # --- worktree helpers -------------------------------------------------------
 def make_worktree(slug: str, ref: str) -> Path:
     """Fresh generation worktree whose leaf dir is exactly ``rulespec-us``
@@ -424,8 +431,7 @@ def encode_entry(item: dict) -> dict:
     try:
         handled = already_handled(slug)
     except RuntimeError as exc:
-        res["detail"] = str(exc)
-        return res
+        return pause_for_retry(res, f"{exc}; retry drain")
     if handled:
         res["status"] = "skipped"
         res["detail"] = "bulk/<slug> PR already exists"
@@ -512,8 +518,10 @@ def encode_entry(item: dict) -> dict:
              "--json", "number"]
         )
         if open_prs is None:
-            res["detail"] = f"could not verify PR state for {branch} before push"
-            return res
+            return pause_for_retry(
+                res,
+                f"could not verify PR state for {branch} before push; retry drain",
+            )
         if open_prs:
             ensure_draft_pr(branch)
             res["status"] = "skipped"
@@ -619,8 +627,8 @@ def write_progress(results: list, remaining: int, paused: bool) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [f"# Local drain progress ({now})", ""]
     if paused:
-        lines += ["> **PAUSED on Codex subscription-limit signal.** Re-run after "
-                  "the window resets; the drain resumes idempotently.", ""]
+        lines += ["> **PAUSED on a retryable condition.** Resolve the condition "
+                  "reported below and re-run; the drain resumes idempotently.", ""]
     lines += [f"- Remaining pending: {remaining}",
               f"- Handled this run: {len(results)}", "",
               "| citation | result | detail |", "| --- | --- | --- |"]

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -413,7 +413,14 @@ def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
         failures = {
             str(check.get("conclusion") or check.get("state") or "").upper()
             for check in checks
-        } & {"ACTION_REQUIRED", "CANCELLED", "ERROR", "FAILURE", "TIMED_OUT"}
+        } & {
+            "ACTION_REQUIRED",
+            "CANCELLED",
+            "ERROR",
+            "FAILURE",
+            "STALE",
+            "TIMED_OUT",
+        }
         if failures:
             return f"checks={','.join(sorted(failures))} (needs triage)"
         pending = any(

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -13,16 +13,13 @@ script).
 Two decisions matter and are baked in here so PRs go green:
 
 * **Generation uses the toolchain-pinned encoder** (``.axiom/toolchain.toml``
-  ``axiom_encode_version``, currently 0.2.1184). The required ``validate /
-  validate`` check validates with that same pin, so generating with anything
-  newer risks schema/manifest skew. Do NOT "upgrade" the generation encoder to
-  match a brief that says ">=0.2.1190" -- that number refers only to the
-  *coverage/sync* tool below, not to generation.
-* **Coverage declaration uses axiom-encode main (>=0.2.1190)**, because the CI
+  ``axiom_encode_version``). The required ``validate / validate`` check uses
+  that same pin, so generation changes only through a reviewed toolchain-pin
+  migration.
+* **Coverage declaration uses axiom-encode main**, because the CI
   changed-file coverage classifier (``oracle-coverage-axiom-encode-ref``,
   default ``main``) is what reclassifies declared-pending outputs from
-  ``unmapped`` to ``pending_classification``. The pinned 1184 encoder does not
-  even have the ``oracle-coverage-pending`` subcommand.
+  ``unmapped`` to ``pending_classification``.
 
 Everything runs foreground. The loop is chunked (``--max-seconds``,
 ``--max-entries``) and every unit of durable state (pushed branch, opened PR,
@@ -34,9 +31,9 @@ Toolchain layout (override via env): a sibling ``_bulk_drain`` workspace holds
 pinned checkouts + venvs built once by the operator:
 
     _bulk_drain/
-      axiom-encode/            # worktree @ pinned axiom_encode_ref (1184)
+      axiom-encode/            # worktree @ pinned axiom_encode_ref
       .venv/                   # pinned encoder venv  -> generation
-      axiom-encode-cov/        # worktree @ axiom-encode main (>=1190)
+      axiom-encode-cov/        # worktree @ axiom-encode main
       .venv-cov/               # coverage/sync venv   -> oracle-coverage-pending
       axiom-rules-engine/      # worktree @ pinned engine ref, cargo build
       axiom-corpus/            # worktree @ pinned corpus ref
@@ -261,7 +258,7 @@ def open_bulk_prs():
             continue
         vv = next((c.get("conclusion") or c.get("state")
                    for c in pr.get("statusCheckRollup") or []
-                   if c.get("name") == "validate / validate"), None)
+                   if str(c.get("name") or "").startswith("validate / validate")), None)
         prs.append({"number": pr["number"], "branch": pr["headRefName"],
                     "merge": pr["mergeStateStatus"], "validate": vv})
     return sorted(prs, key=lambda p: p["number"])
@@ -330,6 +327,11 @@ def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
         if pr["state"] != "OPEN":
             return pr["state"]
         checks = pr.get("statusCheckRollup") or []
+        validation_checks = [
+            check
+            for check in checks
+            if str(check.get("name") or "").startswith("validate / validate")
+        ]
         failures = {
             str(check.get("conclusion") or check.get("state") or "").upper()
             for check in checks
@@ -342,7 +344,7 @@ def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
             or str(check.get("state") or "").upper() in {"EXPECTED", "PENDING"}
             for check in checks
         )
-        if checks and not pending:
+        if validation_checks and not pending:
             return "checks complete; draft review required"
         time.sleep(30)
     return "timeout-waiting-checks"

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -360,6 +360,8 @@ MODULE_RE = re.compile(
 def already_handled(slug: str) -> bool:
     pr = gh_json(["pr", "list", "--repo", REPO, "--head", f"bulk/{slug}",
                   "--state", "all", "--json", "number,state"])
+    if pr is None:
+        raise RuntimeError(f"could not determine PR state for bulk/{slug}")
     return bool(pr)
 
 
@@ -367,7 +369,9 @@ def handled_slugs() -> set:
     """All bulk/<slug> that already have a PR (any state), in one gh call, so a
     drain chunk skips already-PR'd entries without a per-entry API round-trip."""
     data = gh_json(["pr", "list", "--repo", REPO, "--state", "all", "--limit", "400",
-                    "--json", "headRefName"]) or []
+                    "--json", "headRefName"])
+    if data is None:
+        raise RuntimeError("could not list existing bulk PRs")
     return {p["headRefName"].split("/", 1)[1] for p in data
             if p.get("headRefName", "").startswith("bulk/")}
 
@@ -379,7 +383,12 @@ def encode_entry(item: dict) -> dict:
     if _PAUSE.is_set():
         res["detail"] = "paused"
         return res
-    if already_handled(slug):
+    try:
+        handled = already_handled(slug)
+    except RuntimeError as exc:
+        res["detail"] = str(exc)
+        return res
+    if handled:
         res["status"] = "skipped"
         res["detail"] = "bulk/<slug> PR already exists"
         return res
@@ -460,6 +469,18 @@ def encode_entry(item: dict) -> dict:
                       "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
         run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
              "-c", "user.name=bulk-encode", "commit", "-q", "--amend", "-m", commit_msg])
+        open_prs = gh_json(
+            ["pr", "list", "--repo", REPO, "--state", "open", "--head", branch,
+             "--json", "number"]
+        )
+        if open_prs is None:
+            res["detail"] = f"could not verify PR state for {branch} before push"
+            return res
+        if open_prs:
+            ensure_draft_pr(branch)
+            res["status"] = "skipped"
+            res["detail"] = f"existing draft PR normalized for {branch}; no push performed"
+            return res
         run(["git", "-C", str(leaf), "push", "-f", "origin",
              f"HEAD:refs/heads/{branch}"], check=True)
         run(["gh", "label", "create", "bulk-encode", "--repo", REPO,

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -308,6 +308,7 @@ def unstick_pr(branch: str, wait: bool) -> str:
                "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
         run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
              "-c", "user.name=bulk-encode", "commit", "-q", "-m", msg])
+        ensure_draft_pr(branch)
         run(["git", "-C", str(leaf), "push", "-f", "origin",
              f"HEAD:refs/heads/{branch}"], check=True)
         ensure_draft_pr(branch)
@@ -461,9 +462,13 @@ def encode_entry(item: dict) -> dict:
                 f"### Acceptance criteria\n\n{acceptance_criteria}\n")
         bf = WT_ROOT / slug / "pr-body.md"
         bf.write_text(body)
-        run(["gh", "pr", "create", "--repo", REPO, "--base", "main", "--head", branch,
+        run(
+            ["gh", "pr", "create", "--repo", REPO, "--base", "main", "--head", branch,
              "--title", title, "--body-file", str(bf), "--label", "bulk-encode",
-             "--draft"])
+             "--draft"],
+            check=True,
+        )
+        ensure_draft_pr(branch)
         res["status"] = gate_status
         res["detail"] = f"draft PR opened on {branch}; {sync_summary}"
         return res
@@ -492,11 +497,12 @@ def flip_statuses(updates: dict) -> None:
              "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"])
         run(["git", "-C", str(leaf), "push", "-f", "origin",
              "HEAD:refs/heads/bulk/worklist-status-flip"], check=True)
+        branch = "bulk/worklist-status-flip"
         run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
-             "--head", "bulk/worklist-status-flip", "--title",
-             "Flip drained worklist statuses (bulk)", "--body",
-             "Status flips for locally-drained entries.", "--label", "bulk-encode",
-             "--draft"])
+             "--head", branch, "--title", "Flip drained worklist statuses (bulk)",
+             "--body", "Status flips for locally-drained entries.", "--label",
+             "bulk-encode", "--draft"], check=True)
+        ensure_draft_pr(branch)
     finally:
         drop_worktree(leaf)
 

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -141,6 +141,8 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert "python bulk/applied_artifacts.py" in workflow
     assert 'git switch --detach "origin/$DEFAULT_BRANCH"' in workflow
     assert "--label bulk-encode --draft" in workflow
-    assert 'gh pr merge "$branch"' not in workflow
+    assert ".isDraft == true and .autoMergeRequest == null" in workflow
+    assert "ensure_draft_pr(branch)" in local_drain
+    assert 'gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto' not in workflow
     assert '"--label", "bulk-encode",\n             "--draft"' in local_drain
-    assert '"pr", "merge", branch' not in local_drain
+    assert '"pr", "merge", branch, "--repo", REPO, "--auto"' not in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,22 +1,29 @@
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 
 def _load_bulk_module(name: str):
-    path = Path(__file__).resolve().parents[1] / "bulk" / f"{name}.py"
+    bulk_dir = Path(__file__).resolve().parents[1] / "bulk"
+    path = bulk_dir / f"{name}.py"
     spec = importlib.util.spec_from_file_location(f"bulk_{name}", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.path.insert(0, str(bulk_dir))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(bulk_dir))
     return module
 
 
 _applied_artifacts = _load_bulk_module("applied_artifacts")
 _compute_matrix = _load_bulk_module("compute_matrix")
+_local_drain = _load_bulk_module("local_drain")
 changed_paths = _applied_artifacts.changed_paths
 discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
 select = _compute_matrix.select
@@ -174,6 +181,44 @@ def test_rejects_manifest_for_different_citation(tmp_path: Path) -> None:
             citation=citation,
             paths=[module, test_file, manifest],
         )
+
+
+def test_rejects_canonical_manifest_for_wrong_requested_jurisdiction(
+    tmp_path: Path,
+) -> None:
+    citation = "us-ca/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:policies/dss/snap/1105/block-1",
+        {module, test_file},
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_pr_lookup_failure_pauses_without_permanent_failure(monkeypatch) -> None:
+    _local_drain._PAUSE.clear()
+    monkeypatch.setattr(_local_drain, "gh_json", lambda _args: None)
+
+    result = _local_drain.encode_entry(
+        {"citation": "us-mo/manual/dss/snap/1105/block-1", "slug": "retry"}
+    )
+
+    assert result["status"] == "paused"
+    assert "retry drain" in result["detail"]
+    assert _local_drain._PAUSE.is_set()
+    _local_drain._PAUSE.clear()
 
 
 def test_matrix_preserves_acceptance_criteria() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -181,4 +181,6 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert '"--head",\n            branch,\n            "--json",\n            "number"' in local_drain
     assert "if not existing_pr:" in local_drain
     assert "wait_for_merge" not in local_drain
+    assert 'startswith("validate / validate")' in local_drain
+    assert "if validation_checks and not pending:" in local_drain
     assert 'return "checks complete; draft review required"' in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,0 +1,142 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bulk.applied_artifacts import discover_applied_artifacts
+from bulk.compute_matrix import select
+
+
+def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "citation": citation,
+                "applied_files": [
+                    {"path": applied_path, "sha256": "0" * 64}
+                    for applied_path in sorted(applied_paths)
+                ],
+            }
+        )
+    )
+
+
+def test_discovers_repo_root_manifest_for_manual_module(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+    ) == (module, test_file, manifest)
+
+
+def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> None:
+    citation = "us-oh/statute/5747.71"
+    module = "us-oh/statutes/5747/71.yaml"
+    test_file = "us-oh/statutes/5747/71.test.yaml"
+    manifest = "us-oh/.axiom/encoding-manifests/statutes/5747/71.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        citation,
+        {"statutes/5747/71.yaml", "statutes/5747/71.test.yaml"},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+@pytest.mark.parametrize(
+    ("extra_path", "message"),
+    [
+        ("us-mo/manual/dss/snap/1105/other.yaml", "expected one applied module"),
+        (
+            ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/other.json",
+            "expected one applied manifest",
+        ),
+    ],
+)
+def test_rejects_ambiguous_artifacts(
+    tmp_path: Path, extra_path: str, message: str
+) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    if extra_path.endswith(".json"):
+        _write_manifest(tmp_path / extra_path, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match=message):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest, extra_path],
+        )
+
+
+def test_rejects_manifest_for_different_citation(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, "us-mo/manual/different", {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_matrix_preserves_acceptance_criteria() -> None:
+    data = {
+        "defaults": {"backend": "openai", "model": "gpt-5.5"},
+        "entries": [
+            {
+                "citation": "us-sc/manual/dss/snap-policy-manual/page-159",
+                "status": "pending",
+                "batch": "SNAP-SC-UTIL",
+                "note": "Verify mutual exclusivity.",
+            }
+        ],
+    }
+
+    selected = select(data, "pending", "SNAP-SC-UTIL", None)
+
+    assert selected[0]["acceptance_criteria"] == "Verify mutual exclusivity."
+
+
+def test_bulk_runners_require_review_before_merge() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    local_drain = (root / "bulk/local_drain.py").read_text()
+
+    assert "python bulk/applied_artifacts.py" in workflow
+    assert 'git switch --detach "origin/$DEFAULT_BRANCH"' in workflow
+    assert "--label bulk-encode --draft" in workflow
+    assert 'gh pr merge "$branch"' not in workflow
+    assert '"--label", "bulk-encode",\n             "--draft"' in local_drain
+    assert '"pr", "merge", branch' not in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -260,6 +260,29 @@ def test_pr_lookup_failure_pauses_without_permanent_failure(monkeypatch) -> None
     _local_drain._PAUSE.clear()
 
 
+def test_unstick_recognizes_both_manifest_roots() -> None:
+    assert _local_drain.is_encoding_manifest_path(
+        ".axiom/encoding-manifests/us-mo/policies/dss/snap/block-1.json"
+    )
+    assert _local_drain.is_encoding_manifest_path(
+        "us-mo/.axiom/encoding-manifests/policies/dss/snap/block-1.json"
+    )
+    assert not _local_drain.is_encoding_manifest_path(
+        "_axiom/axiom-encode/.axiom/encoding-manifests/example.json"
+    )
+
+
+def test_validation_state_aggregates_all_shards() -> None:
+    success = {"name": "validate / validate (us-ca)", "conclusion": "SUCCESS"}
+    failure = {"name": "validate / validate (us-ny)", "conclusion": "FAILURE"}
+    pending = {"name": "validate / validate (us-tx)", "state": "IN_PROGRESS"}
+
+    assert _local_drain.aggregate_validation_state([success, failure]) == "FAILURE"
+    assert _local_drain.aggregate_validation_state([success, pending]) == "PENDING"
+    assert _local_drain.aggregate_validation_state([success]) == "SUCCESS"
+    assert _local_drain.aggregate_validation_state([]) is None
+
+
 def test_matrix_preserves_acceptance_criteria() -> None:
     data = {
         "defaults": {"backend": "openai", "model": "gpt-5.5"},

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from bulk.applied_artifacts import discover_applied_artifacts
+from bulk.applied_artifacts import changed_paths, discover_applied_artifacts
 from bulk.compute_matrix import select
 
 
@@ -63,6 +63,36 @@ def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> No
         citation=citation,
         paths=[module, test_file, manifest],
     ) == (module, test_file, manifest)
+
+
+def test_changed_paths_ignores_rename_source_record(tmp_path: Path) -> None:
+    old_module = "us-mo/manual/dss/snap/old.yaml"
+    new_module = "us-mo/manual/dss/snap/new.yaml"
+    (tmp_path / old_module).parent.mkdir(parents=True)
+    (tmp_path / old_module).write_text("format: rulespec/v1\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", old_module], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.name=Axiom Test",
+            "-c",
+            "user.email=test@axiom.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "mv", old_module, new_module], check=True
+    )
+
+    assert changed_paths(tmp_path) == [new_module]
 
 
 @pytest.mark.parametrize(
@@ -148,3 +178,5 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert 'gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto' not in workflow
     assert '"--label", "bulk-encode",\n             "--draft"' in local_drain
     assert '"pr", "merge", branch, "--repo", REPO, "--auto"' not in local_drain
+    assert '"--head",\n            branch,\n            "--json",\n            "number"' in local_drain
+    assert "if not existing_pr:" in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -107,6 +107,45 @@ def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> No
     ) == (module, test_file, manifest)
 
 
+def test_accepts_canonical_cfr_module_for_regulation_source(tmp_path: Path) -> None:
+    citation = "us/regulation/7/247/9/b"
+    module = "us/regulations/7-cfr/247/9/b.yaml"
+    test_file = "us/regulations/7-cfr/247/9/b.test.yaml"
+    manifest = "us/.axiom/encoding-manifests/regulations/7-cfr/247/9/b.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        citation,
+        {"regulations/7-cfr/247/9/b.yaml", "regulations/7-cfr/247/9/b.test.yaml"},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+def test_rejects_cfr_module_for_different_regulation(tmp_path: Path) -> None:
+    citation = "us/regulation/7/247/9/b"
+    module = "us/regulations/7-cfr/247/9/c.yaml"
+    test_file = "us/regulations/7-cfr/247/9/c.test.yaml"
+    manifest = "us/.axiom/encoding-manifests/regulations/7-cfr/247/9/c.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match requested citation"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
 def test_changed_paths_ignores_rename_source_record(tmp_path: Path) -> None:
     old_module = "us-mo/manual/dss/snap/old.yaml"
     new_module = "us-mo/manual/dss/snap/new.yaml"

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -142,7 +142,9 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert 'git switch --detach "origin/$DEFAULT_BRANCH"' in workflow
     assert "--label bulk-encode --draft" in workflow
     assert ".isDraft == true and .autoMergeRequest == null" in workflow
+    assert workflow.count("ensure_draft") >= 3
     assert "ensure_draft_pr(branch)" in local_drain
+    assert local_drain.count("ensure_draft_pr(branch)") >= 4
     assert 'gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto' not in workflow
     assert '"--label", "bulk-encode",\n             "--draft"' in local_drain
     assert '"pr", "merge", branch, "--repo", REPO, "--auto"' not in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -25,13 +25,17 @@ def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
 
 def test_discovers_repo_root_manifest_for_manual_module(tmp_path: Path) -> None:
     citation = "us-mo/manual/dss/snap/1105/block-1"
-    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
-    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
-    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
     (tmp_path / module).parent.mkdir(parents=True)
     (tmp_path / module).write_text("format: rulespec/v1\n")
     (tmp_path / test_file).write_text("cases: []\n")
-    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:policies/dss/snap/1105/block-1",
+        {module, test_file},
+    )
     subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
 
     assert discover_applied_artifacts(
@@ -101,7 +105,7 @@ def test_rejects_manifest_for_different_citation(tmp_path: Path) -> None:
     (tmp_path / test_file).parent.mkdir(parents=True)
     (tmp_path / module).write_text("format: rulespec/v1\n")
     (tmp_path / test_file).write_text("cases: []\n")
-    _write_manifest(tmp_path / manifest, "us-mo/manual/different", {module, test_file})
+    _write_manifest(tmp_path / manifest, "us-mo:policies/dss/snap/other", {module, test_file})
 
     with pytest.raises(ValueError, match="does not match"):
         discover_applied_artifacts(

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -65,6 +65,27 @@ def test_discovers_repo_root_manifest_for_manual_module(tmp_path: Path) -> None:
     ) == (module, test_file, manifest)
 
 
+def test_accepts_manual_bucket_for_manual_source(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1115/block-1"
+    module = "us-mo/manual/dss/snap/1115/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1115/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1115/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:manual/dss/snap/1115/block-1",
+        {module, test_file},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
 def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> None:
     citation = "us-oh/statute/5747.71"
     module = "us-oh/statutes/5747/71.yaml"
@@ -200,6 +221,24 @@ def test_rejects_canonical_manifest_for_wrong_requested_jurisdiction(
     )
 
     with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_rejects_exact_request_manifest_for_wrong_module(tmp_path: Path) -> None:
+    citation = "us-ca/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match requested citation"):
         discover_applied_artifacts(
             tmp_path,
             citation=citation,

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -95,6 +95,23 @@ def test_changed_paths_ignores_rename_source_record(tmp_path: Path) -> None:
     assert changed_paths(tmp_path) == [new_module]
 
 
+def test_accepts_manifest_covering_only_changed_module(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module})
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, manifest],
+    ) == (module, test_file, manifest)
+
+
 @pytest.mark.parametrize(
     ("extra_path", "message"),
     [
@@ -172,6 +189,8 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert 'git switch --detach "origin/$DEFAULT_BRANCH"' in workflow
     assert "--label bulk-encode --draft" in workflow
     assert ".isDraft == true and .autoMergeRequest == null" in workflow
+    assert 'pr_json="$(retry gh pr list' in workflow
+    assert '.[0].state // empty' in workflow
     assert workflow.count("ensure_draft") >= 3
     assert "ensure_draft_pr(branch)" in local_drain
     assert local_drain.count("ensure_draft_pr(branch)") >= 4
@@ -184,3 +203,5 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert 'startswith("validate / validate")' in local_drain
     assert "if validation_checks and not pending:" in local_drain
     assert 'return "checks complete; draft review required"' in local_drain
+    assert "could not determine PR state" in local_drain
+    assert "before push" in local_drain

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -285,6 +285,25 @@ def test_rejects_exact_request_manifest_for_wrong_module(tmp_path: Path) -> None
         )
 
 
+def test_rejects_non_object_manifest(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    (tmp_path / manifest).parent.mkdir(parents=True)
+    (tmp_path / manifest).write_text("[]\n")
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
 def test_pr_lookup_failure_pauses_without_permanent_failure(monkeypatch) -> None:
     _local_drain._PAUSE.clear()
     monkeypatch.setattr(_local_drain, "gh_json", lambda _args: None)
@@ -297,6 +316,28 @@ def test_pr_lookup_failure_pauses_without_permanent_failure(monkeypatch) -> None
     assert "retry drain" in result["detail"]
     assert _local_drain._PAUSE.is_set()
     _local_drain._PAUSE.clear()
+
+
+def test_wait_for_checks_rejects_stale_validation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        _local_drain,
+        "gh_json",
+        lambda _args: {
+            "state": "OPEN",
+            "isDraft": True,
+            "statusCheckRollup": [
+                {
+                    "name": "validate / validate (us-mo)",
+                    "status": "COMPLETED",
+                    "conclusion": "STALE",
+                }
+            ],
+        },
+    )
+
+    assert _local_drain.wait_for_checks("bulk/example", timeout_s=1) == (
+        "checks=STALE (needs triage)"
+    )
 
 
 def test_unstick_recognizes_both_manifest_roots() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -180,3 +180,5 @@ def test_bulk_runners_require_review_before_merge() -> None:
     assert '"pr", "merge", branch, "--repo", REPO, "--auto"' not in local_drain
     assert '"--head",\n            branch,\n            "--json",\n            "number"' in local_drain
     assert "if not existing_pr:" in local_drain
+    assert "wait_for_merge" not in local_drain
+    assert 'return "checks complete; draft review required"' in local_drain


### PR DESCRIPTION
## Summary
- make the agent-operated local drain review-safe: one draft PR per encoder-generated module, no auto-merge
- discover and validate signed `encode --apply` artifacts at both supported manifest roots
- tie generated modules and manifests to the requested citation, including manual/policies and CFR canonical layouts
- preserve manifests during recovery and aggregate every validation shard
- fail closed on GitHub lookup failures, stale checks, malformed manifests, and classifier provenance drift
- preserve worklist acceptance criteria in generated draft PRs

## Scope and provenance
- no RuleSpec YAML or companion fixture is changed by this PR
- generated artifacts remain exclusively owned by `axiom-encode encode --apply`
- local coverage classification requires axiom-encode `c83416309a4331d225bcde16907e3b4eb79e26f1`
- local oracle dependency requires axiom-oracles `9901e2479ac39bba865b8232e1c7d879ba447d8d`
- generation remains on the repository-pinned encoder `0.2.1200`; changing that requires a separate reviewed toolchain/corpus migration
- the legacy cloud workflow is unchanged; agent-operated drains use `bulk/local_drain.py`

## Checks
- `uv run ruff check bulk/local_drain.py bulk/compute_matrix.py bulk/applied_artifacts.py tests/test_bulk_applied_artifacts.py`
- `uv run python -m compileall -q bulk`
- `uv run pytest`: 40 passed, 1 existing warning for 17 historical unmanifested modules
- `uv run python bulk/local_drain.py doctor`: all operational dependencies and signing key present; exact classifier/oracle refs verified
- direct discovery check passed against the existing signed `us/regulation/7/247/9/b` CFR artifact
- `git diff --check`

## Review cycle
- fixed retry persistence and unrelated-module acceptance from the first post-rebase review
- fixed valid `manual/` output handling in the next review
- fixed manifest preservation and multi-shard validation aggregation
- fixed CFR canonical artifact matching
- fixed stale-check and non-object-manifest fail-closed behavior
- final exact-head repeat review on `bcfcd025`: no actionable findings