### PR TITLE
Bump the corpus pin for the Texas Works Handbook C-120 ingest

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "c3a7a15c5bb6c6a6e39bbff22edf671e83d67bf1"
+axiom_corpus_ref = "f77f736ada4414564350baf8bc1c96590126cc8e"
 # Canonical-targets checkout for cross-repo validation; bump to the
 # merged monorepo SHA in the post-merge follow-up.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Dedicated toolchain PR per the canonical-provenance regime (TheAxiomFoundation/.github#39, rule 1: `.axiom/toolchain.toml` never moves in a feature PR).

One hunk: `axiom_corpus_ref` c3a7a15c → f77f736a — a fast-forward by exactly one corpus commit (TheAxiomFoundation/axiom-corpus#325, the Texas Works Handbook C-120 SNAP deduction amounts ingest). Required by TheAxiomFoundation/rulespec-us#891, whose proof atoms cite the C-120 block-4 provisions ('Standard utility allowance (SUA) of $445' etc.).

Sequencing options (Max's call, laid out on #891):
- **Split path (regime-compliant)**: merge this first → #891 rebases, drops its toolchain hunk, becomes a pure feature PR.
- **Grandfather path**: merge #891 as-is (it predates #39 and carries this same hunk) → close this PR as redundant.
- **Superseded path**: if the `us-rulespec-2026-07-13` release cut lands first and re-pins the repo to the signed release, close this PR — the TX citations ride the release (they're on corpus main since 7/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)