### PR TITLE
Pin pending-safe validation bridge

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@55686f89c852b45b26b25ddd4157d6b37bf81926 # pinned (was @main); axiom-encode#1101
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@3d071a25a1a28a4364ff2e801d8359e161913007 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- pin repository checks to the temporary pending-safe legacy validator finalized in TheAxiomFoundation/.github#42
- preserve the existing validation inputs and inherited signing secret
- keep this migration infrastructure isolated from RuleSpec and waiver changes

The bridge keeps protected-base active waivers working and permits only exact evidence-backed pending v5 failures to remain skipped without activating them. It will be replaced by the hardened validator in #909 after the v5 migration is complete.

## Checks

- YAML parse
- actionlint v1.7.11
- git diff --check
- one-file, one-line caller-pin diff
- all 52 jurisdiction validation legs
- generated guard and waiver-change guard
- reverse index and source-staleness report

## Review cycle

The original one-line pin was independently reviewed with no actionable findings. The pin was then updated to the reviewed follow-up bridge commit from TheAxiomFoundation/.github#42 and independently reviewed again. Final result: no actionable regression evident.
