### PR TITLE
Normalize the validation waiver root schema

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -1,40 +1,3 @@
-# Pre-existing content debt surfaced when the per-state repos were
-# consolidated and the full repository discipline (companion-test
-# pairing, shape, derived coverage) ran across every jurisdiction for
-# the first time — the standalone state repos had no tests/ directory,
-# so these checks never executed there.
-#
-# tests/test_repository_layout.py fails on gaps NOT listed here and on
-# listed entries that get fixed (remove them as you go), so this list
-# only ratchets down. Do not add entries without an issue link.
-# Tracked in the issue referenced below.
-issue: https://github.com/TheAxiomFoundation/rulespec-us/issues/394
-missing_companion_tests:
-  - us-ny/regulations/18-nycrr/385/3.yaml
-  - us-ny/regulations/18-nycrr/387/10.yaml
-  - us-ny/regulations/18-nycrr/387/12/a.yaml
-  - us-ny/regulations/18-nycrr/387/12/b.yaml
-  - us-ny/regulations/18-nycrr/387/9/a/1.yaml
-  - us-ny/regulations/18-nycrr/387/9/a/2.yaml
-  - us-sc/policies/dss/snap-policy-manual/page-398.yaml
-shape_issues:
-  - us-ca/regulations/mpp/63-406/1.yaml
-uncovered_derived_rules:
-  # Social Security Title II AIME/PIA/COLA derived outputs (42 USC 415) reach AIME
-  # through the engine's sum_top_n_over_periods over-periods reduction, valid only
-  # under lifetime execution; the per-period companion-test harness cannot assert
-  # them. Hand-verified in each module; tracked for machine coverage by
-  # https://github.com/TheAxiomFoundation/axiom-encode/issues/1036.
-  - us/statutes/42/415/a.yaml#aime_in_first_pia_segment
-  - us/statutes/42/415/a.yaml#aime_in_second_pia_segment
-  - us/statutes/42/415/a.yaml#aime_in_third_pia_segment
-  - us/statutes/42/415/a.yaml#unrounded_primary_insurance_amount
-  - us/statutes/42/415/a.yaml#primary_insurance_amount
-  - us/statutes/42/415/b.yaml#old_age_benefit_computation_year_earnings_total
-  - us/statutes/42/415/b.yaml#average_indexed_monthly_earnings
-  - us/statutes/42/415/i.yaml#unrounded_pia_after_cost_of_living_increase
-  - us/statutes/42/415/i.yaml#primary_insurance_amount_after_cost_of_living_increase
-
 # Modules failing encode validate (source grounding etc.) at consolidation
 # time — see https://github.com/TheAxiomFoundation/rulespec-us/issues/396 for the per-jurisdiction burn-down (vendor corpus slices
 # per the rulespec-uk data/corpus pattern, then remove entries).
@@ -5421,18 +5384,3 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-
-# Encoding-manifest sync guard (tests/test_encoding_manifests.py) — modules
-# whose axiom-encode provenance manifest is out of sync at guard-introduction
-# time. Same ratchet contract as above: the guard fails on drift NOT listed
-# here and on listed entries that get fixed. Fix = re-run axiom-encode for
-# the module or refresh/move its manifest, then remove the entry.
-# Motivation: https://github.com/TheAxiomFoundation/rulespec-us/pull/566
-# (review flag on a hand-edited encoded rule) and
-# https://github.com/TheAxiomFoundation/axiom-rules-engine/issues/88.
-stale_encoding_manifests: []
-orphaned_encoding_manifests:
-  # Module moved to us-ca/policies/cdss/snap/standard-utility-allowance.yaml
-  # during the us-ca subtree absorption; its manifest stayed at the old
-  # guidance/ path.
-  - us-ca/guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.yaml

--- a/tests/test_encoding_manifests.py
+++ b/tests/test_encoding_manifests.py
@@ -14,6 +14,12 @@ from test_repository_layout import (
     jurisdiction_dirs,
 )
 
+KNOWN_ORPHANED_ENCODING_MANIFESTS = [
+    # The module moved to us-ca/policies/cdss/snap/standard-utility-allowance.yaml
+    # during subtree absorption; its manifest stayed at the old guidance path.
+    "us-ca/guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.yaml",
+]
+
 # Manifest-sync guard: axiom-encode writes an applied-rulespec manifest
 # (schema axiom-encode/applied-rulespec/v1) next to every encoding run,
 # recording the sha256 of each file it applied. A hand-edit to an encoded
@@ -102,13 +108,12 @@ def test_encoded_modules_match_their_manifests() -> None:
         if hashlib.sha256(module.read_bytes()).hexdigest() != expected:
             stale.append(module.relative_to(ROOT).as_posix())
 
-    problems = apply_gap_ratchet("stale_encoding_manifests", stale)
-    assert problems == [], (
+    assert stale == [], (
         "Encoded rule modules drifted from their encoding manifests "
         "(edited outside the axiom-encode path?). Re-run axiom-encode for "
         "each module below, or refresh its manifest under "
         ".axiom/encoding-manifests/ if the edit is being accepted as-is:\n"
-        + "\n".join(problems)
+        + "\n".join(stale)
     )
 
 
@@ -119,12 +124,11 @@ def test_manifests_reference_existing_modules() -> None:
         if not module.is_file() and entry.get("sha256") and not entry.get("deleted")
     ]
 
-    problems = apply_gap_ratchet("orphaned_encoding_manifests", orphaned)
-    assert problems == [], (
+    assert orphaned == KNOWN_ORPHANED_ENCODING_MANIFESTS, (
         "Encoding manifests reference modules that no longer exist at the "
         "recorded path. Move or regenerate the manifest alongside the "
         "module, or delete it if the module was retired:\n"
-        + "\n".join(problems)
+        + "\n".join(orphaned)
     )
 
 

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -22,6 +22,27 @@ DISALLOWED_GENERIC_RULE_NAMES = {
     "threshold",
     "value",
 }
+KNOWN_MISSING_COMPANION_TESTS = [
+    "us-ny/regulations/18-nycrr/385/3.yaml",
+    "us-ny/regulations/18-nycrr/387/10.yaml",
+    "us-ny/regulations/18-nycrr/387/12/a.yaml",
+    "us-ny/regulations/18-nycrr/387/12/b.yaml",
+    "us-ny/regulations/18-nycrr/387/9/a/1.yaml",
+    "us-ny/regulations/18-nycrr/387/9/a/2.yaml",
+    "us-sc/policies/dss/snap-policy-manual/page-398.yaml",
+]
+KNOWN_SHAPE_ISSUES = ["us-ca/regulations/mpp/63-406/1.yaml"]
+KNOWN_UNCOVERED_DERIVED_RULES = [
+    "us/statutes/42/415/a.yaml#aime_in_first_pia_segment",
+    "us/statutes/42/415/a.yaml#aime_in_second_pia_segment",
+    "us/statutes/42/415/a.yaml#aime_in_third_pia_segment",
+    "us/statutes/42/415/a.yaml#unrounded_primary_insurance_amount",
+    "us/statutes/42/415/a.yaml#primary_insurance_amount",
+    "us/statutes/42/415/b.yaml#old_age_benefit_computation_year_earnings_total",
+    "us/statutes/42/415/b.yaml#average_indexed_monthly_earnings",
+    "us/statutes/42/415/i.yaml#unrounded_pia_after_cost_of_living_increase",
+    "us/statutes/42/415/i.yaml#primary_insurance_amount_after_cost_of_living_increase",
+]
 
 
 def jurisdiction_dirs() -> list[Path]:
@@ -159,7 +180,11 @@ def test_rulespec_files_have_companion_tests() -> None:
         if not path.with_name(f"{path.stem}.test.yaml").exists()
     ]
 
-    assert apply_gap_ratchet("missing_companion_tests", missing) == []
+    # These seven modules have no executable rules, so [] companions are the
+    # repository idiom. The companions land with the canonical-provenance
+    # migration PR; this main-first schema change cannot touch jurisdiction
+    # content while the pinned generated guard is active.
+    assert missing == KNOWN_MISSING_COMPANION_TESTS
 
 
 def test_companion_tests_have_rulespec_files() -> None:
@@ -203,7 +228,7 @@ def test_rulespec_files_use_rulespec_v1_shape() -> None:
                 invalid.append(f"{path.relative_to(ROOT)}: rules[{index}] missing versions")
 
     invalid_paths = sorted({item.split(":", 1)[0] for item in invalid})
-    assert apply_gap_ratchet("shape_issues", invalid_paths) == []
+    assert invalid_paths == KNOWN_SHAPE_ISSUES
 
 
 def test_rulespec_rules_have_source_metadata() -> None:
@@ -329,4 +354,7 @@ def test_derived_rules_are_exercised_by_companion_tests() -> None:
             if canonical_rule_id(path, rule_name) not in covered_outputs
         )
 
-    assert apply_gap_ratchet("uncovered_derived_rules", missing) == []
+    # These Title II lifetime reductions cannot be asserted by the per-period
+    # companion harness; tracked by axiom-encode#1036. Freeze the exact legacy
+    # budget outside the strict canonical waiver document.
+    assert missing == KNOWN_UNCOVERED_DERIVED_RULES


### PR DESCRIPTION
Main-first hard-cut preflight for the canonical-provenance migration (uk#136/be#113 precedent): resolve the five legacy waiver categories so the strict schema (root exactly `validate_failures`) parses on the protected base — the 897 canonical active records carry over untouched. Missing-companion/shape/derived/orphaned-manifest categories are pinned or relocated into frozen test constants per precedent; no content-root changes (old-pin generated guard). The migration PR follows once `us-rulespec-2026-07-13` publishes (recovery: 706/711 citations from official sources; 5 GA citations documented as official-source-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)