### PR TITLE
Pin hardened migration bridge

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -13,6 +13,10 @@ on:
     - cron: "13 6 * * *"
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   validate:
     uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@f3098b4171b69a4e3819f2964c13b820f7992e73 # temporary v5 migration bridge

--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@f3098b4171b69a4e3819f2964c13b820f7992e73 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@b4ee8522c893e391118248886593f6b4d8be5f9a # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto

--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@c2caa2be61ac45f4e040f0da16b066e042f55ef8 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@f3098b4171b69a4e3819f2964c13b820f7992e73 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- repin the temporary RuleSpec validation caller to the reviewed and merged hardened migration bridge

## Checks
- `git diff --check`
- immutable reusable-workflow commit verified against merged `.github` PR #44

This is a bridge refresh only; no RuleSpec or waiver content changes.