### PR TITLE
Harden bulk queue and review runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ into runnable programs.
 - `tests/`: repository-wide validation — layout, companion-test pairing,
   RuleSpec shape, derived-rule coverage, and program-spec scope auditing —
   plus `generate_reverse_index.py`, which builds the provision→rules index.
-- `.axiom/toolchain.toml`: pinned validation toolchain (full commit SHAs).
+- `.axiom/toolchain.toml`: immutable corpus-release and validation-waiver evidence identities.
+- `.axiom/workflow-toolchain.toml`: immutable dependency checkout SHAs used by validation and generation workflows.
 - `.axiom/index/provisions_to_rules.json`: generated reverse index mapping
   each corpus citation path to the modules that depend on it (via module
   `source_verification` and proof-atom sources). Regenerate with

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -1,10 +1,9 @@
 # Bulk encode
 
-A durable queue → runner → PR loop for bulk RuleSpec encoding, independent of
-any local session. It encodes already-ingested provisions with
+A durable queue -> runner -> PR loop for bulk RuleSpec encoding. It encodes
+already-ingested provisions with
 `axiom-encode encode <citation> --apply`, pre-checks them with the same gate
-battery the PR CI runs, opens one PR per module, and lets each PR auto-merge on
-green.
+battery the PR CI runs, and opens one PR per module.
 
 The encoder and the CI gates own correctness. This system is **plumbing**: it
 never edits or invents generated values. Its only judgement is *which*
@@ -16,12 +15,17 @@ provisions to queue.
 | --- | --- |
 | `bulk/worklist.yaml` | The durable queue. One entry per module. Committed. |
 | `bulk/compute_matrix.py` | Turns the worklist into the CI job matrix; single source of truth for status selection. |
-| `bulk/roots_for.py` | Maps an applied module path to `guard-generated --roots`. |
-| `.github/workflows/bulk-encode.yml` | The runner: dispatch → matrix → encode `--apply` → gate battery → PR + auto-merge. |
+| `.axiom/workflow-toolchain.toml` | Immutable checkout SHAs used by CI and generation. |
+| `bulk/local_drain.py` | Legacy recovery runner. Do not use it for signed apply with the current broker-only encoder. |
+| `bulk/applied_artifacts.py` | Validates the module, companion test, and signed manifest written by one encoder apply. |
+| `.github/workflows/bulk-encode.yml` | Fail-closed stub until the protected activation PR enables brokered generation. |
 
 ## Running it
 
-Dispatch from the Actions tab (**Bulk encode → Run workflow**) or the CLI:
+Cloud generation is temporarily disabled by the protected migration base. The
+activation PR replaces the fail-closed stub only after this queue and runner
+support has passed review. After activation, dispatch from the Actions tab
+(**Bulk encode -> Run workflow**) or the CLI:
 
 ```bash
 # Encode the first 8 pending batch-A entries:
@@ -31,39 +35,58 @@ gh workflow run bulk-encode.yml -f batch=A -f limit=8 --repo TheAxiomFoundation/
 gh workflow run bulk-encode.yml -f limit=12 --repo TheAxiomFoundation/rulespec-us
 ```
 
-The `schedule` trigger runs weekly and drains any remaining `pending` entries
-with no human action. Parallelism is capped at 4 (`max-parallel`) to stay under
-OpenAI rate limits; a top-level `concurrency` group serialises whole dispatches
-so two runs never fight over the same `bulk/<slug>` branches.
+After activation, the `schedule` trigger runs weekly and drains any remaining
+`pending` entries with no human action. Parallelism is capped at 4
+(`max-parallel`) to stay under OpenAI rate limits; a top-level `concurrency`
+group serialises whole dispatches so two runs never fight over the same
+`bulk/<slug>` branches.
+
+### Review-safe generation
+
+Once activated, signed apply runs only in the main-branch `bulk-encode.yml`
+workflow. The workflow provisions a root-owned Python runtime and launches the
+current encoder through `axiom-encode-apply-signer`; the private key is consumed
+by the external signer and never reaches the encoder process. `allow_context`
+and `program_scope_sync` metadata travel with each durable queue entry, so a
+restarted job reconstructs the same reviewed command without hand edits.
+
+Every generated PR must complete the independent review/fix cycle and current
+CI before merge. RuleSpec YAML and companion fixtures are never hand-edited;
+findings are fixed in source material, prompts, harnesses, or encoder code and
+then regenerated with `encode --apply`.
 
 ### Secrets (repo Actions secrets on rulespec-us)
 
 | Secret | Why |
 | --- | --- |
 | `OPENAI_API_KEY` | Headless `--backend openai` generation. |
-| `AXIOM_ENCODE_APPLY_SIGNING_KEY` | Signs the apply manifest so `guard-generated` accepts the new files. Must match the key that signs manifests elsewhere. |
-| `BULK_ENCODE_TOKEN` | A `repo`+`workflow`-scoped token used to push the branch and open the PR. **Required**: PRs opened by the default `GITHUB_TOKEN` do **not** trigger the `pull_request` event, so the required `validate / validate` check would never run and auto-merge would hang forever. This token makes the PR a real event that triggers CI. |
+| `AXIOM_ENCODE_APPLY_SIGNING_KEY` | Consumed only by the protected external signer. It must match `AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY`; the encoder never receives it. |
+| `BULK_ENCODE_TOKEN` | A `repo`+`workflow`-scoped token used to push the branch and open the draft PR. **Required**: PRs opened by the default `GITHUB_TOKEN` do **not** trigger the `pull_request` event, so required validation would never run. This token makes the PR a real event that triggers CI. |
 
-## What each job does
+## Activated workflow
+
+The protected activation PR supplies these jobs after the feature PR lands:
 
 1. **dispatch** — installs PyYAML, runs `compute_matrix.py --status pending`
    (optionally `--batch`, `--limit`), and emits the matrix.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.
-   - Reads `.axiom/toolchain.toml` and checks out **the pinned** `axiom-encode`,
+   - Reads `.axiom/workflow-toolchain.toml` and checks out **the pinned** `axiom-encode`,
      `axiom-rules-engine`, and `axiom-corpus`, then builds the engine. Using the
      pinned encoder means generation and the downstream PR CI validate with the
      identical version — no version-skew surprises.
-   - Runs `axiom-encode encode <citation> --apply`. `--apply` validates the main
+   - Provisions the protected signing supervisor and runs
+     `axiom-encode encode <citation> --apply` through the external apply signer.
+     `--apply` validates the main
      file, companion test, and direct dependents in a temporary overlay and
      writes nothing on failure (fail-closed), then installs the three artifacts:
      `statutes/**/<sec>.yaml`, `<sec>.test.yaml`, and a signed
      `.axiom/encoding-manifests/**/<sec>.json`.
    - Runs the gate battery in PR-CI order: `guard-generated` (manifest present),
      `validate --skip-reviewers`, `proof-validate`, then the companion `test`.
-   - Opens `bulk/<slug>` with the manifest summary + gate output as the PR body,
-     labels it `bulk-encode`, and runs `gh pr merge --auto --squash`.
+   - Opens `bulk/<slug>` as a draft with the acceptance criteria, manifest
+     summary, and gate output in the PR body. It never enables auto-merge.
 
 The job **never** uses `--admin`, never bypasses a red check, and never merges
 directly. The authoritative gate is the repository's required
@@ -77,8 +100,8 @@ Set in `worklist.yaml`. The runner reads `pending`; humans/follow-ups own the re
 | --- | --- |
 | `pending` | Queued. The next dispatch may pick it up. |
 | `in-progress` | A run is encoding it (transient). |
-| `needs-fixtures` | Encoded + applied, but the gpt-5.5 companion fixtures hit the #1060 ceiling. The PR opens; auto-merge holds on the red required check until fixtures land. |
-| `pr-open` | A PR exists and is set to auto-merge on green. |
+| `needs-fixtures` | Encoded + applied, but the gpt-5.5 companion fixtures hit the #1060 ceiling. The draft PR remains open for an encoder fix and rerun. |
+| `pr-open` | A draft PR exists and is waiting for its review/fix cycle and CI. |
 | `merged` | The PR merged to main. Terminal success. |
 | `failed` | Encode or a non-fixture gate failed. Needs human triage. Never auto-retried, never merged. |
 
@@ -91,14 +114,13 @@ local convenience.
 `--apply` succeeds when the module compiles, validates, and its proof tree
 checks. The **companion test fixtures** are a separate quality tier: the #1060
 ceiling means gpt-5.5-authored fixtures sometimes fail. When that happens the
-runner marks the module `needs-fixtures` and still opens the PR, so the encoded
-module is reviewable and its auto-merge simply waits.
+runner marks the module `needs-fixtures` and still opens a draft PR so the
+encoded module and failure are reviewable.
 
-A follow-up agent pass then writes correct fixtures — honestly split, i.e. the
-fixture values come from re-deriving expected outputs against the engine, never
-back-filled to make a test pass. Once fixtures are committed to the PR branch,
-the required check goes green and auto-merge completes. Update the worklist entry
-to `pr-open`, then `merged`.
+A follow-up pass fixes the encoder prompt, harness, source material, or other
+root cause and reruns `encode --apply`; generated fixtures are never hand-edited
+or back-filled to make a test pass. Once the regenerated artifacts pass review
+and CI, the PR can merge. Update the worklist entry to `pr-open`, then `merged`.
 
 ## Failure taxonomy
 
@@ -106,7 +128,7 @@ to `pr-open`, then `merged`.
 | --- | --- | --- |
 | `Generated RuleSpec failed CI validation` at apply | apply-blocked | Read `*.repair.json` under the run's `encode-out`; usually a bad generated formula or unresolved import. Re-encode (a new run), do not hand-edit. |
 | `points to a RuleSpec file that could not be resolved: rulespec-us-<state>/...` | resolver/layout | The checkout leaf dir was not `rulespec-us`, or a sibling checkout was missing. The workflow guards the leaf-dir name; check the sibling symlink step. |
-| companion test red only | fixtures (#1060) | `needs-fixtures`; run the follow-up fixture pass. |
+| companion test red only | fixtures (#1060) | `needs-fixtures`; fix the encoder or its inputs and re-encode. |
 | self-import / same-section subsection import error | encode#1058 | The section is too cross-reference-heavy for a clean atomic encode. Drop it from the worklist or split the citation to the self-contained fragment. |
 | `oracle coverage ... unmapped` on the PR | oracle mapping | The output needs a PolicyEngine oracle mapping entry (`axiom-encode classify`). Out of scope for the encode job; handle as a mapping follow-up. |
 | 429 from OpenAI | rate limit | Lower `limit`/`max-parallel` or re-dispatch later. The concurrency group prevents overlapping runs. |
@@ -158,6 +180,6 @@ already lives org-wide in
 country adopts bulk encoding, lift `bulk-encode.yml` into the org `.github`
 repo as a `workflow_call` reusable workflow parameterised by repo + worklist
 path, and keep a thin per-repo `bulk/worklist.yaml` + caller. The gate battery,
-toolchain-pin resolution, and PR/auto-merge logic are already repo-agnostic
+toolchain-pin resolution, and draft-PR logic are already repo-agnostic
 except for the hard-coded `rulespec-us` leaf-dir guard, which would become an
 input.

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -12,7 +12,11 @@ from pathlib import Path, PurePosixPath
 MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
 JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
 SOURCE_BUCKETS = {
+    "form": frozenset({"policies"}),
+    "forms": frozenset({"policies"}),
+    "guidance": frozenset({"policies"}),
     "manual": frozenset({"manual", "policies"}),
+    "manuals": frozenset({"manual", "policies"}),
     "policy": frozenset({"policies"}),
     "policies": frozenset({"policies"}),
     "regulation": frozenset({"regulations"}),
@@ -103,7 +107,11 @@ def _module_matches_request(citation: str, module: str) -> bool:
         return False
     request_tokens = _legal_path_tokens(tuple(request_tail))
     output_tokens = _legal_path_tokens(output.parts[2:])
-    if source_bucket.lower() in {"regulation", "regulations"}:
+    if (
+        source_bucket.lower() in {"regulation", "regulations"}
+        and request_tail
+        and request_tail[0].isdigit()
+    ):
         # Federal regulation modules canonicalize a numeric title as ``N-cfr``.
         if len(output_tokens) >= 2 and output_tokens[1] == "cfr":
             output_tokens = (output_tokens[0], *output_tokens[2:])

--- a/bulk/applied_artifacts.py
+++ b/bulk/applied_artifacts.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Locate and validate the artifacts written by one bulk encode apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+MODULE_BUCKETS = {"manual", "policies", "regulations", "statutes"}
+JURISDICTION_RE = re.compile(r"[a-z]{2}(?:-[a-z0-9-]+)?")
+SOURCE_BUCKETS = {
+    "manual": frozenset({"manual", "policies"}),
+    "policy": frozenset({"policies"}),
+    "policies": frozenset({"policies"}),
+    "regulation": frozenset({"regulations"}),
+    "regulations": frozenset({"regulations"}),
+    "statute": frozenset({"statutes"}),
+    "statutes": frozenset({"statutes"}),
+}
+
+
+def changed_paths(repo: Path) -> list[str]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    records = completed.stdout.split(b"\0")
+    paths: list[str] = []
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if not record:
+            continue
+        if len(record) < 4 or record[2:3] != b" ":
+            raise ValueError("malformed git status --porcelain=v1 -z output")
+        status = record[:2]
+        paths.append(record[3:].decode("utf-8", errors="strict"))
+        if b"R" in status or b"C" in status:
+            if index >= len(records) or not records[index]:
+                raise ValueError("git rename/copy status is missing its source path")
+            index += 1
+    return paths
+
+
+def _is_module(path: PurePosixPath) -> bool:
+    return (
+        len(path.parts) >= 3
+        and bool(JURISDICTION_RE.fullmatch(path.parts[0]))
+        and path.parts[1] in MODULE_BUCKETS
+        and path.suffix == ".yaml"
+        and not path.name.endswith(".test.yaml")
+    )
+
+
+def _is_manifest(path: PurePosixPath) -> bool:
+    parts = path.parts
+    return (
+        bool(parts)
+        and parts[0] != "_axiom"
+        and path.suffix == ".json"
+        and any(
+            parts[index : index + 2] == (".axiom", "encoding-manifests")
+            for index in range(len(parts) - 1)
+        )
+    )
+
+
+def _canonical_module_citation(module: str) -> str:
+    path = PurePosixPath(module)
+    relative = path.with_suffix("").parts
+    return f"{relative[0]}:{'/'.join(relative[1:])}"
+
+
+def _legal_path_tokens(parts: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        token.lower()
+        for part in parts
+        for token in re.findall(r"[a-z0-9]+", part.lower())
+    )
+
+
+def _module_matches_request(citation: str, module: str) -> bool:
+    request = PurePosixPath(citation)
+    output = PurePosixPath(module).with_suffix("")
+    if len(request.parts) < 3 or len(output.parts) < 3:
+        return False
+    jurisdiction, source_bucket, *request_tail = request.parts
+    expected_buckets = SOURCE_BUCKETS.get(source_bucket.lower())
+    if expected_buckets is None:
+        return False
+    request_tokens = _legal_path_tokens(tuple(request_tail))
+    output_tokens = _legal_path_tokens(output.parts[2:])
+    if source_bucket.lower() in {"regulation", "regulations"}:
+        # Federal regulation modules canonicalize a numeric title as ``N-cfr``.
+        if len(output_tokens) >= 2 and output_tokens[1] == "cfr":
+            output_tokens = (output_tokens[0], *output_tokens[2:])
+    return (
+        output.parts[0].lower() == jurisdiction.lower()
+        and output.parts[1].lower() in expected_buckets
+        and request_tokens == output_tokens
+    )
+
+
+def discover_applied_artifacts(
+    repo: Path,
+    *,
+    citation: str,
+    paths: list[str] | None = None,
+) -> tuple[str, str, str]:
+    repo = Path(repo)
+    candidates = paths if paths is not None else changed_paths(repo)
+    modules = sorted(path for path in candidates if _is_module(PurePosixPath(path)))
+    manifests = sorted(path for path in candidates if _is_manifest(PurePosixPath(path)))
+    if len(modules) != 1:
+        raise ValueError(
+            f"expected one applied module; found {len(modules)}: {modules}"
+        )
+    if len(manifests) != 1:
+        raise ValueError(
+            f"expected one applied manifest; found {len(manifests)}: {manifests}"
+        )
+
+    module = modules[0]
+    test_file = f"{module[: -len('.yaml')]}.test.yaml"
+    if not (repo / module).is_file():
+        raise ValueError(f"applied module does not exist: {module}")
+    if not (repo / test_file).is_file():
+        raise ValueError(f"companion test does not exist: {test_file}")
+
+    manifest_rel = manifests[0]
+    try:
+        manifest = json.loads((repo / manifest_rel).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"could not read applied manifest {manifest_rel}: {exc}"
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(f"applied manifest {manifest_rel} must contain a JSON object")
+    if not _module_matches_request(citation, module):
+        raise ValueError(
+            f"applied module {module!r} does not match requested citation {citation!r}"
+        )
+    manifest_citation = manifest.get("citation")
+    accepted_citations = {citation, _canonical_module_citation(module)}
+    if manifest_citation not in accepted_citations:
+        raise ValueError(
+            f"manifest citation {manifest_citation!r} does not match input "
+            f"{citation!r} or generated module {module!r}"
+        )
+
+    applied_files = manifest.get("applied_files")
+    if not isinstance(applied_files, list):
+        raise ValueError(f"manifest {manifest_rel} has no applied_files list")
+    actual_paths = {
+        item.get("path")
+        for item in applied_files
+        if isinstance(item, dict)
+        and item.get("deleted") is not True
+        and isinstance(item.get("path"), str)
+    }
+    expected_full = {module, test_file}
+    expected_local = {
+        path.split("/", 1)[1] if "/" in path else path for path in expected_full
+    }
+    local_module = module.split("/", 1)[1]
+    covers_changed_module = (
+        actual_paths <= expected_full and module in actual_paths
+    ) or (actual_paths <= expected_local and local_module in actual_paths)
+    if not covers_changed_module:
+        raise ValueError(
+            f"manifest {manifest_rel} covers {sorted(actual_paths)}; expected the "
+            f"changed module in {sorted(expected_full)} or {sorted(expected_local)}"
+        )
+    if PurePosixPath(module).parts[1] == "manual":
+        raise ValueError(
+            f"applied module {module!r} uses the frozen legacy manual root; "
+            "manual sources must encode to the policies root"
+        )
+    return module, test_file, manifest_rel
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--citation", required=True)
+    args = parser.parse_args()
+    try:
+        artifacts = discover_applied_artifacts(args.repo, citation=args.citation)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        parser.error(str(exc))
+    print("\n".join(artifacts))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -15,9 +15,10 @@ Usage:
   # Read one field (used by the runner to look up backend/model per entry):
   python bulk/compute_matrix.py --get us-ny/statute/TAX/673 --field model
 
-The matrix shape is {"include": [{"citation", "repo", "backend", "model",
-"slug"}, ...]}. `slug` is the branch-safe citation slug used for
-`bulk/<slug>` branches and the PR title.
+The matrix shape preserves the reviewed execution metadata needed by local
+jobs, in addition to the citation/backend/model fields used by cloud jobs.
+`slug` is the branch-safe citation slug used for `bulk/<slug>` branches and the
+PR title.
 
 Status writes are intentionally NOT done here: the workflow updates statuses by
 committing to the worklist through a dedicated follow-up (so status changes are
@@ -37,7 +38,8 @@ import yaml
 
 WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
-SELECTABLE_STATUSES = {"pending"}
+SELECTABLE_STATUSES = {"pending", "pending-local"}
+REPO_ROOT = WORKLIST.parents[1]
 
 
 def citation_slug(citation: str) -> str:
@@ -66,6 +68,29 @@ def entry_model(data: dict, entry: dict) -> str:
     return entry.get("model") or data.get("defaults", {}).get("model", "gpt-5.5")
 
 
+def entry_allow_context(entry: dict) -> list[str]:
+    """Return reviewed repo-local encoder context paths for one queue entry."""
+    citation = entry.get("citation", "unknown citation")
+    values = entry.get("allow_context", [])
+    if not isinstance(values, list) or not all(
+        isinstance(value, str) and value and "\n" not in value for value in values
+    ):
+        raise ValueError(
+            f"{citation}: allow_context must be a list of non-empty path strings"
+        )
+    root = REPO_ROOT.resolve()
+    for value in values:
+        path = Path(value)
+        resolved = (root / path).resolve()
+        if path.is_absolute() or not resolved.is_relative_to(root):
+            raise ValueError(f"{citation}: allow_context path escapes the repository")
+        if not resolved.is_file():
+            raise ValueError(
+                f"{citation}: allow_context path is not a repository file: {value}"
+            )
+    return values
+
+
 def select(data: dict, status: str, batch: str | None, limit: int | None) -> list[dict]:
     out: list[dict] = []
     for entry in data["entries"]:
@@ -73,13 +98,59 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
             continue
         if batch and str(entry.get("batch", "")).upper() != batch.upper():
             continue
+        dependencies = entry.get("requires_merged_citations", [])
+        if not isinstance(dependencies, list) or not all(
+            isinstance(value, str) and value for value in dependencies
+        ):
+            raise ValueError(
+                f"{entry.get('citation')}: requires_merged_citations must be "
+                "a list of non-empty strings"
+            )
+        program_scope_sync = entry.get("program_scope_sync")
+        if program_scope_sync is not None and not isinstance(program_scope_sync, dict):
+            raise ValueError(
+                f"{entry.get('citation')}: program_scope_sync must be a mapping"
+            )
+        if program_scope_sync is not None:
+            program_spec = program_scope_sync.get("program_spec")
+            scope = program_scope_sync.get("scope")
+            additions = program_scope_sync.get("add", [])
+            removals = program_scope_sync.get("remove", [])
+            if not isinstance(program_spec, str) or not program_spec:
+                raise ValueError(
+                    f"{entry.get('citation')}: program_scope_sync.program_spec "
+                    "must be a non-empty string"
+                )
+            if scope not in {"federal", "state", "local"}:
+                raise ValueError(
+                    f"{entry.get('citation')}: program_scope_sync.scope must be "
+                    "federal, state, or local"
+                )
+            for field, values in (("add", additions), ("remove", removals)):
+                if not isinstance(values, list) or not all(
+                    isinstance(value, str) and value and "\n" not in value
+                    for value in values
+                ):
+                    raise ValueError(
+                        f"{entry.get('citation')}: program_scope_sync.{field} "
+                        "must be a list of non-empty strings"
+                    )
+            if not additions and not removals:
+                raise ValueError(
+                    f"{entry.get('citation')}: program_scope_sync must add or "
+                    "remove at least one module"
+                )
         out.append(
             {
                 "citation": entry["citation"],
                 "repo": entry.get("repo", "rulespec-us"),
                 "backend": entry_backend(data, entry),
                 "model": entry_model(data, entry),
+                "acceptance_criteria": entry.get("note", ""),
                 "slug": citation_slug(entry["citation"]),
+                "allow_context": entry_allow_context(entry),
+                "requires_merged_citations": dependencies,
+                "program_scope_sync": program_scope_sync,
             }
         )
     if limit is not None:
@@ -89,9 +160,15 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--status", default="pending", help="Entry status to select (or 'any').")
-    ap.add_argument("--batch", default=None, help="Restrict to a batch label (A, B, ...).")
-    ap.add_argument("--limit", type=int, default=None, help="Cap the number of entries.")
+    ap.add_argument(
+        "--status", default="pending", help="Entry status to select (or 'any')."
+    )
+    ap.add_argument(
+        "--batch", default=None, help="Restrict to a batch label (A, B, ...)."
+    )
+    ap.add_argument(
+        "--limit", type=int, default=None, help="Cap the number of entries."
+    )
     ap.add_argument(
         "--format",
         choices=["matrix", "table", "count"],
@@ -99,7 +176,11 @@ def main() -> int:
         help="matrix = GitHub Actions include JSON; table = human listing.",
     )
     ap.add_argument("--get", default=None, help="Look up a single citation's entry.")
-    ap.add_argument("--field", default=None, help="With --get, print one field (model/backend/status/slug).")
+    ap.add_argument(
+        "--field",
+        default=None,
+        help="With --get, print one field (model/backend/status/slug).",
+    )
     ap.add_argument(
         "--set-status",
         nargs=2,
@@ -108,6 +189,12 @@ def main() -> int:
         help="LOCAL ONLY: set an entry's status in place.",
     )
     args = ap.parse_args()
+
+    if args.status not in SELECTABLE_STATUSES | {"any"}:
+        raise SystemExit(
+            f"unsupported selectable status: {args.status}; expected one of "
+            f"{', '.join(sorted(SELECTABLE_STATUSES | {'any'}))}"
+        )
 
     data = load()
 
@@ -147,8 +234,12 @@ def main() -> int:
         print(len(selected))
     elif args.format == "table":
         for item in selected:
-            print(f"{item['slug']:34s} {item['backend']}:{item['model']:10s} {item['citation']}")
-        print(f"\n{len(selected)} entr{'y' if len(selected) == 1 else 'ies'} selected (status={args.status}).")
+            print(
+                f"{item['slug']:34s} {item['backend']}:{item['model']:10s} {item['citation']}"
+            )
+        print(
+            f"\n{len(selected)} entr{'y' if len(selected) == 1 else 'ies'} selected (status={args.status})."
+        )
     else:
         print(json.dumps({"include": selected}))
     return 0

--- a/bulk/local_drain.py
+++ b/bulk/local_drain.py
@@ -3,26 +3,23 @@
 
 Drains ``bulk/worklist.yaml`` on the operator's machine using the local Codex
 CLI (ChatGPT subscription, ``gpt-5.5``) instead of the cloud ``bulk-encode.yml``
-dispatcher, opening the identical one-PR-per-module with auto-merge. It is a
-faithful local mirror of ``.github/workflows/bulk-encode.yml`` plus the
-oracle-coverage-pending declaration step the cloud dispatcher is missing (that
-missing step is why every new-state bulk PR fails the changed-file oracle
-coverage gate; see ``unstick`` below and the workflow fix in the same PR as this
-script).
+dispatcher, opening one draft PR per module for independent review. It mirrors
+the generation path while adding the exact-checkout oracle-coverage-pending
+declaration needed to keep new-state PRs out of the unmapped coverage state.
 
 Two decisions matter and are baked in here so PRs go green:
 
-* **Generation uses the toolchain-pinned encoder** (``.axiom/toolchain.toml``
-  ``axiom_encode_version``, currently 0.2.1184). The required ``validate /
+* **Generation uses the workflow-pinned encoder**
+  (``.axiom/workflow-toolchain.toml``
+  ``axiom_encode_version``). The required ``validate /
   validate`` check validates with that same pin, so generating with anything
   newer risks schema/manifest skew. Do NOT "upgrade" the generation encoder to
   match a brief that says ">=0.2.1190" -- that number refers only to the
   *coverage/sync* tool below, not to generation.
-* **Coverage declaration uses axiom-encode main (>=0.2.1190)**, because the CI
-  changed-file coverage classifier (``oracle-coverage-axiom-encode-ref``,
-  default ``main``) is what reclassifies declared-pending outputs from
-  ``unmapped`` to ``pending_classification``. The pinned 1184 encoder does not
-  even have the ``oracle-coverage-pending`` subcommand.
+* **Coverage declaration uses the immutable protected workflow pin.** Before
+  any mutation, the runner requires the recovery checkout to match
+  ``.axiom/workflow-toolchain.toml``. This keeps the coverage classifier aligned
+  with the exact-checkout contract used by required CI.
 
 Everything runs foreground. The loop is chunked (``--max-seconds``,
 ``--max-entries``) and every unit of durable state (pushed branch, opened PR,
@@ -34,19 +31,17 @@ Toolchain layout (override via env): a sibling ``_bulk_drain`` workspace holds
 pinned checkouts + venvs built once by the operator:
 
     _bulk_drain/
-      axiom-encode/            # worktree @ pinned axiom_encode_ref (1184)
+      axiom-encode/            # worktree @ pinned axiom_encode_ref
       .venv/                   # pinned encoder venv  -> generation
-      axiom-encode-cov/        # worktree @ axiom-encode main (>=1190)
+      axiom-encode-cov/        # worktree @ workflow-pinned axiom_encode_ref
       .venv-cov/               # coverage/sync venv   -> oracle-coverage-pending
       axiom-rules-engine/      # worktree @ pinned engine ref, cargo build
       axiom-corpus/            # worktree @ pinned corpus ref
       wt/<slug>/rulespec-us/   # per-entry generation worktrees (leaf MUST be rulespec-us)
 
 Usage:
-    python bulk/local_drain.py drain   [--limit N] [--batch A] [--concurrency 3]
-                                       [--max-entries N] [--max-seconds 540]
     python bulk/local_drain.py unstick [--pr N ...] [--all] [--wait]
-    python bulk/local_drain.py doctor  # verify toolchain + auth + signing key
+    python bulk/local_drain.py doctor  # verify recovery toolchain + auth
 """
 
 from __future__ import annotations
@@ -60,14 +55,21 @@ import subprocess
 import sys
 import threading
 import time
-import tomllib
-from datetime import date, datetime, timezone
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 local drain environments.
+    import tomli as tomllib
+from datetime import datetime, timezone
 from pathlib import Path
+
+from applied_artifacts import discover_applied_artifacts
 
 REPO = "TheAxiomFoundation/rulespec-us"
 REPO_NAME = "rulespec-us"
-HERE = Path(__file__).resolve().parent           # <checkout>/bulk
-CHECKOUT = HERE.parent                            # this checkout root
+COV_ORACLES_REF = "9901e2479ac39bba865b8232e1c7d879ba447d8d"
+HERE = Path(__file__).resolve().parent  # <checkout>/bulk
+CHECKOUT = HERE.parent  # this checkout root
 
 # --- toolchain / workspace resolution ---------------------------------------
 DRAIN_BASE = Path(
@@ -76,6 +78,9 @@ DRAIN_BASE = Path(
 GEN_AE = Path(os.environ.get("DRAIN_GEN_AE", DRAIN_BASE / ".venv/bin/axiom-encode"))
 COV_AE = Path(os.environ.get("DRAIN_COV_AE", DRAIN_BASE / ".venv-cov/bin/axiom-encode"))
 COV_PY = Path(os.environ.get("DRAIN_COV_PY", DRAIN_BASE / ".venv-cov/bin/python"))
+COV_CHECKOUT = Path(
+    os.environ.get("DRAIN_COV_CHECKOUT", DRAIN_BASE / "axiom-encode-cov")
+).resolve()
 ENGINE = Path(os.environ.get("DRAIN_ENGINE", DRAIN_BASE / "axiom-rules-engine"))
 CORPUS = Path(os.environ.get("DRAIN_CORPUS", DRAIN_BASE / "axiom-corpus"))
 ENGINE_BIN = ENGINE / "target" / "debug"
@@ -92,7 +97,7 @@ LIMIT_SIGNS = re.compile(
 )
 
 _print_lock = threading.Lock()
-_wt_lock = threading.Lock()          # git worktree add/remove is not concurrency-safe
+_wt_lock = threading.Lock()  # git worktree add/remove is not concurrency-safe
 _PAUSE = threading.Event()
 
 
@@ -101,48 +106,52 @@ def log(msg: str) -> None:
         print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
 
 
-def run(cmd, cwd=None, env=None, capture=True, check=False, timeout=None):
+def run(
+    cmd,
+    cwd=None,
+    env=None,
+    capture=True,
+    check=False,
+    timeout=None,
+    merge_stderr=True,
+):
     """Run a subprocess, returning (rc, combined_output)."""
     full = dict(os.environ)
     if env:
-        full.update(env)
+        for key, value in env.items():
+            if value is None:
+                full.pop(key, None)
+            else:
+                full[key] = value
     proc = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd else None,
         env=full,
         stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.STDOUT if capture else None,
+        stderr=(subprocess.STDOUT if merge_stderr else subprocess.DEVNULL)
+        if capture
+        else None,
         text=True,
         timeout=timeout,
     )
     out = proc.stdout or "" if capture else ""
     if check and proc.returncode != 0:
-        raise RuntimeError(f"cmd failed ({proc.returncode}): {' '.join(map(str, cmd))}\n{out}")
+        raise RuntimeError(
+            f"cmd failed ({proc.returncode}): {' '.join(map(str, cmd))}\n{out}"
+        )
     return proc.returncode, out
 
 
 def signing_key() -> str:
-    key = os.environ.get("AXIOM_ENCODE_APPLY_SIGNING_KEY", "").strip()
-    if key:
-        return key
-    agent_secret = str(Path.home() / "bin/agent-secret")
-    for cmd in (
-        [agent_secret, "get", "agent/axiom-encode-apply-signing-key"],
-        ["agent-secret", "get", "agent/axiom-encode-apply-signing-key"],
-    ):
-        try:
-            rc, out = run(cmd)
-            if rc == 0 and out.strip():
-                return out.strip()
-        except FileNotFoundError:
-            continue
-    raise SystemExit("Signing key AXIOM_ENCODE_APPLY_SIGNING_KEY unavailable "
-                     "(tried env + agent-secret + manage-secret.sh).")
+    raise SystemExit(
+        "Local signed generation is disabled. Use the protected bulk-encode "
+        "workflow so the private key remains inside the external signer."
+    )
 
 
 def pinned_toolchain() -> dict:
-    data = tomllib.loads((CHECKOUT / ".axiom/toolchain.toml").read_text())
-    return data.get("toolchain", data)
+    data = tomllib.loads((CHECKOUT / ".axiom/workflow-toolchain.toml").read_text())
+    return data["workflow_toolchain"]
 
 
 def citation_slug(citation: str) -> str:
@@ -160,6 +169,40 @@ def gh_json(args):
         return None
 
 
+def ensure_draft_pr(branch: str) -> None:
+    pr = gh_json(
+        ["pr", "view", branch, "--repo", REPO, "--json", "isDraft,autoMergeRequest"]
+    )
+    if pr is None:
+        raise RuntimeError(f"could not read PR state for {branch}")
+    if pr.get("autoMergeRequest") is not None:
+        run(
+            ["gh", "pr", "merge", branch, "--repo", REPO, "--disable-auto"],
+            check=True,
+        )
+    if pr.get("isDraft") is not True:
+        run(["gh", "pr", "ready", branch, "--repo", REPO, "--undo"], check=True)
+
+    verified = gh_json(
+        ["pr", "view", branch, "--repo", REPO, "--json", "isDraft,autoMergeRequest"]
+    )
+    if (
+        verified is None
+        or verified.get("isDraft") is not True
+        or verified.get("autoMergeRequest") is not None
+    ):
+        raise RuntimeError(
+            f"refusing to continue: {branch} is not a draft with auto-merge disabled"
+        )
+
+
+def pause_for_retry(result: dict, detail: str) -> dict:
+    _PAUSE.set()
+    result["status"] = "paused"
+    result["detail"] = detail
+    return result
+
+
 # --- worktree helpers -------------------------------------------------------
 def make_worktree(slug: str, ref: str) -> Path:
     """Fresh generation worktree whose leaf dir is exactly ``rulespec-us``
@@ -168,7 +211,9 @@ def make_worktree(slug: str, ref: str) -> Path:
     leaf = parent / REPO_NAME
     with _wt_lock:
         if leaf.exists():
-            run(["git", "-C", str(CHECKOUT), "worktree", "remove", "--force", str(leaf)])
+            run(
+                ["git", "-C", str(CHECKOUT), "worktree", "remove", "--force", str(leaf)]
+            )
         parent.mkdir(parents=True, exist_ok=True)
         run(["git", "-C", str(CHECKOUT), "fetch", "origin", "main", "--quiet"])
         run(["git", "-C", str(CHECKOUT), "worktree", "add", "--detach", str(leaf), ref])
@@ -192,11 +237,24 @@ def regen_index(leaf: Path) -> None:
 
 
 def sync_pending(leaf: Path) -> str:
-    """Write oracle-coverage-pending.yaml for REPO_NAME using the >=1190 tool.
+    """Write oracle-coverage-pending.yaml using the pinned classifier.
     Returns the sync summary line."""
-    rc, out = run([str(COV_AE), "oracle-coverage-pending", "sync",
-                   "--root", str(leaf.parent), "--repo", REPO_NAME, "--source", "bulk"],
-                  env={"PATH": f"{ENGINE_BIN}:{os.environ['PATH']}"})
+    require_coverage_ref()
+    rc, out = run(
+        [
+            str(COV_AE),
+            "oracle-coverage-pending",
+            "sync",
+            "--root",
+            str(leaf),
+            "--source",
+            "bulk",
+        ],
+        env={
+            "PATH": f"{ENGINE_BIN}:{os.environ['PATH']}",
+            "AXIOM_ENCODE_APPLY_SIGNING_KEY": None,
+        },
+    )
     if rc != 0:
         raise RuntimeError(f"oracle-coverage-pending sync failed:\n{out}")
     return out.strip().splitlines()[-1] if out.strip() else "(no output)"
@@ -211,8 +269,19 @@ def finalize_pending(leaf: Path) -> bool:
     pf = leaf / "oracle-coverage-pending.yaml"
     if not pf.exists():
         return False
-    tracked = run(["git", "-C", str(leaf), "ls-files", "--error-unmatch",
-                   "oracle-coverage-pending.yaml"])[0] == 0
+    tracked = (
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "ls-files",
+                "--error-unmatch",
+                "oracle-coverage-pending.yaml",
+            ]
+        )[0]
+        == 0
+    )
     has_entries = "- legal_id:" in pf.read_text(encoding="utf-8")
     if not has_entries and not tracked:
         pf.unlink()
@@ -220,21 +289,72 @@ def finalize_pending(leaf: Path) -> bool:
     return True
 
 
+def is_encoding_manifest_path(path: str) -> bool:
+    return path.startswith(".axiom/encoding-manifests/") or bool(
+        re.match(
+            r"^[a-z]{2}(?:-[a-z0-9-]+)?/\.axiom/encoding-manifests/",
+            path,
+        )
+    )
+
+
+def aggregate_validation_state(checks: list[dict]) -> str | None:
+    states = [
+        str(check.get("conclusion") or check.get("state") or "").upper()
+        for check in checks
+        if str(check.get("name") or "").startswith("validate / validate")
+    ]
+    if not states:
+        return None
+    failed = {
+        "ACTION_REQUIRED",
+        "CANCELLED",
+        "ERROR",
+        "FAILURE",
+        "STALE",
+        "TIMED_OUT",
+    }
+    if any(state in failed for state in states):
+        return "FAILURE"
+    complete = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+    if any(state not in complete for state in states):
+        return "PENDING"
+    return "SUCCESS"
+
+
 # ---------------------------------------------------------------------------
 # PART A: unstick already-open new-state bulk PRs (priority).
 # ---------------------------------------------------------------------------
 def open_bulk_prs():
-    data = gh_json(["pr", "list", "--repo", REPO, "--state", "open", "--limit", "200",
-                    "--json", "number,headRefName,mergeStateStatus,statusCheckRollup"])
+    data = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,headRefName,mergeStateStatus,statusCheckRollup",
+        ]
+    )
+    if data is None:
+        raise RuntimeError("could not list open bulk PRs")
     prs = []
-    for pr in data or []:
+    for pr in data:
         if not pr["headRefName"].startswith("bulk/"):
             continue
-        vv = next((c.get("conclusion") or c.get("state")
-                   for c in pr.get("statusCheckRollup") or []
-                   if c.get("name") == "validate / validate"), None)
-        prs.append({"number": pr["number"], "branch": pr["headRefName"],
-                    "merge": pr["mergeStateStatus"], "validate": vv})
+        vv = aggregate_validation_state(pr.get("statusCheckRollup") or [])
+        prs.append(
+            {
+                "number": pr["number"],
+                "branch": pr["headRefName"],
+                "merge": pr["mergeStateStatus"],
+                "validate": vv,
+            }
+        )
     return sorted(prs, key=lambda p: p["number"])
 
 
@@ -253,81 +373,332 @@ def unstick_pr(branch: str, wait: bool) -> str:
     try:
         run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
         run(["git", "-C", str(leaf), "fetch", "origin", branch, "--quiet"])
-        _, diff = run(["git", "-C", str(leaf), "diff", "--name-only",
-                       f"origin/main...FETCH_HEAD"])
-        artifacts = [f for f in diff.splitlines()
-                     if (MODULE_RE.match(f) or f.endswith(".test.yaml")
-                         or "/.axiom/encoding-manifests/" in f)]
+        _, diff = run(
+            ["git", "-C", str(leaf), "diff", "--name-only", "origin/main...FETCH_HEAD"]
+        )
+        program_specs = [f for f in diff.splitlines() if PROGRAM_SPEC_RE.match(f)]
+        artifacts = [
+            f
+            for f in diff.splitlines()
+            if (
+                MODULE_RE.match(f)
+                or f.endswith(".test.yaml")
+                or is_encoding_manifest_path(f)
+            )
+        ]
         if not artifacts:
             return f"{branch}: no module artifacts in diff (already merged?)"
-        run(["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],
-            check=True)
+        run(
+            ["git", "-C", str(leaf), "checkout", "FETCH_HEAD", "--", *artifacts],
+            check=True,
+        )
+        composition_files = []
+        if program_specs:
+            item = worklist_item_for_slug(leaf, slug)
+            configured_spec = (item.get("program_scope_sync") or {}).get("program_spec")
+            if program_specs != [configured_spec]:
+                raise RuntimeError(
+                    f"{branch}: changed ProgramSpecs {program_specs} do not match "
+                    f"the queue configuration {configured_spec!r}"
+                )
+            composition_files = apply_program_scope_sync(leaf, item, {})
         summary = sync_pending(leaf)
         keep_pending = finalize_pending(leaf)
         regen_index(leaf)
-        add_files = [*artifacts, ".axiom/index/provisions_to_rules.json"]
+        add_files = [
+            *artifacts,
+            *composition_files,
+            ".axiom/index/provisions_to_rules.json",
+        ]
         if keep_pending:
             add_files.append("oracle-coverage-pending.yaml")
         run(["git", "-C", str(leaf), "add", "--", *add_files])
-        module = next((a for a in artifacts if MODULE_RE.match(a)
-                       and not a.endswith(".test.yaml")), artifacts[0])
-        msg = (f"Encode {module.rsplit('/', 1)[0]} + declare oracle-coverage "
-               f"pending lane ({slug}, bulk)\n\n"
-               "Rebuilt on origin/main with the module's unmapped outputs "
-               "declared in oracle-coverage-pending.yaml so the changed-file "
-               "PolicyEngine oracle-coverage gate passes.\n\n"
-               "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
-        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
-             "-c", "user.name=bulk-encode", "commit", "-q", "-m", msg])
-        run(["git", "-C", str(leaf), "push", "-f", "origin",
-             f"HEAD:refs/heads/{branch}"], check=True)
-        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
-        result = f"rebuilt+pushed {branch}: {summary}"
+        module = next(
+            (
+                a
+                for a in artifacts
+                if MODULE_RE.match(a) and not a.endswith(".test.yaml")
+            ),
+            artifacts[0],
+        )
+        msg = (
+            f"Encode {module.rsplit('/', 1)[0]} + declare oracle-coverage "
+            f"pending lane ({slug}, bulk)\n\n"
+            "Rebuilt on origin/main with the module's unmapped outputs "
+            "declared in oracle-coverage-pending.yaml so the changed-file "
+            "PolicyEngine oracle-coverage gate passes.\n\n"
+            "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+        )
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "-c",
+                "user.email=bulk-encode@axiom",
+                "-c",
+                "user.name=bulk-encode",
+                "commit",
+                "-q",
+                "-m",
+                msg,
+            ]
+        )
+        ensure_draft_pr(branch)
+        require_coverage_ref()
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "push",
+                "-f",
+                "origin",
+                f"HEAD:refs/heads/{branch}",
+            ],
+            check=True,
+        )
+        ensure_draft_pr(branch)
+        result = f"rebuilt+pushed draft {branch}: {summary}"
         if wait:
-            result += "; " + wait_for_merge(branch)
+            result += "; " + wait_for_checks(branch)
         return result
     finally:
         drop_worktree(leaf)
 
 
-def wait_for_merge(branch: str, timeout_s: int = 1500) -> str:
+def wait_for_checks(branch: str, timeout_s: int = 1500) -> str:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
-        pr = gh_json(["pr", "view", branch, "--repo", REPO,
-                      "--json", "state,mergeStateStatus,statusCheckRollup"])
+        pr = gh_json(
+            [
+                "pr",
+                "view",
+                branch,
+                "--repo",
+                REPO,
+                "--json",
+                "state,isDraft,statusCheckRollup",
+            ]
+        )
         if not pr:
             return "poll-error"
-        if pr["state"] == "MERGED":
-            return "MERGED"
-        vv = next((c.get("conclusion") or c.get("state")
-                   for c in pr.get("statusCheckRollup") or []
-                   if c.get("name") == "validate / validate"), None)
-        if vv in ("FAILURE", "ERROR"):
-            return f"validate={vv} (needs triage)"
+        if pr["state"] != "OPEN":
+            return pr["state"]
+        checks = pr.get("statusCheckRollup") or []
+        validation_checks = [
+            check
+            for check in checks
+            if str(check.get("name") or "").startswith("validate / validate")
+        ]
+        failures = {
+            str(check.get("conclusion") or check.get("state") or "").upper()
+            for check in checks
+        } & {
+            "ACTION_REQUIRED",
+            "CANCELLED",
+            "ERROR",
+            "FAILURE",
+            "STALE",
+            "TIMED_OUT",
+        }
+        if failures:
+            return f"checks={','.join(sorted(failures))} (needs triage)"
+        pending = any(
+            str(check.get("status") or "").upper() not in {"", "COMPLETED"}
+            or str(check.get("state") or "").upper() in {"EXPECTED", "PENDING"}
+            for check in checks
+        )
+        if validation_checks and not pending:
+            return "checks complete; draft review required"
         time.sleep(30)
-    return "timeout-waiting-merge"
+    return "timeout-waiting-checks"
 
 
 # ---------------------------------------------------------------------------
 # PART B: generate + PR one pending worklist entry via local Codex.
 # ---------------------------------------------------------------------------
 MODULE_RE = re.compile(
-    r"^[a-z]{2}(-[a-z0-9-]+)?/(statutes|regulations|policies)/.*\.yaml$")
+    r"^[a-z]{2}(-[a-z0-9-]+)?/(manual|statutes|regulations|policies)/.*\.yaml$"
+)
+PROGRAM_SPEC_RE = re.compile(r"^[a-z]{2}(?:-[a-z0-9]+)*/programs/.+\.yaml$")
 
 
 def already_handled(slug: str) -> bool:
-    pr = gh_json(["pr", "list", "--repo", REPO, "--head", f"bulk/{slug}",
-                  "--state", "all", "--json", "number,state"])
+    pr = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--head",
+            f"bulk/{slug}",
+            "--state",
+            "all",
+            "--json",
+            "number,state",
+        ]
+    )
+    if pr is None:
+        raise RuntimeError(f"could not determine PR state for bulk/{slug}")
     return bool(pr)
 
 
 def handled_slugs() -> set:
     """All bulk/<slug> that already have a PR (any state), in one gh call, so a
     drain chunk skips already-PR'd entries without a per-entry API round-trip."""
-    data = gh_json(["pr", "list", "--repo", REPO, "--state", "all", "--limit", "400",
-                    "--json", "headRefName"]) or []
-    return {p["headRefName"].split("/", 1)[1] for p in data
-            if p.get("headRefName", "").startswith("bulk/")}
+    data = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "all",
+            "--limit",
+            "400",
+            "--json",
+            "headRefName",
+        ]
+    )
+    if data is None:
+        raise RuntimeError("could not list existing bulk PRs")
+    return {
+        p["headRefName"].split("/", 1)[1]
+        for p in data
+        if p.get("headRefName", "").startswith("bulk/")
+    }
+
+
+def worklist_item_for_slug(leaf: Path, slug: str) -> dict:
+    process = subprocess.run(
+        [
+            str(COV_PY),
+            str(leaf / "bulk/compute_matrix.py"),
+            "--status",
+            "any",
+            "--format",
+            "matrix",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=leaf,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"could not read worklist metadata for {slug}: {process.stderr.strip()}"
+        )
+    try:
+        entries = json.loads(process.stdout)["include"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise RuntimeError(f"invalid worklist matrix while resolving {slug}") from exc
+    matches = [entry for entry in entries if entry.get("slug") == slug]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one worklist entry for {slug}; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def merged_dependency(citation: str) -> bool:
+    branch = f"bulk/{citation_slug(citation)}"
+    prs = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "merged",
+            "--head",
+            branch,
+            "--json",
+            "number",
+        ]
+    )
+    if prs is None:
+        raise RuntimeError(f"could not determine merged state for {branch}")
+    return bool(prs)
+
+
+def apply_program_scope_sync(leaf: Path, item: dict, env: dict) -> list[str]:
+    spec = item.get("program_scope_sync")
+    if spec is None:
+        return []
+    if not isinstance(spec, dict):
+        raise ValueError("program_scope_sync must be a mapping")
+    program_spec = spec.get("program_spec")
+    scope = spec.get("scope")
+    add = spec.get("add", [])
+    remove = spec.get("remove", [])
+    if not isinstance(program_spec, str) or not program_spec:
+        raise ValueError("program_scope_sync.program_spec must be a non-empty string")
+    if scope not in {"federal", "state", "local"}:
+        raise ValueError("program_scope_sync.scope must be federal, state, or local")
+    if not isinstance(add, list) or not all(isinstance(v, str) for v in add):
+        raise ValueError("program_scope_sync.add must be a string list")
+    if not isinstance(remove, list) or not all(isinstance(v, str) for v in remove):
+        raise ValueError("program_scope_sync.remove must be a string list")
+    if not add and not remove:
+        raise ValueError("program_scope_sync must add or remove at least one module")
+    command = [
+        str(COV_AE),
+        "program-scope-sync",
+        "--repo",
+        str(leaf),
+        "--program-spec",
+        program_spec,
+        "--scope",
+        scope,
+    ]
+    for value in add:
+        command.extend(["--add", value])
+    for value in remove:
+        command.extend(["--remove", value])
+    protected_env = {**env, "AXIOM_ENCODE_APPLY_SIGNING_KEY": None}
+    rc, out = run(command, cwd=leaf, env=protected_env)
+    if rc != 0:
+        raise RuntimeError(f"program-scope-sync failed:\n{out}")
+    return [program_spec]
+
+
+def encode_command(leaf: Path, tmp: Path, item: dict) -> list[str]:
+    """Build the reviewed encoder command, including repo-local legal context."""
+    root = leaf.resolve()
+    context_paths: list[Path] = []
+    for value in item.get("allow_context", []):
+        if not isinstance(value, str) or not value or "\n" in value:
+            raise ValueError("allow_context must contain non-empty path strings")
+        path = Path(value)
+        resolved = (root / path).resolve()
+        if path.is_absolute() or not resolved.is_relative_to(root):
+            raise ValueError("allow_context path escapes the RuleSpec checkout")
+        if not resolved.is_file():
+            raise ValueError(f"allow_context file does not exist: {value}")
+        context_paths.append(resolved)
+
+    command = [
+        str(GEN_AE),
+        "encode",
+        item["citation"],
+        "--backend",
+        BACKEND,
+        "--model",
+        MODEL,
+        "--policy-repo-path",
+        str(leaf),
+        "--axiom-rules-engine-path",
+        str(ENGINE),
+        "--corpus-path",
+        str(CORPUS),
+        "--output",
+        str(tmp),
+        "--apply",
+        "--no-sync",
+    ]
+    for path in context_paths:
+        command.extend(["--allow-context", str(path)])
+    return command
 
 
 def encode_entry(item: dict) -> dict:
@@ -337,14 +708,30 @@ def encode_entry(item: dict) -> dict:
     if _PAUSE.is_set():
         res["detail"] = "paused"
         return res
-    if already_handled(slug):
+    try:
+        unmet = [
+            dependency
+            for dependency in item.get("requires_merged_citations", [])
+            if not merged_dependency(dependency)
+        ]
+    except RuntimeError as exc:
+        return pause_for_retry(res, f"{exc}; retry drain")
+    if unmet:
+        res["status"] = "blocked"
+        res["detail"] = "waiting for merged dependencies: " + ", ".join(unmet)
+        return res
+    try:
+        handled = already_handled(slug)
+    except RuntimeError as exc:
+        return pause_for_retry(res, f"{exc}; retry drain")
+    if handled:
         res["status"] = "skipped"
         res["detail"] = "bulk/<slug> PR already exists"
         return res
     leaf = make_worktree(slug, "origin/main")
     tmp = WT_ROOT / slug / "encode-out"
     env = {
-        "AXIOM_ENCODE_APPLY_SIGNING_KEY": signing_key(),
+        "AXIOM_ENCODE_APPLY_SIGNING_KEY": None,
         "AXIOM_CORPUS_REPO": str(CORPUS),
         "AXIOM_RULESPEC_REPO_ROOTS": str(leaf),
         # The pinned encoder's bin MUST be on PATH: the --apply manifest step
@@ -353,54 +740,109 @@ def encode_entry(item: dict) -> dict:
         "PATH": f"{GEN_AE.parent}:{ENGINE_BIN}:{os.environ['PATH']}",
     }
     try:
-        rc, out = run(
-            [str(GEN_AE), "encode", citation, "--backend", BACKEND, "--model", MODEL,
-             "--policy-repo-path", str(leaf),
-             "--axiom-rules-engine-path", str(ENGINE),
-             "--corpus-path", str(CORPUS),
-             "--output", str(tmp), "--apply", "--no-sync"],
-            cwd=leaf, env=env, timeout=3600)
+        rc, out = run(encode_command(leaf, tmp, item), cwd=leaf, env=env, timeout=3600)
         if LIMIT_SIGNS.search(out):
             _PAUSE.set()
             res["status"], res["detail"] = "paused", "codex subscription-limit signal"
             return res
-        _, st = run(["git", "-C", str(leaf), "status", "--porcelain", "-uall"])
-        applied = [ln[3:] for ln in st.splitlines()
-                   if MODULE_RE.match(ln[3:]) and not ln[3:].endswith(".test.yaml")]
-        if rc != 0 or not applied:
+        if rc != 0:
             res["detail"] = f"encode/apply failed (rc={rc}); see {tmp}"
             return res
-        module = applied[0]
-        test_file = module[:-5] + ".test.yaml"
-        juris = module.split("/", 1)[0]
-        rest = module[len(juris) + 1:]
-        manifest = f"{juris}/.axiom/encoding-manifests/{rest[:-5]}.json"
-        if not (leaf / manifest).exists():
-            hits = list((leaf / juris / ".axiom/encoding-manifests").rglob(
-                Path(module).stem + ".json"))
-            manifest = str(hits[0].relative_to(leaf)) if hits else manifest
+        try:
+            module, test_file, manifest = discover_applied_artifacts(
+                leaf, citation=citation
+            )
+        except ValueError as exc:
+            res["detail"] = f"applied artifact discovery failed: {exc}"
+            return res
+        try:
+            composition_files = apply_program_scope_sync(leaf, item, env)
+        except (RuntimeError, ValueError) as exc:
+            res["detail"] = str(exc)
+            return res
         regen_index(leaf)
 
         # gate battery (fail-closed pre-check, PR-CI order)
-        run(["git", "-C", str(leaf), "add", "--", module, test_file, manifest,
-             ".axiom/index/provisions_to_rules.json"])
-        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
-             "-c", "user.name=bulk-encode", "commit", "-q", "-m", f"wip: {citation}"])
-        roots = subprocess.run([str(COV_PY), str(leaf / "bulk/roots_for.py"), module],
-                               capture_output=True, text=True).stdout.strip() or "us"
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "add",
+                "--",
+                module,
+                test_file,
+                manifest,
+                *composition_files,
+                ".axiom/index/provisions_to_rules.json",
+            ]
+        )
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "-c",
+                "user.email=bulk-encode@axiom",
+                "-c",
+                "user.name=bulk-encode",
+                "commit",
+                "-q",
+                "-m",
+                f"wip: {citation}",
+            ]
+        )
+        jurisdiction = module.split("/", 1)[0]
         for gate in (
-            [str(GEN_AE), "guard-generated", "--repo", str(leaf),
-             "--base-ref", "origin/main", "--head-ref", "HEAD", "--roots", roots],
-            [str(GEN_AE), "validate", str(leaf / module), "--skip-reviewers"],
-            [str(GEN_AE), "proof-validate", str(leaf / module)],
+            [
+                str(GEN_AE),
+                "guard-generated",
+                "--repo",
+                str(leaf),
+                "--base-ref",
+                "origin/main",
+                "--head-ref",
+                "HEAD",
+                "--corpus-path",
+                str(CORPUS),
+                "--expected-encoder-checkout",
+                str(DRAIN_BASE / "axiom-encode"),
+            ],
+            [
+                str(GEN_AE),
+                "validate",
+                str(leaf / module),
+                "--skip-reviewers",
+                "--corpus-path",
+                str(CORPUS),
+                "--axiom-rules-engine-path",
+                str(ENGINE),
+            ],
+            [
+                str(GEN_AE),
+                "proof-validate",
+                str(leaf / module),
+                "--corpus-path",
+                str(CORPUS),
+            ],
         ):
             grc, gout = run(gate, cwd=leaf, env=env)
             if grc != 0:
                 res["detail"] = f"gate failed: {gate[1]}\n{gout[-800:]}"
                 return res
-        trc, _ = run([str(GEN_AE), "test", "--root", str(leaf),
-                      "--axiom-rules-engine-path", str(ENGINE), str(leaf / test_file)],
-                     cwd=leaf, env=env)
+        trc, _ = run(
+            [
+                str(GEN_AE),
+                "test",
+                "--root",
+                str(leaf / jurisdiction),
+                "--axiom-rules-engine-path",
+                str(ENGINE),
+                str(leaf / test_file),
+            ],
+            cwd=leaf,
+            env=env,
+        )
         gate_status = "green" if trc == 0 else "needs-fixtures"
 
         # declare oracle-coverage pending lane (the step the cloud dispatcher lacks)
@@ -412,34 +854,123 @@ def encode_entry(item: dict) -> dict:
         title = f"Encode {citation} (bulk)"
         if gate_status == "needs-fixtures":
             title = f"Encode {citation} (bulk, needs-fixtures)"
-        add_files = [".axiom/index/provisions_to_rules.json"]
+        add_files = [*composition_files, ".axiom/index/provisions_to_rules.json"]
         if keep_pending:
             add_files.append("oracle-coverage-pending.yaml")
         run(["git", "-C", str(leaf), "add", "--", *add_files])
-        commit_msg = (f"Encode {citation} via local drain\n\n"
-                      f"Produced by axiom-encode encode {citation} --apply "
-                      f"(backend {BACKEND}, model {MODEL}, pinned encoder). "
-                      f"{sync_summary}\n\n"
-                      "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>")
-        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
-             "-c", "user.name=bulk-encode", "commit", "-q", "--amend", "-m", commit_msg])
-        run(["git", "-C", str(leaf), "push", "-f", "origin",
-             f"HEAD:refs/heads/{branch}"], check=True)
-        run(["gh", "label", "create", "bulk-encode", "--repo", REPO,
-             "--color", "1f6feb", "-d", "Opened by the bulk-encode dispatcher"])
-        body = (f"## Locally bulk-encoded module\n\n- Citation: `{citation}`\n"
-                f"- Module: `{module}`\n- Encoder: `{BACKEND}:{MODEL}` "
-                f"(toolchain-pinned axiom-encode)\n- Local gate: **{gate_status}**\n"
-                f"- {sync_summary}\n\nProduced by `bulk/local_drain.py` "
-                "(local Codex mirror of the bulk-encode dispatcher). The "
-                "authoritative gate is the required `validate / validate` check.")
+        commit_msg = (
+            f"Encode {citation} via local drain\n\n"
+            f"Produced by axiom-encode encode {citation} --apply "
+            f"(backend {BACKEND}, model {MODEL}, pinned encoder). "
+            f"{sync_summary}\n\n"
+            "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+        )
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "-c",
+                "user.email=bulk-encode@axiom",
+                "-c",
+                "user.name=bulk-encode",
+                "commit",
+                "-q",
+                "--amend",
+                "-m",
+                commit_msg,
+            ]
+        )
+        open_prs = gh_json(
+            [
+                "pr",
+                "list",
+                "--repo",
+                REPO,
+                "--state",
+                "open",
+                "--head",
+                branch,
+                "--json",
+                "number",
+            ]
+        )
+        if open_prs is None:
+            return pause_for_retry(
+                res,
+                f"could not verify PR state for {branch} before push; retry drain",
+            )
+        if open_prs:
+            ensure_draft_pr(branch)
+            res["status"] = "skipped"
+            res["detail"] = (
+                f"existing draft PR normalized for {branch}; no push performed"
+            )
+            return res
+        require_coverage_ref()
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "push",
+                "-f",
+                "origin",
+                f"HEAD:refs/heads/{branch}",
+            ],
+            check=True,
+        )
+        run(
+            [
+                "gh",
+                "label",
+                "create",
+                "bulk-encode",
+                "--repo",
+                REPO,
+                "--color",
+                "1f6feb",
+                "-d",
+                "Opened by the bulk-encode dispatcher",
+            ]
+        )
+        acceptance_criteria = item.get("acceptance_criteria", "")
+        body = (
+            f"## Locally bulk-encoded module\n\n- Citation: `{citation}`\n"
+            f"- Module: `{module}`\n- Encoder: `{BACKEND}:{MODEL}` "
+            f"(toolchain-pinned axiom-encode)\n- Local gate: **{gate_status}**\n"
+            f"- ProgramSpec sync: `{', '.join(composition_files) or 'none'}`\n"
+            f"- {sync_summary}\n\nProduced by `bulk/local_drain.py` "
+            "(local Codex mirror of the bulk-encode dispatcher). The "
+            "authoritative gate is the required `validate / validate` check.\n\n"
+            f"### Acceptance criteria\n\n{acceptance_criteria}\n"
+        )
         bf = WT_ROOT / slug / "pr-body.md"
         bf.write_text(body)
-        run(["gh", "pr", "create", "--repo", REPO, "--base", "main", "--head", branch,
-             "--title", title, "--body-file", str(bf), "--label", "bulk-encode"])
-        run(["gh", "pr", "merge", branch, "--repo", REPO, "--auto", "--squash"])
+        run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                REPO,
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body-file",
+                str(bf),
+                "--label",
+                "bulk-encode",
+                "--draft",
+            ],
+            check=True,
+        )
+        ensure_draft_pr(branch)
         res["status"] = gate_status
-        res["detail"] = f"PR opened on {branch}; {sync_summary}"
+        res["detail"] = f"draft PR opened on {branch}; {sync_summary}"
         return res
     except subprocess.TimeoutExpired:
         res["detail"] = "encode timed out (>3600s)"
@@ -453,25 +984,119 @@ def flip_statuses(updates: dict) -> None:
     """updates: {citation: status}. Commits to worklist on a small branch + PR."""
     if not updates:
         return
+    branch = "bulk/worklist-status-flip"
+    open_prs = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "open",
+            "--head",
+            branch,
+            "--json",
+            "number",
+        ]
+    )
+    if open_prs is None:
+        raise RuntimeError(f"could not determine whether {branch} already has a PR")
+    existing_pr = bool(open_prs)
+    if existing_pr:
+        ensure_draft_pr(branch)
+
     leaf = make_worktree("worklist-flip", "origin/main")
     try:
-        run(["git", "-C", str(leaf), "checkout", "-B", "bulk/worklist-status-flip"])
+        if existing_pr:
+            run(["git", "-C", str(leaf), "fetch", "origin", branch], check=True)
+            run(
+                ["git", "-C", str(leaf), "checkout", "-B", branch, "FETCH_HEAD"],
+                check=True,
+            )
+            run(["git", "-C", str(leaf), "rebase", "origin/main"], check=True)
+        else:
+            run(["git", "-C", str(leaf), "checkout", "-B", branch], check=True)
         for citation, status in updates.items():
-            run([str(COV_PY), str(leaf / "bulk/compute_matrix.py"),
-                 "--set-status", citation, status], cwd=leaf)
-        run(["git", "-C", str(leaf), "add", "bulk/worklist.yaml"])
-        run(["git", "-C", str(leaf), "-c", "user.email=bulk-encode@axiom",
-             "-c", "user.name=bulk-encode", "commit", "-q", "-m",
-             "Flip drained worklist statuses (bulk)\n\n"
-             "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"])
-        run(["git", "-C", str(leaf), "push", "-f", "origin",
-             "HEAD:refs/heads/bulk/worklist-status-flip"], check=True)
-        run(["gh", "pr", "create", "--repo", REPO, "--base", "main",
-             "--head", "bulk/worklist-status-flip", "--title",
-             "Flip drained worklist statuses (bulk)", "--body",
-             "Status flips for locally-drained entries.", "--label", "bulk-encode"])
-        run(["gh", "pr", "merge", "bulk/worklist-status-flip", "--repo", REPO,
-             "--auto", "--squash"])
+            run(
+                [
+                    str(COV_PY),
+                    str(leaf / "bulk/compute_matrix.py"),
+                    "--set-status",
+                    citation,
+                    status,
+                ],
+                cwd=leaf,
+                check=True,
+            )
+        _, worklist_diff = run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "status",
+                "--porcelain",
+                "--",
+                "bulk/worklist.yaml",
+            ]
+        )
+        if worklist_diff:
+            run(["git", "-C", str(leaf), "add", "bulk/worklist.yaml"])
+            run(
+                [
+                    "git",
+                    "-C",
+                    str(leaf),
+                    "-c",
+                    "user.email=bulk-encode@axiom",
+                    "-c",
+                    "user.name=bulk-encode",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "Flip drained worklist statuses (bulk)\n\n"
+                    "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>",
+                ],
+                check=True,
+            )
+        elif not existing_pr:
+            return
+        if existing_pr:
+            ensure_draft_pr(branch)
+        run(
+            [
+                "git",
+                "-C",
+                str(leaf),
+                "push",
+                "-f",
+                "origin",
+                f"HEAD:refs/heads/{branch}",
+            ],
+            check=True,
+        )
+        if not existing_pr:
+            run(
+                [
+                    "gh",
+                    "pr",
+                    "create",
+                    "--repo",
+                    REPO,
+                    "--base",
+                    "main",
+                    "--head",
+                    branch,
+                    "--title",
+                    "Flip drained worklist statuses (bulk)",
+                    "--body",
+                    "Status flips for locally-drained entries.",
+                    "--label",
+                    "bulk-encode",
+                    "--draft",
+                ],
+                check=True,
+            )
+        ensure_draft_pr(branch)
     finally:
         drop_worktree(leaf)
 
@@ -482,11 +1107,18 @@ def write_progress(results: list, remaining: int, paused: bool) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [f"# Local drain progress ({now})", ""]
     if paused:
-        lines += ["> **PAUSED on Codex subscription-limit signal.** Re-run after "
-                  "the window resets; the drain resumes idempotently.", ""]
-    lines += [f"- Remaining pending: {remaining}",
-              f"- Handled this run: {len(results)}", "",
-              "| citation | result | detail |", "| --- | --- | --- |"]
+        lines += [
+            "> **PAUSED on a retryable condition.** Resolve the condition "
+            "reported below and re-run; the drain resumes idempotently.",
+            "",
+        ]
+    lines += [
+        f"- Remaining pending: {remaining}",
+        f"- Handled this run: {len(results)}",
+        "",
+        "| citation | result | detail |",
+        "| --- | --- | --- |",
+    ]
     for r in results:
         d = r["detail"].splitlines()[0][:80] if r["detail"] else ""
         lines.append(f"| `{r['citation']}` | {r['status']} | {d} |")
@@ -494,26 +1126,122 @@ def write_progress(results: list, remaining: int, paused: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
+def require_coverage_ref() -> str:
+    if not COV_CHECKOUT.is_dir():
+        raise SystemExit(f"coverage encoder checkout is missing: {COV_CHECKOUT}")
+    rc, head = run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=COV_CHECKOUT,
+        merge_stderr=False,
+    )
+    actual = head.strip() if rc == 0 else "unavailable"
+    expected = pinned_toolchain().get("axiom_encode_ref")
+    if not isinstance(expected, str) or re.fullmatch(r"[0-9a-f]{40}", expected) is None:
+        raise SystemExit("workflow toolchain axiom_encode_ref is not a full commit SHA")
+    if actual != expected:
+        raise SystemExit(
+            f"coverage encoder checkout must match protected workflow pin {expected}; "
+            f"got {actual}"
+        )
+    rc, dirty = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=COV_CHECKOUT,
+        merge_stderr=False,
+    )
+    if rc != 0 or dirty.strip():
+        raise SystemExit(f"coverage encoder checkout must be clean: {COV_CHECKOUT}")
+    if not COV_PY.is_file():
+        raise SystemExit(f"coverage encoder interpreter is missing: {COV_PY}")
+    if not COV_AE.is_file():
+        raise SystemExit(f"coverage encoder executable is missing: {COV_AE}")
+    rc, module_file = run(
+        [
+            str(COV_PY),
+            "-c",
+            "import axiom_encode; print(axiom_encode.__file__)",
+        ],
+        merge_stderr=False,
+    )
+    if rc != 0:
+        raise SystemExit(f"coverage encoder import failed via {COV_PY}")
+    imported_module = Path(module_file.strip()).resolve()
+    expected_module = (COV_CHECKOUT / "src/axiom_encode/__init__.py").resolve()
+    if imported_module != expected_module:
+        raise SystemExit(
+            f"coverage encoder imports {imported_module}; expected {expected_module}"
+        )
+    expected_executable = COV_PY.parent / "axiom-encode"
+    if COV_AE.resolve() != expected_executable.resolve():
+        raise SystemExit(
+            f"coverage executable must be {expected_executable}; got {COV_AE}"
+        )
+    rc, oracle_ref = run(
+        [
+            str(COV_PY),
+            "-c",
+            (
+                "import importlib.metadata,json; "
+                "d=importlib.metadata.distribution('axiom-oracles'); "
+                "u=json.loads(d.read_text('direct_url.json')); "
+                "print(u.get('vcs_info',{}).get('commit_id',''))"
+            ),
+        ],
+        env={"AXIOM_ENCODE_APPLY_SIGNING_KEY": None},
+        merge_stderr=False,
+    )
+    actual_oracle_ref = oracle_ref.strip() if rc == 0 else "unavailable"
+    if actual_oracle_ref != COV_ORACLES_REF:
+        raise SystemExit(
+            f"coverage oracle dependency must be {COV_ORACLES_REF}; "
+            f"got {actual_oracle_ref}"
+        )
+    return actual
+
+
 def cmd_doctor(_args) -> int:
     tc = pinned_toolchain()
     print(f"DRAIN_BASE           : {DRAIN_BASE}")
-    for label, ae, want_pending in (("gen encoder (pin)", GEN_AE, False),
-                                    ("cov encoder (main)", COV_AE, True)):
-        has_pending = ae.exists() and run(
-            [str(ae), "oracle-coverage-pending", "--help"])[0] == 0
-        ok = ae.exists() and (has_pending == want_pending)
-        print(f"{label:20s}: {'OK' if ok else 'CHECK'} "
-              f"(oracle-coverage-pending {'present' if has_pending else 'absent'})")
-    print(f"pinned encoder ver   : {tc.get('axiom_encode_version')}")
-    print(f"engine bin           : {'OK' if ENGINE_BIN.exists() else 'MISSING'} {ENGINE_BIN}")
-    print(f"corpus               : {'OK' if CORPUS.exists() else 'MISSING'} {CORPUS}")
+    command_ok = True
+    for label, ae, required_commands in (
+        ("gen encoder (pin)", GEN_AE, ("encode",)),
+        ("current encoder", COV_AE, ("oracle-coverage-pending", "program-scope-sync")),
+    ):
+        has_pending = (
+            ae.exists() and run([str(ae), "oracle-coverage-pending", "--help"])[0] == 0
+        )
+        has_scope_sync = (
+            ae.exists() and run([str(ae), "program-scope-sync", "--help"])[0] == 0
+        )
+        available = {
+            "encode": ae.exists() and run([str(ae), "encode", "--help"])[0] == 0,
+            "oracle-coverage-pending": has_pending,
+            "program-scope-sync": has_scope_sync,
+        }
+        ok = ae.exists() and all(available[command] for command in required_commands)
+        command_ok = command_ok and ok
+        print(
+            f"{label:20s}: {'OK' if ok else 'CHECK'} "
+            f"(commands: {', '.join(command for command in required_commands if available[command])})"
+        )
     try:
-        print(f"signing key          : present (len {len(signing_key())})")
-    except SystemExit as e:
-        print(f"signing key          : {e}")
+        actual_cov_ref = require_coverage_ref()
+        cov_ref_ok = True
+    except SystemExit:
+        actual_cov_ref = "unavailable or mismatched"
+        cov_ref_ok = False
+    print(
+        f"coverage encoder ref: {'OK' if cov_ref_ok else 'CHECK'} "
+        f"({actual_cov_ref}; want {tc.get('axiom_encode_ref')})"
+    )
+    print(f"pinned encoder ver   : {tc.get('axiom_encode_version')}")
+    engine_ok = ENGINE_BIN.exists()
+    corpus_ok = CORPUS.exists()
+    print(f"engine bin           : {'OK' if engine_ok else 'MISSING'} {ENGINE_BIN}")
+    print(f"corpus               : {'OK' if corpus_ok else 'MISSING'} {CORPUS}")
+    print("local generation     : disabled (protected workflow only)")
     rc, out = run(["codex", "--version"])
     print(f"codex CLI            : {'OK ' + out.strip() if rc == 0 else 'MISSING'}")
-    return 0
+    return 0 if all((command_ok, cov_ref_ok, engine_ok, corpus_ok, rc == 0)) else 1
 
 
 def cmd_unstick(args) -> int:
@@ -521,38 +1249,64 @@ def cmd_unstick(args) -> int:
     if args.pr:
         targets = [p for p in prs if p["number"] in set(args.pr)]
     elif args.all:
-        targets = [p for p in prs if p["validate"] in (None, "FAILURE", "ERROR", "PENDING")]
+        targets = [
+            p for p in prs if p["validate"] in (None, "FAILURE", "ERROR", "PENDING")
+        ]
     else:
         print("Specify --pr N [N ...] or --all. Open bulk PRs:")
         for p in prs:
-            print(f"  #{p['number']:4d} {p['branch']:40s} validate={p['validate']} merge={p['merge']}")
+            print(
+                f"  #{p['number']:4d} {p['branch']:40s} validate={p['validate']} merge={p['merge']}"
+            )
         return 0
+    if targets:
+        require_coverage_ref()
     log(f"unstick {len(targets)} PR(s): {[p['number'] for p in targets]}")
     for p in targets:
         try:
-            log(f"#{p['number']} {p['branch']}: {unstick_pr(p['branch'], wait=args.wait)}")
+            log(
+                f"#{p['number']} {p['branch']}: {unstick_pr(p['branch'], wait=args.wait)}"
+            )
         except Exception as exc:  # noqa: BLE001 - operator tool, report and continue
             log(f"#{p['number']} {p['branch']}: ERROR {exc}")
     return 0
 
 
 def cmd_drain(args) -> int:
-    matrix = json.loads(subprocess.run(
-        [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
-         "--status", "pending", "--format", "matrix",
-         *(["--batch", args.batch] if args.batch else []),
-         *(["--limit", str(args.limit)] if args.limit else [])],
-        capture_output=True, text=True, cwd=CHECKOUT).stdout)["include"]
+    signing_key()
+    require_coverage_ref()
+    matrix = json.loads(
+        subprocess.run(
+            [
+                str(COV_PY),
+                str(CHECKOUT / "bulk/compute_matrix.py"),
+                "--status",
+                args.status,
+                "--format",
+                "matrix",
+                *(["--batch", args.batch] if args.batch else []),
+                *(["--limit", str(args.limit)] if args.limit else []),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=CHECKOUT,
+        ).stdout
+    )["include"]
     handled = handled_slugs()
     failed_path = DRAIN_BASE / "drain_failed.json"
     failed = set(json.loads(failed_path.read_text())) if failed_path.exists() else set()
-    matrix = [it for it in matrix
-              if it["slug"] not in handled and it["citation"] not in failed]
+    matrix = [
+        it
+        for it in matrix
+        if it["slug"] not in handled and it["citation"] not in failed
+    ]
     if args.max_entries:
         matrix = matrix[: args.max_entries]
-    log(f"drain: {len(handled)} already PR'd, {len(failed)} known-failed -> "
+    log(
+        f"drain: {len(handled)} already PR'd, {len(failed)} known-failed -> "
         f"{len(matrix)} to attempt; concurrency={args.concurrency}, "
-        f"max_seconds={args.max_seconds}")
+        f"max_seconds={args.max_seconds}"
+    )
     results, flips = [], {}
     deadline = time.time() + args.max_seconds
     # Rolling bounded pool: keep `concurrency` encodes in flight; stop launching
@@ -568,25 +1322,41 @@ def cmd_drain(args) -> int:
                 inflight.add(ex.submit(encode_entry, item))
         while inflight:
             done, inflight = concurrent.futures.wait(
-                inflight, return_when=concurrent.futures.FIRST_COMPLETED)
+                inflight, return_when=concurrent.futures.FIRST_COMPLETED
+            )
             for fut in done:
                 r = fut.result()
                 results.append(r)
-                log(f"{r['citation']}: {r['status']} - "
-                    f"{r['detail'].splitlines()[0] if r['detail'] else ''}")
+                log(
+                    f"{r['citation']}: {r['status']} - "
+                    f"{r['detail'].splitlines()[0] if r['detail'] else ''}"
+                )
                 if r["status"] in ("green", "needs-fixtures"):
-                    flips[r["citation"]] = ("pr-open" if r["status"] == "green"
-                                            else "needs-fixtures")
+                    flips[r["citation"]] = (
+                        "pr-open" if r["status"] == "green" else "needs-fixtures"
+                    )
                 elif r["status"] == "failed":
                     flips[r["citation"]] = "failed"
                 if not _PAUSE.is_set() and time.time() < deadline:
                     item = next(it, None)
                     if item is not None:
                         inflight.add(ex.submit(encode_entry, item))
-    remaining = int(subprocess.run(
-        [str(COV_PY), str(CHECKOUT / "bulk/compute_matrix.py"),
-         "--status", "pending", "--format", "count"],
-        capture_output=True, text=True, cwd=CHECKOUT).stdout or 0)
+    remaining = int(
+        subprocess.run(
+            [
+                str(COV_PY),
+                str(CHECKOUT / "bulk/compute_matrix.py"),
+                "--status",
+                args.status,
+                "--format",
+                "count",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=CHECKOUT,
+        ).stdout
+        or 0
+    )
     write_progress(results, remaining, _PAUSE.is_set())
     # Persist flips durably to a file and batch them into ONE worklist PR later
     # (`local_drain.py flip`), instead of a per-chunk PR that would thrash under
@@ -600,8 +1370,10 @@ def cmd_drain(args) -> int:
     if new_failed:
         failed |= new_failed
         failed_path.write_text(json.dumps(sorted(failed), indent=1))
-    log(f"chunk done: opened/gated={sum(1 for r in results if r['status'] in ('green','needs-fixtures'))} "
-        f"failed={len(new_failed)} attempted={len(results)}, paused={_PAUSE.is_set()}")
+    log(
+        f"chunk done: opened/gated={sum(1 for r in results if r['status'] in ('green', 'needs-fixtures'))} "
+        f"failed={len(new_failed)} attempted={len(results)}, paused={_PAUSE.is_set()}"
+    )
     return 0
 
 
@@ -622,10 +1394,12 @@ def cmd_flip(_args) -> int:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     sub = ap.add_subparsers(dest="cmd", required=True)
-    d = sub.add_parser("drain", help="Encode pending worklist entries via local Codex.")
+    d = sub.add_parser("drain", help="Disabled; use protected cloud generation.")
+    d.add_argument("--status", choices=("pending", "pending-local"), default="pending")
     d.add_argument("--limit", type=int)
     d.add_argument("--batch")
     d.add_argument("--concurrency", type=int, default=3)
@@ -635,11 +1409,15 @@ def main() -> int:
     u = sub.add_parser("unstick", help="Sync-declare + rebase open new-state bulk PRs.")
     u.add_argument("--pr", type=int, nargs="*", default=[])
     u.add_argument("--all", action="store_true")
-    u.add_argument("--wait", action="store_true", help="Poll each PR until merged.")
+    u.add_argument(
+        "--wait", action="store_true", help="Poll each PR until CI finishes."
+    )
     u.set_defaults(func=cmd_unstick)
-    doc = sub.add_parser("doctor", help="Verify toolchain, auth, signing key.")
+    doc = sub.add_parser("doctor", help="Verify recovery toolchain and auth.")
     doc.set_defaults(func=cmd_doctor)
-    fl = sub.add_parser("flip", help="Batch accumulated drain status flips into one PR.")
+    fl = sub.add_parser(
+        "flip", help="Batch accumulated drain status flips into one PR."
+    )
     fl.set_defaults(func=cmd_flip)
     args = ap.parse_args()
     return args.func(args)

--- a/bulk/worklist.yaml
+++ b/bulk/worklist.yaml
@@ -1564,3 +1564,63 @@ entries:
   class: deduction
   note: Self-contained itemized-deduction allowance for expenses of producing income;
     zero external Section refs.
+- citation: us-sc/manual/dss/snap-policy-manual/page-163
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL-PREREQ
+  status: pending
+  backend: openai
+  model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-164.yaml
+  heading: South Carolina SNAP utility allowance assignment
+  class: eligibility
+  note: Re-encode through canonical encode --apply. Regression review must verify
+    that page-164 BUA eligibility replaces unresolved generic inputs and that an
+    MUA-entitled household cannot simultaneously receive BUA.
+- citation: us-sc/manual/dss/snap-policy-manual/page-165
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL-PREREQ
+  status: pending
+  backend: openai
+  model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-163.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-164.yaml
+  heading: South Carolina SNAP utility allowance exclusions and telephone standard
+  class: eligibility
+  note: Re-encode through canonical encode --apply. Regression review must cover
+    a coherent telephone-only household and require an anticipated ongoing state
+    telephone-standard charge without contradictory utility-count predicates.
+  requires_merged_citations:
+  - us-sc/manual/dss/snap-policy-manual/page-163
+- citation: us-sc/manual/dss/snap-policy-manual/page-159
+  repo: rulespec-us
+  batch: SNAP-SC-UTIL-AMOUNTS
+  status: pending
+  backend: openai
+  model: gpt-5.5
+  allow_context:
+  - us/regulations/7-cfr/273/9.yaml
+  - us/regulations/7-cfr/273/9/d/6/iii.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-163.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-164.yaml
+  - us-sc/policies/dss/snap-policy-manual/page-165.yaml
+  heading: South Carolina SNAP utility allowance amounts
+  class: parameter
+  note: Encode the current MUA, BUA, and telephone amounts from page 159 through
+    the canonical encode --apply path. Review must verify integration with pages
+    163-165, mutual exclusivity, FY2026 composition, and current-source precedence.
+  requires_merged_citations:
+  - us-sc/manual/dss/snap-policy-manual/page-163
+  - us-sc/manual/dss/snap-policy-manual/page-165
+  program_scope_sync:
+    program_spec: us-sc/programs/snap/fy-2026.yaml
+    scope: state
+    add:
+    - policies/dss/snap-policy-manual/page-159
+    remove:
+    - policies/dss/snap-policy-manual/page-369

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -108,8 +108,16 @@ def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> No
     ) == (module, test_file, manifest)
 
 
-def test_accepts_canonical_cfr_module_for_regulation_source(tmp_path: Path) -> None:
-    citation = "us/regulation/7/247/9/b"
+@pytest.mark.parametrize(
+    "citation",
+    [
+        "us/regulation/7/247/9/b",
+        "us/regulations/7-cfr/247/9/b",
+    ],
+)
+def test_accepts_canonical_cfr_module_for_regulation_source(
+    tmp_path: Path, citation: str
+) -> None:
     module = "us/regulations/7-cfr/247/9/b.yaml"
     test_file = "us/regulations/7-cfr/247/9/b.test.yaml"
     manifest = "us/.axiom/encoding-manifests/regulations/7-cfr/247/9/b.json"
@@ -121,6 +129,33 @@ def test_accepts_canonical_cfr_module_for_regulation_source(tmp_path: Path) -> N
         citation,
         {"regulations/7-cfr/247/9/b.yaml", "regulations/7-cfr/247/9/b.test.yaml"},
     )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        "us/form/irs/publication-1",
+        "us/forms/irs/publication-1",
+        "us/guidance/irs/publication-1",
+        "us/manuals/irs/publication-1",
+    ],
+)
+def test_accepts_policy_module_for_policy_source_aliases(
+    tmp_path: Path, citation: str
+) -> None:
+    module = "us/policies/irs/publication-1.yaml"
+    test_file = "us/policies/irs/publication-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us/policies/irs/publication-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
 
     assert discover_applied_artifacts(
         tmp_path,

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,0 +1,632 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_bulk_module(name: str):
+    bulk_dir = Path(__file__).resolve().parents[1] / "bulk"
+    path = bulk_dir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"bulk_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(bulk_dir))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(bulk_dir))
+    return module
+
+
+_applied_artifacts = _load_bulk_module("applied_artifacts")
+_compute_matrix = _load_bulk_module("compute_matrix")
+_local_drain = _load_bulk_module("local_drain")
+changed_paths = _applied_artifacts.changed_paths
+discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
+select = _compute_matrix.select
+
+
+def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "citation": citation,
+                "applied_files": [
+                    {"path": applied_path, "sha256": "0" * 64}
+                    for applied_path in sorted(applied_paths)
+                ],
+            }
+        )
+    )
+
+
+def test_discovers_repo_root_manifest_for_manual_module(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:policies/dss/snap/1105/block-1",
+        {module, test_file},
+    )
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+    ) == (module, test_file, manifest)
+
+
+def test_rejects_frozen_manual_bucket_for_manual_source(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1115/block-1"
+    module = "us-mo/manual/dss/snap/1115/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1115/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1115/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:manual/dss/snap/1115/block-1",
+        {module, test_file},
+    )
+
+    with pytest.raises(ValueError, match="frozen legacy manual root"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_discovers_jurisdiction_manifest_for_legacy_module(tmp_path: Path) -> None:
+    citation = "us-oh/statute/5747.71"
+    module = "us-oh/statutes/5747/71.yaml"
+    test_file = "us-oh/statutes/5747/71.test.yaml"
+    manifest = "us-oh/.axiom/encoding-manifests/statutes/5747/71.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        citation,
+        {"statutes/5747/71.yaml", "statutes/5747/71.test.yaml"},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+def test_accepts_canonical_cfr_module_for_regulation_source(tmp_path: Path) -> None:
+    citation = "us/regulation/7/247/9/b"
+    module = "us/regulations/7-cfr/247/9/b.yaml"
+    test_file = "us/regulations/7-cfr/247/9/b.test.yaml"
+    manifest = "us/.axiom/encoding-manifests/regulations/7-cfr/247/9/b.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        citation,
+        {"regulations/7-cfr/247/9/b.yaml", "regulations/7-cfr/247/9/b.test.yaml"},
+    )
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, test_file, manifest],
+    ) == (module, test_file, manifest)
+
+
+def test_rejects_cfr_module_for_different_regulation(tmp_path: Path) -> None:
+    citation = "us/regulation/7/247/9/b"
+    module = "us/regulations/7-cfr/247/9/c.yaml"
+    test_file = "us/regulations/7-cfr/247/9/c.test.yaml"
+    manifest = "us/.axiom/encoding-manifests/regulations/7-cfr/247/9/c.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match requested citation"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_changed_paths_ignores_rename_source_record(tmp_path: Path) -> None:
+    old_module = "us-mo/manual/dss/snap/old.yaml"
+    new_module = "us-mo/manual/dss/snap/new.yaml"
+    (tmp_path / old_module).parent.mkdir(parents=True)
+    (tmp_path / old_module).write_text("format: rulespec/v1\n")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", old_module], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.name=Axiom Test",
+            "-c",
+            "user.email=test@axiom.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "mv", old_module, new_module], check=True
+    )
+
+    assert changed_paths(tmp_path) == [new_module]
+
+
+def test_accepts_manifest_covering_only_changed_module(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module})
+
+    assert discover_applied_artifacts(
+        tmp_path,
+        citation=citation,
+        paths=[module, manifest],
+    ) == (module, test_file, manifest)
+
+
+@pytest.mark.parametrize(
+    ("extra_path", "message"),
+    [
+        ("us-mo/manual/dss/snap/1105/other.yaml", "expected one applied module"),
+        (
+            ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/other.json",
+            "expected one applied manifest",
+        ),
+    ],
+)
+def test_rejects_ambiguous_artifacts(
+    tmp_path: Path, extra_path: str, message: str
+) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+    if extra_path.endswith(".json"):
+        _write_manifest(tmp_path / extra_path, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match=message):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest, extra_path],
+        )
+
+
+def test_rejects_manifest_for_different_citation(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / test_file).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest, "us-mo:policies/dss/snap/other", {module, test_file}
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_rejects_canonical_manifest_for_wrong_requested_jurisdiction(
+    tmp_path: Path,
+) -> None:
+    citation = "us-ca/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(
+        tmp_path / manifest,
+        "us-mo:policies/dss/snap/1105/block-1",
+        {module, test_file},
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_rejects_exact_request_manifest_for_wrong_module(tmp_path: Path) -> None:
+    citation = "us-ca/manual/dss/snap/1105/block-1"
+    module = "us-mo/policies/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/policies/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/policies/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    _write_manifest(tmp_path / manifest, citation, {module, test_file})
+
+    with pytest.raises(ValueError, match="does not match requested citation"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_rejects_non_object_manifest(tmp_path: Path) -> None:
+    citation = "us-mo/manual/dss/snap/1105/block-1"
+    module = "us-mo/manual/dss/snap/1105/block-1.yaml"
+    test_file = "us-mo/manual/dss/snap/1105/block-1.test.yaml"
+    manifest = ".axiom/encoding-manifests/us-mo/manual/dss/snap/1105/block-1.json"
+    (tmp_path / module).parent.mkdir(parents=True)
+    (tmp_path / module).write_text("format: rulespec/v1\n")
+    (tmp_path / test_file).write_text("cases: []\n")
+    (tmp_path / manifest).parent.mkdir(parents=True)
+    (tmp_path / manifest).write_text("[]\n")
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        discover_applied_artifacts(
+            tmp_path,
+            citation=citation,
+            paths=[module, test_file, manifest],
+        )
+
+
+def test_pr_lookup_failure_pauses_without_permanent_failure(monkeypatch) -> None:
+    _local_drain._PAUSE.clear()
+    monkeypatch.setattr(_local_drain, "gh_json", lambda _args: None)
+
+    result = _local_drain.encode_entry(
+        {"citation": "us-mo/manual/dss/snap/1105/block-1", "slug": "retry"}
+    )
+
+    assert result["status"] == "paused"
+    assert "retry drain" in result["detail"]
+    assert _local_drain._PAUSE.is_set()
+    _local_drain._PAUSE.clear()
+
+
+def test_wait_for_checks_rejects_stale_validation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        _local_drain,
+        "gh_json",
+        lambda _args: {
+            "state": "OPEN",
+            "isDraft": True,
+            "statusCheckRollup": [
+                {
+                    "name": "validate / validate (us-mo)",
+                    "status": "COMPLETED",
+                    "conclusion": "STALE",
+                }
+            ],
+        },
+    )
+
+    assert _local_drain.wait_for_checks("bulk/example", timeout_s=1) == (
+        "checks=STALE (needs triage)"
+    )
+
+
+def test_unstick_recognizes_both_manifest_roots() -> None:
+    assert _local_drain.is_encoding_manifest_path(
+        ".axiom/encoding-manifests/us-mo/policies/dss/snap/block-1.json"
+    )
+    assert _local_drain.is_encoding_manifest_path(
+        "us-mo/.axiom/encoding-manifests/policies/dss/snap/block-1.json"
+    )
+    assert not _local_drain.is_encoding_manifest_path(
+        "_axiom/axiom-encode/.axiom/encoding-manifests/example.json"
+    )
+
+
+def test_validation_state_aggregates_all_shards() -> None:
+    success = {"name": "validate / validate (us-ca)", "conclusion": "SUCCESS"}
+    failure = {"name": "validate / validate (us-ny)", "conclusion": "FAILURE"}
+    pending = {"name": "validate / validate (us-tx)", "state": "IN_PROGRESS"}
+
+    assert _local_drain.aggregate_validation_state([success, failure]) == "FAILURE"
+    assert _local_drain.aggregate_validation_state([success, pending]) == "PENDING"
+    assert _local_drain.aggregate_validation_state([success]) == "SUCCESS"
+    assert _local_drain.aggregate_validation_state([]) is None
+
+
+def test_matrix_preserves_acceptance_criteria() -> None:
+    data = {
+        "defaults": {"backend": "openai", "model": "gpt-5.5"},
+        "entries": [
+            {
+                "citation": "us-sc/manual/dss/snap-policy-manual/page-159",
+                "status": "pending-local",
+                "batch": "SNAP-SC-UTIL",
+                "note": "Verify mutual exclusivity.",
+                "allow_context": [
+                    "us/regulations/7-cfr/273/9.yaml",
+                    "us/regulations/7-cfr/273/9/d/6/iii.yaml",
+                ],
+                "requires_merged_citations": ["us-sc/manual/page-163"],
+                "program_scope_sync": {
+                    "program_spec": "us-sc/programs/snap/fy-2026.yaml",
+                    "scope": "state",
+                    "add": ["policies/dss/snap-policy-manual/page-159"],
+                    "remove": ["policies/dss/snap-policy-manual/page-369"],
+                },
+            }
+        ],
+    }
+
+    selected = select(data, "pending-local", "SNAP-SC-UTIL", None)
+
+    assert selected[0]["acceptance_criteria"] == "Verify mutual exclusivity."
+    assert selected[0]["allow_context"] == [
+        "us/regulations/7-cfr/273/9.yaml",
+        "us/regulations/7-cfr/273/9/d/6/iii.yaml",
+    ]
+    assert selected[0]["requires_merged_citations"] == ["us-sc/manual/page-163"]
+    assert selected[0]["program_scope_sync"]["scope"] == "state"
+
+
+def test_program_scope_sync_uses_pinned_encoder(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+    environments = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        environments.append(kwargs.get("env"))
+        return 0, "updated\n"
+
+    monkeypatch.setattr(_local_drain, "run", fake_run)
+    item = {
+        "program_scope_sync": {
+            "program_spec": "us-sc/programs/snap/fy-2026.yaml",
+            "scope": "state",
+            "add": ["policies/dss/snap-policy-manual/page-159"],
+            "remove": ["policies/dss/snap-policy-manual/page-369"],
+        }
+    }
+
+    changed = _local_drain.apply_program_scope_sync(
+        tmp_path,
+        item,
+        {"AXIOM_ENCODE_APPLY_SIGNING_KEY": "ambient-secret", "KEEP": "value"},
+    )
+
+    assert changed == ["us-sc/programs/snap/fy-2026.yaml"]
+    assert calls == [
+        [
+            str(_local_drain.COV_AE),
+            "program-scope-sync",
+            "--repo",
+            str(tmp_path),
+            "--program-spec",
+            "us-sc/programs/snap/fy-2026.yaml",
+            "--scope",
+            "state",
+            "--add",
+            "policies/dss/snap-policy-manual/page-159",
+            "--remove",
+            "policies/dss/snap-policy-manual/page-369",
+        ]
+    ]
+    assert environments == [{"AXIOM_ENCODE_APPLY_SIGNING_KEY": None, "KEEP": "value"}]
+
+
+def test_program_scope_sync_rejects_empty_mapping(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="program_spec"):
+        _local_drain.apply_program_scope_sync(tmp_path, {"program_scope_sync": {}}, {})
+
+
+def test_matrix_rejects_scalar_dependency_metadata() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-159",
+                "status": "pending-local",
+                "requires_merged_citations": "us-sc/manual/page-163",
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="requires_merged_citations"):
+        select(data, "pending-local", None, None)
+
+
+def test_matrix_rejects_incomplete_program_scope_sync() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-159",
+                "status": "pending",
+                "program_scope_sync": {
+                    "program_spec": "us-sc/programs/snap/fy-2026.yaml",
+                    "scope": "state",
+                },
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="must add or remove"):
+        select(data, "pending", None, None)
+
+
+def test_matrix_rejects_context_outside_repository() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-163",
+                "status": "pending-local",
+                "allow_context": ["/etc/passwd"],
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="escapes the repository"):
+        select(data, "pending-local", None, None)
+
+
+def test_matrix_preserves_context_for_cloud_entry() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-163",
+                "status": "pending",
+                "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+            }
+        ]
+    }
+
+    selected = select(data, "pending", None, None)
+
+    assert selected[0]["allow_context"] == ["us/regulations/7-cfr/273/9.yaml"]
+
+
+@pytest.mark.parametrize("status", ["pr-open", "needs-fixtures", "failed", "merged"])
+def test_matrix_preserves_context_after_local_status_transition(status: str) -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-163",
+                "status": status,
+                "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+            }
+        ]
+    }
+
+    selected = select(data, "any", None, None)
+
+    assert selected[0]["allow_context"] == ["us/regulations/7-cfr/273/9.yaml"]
+
+
+def test_encode_command_includes_reviewed_repo_context(tmp_path: Path) -> None:
+    context = tmp_path / "us/regulations/7-cfr/273/9.yaml"
+    context.parent.mkdir(parents=True)
+    context.write_text("format: rulespec/v1\n")
+
+    command = _local_drain.encode_command(
+        tmp_path,
+        tmp_path / "encode-out",
+        {
+            "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
+            "allow_context": ["us/regulations/7-cfr/273/9.yaml"],
+        },
+    )
+
+    assert command[-2:] == ["--allow-context", str(context.resolve())]
+
+
+def test_encode_command_rejects_context_outside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes the RuleSpec checkout"):
+        _local_drain.encode_command(
+            tmp_path,
+            tmp_path / "encode-out",
+            {
+                "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
+                "allow_context": ["../outside.yaml"],
+            },
+        )
+
+
+def test_sc_queue_schedules_prerequisites_before_dependent() -> None:
+    selected = select(_compute_matrix.load(), "any", None, None)
+
+    citations = [item["citation"] for item in selected]
+    assert citations.index("us-sc/manual/dss/snap-policy-manual/page-163") < (
+        citations.index("us-sc/manual/dss/snap-policy-manual/page-159")
+    )
+    assert citations.index("us-sc/manual/dss/snap-policy-manual/page-165") < (
+        citations.index("us-sc/manual/dss/snap-policy-manual/page-159")
+    )
+
+
+def test_unstick_recognizes_program_specs() -> None:
+    assert _local_drain.PROGRAM_SPEC_RE.match("us-sc/programs/snap/fy-2026.yaml")
+    assert not _local_drain.PROGRAM_SPEC_RE.match("us-sc/policies/dss/snap/page.yaml")
+
+
+def test_worklist_item_for_slug_reads_all_statuses(monkeypatch, tmp_path: Path) -> None:
+    item = {
+        "citation": "us-sc/manual/page-159",
+        "slug": "us-sc-manual-page-159",
+        "program_scope_sync": {"program_spec": "us-sc/programs/snap/fy-2026.yaml"},
+    }
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps({"include": [item]}), stderr=""
+        )
+
+    monkeypatch.setattr(_local_drain.subprocess, "run", fake_run)
+
+    assert (
+        _local_drain.worklist_item_for_slug(tmp_path, "us-sc-manual-page-159") == item
+    )
+    assert "--status" in calls[0][0]
+    assert "any" in calls[0][0]
+
+
+def test_local_runner_requires_review_before_merge() -> None:
+    root = Path(__file__).resolve().parents[1]
+    local_drain = (root / "bulk/local_drain.py").read_text()
+
+    assert "discover_applied_artifacts(" in local_drain
+    assert "ensure_draft_pr(branch)" in local_drain
+    assert local_drain.count("ensure_draft_pr(branch)") >= 4
+    assert local_drain.count('"--draft"') >= 2
+    assert '"pr", "merge", branch, "--repo", REPO, "--auto"' not in local_drain
+    assert (
+        '"--head",\n            branch,\n            "--json",\n            "number"'
+        in local_drain
+    )
+    assert "if not existing_pr:" in local_drain
+    assert "wait_for_merge" not in local_drain
+    assert 'startswith("validate / validate")' in local_drain
+    assert "if validation_checks and not pending:" in local_drain
+    assert 'return "checks complete; draft review required"' in local_drain
+    assert "could not determine PR state" in local_drain
+    assert "before push" in local_drain
+    assert 'expected = pinned_toolchain().get("axiom_encode_ref")' in local_drain
+    assert "COV_ENCODER_REF" not in local_drain
+    assert "refs/heads/main" not in local_drain
+    assert '"program-scope-sync", "--help"' in local_drain
+    assert 'COV_ORACLES_REF = "9901e2479ac39bba865b8232e1c7d879ba447d8d"' in local_drain
+    assert local_drain.count("require_coverage_ref()") >= 5
+    assert "Local signed generation is disabled" in local_drain
+    assert '"AXIOM_ENCODE_APPLY_SIGNING_KEY": signing_key()' not in local_drain
+    assert "find-generic-password" not in local_drain


### PR DESCRIPTION
## Summary

Step 2 of the canonical bulk-encoding rollout, stacked on #927.

- preserve reviewed queue metadata for acceptance criteria, allowed context, dependencies, and ProgramSpec scope updates
- add exact applied-artifact discovery and reject frozen legacy `manual/` outputs
- normalize every recovery PR to draft with auto-merge disabled
- bind recovery tools to the protected workflow pin instead of mutable `main`
- prevent ambient apply-signing keys from reaching encoder helper commands
- queue the South Carolina SNAP utility prerequisite and current-amount provisions
- keep local signed generation disabled; brokered generation is enabled only by the separate protected activation PR

This PR changes feature code, tests, documentation, and the durable worklist. It does not modify `.github/` or `.axiom/` relative to its base.

## Review cycle

- Round 1 found unsafe cloud coupling, missing protected pin inheritance, and an incorrect canonical ProgramSpec path; the rollout was split and the path fixed.
- Round 2 found stale mutable-main recovery pinning, ambient key inheritance, and acceptance of frozen manual outputs; all three were fixed.
- Final independent re-review found no actionable findings.

## Checks

- `59 passed` across the complete repository test suite (one existing warning for 46 unmanifested modules)
- Ruff check and format
- actionlint
- exact legacy freeze verification
- SC SNAP queue matrix inspection, including context, dependencies, acceptance criteria, and ProgramSpec scope sync
- `git diff --check`

Keep this draft until #911 and #927 land. Then retarget in stack order, rerun hosted CI, and complete maintainer review before merge.
