### PR TITLE
Refresh legacy validation bridge pin

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@3d071a25a1a28a4364ff2e801d8359e161913007 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@c2caa2be61ac45f4e040f0da16b066e042f55ef8 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- refresh the immutable shared legacy validation bridge pin to the reviewed merge commit from TheAxiomFoundation/.github PR #46
- keep the caller change isolated to one file and one line

## Validation

- YAML safe-load and `git diff --check` pass
- independent review found no actionable issues
- CI explicitly selected `RuleSpec validation mode: changed`
- all required checks and every validation shard pass

The shared guard review verified that this exact refresh shape remains in changed-file mode while broader workflow edits still trigger full validation.
