### PR TITLE
Pass reviewed legal context to bulk encodes

### DIFF
--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -39,6 +39,7 @@ import yaml
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
 SELECTABLE_STATUSES = {"pending", "pending-local"}
+REPO_ROOT = WORKLIST.parents[1]
 
 
 def citation_slug(citation: str) -> str:
@@ -65,6 +66,34 @@ def entry_backend(data: dict, entry: dict) -> str:
 
 def entry_model(data: dict, entry: dict) -> str:
     return entry.get("model") or data.get("defaults", {}).get("model", "gpt-5.5")
+
+
+def entry_allow_context(entry: dict) -> list[str]:
+    """Return reviewed repo-local encoder context paths for one queue entry."""
+    citation = entry.get("citation", "unknown citation")
+    values = entry.get("allow_context", [])
+    if not isinstance(values, list) or not all(
+        isinstance(value, str) and value and "\n" not in value for value in values
+    ):
+        raise ValueError(
+            f"{citation}: allow_context must be a list of non-empty path strings"
+        )
+    if values and entry.get("status") == "pending":
+        raise ValueError(
+            f"{citation}: allow_context is not supported for cloud pending entries"
+        )
+
+    root = REPO_ROOT.resolve()
+    for value in values:
+        path = Path(value)
+        resolved = (root / path).resolve()
+        if path.is_absolute() or not resolved.is_relative_to(root):
+            raise ValueError(f"{citation}: allow_context path escapes the repository")
+        if not resolved.is_file():
+            raise ValueError(
+                f"{citation}: allow_context path is not a repository file: {value}"
+            )
+    return values
 
 
 def select(data: dict, status: str, batch: str | None, limit: int | None) -> list[dict]:
@@ -95,6 +124,7 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                 "model": entry_model(data, entry),
                 "acceptance_criteria": entry.get("note", ""),
                 "slug": citation_slug(entry["citation"]),
+                "allow_context": entry_allow_context(entry),
                 "requires_merged_citations": dependencies,
                 "program_scope_sync": program_scope_sync,
             }

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -545,6 +545,32 @@ def apply_program_scope_sync(leaf: Path, item: dict, env: dict) -> list[str]:
     return [program_spec]
 
 
+def encode_command(leaf: Path, tmp: Path, item: dict) -> list[str]:
+    """Build the reviewed encoder command, including repo-local legal context."""
+    root = leaf.resolve()
+    context_paths: list[Path] = []
+    for value in item.get("allow_context", []):
+        if not isinstance(value, str) or not value or "\n" in value:
+            raise ValueError("allow_context must contain non-empty path strings")
+        path = Path(value)
+        resolved = (root / path).resolve()
+        if path.is_absolute() or not resolved.is_relative_to(root):
+            raise ValueError("allow_context path escapes the RuleSpec checkout")
+        if not resolved.is_file():
+            raise ValueError(f"allow_context file does not exist: {value}")
+        context_paths.append(resolved)
+
+    command = [
+        str(GEN_AE), "encode", item["citation"], "--backend", BACKEND,
+        "--model", MODEL, "--policy-repo-path", str(leaf),
+        "--axiom-rules-engine-path", str(ENGINE), "--corpus-path", str(CORPUS),
+        "--output", str(tmp), "--apply", "--no-sync",
+    ]
+    for path in context_paths:
+        command.extend(["--allow-context", str(path)])
+    return command
+
+
 def encode_entry(item: dict) -> dict:
     """Full local mirror of bulk-encode.yml for one entry. Returns a result dict."""
     citation, slug = item["citation"], item["slug"]
@@ -585,12 +611,8 @@ def encode_entry(item: dict) -> dict:
     }
     try:
         rc, out = run(
-            [str(GEN_AE), "encode", citation, "--backend", BACKEND, "--model", MODEL,
-             "--policy-repo-path", str(leaf),
-             "--axiom-rules-engine-path", str(ENGINE),
-             "--corpus-path", str(CORPUS),
-             "--output", str(tmp), "--apply", "--no-sync"],
-            cwd=leaf, env=env, timeout=3600)
+            encode_command(leaf, tmp, item), cwd=leaf, env=env, timeout=3600
+        )
         if LIMIT_SIGNS.search(out):
             _PAUSE.set()
             res["status"], res["detail"] = "paused", "codex subscription-limit signal"

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1570,6 +1570,9 @@ entries:
   status: pending-local
   backend: openai
   model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
   heading: South Carolina SNAP utility allowance assignment
   class: eligibility
   note: Re-encode through canonical encode --apply. Regression review must verify
@@ -1581,6 +1584,9 @@ entries:
   status: pending-local
   backend: openai
   model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
   heading: South Carolina SNAP utility allowance exclusions and telephone standard
   class: eligibility
   note: Re-encode through canonical encode --apply. Regression review must cover
@@ -1592,6 +1598,9 @@ entries:
   status: pending-local
   backend: openai
   model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
   heading: South Carolina SNAP utility allowance amounts
   class: parameter
   note: Encode the current MUA, BUA, and telephone amounts from page 159 through

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -369,9 +369,13 @@ def test_matrix_preserves_acceptance_criteria() -> None:
         "entries": [
             {
                 "citation": "us-sc/manual/dss/snap-policy-manual/page-159",
-                "status": "pending",
+                "status": "pending-local",
                 "batch": "SNAP-SC-UTIL",
                 "note": "Verify mutual exclusivity.",
+                "allow_context": [
+                    "us/regulations/7-cfr/273/9.yaml",
+                    "us/regulations/7-cfr/273/9/d/6/iii.yaml",
+                ],
                 "requires_merged_citations": ["us-sc/manual/page-163"],
                 "program_scope_sync": {
                     "program_spec": "programs/us-sc/snap/fy-2026.yaml",
@@ -383,9 +387,13 @@ def test_matrix_preserves_acceptance_criteria() -> None:
         ],
     }
 
-    selected = select(data, "pending", "SNAP-SC-UTIL", None)
+    selected = select(data, "pending-local", "SNAP-SC-UTIL", None)
 
     assert selected[0]["acceptance_criteria"] == "Verify mutual exclusivity."
+    assert selected[0]["allow_context"] == [
+        "us/regulations/7-cfr/273/9.yaml",
+        "us/regulations/7-cfr/273/9/d/6/iii.yaml",
+    ]
     assert selected[0]["requires_merged_citations"] == ["us-sc/manual/page-163"]
     assert selected[0]["program_scope_sync"]["scope"] == "state"
 
@@ -436,6 +444,76 @@ def test_matrix_rejects_scalar_dependency_metadata() -> None:
 
     with pytest.raises(ValueError, match="requires_merged_citations"):
         select(data, "pending-local", None, None)
+
+
+def test_matrix_rejects_context_outside_repository() -> None:
+    data = {
+        "entries": [{
+            "citation": "us-sc/manual/page-163",
+            "status": "pending-local",
+            "allow_context": ["/etc/passwd"],
+        }]
+    }
+
+    with pytest.raises(ValueError, match="escapes the repository"):
+        select(data, "pending-local", None, None)
+
+
+def test_matrix_rejects_context_for_cloud_entry() -> None:
+    data = {
+        "entries": [{
+            "citation": "us-sc/manual/page-163",
+            "status": "pending",
+            "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+        }]
+    }
+
+    with pytest.raises(ValueError, match="not supported for cloud pending"):
+        select(data, "pending", None, None)
+
+
+@pytest.mark.parametrize("status", ["pr-open", "needs-fixtures", "failed", "merged"])
+def test_matrix_preserves_context_after_local_status_transition(status: str) -> None:
+    data = {
+        "entries": [{
+            "citation": "us-sc/manual/page-163",
+            "status": status,
+            "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+        }]
+    }
+
+    selected = select(data, "any", None, None)
+
+    assert selected[0]["allow_context"] == ["us/regulations/7-cfr/273/9.yaml"]
+
+
+def test_encode_command_includes_reviewed_repo_context(tmp_path: Path) -> None:
+    context = tmp_path / "us/regulations/7-cfr/273/9.yaml"
+    context.parent.mkdir(parents=True)
+    context.write_text("format: rulespec/v1\n")
+
+    command = _local_drain.encode_command(
+        tmp_path,
+        tmp_path / "encode-out",
+        {
+            "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
+            "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+        },
+    )
+
+    assert command[-2:] == ["--allow-context", str(context.resolve())]
+
+
+def test_encode_command_rejects_context_outside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes the RuleSpec checkout"):
+        _local_drain.encode_command(
+            tmp_path,
+            tmp_path / "encode-out",
+            {
+                "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
+                "allow_context": ["../outside.yaml"],
+            },
+        )
 
 
 def test_sc_local_queue_schedules_prerequisites_before_dependent() -> None:


### PR DESCRIPTION
## Summary

- add validated repo-local `allow_context` metadata to the local bulk queue matrix
- pass reviewed context through local `axiom-encode encode --apply` commands
- bind the South Carolina SNAP utility runs to the encoded federal 7 CFR 273.9 authority

## Safety

Context paths must resolve to existing files inside the RuleSpec checkout. Absolute paths, traversal, missing files, and newline-bearing paths fail closed before encoding. Cloud `pending` entries cannot use local context metadata. Post-drain local statuses retain it for recovery and unstick. Generated RuleSpecs and fixtures remain produced only by `axiom-encode --apply`.

## Review cycles

1. Initial independent review: no actionable findings.
2. Post-CI independent review found context metadata would be rejected after local status transitions; fixed.
3. Final independent review after the fix: no actionable findings.

The initial head also touched the cloud workflow, which activated full-toolchain validation and exposed unrelated historical numeric-source gaps. That workflow change was removed; the feature is explicitly local-only.

## Checks

- `uv run ruff check bulk/compute_matrix.py bulk/local_drain.py tests/test_bulk_applied_artifacts.py`
- `python -m compileall -q bulk/compute_matrix.py bulk/local_drain.py tests/test_bulk_applied_artifacts.py`
- `uv run pytest` (50 passed, 1 existing warning before the final focused fix)
- `uv run pytest -q tests/test_bulk_applied_artifacts.py` (33 passed after final fix)
- `git diff --check`
