### PR TITLE
Encode Michigan FIP liquid resource eligibility

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -14406,6 +14406,15 @@
         ]
       }
     ],
+    "us-mi/manual/mdhhs/bridges/bem/400/page-5": [
+      {
+        "module": "us-mi/policies/mdhhs/bridges/bem/400/page-5.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mi/manual/mdhhs/bridges/bem/660": [
       {
         "module": "us-mi/policies/mdhhs/bridges/bem/660.yaml",

--- a/us-mi/policies/mdhhs/bridges/bem/400/page-5.test.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/400/page-5.test.yaml
@@ -1,0 +1,17 @@
+- name: liquid_resources_at_limit_are_eligible
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.spm_unit_cash_assets: 15000
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_resources_eligible: holds
+- name: liquid_resources_above_limit_are_ineligible
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.spm_unit_cash_assets: 15001
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_resources_eligible: not_holds
+- name: liquid_resource_limit_parameter
+  period: 2026-01
+  input: {}
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_liquid_resource_limit: 15000

--- a/us-mi/policies/mdhhs/bridges/bem/400/page-5.test.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/400/page-5.test.yaml
@@ -1,17 +1,34 @@
-- name: liquid_resources_at_limit_are_eligible
+- name: cash_investment_retirement_assets_at_limit_are_within_limit
   period: 2026-01
   input:
-    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.spm_unit_cash_assets: 15000
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.mi_fip_countable_cash_investment_retirement_assets: 15000
   output:
-    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_resources_eligible: holds
-- name: liquid_resources_above_limit_are_ineligible
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_cash_investment_retirement_assets_within_limit: holds
+- name: cash_investment_retirement_assets_above_limit_are_not_within_limit
   period: 2026-01
   input:
-    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.spm_unit_cash_assets: 15001
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.mi_fip_countable_cash_investment_retirement_assets: 15001
   output:
-    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_resources_eligible: not_holds
-- name: liquid_resource_limit_parameter
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_cash_investment_retirement_assets_within_limit: not_holds
+- name: real_property_assets_at_limit_are_within_limit
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.mi_fip_countable_real_property_assets: 200000
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_real_property_assets_within_limit: holds
+- name: real_property_assets_above_limit_are_not_within_limit
+  period: 2026-01
+  input:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#input.mi_fip_countable_real_property_assets: 200001
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_real_property_assets_within_limit: not_holds
+- name: cash_investment_retirement_asset_limit_parameter
   period: 2026-01
   input: {}
   output:
-    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_liquid_resource_limit: 15000
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_cash_investment_retirement_asset_limit: 15000
+- name: real_property_asset_limit_parameter
+  period: 2026-01
+  input: {}
+  output:
+    us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_real_property_asset_limit: 200000

--- a/us-mi/policies/mdhhs/bridges/bem/400/page-5.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/400/page-5.yaml
@@ -1,0 +1,63 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/400/page-5
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us-mi/statute/400/57a/3
+        - us-mi/statute/400/57b/1/b
+      rationale: |-
+        Michigan Compiled Laws § 400.57a(3) directs the department to establish
+        FIP income and asset eligibility levels, and § 400.57b(1)(b) conditions
+        FIP eligibility on assets below the limits set by the department. BEM 400
+        supplies the department-set $15,000 liquid-resource amount modeled here.
+  summary: |-
+    Draft, narrow FIP resource slice: FIP treats an asset group with cash,
+    investments, and retirement plans of $15,000 or less as within this liquid
+    resource limit. This module intentionally excludes the separate real-property
+    limit and all other asset, program, and eligibility rules in BEM 400.
+rules:
+  - name: mi_fip_liquid_resource_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Michigan Bridges Eligibility Manual BEM 400, page 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/400/page-5
+              excerpt: "$15,000 or less for cash, investments and retirement plans."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          15000
+  - name: mi_fip_resources_eligible
+    kind: derived
+    entity: SpmUnit
+    dtype: Judgment
+    period: Month
+    source: Michigan Bridges Eligibility Manual BEM 400, page 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/400/page-5
+              excerpt: "$15,000 or less for cash, investments and retirement plans."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_liquid_resource_limit
+              output: mi_fip_liquid_resource_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          spm_unit_cash_assets <= mi_fip_liquid_resource_limit

--- a/us-mi/policies/mdhhs/bridges/bem/400/page-5.yaml
+++ b/us-mi/policies/mdhhs/bridges/bem/400/page-5.yaml
@@ -13,14 +13,23 @@ module:
         Michigan Compiled Laws § 400.57a(3) directs the department to establish
         FIP income and asset eligibility levels, and § 400.57b(1)(b) conditions
         FIP eligibility on assets below the limits set by the department. BEM 400
-        supplies the department-set $15,000 liquid-resource amount modeled here.
+        supplies the department-set asset limits modeled here.
   summary: |-
-    Draft, narrow FIP resource slice: FIP treats an asset group with cash,
-    investments, and retirement plans of $15,000 or less as within this liquid
-    resource limit. This module intentionally excludes the separate real-property
-    limit and all other asset, program, and eligibility rules in BEM 400.
+    FIP asset-limit slice: countable cash, investments, and retirement plans
+    must not exceed $15,000, and countable real-property assets must not exceed
+    $200,000. This module takes the countable totals as inputs; BEM 400's
+    availability, exclusion, valuation, and trust rules are separate rules and
+    are not represented by the limits alone.
+  deferred_outputs:
+    - output: us-mi:policies/mdhhs/bridges/bem/400#mi_fip_asset_eligible
+      blocked_by:
+        - us-mi:policies/mdhhs/bridges/bem/400#mi_fip_countable_asset_composition
+      reason: |-
+        BEM 400 makes countability depend on availability and exclusions and
+        separately addresses trusts. This page supplies the two asset limits,
+        but does not by itself construct all FIP countable assets.
 rules:
-  - name: mi_fip_liquid_resource_limit
+  - name: mi_fip_cash_investment_retirement_asset_limit
     kind: parameter
     dtype: Money
     unit: USD
@@ -37,7 +46,24 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           15000
-  - name: mi_fip_resources_eligible
+  - name: mi_fip_real_property_asset_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Michigan Bridges Eligibility Manual BEM 400, page 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/400/page-5
+              excerpt: "$200,000 for real property assets."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          200000
+  - name: mi_fip_cash_investment_retirement_assets_within_limit
     kind: derived
     entity: SpmUnit
     dtype: Judgment
@@ -54,10 +80,34 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_liquid_resource_limit
-              output: mi_fip_liquid_resource_limit
+              target: us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_cash_investment_retirement_asset_limit
+              output: mi_fip_cash_investment_retirement_asset_limit
               hash: sha256:local
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          spm_unit_cash_assets <= mi_fip_liquid_resource_limit
+          mi_fip_countable_cash_investment_retirement_assets <= mi_fip_cash_investment_retirement_asset_limit
+  - name: mi_fip_real_property_assets_within_limit
+    kind: derived
+    entity: SpmUnit
+    dtype: Judgment
+    period: Month
+    source: Michigan Bridges Eligibility Manual BEM 400, page 5
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us-mi/manual/mdhhs/bridges/bem/400/page-5
+              excerpt: "$200,000 for real property assets."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-mi:policies/mdhhs/bridges/bem/400/page-5#mi_fip_real_property_asset_limit
+              output: mi_fip_real_property_asset_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          mi_fip_countable_real_property_assets <= mi_fip_real_property_asset_limit


### PR DESCRIPTION
## Summary

Adds a review-only RuleSpec candidate for Michigan FIP's liquid-resource eligibility slice from BEM 400 page 5.

- Sets the $15,000 limit for cash, investments, and retirement plans, effective 2026-01-01.
- Exposes `mi_fip_resources_eligible` on `SpmUnit`, aligned to PolicyEngine-US's existing `mi_fip_resources_eligible` surface.
- Includes boundary tests at $15,000 and $15,001, plus a parameter test.

## Scope deliberately excluded

This PR does not model BEM 400's separate $200,000 real-property limit; CDC, RCA, SDA, and FAP rules; asset exclusions; asset-group composition; or FIP's other eligibility conditions.

## Authority

BEM 400 page 5 provides the department-set liquid-resource amount. Michigan Compiled Laws 400.57a(3) and 400.57b(1)(b) delegate FIP asset-level setting to the department; the module records that upstream-authority check.

## Validation

- `axiom-encode validate --skip-reviewers .../page-5.yaml`
- `axiom-encode compile --as-of 2026-01-01 .../page-5.yaml`
- `axiom-encode test .../page-5.test.yaml` (3 cases)

The related corpus-source PR is TheAxiomFoundation/axiom-corpus#332. This is intentionally a draft for review and does not publish or merge any policy.
