### PR TITLE
Encode us-sc/manual/dss/snap-policy-manual/page-163 (bulk)

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 742
+ceiling: 715
 entries:
 - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
   source: bulk
@@ -884,115 +884,16 @@ entries:
 - legal_id: us-mn:statutes/290/0671#working_family_credit_before_phaseout_after_allocation
   source: bulk
   since: '2026-07-08'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_cost_before_cap
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_deduction
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_excess_shelter_income_share
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_homeless_standard_eligible
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_individual_utility_allowance_state_option
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_liheap_sua_threshold
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_limited_utility_allowance_state_option
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_amount
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_lower_utility_allowance_entitled
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_amount
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_non_heating_cooling_standard_entitled
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_occupied_and_vacated_home_actual_utilities_allowed
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_prorated_rent_share
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_selected_homeless_or_excess_shelter_deduction
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_shared_utility_household_receives_full_standard
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_amount
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_entitled
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_standard_utility_allowance_state_option
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_amount
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_telephone_standard_entitled
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_total_utility_allowance
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_unreimbursed_disaster_home_repair_allowed
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_cost_for_shelter_calculation
-  source: manual
-  since: '2026-07-13'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_utility_standard_reassessment_required
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_shelter_costs_allowed
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_home_telephone_standard
-  source: manual
-  since: '2026-07-13'
-- legal_id: us-mo:manual/dss/snap/1115-000-00/1115-035-00/1115-035-25/block-1#missouri_snap_vacated_only_home_utility_allowance
-  source: manual
-  since: '2026-07-12'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_considered_separate_from_resident_boarders_for_eligibility
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_may_participate_in_snap
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#cooperative_buying_club_manager_may_participate_as_part_of_eligibility_eu
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#fns_authorized_retail_store_owner_or_manager_may_participate_as_part_of_eligibility_eu
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#person_not_barred_from_eligibility_eu_by_residence
-  source: bulk
-  since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_living_with_others_meets_separate_status
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#elderly_disabled_individual_minimum_age
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_missouri_administrative_disability_evidence
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_has_qualifying_disability_basis
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_living_alone_purchases_and_prepares_food
@@ -1010,19 +911,22 @@ entries:
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#individual_receives_meals_in_fns_authorized_residential_treatment_program
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
-  source: bulk
-  since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_maximum_gross_income
-  source: bulk
-  since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_table
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_165_percent_poverty_table_maximum_size
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#other_residents_countable_gross_income_within_165_percent_poverty_limit
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1#snap_gross_income_limit_165_percent_fpl_48_states_dc_table
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_cohabiting_spouse_path
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_customarily_purchases_and_prepares_food_together_path
@@ -1040,10 +944,25 @@ entries:
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_residential_treatment_program_path
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#eligibility_group_cohabiting_spouse_path
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#others_countable_income_poverty_level_limit_ratio
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1#others_countable_income_poverty_level_limit_ratio
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_considered_separate_from_resident_boarders_for_eligibility
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#commercial_boarding_house_proprietor_may_participate_in_snap
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#cooperative_buying_club_manager_may_participate_as_part_of_eligibility_eu
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#fns_authorized_retail_store_owner_or_manager_may_participate_as_part_of_eligibility_eu
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/block-1#person_not_barred_from_eligibility_eu_by_residence
+  source: bulk
+  since: '2026-07-13'
+- legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
   source: bulk
   since: '2026-07-13'
 - legal_id: us-mt:statutes/15-30-2318#montana_earned_income_tax_credit

--- a/us-sc/.axiom/encoding-manifests/policies/dss/snap-policy-manual/page-163.json
+++ b/us-sc/.axiom/encoding-manifests/policies/dss/snap-policy-manual/page-163.json
@@ -2,40 +2,49 @@
   "applied_files": [
     {
       "path": "policies/dss/snap-policy-manual/page-163.yaml",
-      "sha256": "5f71b20de45c7a76bcd1d1aa6fa8a392d5d7d38478107e06195e778c955b3552"
+      "sha256": "36fc3479ca34c140578116f1900fb3acc80e208ac18b07217e7f942ef2d55ddc"
     },
     {
       "path": "policies/dss/snap-policy-manual/page-163.test.yaml",
-      "sha256": "ccf98079150db954592a75a63dbcafb894c460f23fb078eabd2a28b13c148a5b"
+      "sha256": "9205b90f9c06b912c21eaa7d114729b88d1a46e313ae294e12b0fffa015ccf26"
     }
   ],
   "axiom_encode_git": {
-    "commit": "431861c8312271b168e0055e2213bcfafcecc31a",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-clean-431861c",
-    "version": "0.2.455",
-    "version_commit": "431861c8312271b168e0055e2213bcfafcecc31a"
+    "root": "/Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.455",
+  "axiom_encode_version": "0.2.1200",
   "backend": "codex",
   "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
-  "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-163/workspace/context-manifest.json",
-  "context_manifest_sha256": "d911ce26863535812a0e679fdb38d8b9a8cf589855ad8aa6b965d789ac807aec",
-  "generated_at": "2026-05-31T04:06:52.176804+00:00",
-  "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/policies/dss/snap-policy-manual/page-163.yaml",
-  "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "5f71b20de45c7a76bcd1d1aa6fa8a392d5d7d38478107e06195e778c955b3552",
-  "generation_prompt_sha256": "416ec0c949f933b54e704638cc34c890c9c03b28f5a33649e2b4234f791742a9",
+  "context_manifest_file": "/Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/wt/us-sc-manual-dss-snap-policy-manual-page-163/encode-out/_eval_workspaces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-163/workspace/context-manifest.json",
+  "context_manifest_sha256": "54246d7ecfe6dd18223b0a231d1d33a052d457ccb567bd221e4aed77ddc254fc",
+  "generated_at": "2026-07-14T19:31:42.457053+00:00",
+  "generated_output_file": "/Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/wt/us-sc-manual-dss-snap-policy-manual-page-163/encode-out/codex-gpt-5.5/policies/dss/snap-policy-manual/page-163.yaml",
+  "generated_output_root": "/Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/wt/us-sc-manual-dss-snap-policy-manual-page-163/encode-out",
+  "generated_output_sha256": "36fc3479ca34c140578116f1900fb3acc80e208ac18b07217e7f942ef2d55ddc",
+  "generation_prompt_sha256": "d4ca22bfd225210ac6357a502c9cd7fe85c2124038708ab2f9deb6cbeb736480",
   "model": "gpt-5.5",
-  "run_id": "48e53a3a",
+  "run_id": "34fa422a",
   "runner": "codex-gpt-5.5",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "31e409e7475d8e4f62c65e27cdf1651511e80dbe57340e673f0df528bd644d6d"
+    "value": "e3cf9422ad06d0d0d16d1e411e3791f8ce68c8c84217fa0c331d02f43e44d151"
+  },
+  "supersedes": {
+    "backend": "codex",
+    "generated_at": "2026-05-31T04:06:52.176804+00:00",
+    "generation_prompt_sha256": "416ec0c949f933b54e704638cc34c890c9c03b28f5a33649e2b4234f791742a9",
+    "manifest_sha256": "44ea327bed51c8275c44fa68e80a74d6a16626f1108214e7ab9916dfef159b7e",
+    "prior_signature": "31e409e7475d8e4f62c65e27cdf1651511e80dbe57340e673f0df528bd644d6d",
+    "run_id": "48e53a3a",
+    "tool": "axiom-encode encode --apply"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-163.json",
-  "trace_sha256": "894a15075ff0dfd82063be712ac9f059766e6f31754b217590faa1a4c897cb03"
+  "trace_file": "/Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/wt/us-sc-manual-dss-snap-policy-manual-page-163/encode-out/traces/codex-gpt-5.5/us-sc-manual-dss-snap-policy-manual-page-163.json",
+  "trace_sha256": "9ae302b2fe3fcda5d3875d9c93f3abc4126c960a0abfc2acbc1d257ce59ba05d"
 }

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -9,13 +9,15 @@
     : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
 - name: liheap_payment_over_threshold_entitles_household_to_mua
   period: 2026-05
   input:
@@ -31,7 +33,6 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua: 20
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
@@ -48,7 +49,7 @@
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: holds
@@ -64,9 +65,20 @@
     : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
+- name: auto_positive_household_basic_utility_allowance_deduction_allowed
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
   output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: holds

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -4,8 +4,15 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: |-
+        Federal SNAP regulations delegate standard utility allowance implementation to state agencies and set a federal LIHEAA/similar energy assistance threshold. The South Carolina SNAP Manual source remains the operative state policy source for the named Mandatory Utility Allowance, Basic Utility Allowance, actual verified utility-cost assignment order, and state verification rule encoded here.
   summary: |-
-    At initial certification, a household will be assigned one utility allowance based on utility cost: actual verified utility cost if not entitled to MUA or BUA, MUA if entitled, BUA if entitled, or no utility deduction. To be entitled to the MUA, the household must incur and be billed for, or expect to incur during the next heating or cooling season, heating or cooling costs; or must have received a LIHEAP payment greater than $20 within the past 12 months.
+    At initial certification, a household will be assigned one of the following utility allowances based on the household's utility cost: actual verified utility cost if not entitled to the MUA or BUA, MUA if entitled, BUA if entitled, or no utility deduction. To be entitled to the MUA, the household must incur and be billed for, or expect to incur during the next heating or cooling season, heating or cooling costs; or must have received a LIHEAP payment greater than $20 within the past 12 months. If actual utility costs or the BUA is assigned and verification is not submitted, the deduction cannot be allowed.
 rules:
   - name: liheap_payment_threshold_for_mua
     kind: parameter
@@ -39,6 +46,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "incur and be billed for, or expect to incur during the next heating or cooling season: Heating cost; Cooling cost"
     versions:
       - effective_from: '0001-01-01'
         formula: |-
@@ -60,7 +68,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-              excerpt: "LIHEAP payment greater than $20 within the past 12 months"
+              excerpt: "received a Low-Income Home Energy Assistance Program (LIHEAP) payment greater than $20 within the past 12 months"
           - path: versions[0].formula
             kind: import
             import:
@@ -83,9 +91,10 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: condition
+            kind: formula
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "To be entitled to the MUA, the following criteria must be met"
           - path: versions[0].formula
             kind: import
             import:
@@ -109,7 +118,7 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: SNAP Manual 12.5(1)(A)
+    source: SNAP Manual 12.5(1)(A), Note
     metadata:
       proof:
         atoms:
@@ -117,6 +126,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "Actual verified utility cost, if not entitled to the MUA or BUA"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "if actual utility costs or the BUA is assigned as the household's utility deduction and verification is not submitted, the deduction cannot be allowed"
           - path: versions[0].formula
             kind: import
             import:
@@ -127,6 +142,7 @@ rules:
       - effective_from: '0001-01-01'
         formula: |-
           household_has_actual_verified_utility_cost
+          and household_submitted_utility_verification
           and not household_entitled_to_mandatory_utility_allowance
           and not household_entitled_to_basic_utility_allowance
 
@@ -135,7 +151,7 @@ rules:
     entity: Household
     dtype: Judgment
     period: Month
-    source: SNAP Manual 12.5(1), Note
+    source: SNAP Manual 12.5(1)(C), Note
     metadata:
       proof:
         atoms:
@@ -143,6 +159,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "Basic utility allowance (BUA) if entitled"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "if actual utility costs or the BUA is assigned as the household's utility deduction and verification is not submitted, the deduction cannot be allowed"
     versions:
       - effective_from: '0001-01-01'
         formula: |-


### PR DESCRIPTION
## Locally bulk-encoded module

- Citation: `us-sc/manual/dss/snap-policy-manual/page-163`
- Module: `us-sc/policies/dss/snap-policy-manual/page-163.yaml`
- Encoder: `codex:gpt-5.5` (toolchain-pinned axiom-encode)
- Local gate: **green**
- ProgramSpec sync: `none`
- Updated /Users/pavelmakarchuk/TheAxiomFoundation/_bulk_drain/wt/us-sc-manual-dss-snap-policy-manual-page-163/rulespec-us/oracle-coverage-pending.yaml: 715 declared (+0 added, -27 drained).

Produced by `bulk/local_drain.py` (local Codex mirror of the bulk-encode dispatcher). The authoritative gate is the required `validate / validate` check.

### Acceptance criteria

Re-encode through canonical encode --apply. Regression review must verify that page-164 BUA eligibility replaces unresolved generic inputs and that an MUA-entitled household cannot simultaneously receive BUA.
