### PR TITLE
Activate protected signed bulk encoding

### DIFF
--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -644,7 +644,7 @@ jobs:
               raise SystemExit(1)
           failures = payload.get("failures") if isinstance(payload, dict) else None
           value_mismatch = re.compile(
-              r"^[^:]+(?:\[[0-9]+\])?: expected .+, got .+$"
+              r"^.+(?:\[[0-9]+\])?: expected .+, got .+$"
           )
           if (
               payload.get("success") is not False

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -848,6 +848,43 @@ jobs:
             done
           }
 
+          pr_state=""
+          pr_number=""
+          reopened_pr=false
+          refresh_complete=false
+
+          rollback_reopened_pr() {
+            local status=$?
+            trap - EXIT
+            if [ "$status" -ne 0 ] && [ "$reopened_pr" = true ] && \
+                [ "$refresh_complete" = false ]; then
+              echo "::warning::Refresh failed after reopening PR #$pr_number; restoring its closed retryable state." >&2
+              retry gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" || \
+                echo "::error::Could not restore PR #$pr_number to closed state." >&2
+            fi
+            exit "$status"
+          }
+          trap rollback_reopened_pr EXIT
+
+          harden_pr_for_review() {
+            local number="$1" controls
+            controls="$(retry gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft,autoMergeRequest)"
+            if [ "$(jq -r '.autoMergeRequest != null' <<< "$controls")" = "true" ]; then
+              retry gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --disable-auto
+            fi
+            if [ "$(jq -r .isDraft <<< "$controls")" != "true" ]; then
+              retry gh pr ready "$number" --repo "$GITHUB_REPOSITORY" --undo
+            fi
+            controls="$(retry gh pr view "$number" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft,autoMergeRequest)"
+            if [ "$(jq -r '.isDraft == true and .autoMergeRequest == null' \
+                <<< "$controls")" != "true" ]; then
+              echo "::error::$branch is not a draft with auto-merge disabled." >&2
+              return 1
+            fi
+          }
+
           # Ensure the bulk-encode label exists.
           gh label create bulk-encode --repo "$GITHUB_REPOSITORY" \
             --color 1f6feb --description "Opened by the bulk-encode dispatcher" 2>/dev/null || true
@@ -896,12 +933,21 @@ jobs:
           fi
           if [ "$pr_state" = "CLOSED" ]; then
             if gh pr reopen "$pr_number" --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
+              reopened_pr=true
+              pr_state="OPEN"
               echo "Reopened closed PR for $branch."
             else
               echo "::warning::Closed PR for $branch cannot be reopened (head orphaned by a prior force-push); opening a fresh PR." >&2
               pr_state=""
               pr_number=""
             fi
+          fi
+
+          # Existing and just-reopened PRs must be review-safe before a new
+          # generated commit can trigger checks. This removes any legacy
+          # auto-merge request and restores draft state before the force-push.
+          if [ -n "$pr_state" ]; then
+            harden_pr_for_review "$pr_number"
           fi
 
           # Push the applied commit onto the bulk branch. This updates the open or
@@ -913,7 +959,7 @@ jobs:
             -m "Produced by axiom-encode encode $CITATION --apply (backend ${{ matrix.item.backend }}, model ${{ matrix.item.model }})." \
             -m "" \
             -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
-          git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:$branch"
+          retry git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:$branch"
 
           if [ -z "$pr_state" ]; then
             pr_url="$(retry gh pr create --repo "$GITHUB_REPOSITORY" \
@@ -933,23 +979,9 @@ jobs:
               --add-label bulk-encode
           fi
 
-          # Generated PRs remain draft until an independent reviewer reports no
-          # actionable findings. Reused PRs can retain an auto-merge request
-          # from the legacy workflow, so explicitly remove it before restoring
-          # and verifying the draft state.
-          pr_json="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft,autoMergeRequest)"
-          if [ "$(jq -r '.autoMergeRequest != null' <<< "$pr_json")" = "true" ]; then
-            retry gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --disable-auto
-          fi
-          is_draft="$(jq -r .isDraft <<< "$pr_json")"
-          if [ "$is_draft" != "true" ]; then
-            retry gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo
-          fi
-          if ! gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
-            --json isDraft,autoMergeRequest \
-            --jq '.isDraft == true and .autoMergeRequest == null' | grep -qx true; then
-            echo "::error::$branch is not a draft with auto-merge disabled." >&2
-            exit 1
-          fi
+          # Recheck new and reused PRs after all mutations. Generated PRs remain
+          # draft until an independent reviewer reports no actionable findings.
+          harden_pr_for_review "$pr_number"
+          refresh_complete=true
 
           echo "Draft PR opened for $CITATION on branch $branch (status: $ENC_STATUS; review required)."

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -454,9 +454,11 @@ jobs:
         shell: bash
         env:
           ALLOW_CONTEXT: ${{ toJSON(matrix.item.allow_context) }}
+          REVIEW_FINDINGS: ${{ matrix.item.acceptance_criteria }}
         run: |
           set -euo pipefail
           jq -r '.[]' <<< "$ALLOW_CONTEXT" > "$RUNNER_TEMP/allow-context"
+          printf '%s\n' "$REVIEW_FINDINGS" > "$RUNNER_TEMP/review-findings.md"
           date +%s > "$RUNNER_TEMP/encode-start"
 
       # Keep the signing secret on a single-purpose step. This shell performs
@@ -487,6 +489,9 @@ jobs:
           while IFS= read -r context; do
             encode_args+=(--allow-context "$GITHUB_WORKSPACE/$context")
           done < "$RUNNER_TEMP/allow-context"
+          if [ -s "$RUNNER_TEMP/review-findings.md" ]; then
+            encode_args+=(--review-findings "$RUNNER_TEMP/review-findings.md")
+          fi
 
           # --- Encode + apply (writes main YAML, companion test, signed manifest) ---
           # `--apply` validates the generated main file, companion test, and

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: read
       pull-requests: read
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
@@ -88,9 +89,14 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
             > "$RUNNER_TEMP/pulls.json"
+          gh api --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues?state=open&labels=bulk-encode-failed&per_page=100" \
+            > "$RUNNER_TEMP/failure-issues.json"
           args=(
             --status pending --format matrix --limit "$LIMIT"
             --exclude-prs "$RUNNER_TEMP/pulls.json"
+            --exclude-failure-issues "$RUNNER_TEMP/failure-issues.json"
             --repo-full-name "$GITHUB_REPOSITORY"
           )
           if [ -n "$BATCH" ]; then
@@ -100,7 +106,7 @@ jobs:
           count="$(python -c 'import json,sys; print(len(json.loads(sys.argv[1])["include"]))' "$matrix")"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Selected $count pending module(s) without an open or merged bulk PR:"
+          echo "Selected $count ready module(s) without an active PR or hard-failure hold:"
           python bulk/compute_matrix.py "${args[@]/--format matrix/--format table}" || true
 
       - name: Fail if nothing to encode
@@ -125,6 +131,7 @@ jobs:
         item: ${{ fromJSON(needs.dispatch.outputs.matrix).include }}
     permissions:
       contents: read
+      issues: write
       pull-requests: read
     steps:
       - name: Checkout rules repository (leaf dir MUST be named rulespec-us)
@@ -405,23 +412,23 @@ jobs:
           REQUIRED_CITATIONS: ${{ toJSON(matrix.item.requires_merged_citations) }}
         run: |
           set -euo pipefail
+          gh api --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
+            > "$RUNNER_TEMP/dependency-pulls.json"
           while IFS= read -r dependency; do
             slug="$(python -c \
               'import sys; from bulk.compute_matrix import citation_slug; print(citation_slug(sys.argv[1]))' \
               "$dependency")"
-            open_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-              --head "bulk/$slug" --json number --jq 'length')"
-            if [ "$open_count" -ne 0 ]; then
-              echo "::error::$CITATION is waiting for the open dependency PR for $dependency." >&2
-              exit 1
-            fi
-            merge_commit="$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
-              --head "bulk/$slug" --limit 100 --json mergedAt,mergeCommit \
-              --jq 'sort_by(.mergedAt) | last | .mergeCommit.oid // ""')"
-            if [ -z "$merge_commit" ]; then
+            dependency_pr="$(python bulk/compute_matrix.py \
+              --exclude-prs "$RUNNER_TEMP/dependency-pulls.json" \
+              --repo-full-name "$GITHUB_REPOSITORY" \
+              --find-pr-branch "bulk/$slug")"
+            if [ "$(jq -r '.state // ""' <<< "$dependency_pr")" != "MERGED" ]; then
               echo "::error::$CITATION is waiting for merged dependency $dependency." >&2
               exit 1
             fi
+            merge_commit="$(jq -r '.merge_commit // ""' <<< "$dependency_pr")"
             if ! git merge-base --is-ancestor "$merge_commit" HEAD; then
               echo "::error::$CITATION dependency $dependency is not present in checked-out HEAD; dispatch again from updated main." >&2
               exit 1
@@ -441,6 +448,7 @@ jobs:
       # only built-in argument assembly and immediately execs the hardened
       # launcher, so no unrelated child process inherits the key.
       - name: Encode --apply through protected signer
+        id: apply
         shell: bash
         env:
           CITATION: ${{ matrix.item.citation }}
@@ -685,6 +693,42 @@ jobs:
             exit "$test_status"
           fi
 
+      - name: Persist hard failure for triage
+        if: ${{ failure() && (steps.apply.outcome == 'failure' || steps.encode.outcome == 'failure') }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CITATION: ${{ matrix.item.citation }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Bulk encode hard failure: $CITATION"
+          gh label create bulk-encode-failed --repo "$GITHUB_REPOSITORY" \
+            --color b60205 \
+            --description "Hard bulk-encode failure; excluded from automatic retry" \
+            2>/dev/null || true
+          issues="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label bulk-encode-failed --limit 1000 --json number,title)"
+          existing="$(python -c \
+            'import json,sys; title=sys.argv[1]; print(next((i["number"] for i in json.load(sys.stdin) if i.get("title") == title), ""))' \
+            "$title" <<< "$issues")"
+          body="The protected bulk encoder failed after generation started.
+
+          Citation: \`$CITATION\`
+          Run: $RUN_URL
+
+          This open issue is durable retry state: dispatch excludes the citation
+          until the failure is triaged. Fix the encoder, corpus, or reviewed queue
+          metadata as appropriate, then close this issue to permit a fresh run.
+          Generated RuleSpec and fixtures must not be edited manually."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Hard failure repeated: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --label bulk-encode-failed --body "$body"
+          fi
+
       - name: Assemble PR body
         id: prbody
         # Only assemble/open a PR when the local gate battery actually passed.
@@ -808,24 +852,30 @@ jobs:
           # time. If the branch was already orphaned by an earlier failed run,
           # reopen is impossible; open a fresh PR instead -- GitHub permits a new
           # PR from a branch whose prior PR is closed.
-          # Query every state through the bounded retry wrapper. An empty JSON
-          # object is an explicit not-found result; API failures remain failures
-          # and cannot be mistaken for permission to mutate the branch.
-          pr_json="$(retry gh pr list --repo "$GITHUB_REPOSITORY" \
-            --state all --head "$branch" --limit 100 \
-            --json state,updatedAt \
-            --jq 'sort_by(.updatedAt) | last // {}')"
+          # Query every state and bind reconciliation to this repository's exact
+          # head branch. A fork can use the same ref name; branch-only gh filters
+          # are therefore insufficient for any mutation.
+          retry gh api --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
+            > "$RUNNER_TEMP/reconcile-pulls.json"
+          pr_json="$(python bulk/compute_matrix.py \
+            --exclude-prs "$RUNNER_TEMP/reconcile-pulls.json" \
+            --repo-full-name "$GITHUB_REPOSITORY" \
+            --find-pr-branch "$branch")"
           pr_state="$(jq -r '.state // ""' <<< "$pr_json")"
+          pr_number="$(jq -r '.number // ""' <<< "$pr_json")"
           if [ "$pr_state" = "MERGED" ]; then
             echo "::warning::$CITATION already has a merged PR on $branch; skipping stale pending queue entry before branch mutation." >&2
             exit 0
           fi
           if [ "$pr_state" = "CLOSED" ]; then
-            if gh pr reopen "$branch" --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
+            if gh pr reopen "$pr_number" --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
               echo "Reopened closed PR for $branch."
             else
               echo "::warning::Closed PR for $branch cannot be reopened (head orphaned by a prior force-push); opening a fresh PR." >&2
               pr_state=""
+              pr_number=""
             fi
           fi
 
@@ -841,13 +891,19 @@ jobs:
           git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:$branch"
 
           if [ -z "$pr_state" ]; then
-            retry gh pr create --repo "$GITHUB_REPOSITORY" \
+            pr_url="$(retry gh pr create --repo "$GITHUB_REPOSITORY" \
               --base "$DEFAULT_BRANCH" --head "$branch" \
               --title "$title" \
               --body-file "${{ steps.prbody.outputs.path }}" \
-              --label bulk-encode --draft
+              --label bulk-encode --draft)"
+            pr_url="${pr_url##*$'\n'}"
+            pr_number="${pr_url##*/}"
+            if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+              echo "::error::Could not identify created PR from $pr_url." >&2
+              exit 1
+            fi
           else
-            retry gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" \
+            retry gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" \
               --title "$title" --body-file "${{ steps.prbody.outputs.path }}" \
               --add-label bulk-encode
           fi
@@ -856,15 +912,15 @@ jobs:
           # actionable findings. Reused PRs can retain an auto-merge request
           # from the legacy workflow, so explicitly remove it before restoring
           # and verifying the draft state.
-          pr_json="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json isDraft,autoMergeRequest)"
+          pr_json="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft,autoMergeRequest)"
           if [ "$(jq -r '.autoMergeRequest != null' <<< "$pr_json")" = "true" ]; then
-            retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto
+            retry gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --disable-auto
           fi
           is_draft="$(jq -r .isDraft <<< "$pr_json")"
           if [ "$is_draft" != "true" ]; then
-            retry gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo
+            retry gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo
           fi
-          if ! gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+          if ! gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
             --json isDraft,autoMergeRequest \
             --jq '.isDraft == true and .autoMergeRequest == null' | grep -qx true; then
             echo "::error::$branch is not a draft with auto-merge disabled." >&2

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -423,7 +423,7 @@ jobs:
             dependency_pr="$(python bulk/compute_matrix.py \
               --exclude-prs "$RUNNER_TEMP/dependency-pulls.json" \
               --repo-full-name "$GITHUB_REPOSITORY" \
-              --find-pr-branch "bulk/$slug")"
+              --find-pr-branch "bulk/$slug" --find-pr-state MERGED)"
             if [ "$(jq -r '.state // ""' <<< "$dependency_pr")" != "MERGED" ]; then
               echo "::error::$CITATION is waiting for merged dependency $dependency." >&2
               exit 1
@@ -855,10 +855,20 @@ jobs:
           # Query every state and bind reconciliation to this repository's exact
           # head branch. A fork can use the same ref name; branch-only gh filters
           # are therefore insufficient for any mutation.
-          retry gh api --paginate --slurp \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
-            > "$RUNNER_TEMP/reconcile-pulls.json"
+          fetch_reconcile_pulls() {
+            local temporary="$RUNNER_TEMP/reconcile-pulls.$$.tmp"
+            rm -f "$temporary"
+            if gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
+              > "$temporary"; then
+              mv "$temporary" "$RUNNER_TEMP/reconcile-pulls.json"
+              return 0
+            fi
+            rm -f "$temporary"
+            return 1
+          }
+          retry fetch_reconcile_pulls
           pr_json="$(python bulk/compute_matrix.py \
             --exclude-prs "$RUNNER_TEMP/reconcile-pulls.json" \
             --repo-full-name "$GITHUB_REPOSITORY" \

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -1,20 +1,857 @@
 name: Bulk encode
 
-# Fail closed during the canonical-provenance migration. The protected signer
-# workflow is enabled only after its reviewed matrix and local runner support
-# land in the separate feature PR.
+# Durable queue -> runner -> PR loop for bulk RuleSpec encoding, independent of
+# any local session.
+#
+#   * The queue is bulk/worklist.yaml (committed). bulk/compute_matrix.py turns
+#     it into the job matrix.
+#   * Each matrix job encodes ONE already-ingested provision with
+#     `axiom-encode encode <citation> --apply` using the toolchain-pinned
+#     encoder (.axiom/workflow-toolchain.toml), so generation and downstream CI
+#     use the identical encoder version.
+#   * The job runs the same gate battery the PR CI runs (guard-generated is
+#     satisfied by the signed apply manifest; validate + companion test +
+#     proof-validate run locally as a fast fail-closed pre-check), and opens one
+#     draft PR per module on `bulk/<slug>` for the required review/fix cycle.
+#   * The job NEVER bypasses red. It never admin-merges. The authoritative gate
+#     is the repository's required `validate / validate` check on the PR; this
+#     workflow only queues work and pre-checks it.
+#
+# The encoder and gates own correctness. This workflow is plumbing: it never
+# edits generated values.
+
 on:
   workflow_dispatch:
+    inputs:
+      batch:
+        description: "Worklist batch label to encode (e.g. A, B). Empty = all pending."
+        required: false
+        type: string
+        default: ""
+      limit:
+        description: "Max modules to encode this run."
+        required: false
+        type: string
+        default: "8"
+  schedule:
+    # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
+    # still `pending` in the worklist without a human dispatch.
+    - cron: "41 6 * * 2"
 
+# The default GITHUB_TOKEN is intentionally minimal; PR creation uses
+# BULK_ENCODE_TOKEN so the opened PR triggers the required validate CI.
 permissions:
   contents: read
 
+concurrency:
+  # One bulk run at a time so two dispatches never race on the same branches.
+  group: bulk-encode
+  cancel-in-progress: false
+
 jobs:
-  disabled:
-    name: disabled pending reviewed activation
+  dispatch:
+    name: dispatch
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      count: ${{ steps.compute.outputs.count }}
     steps:
-      - name: Reject bulk dispatch while migration is incomplete
+      - name: Checkout rules repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install PyYAML
+        run: python -m pip install --upgrade pip pyyaml
+
+      - name: Compute matrix from worklist
+        id: compute
+        shell: bash
+        env:
+          BATCH: ${{ inputs.batch }}
+          LIMIT: ${{ inputs.limit || '8' }}
         run: |
-          echo "Bulk encoding is disabled pending the reviewed activation PR." >&2
-          exit 1
+          set -euo pipefail
+          args=(--status pending --format matrix --limit "$LIMIT")
+          if [ -n "$BATCH" ]; then
+            args+=(--batch "$BATCH")
+          fi
+          matrix="$(python bulk/compute_matrix.py "${args[@]}")"
+          count="$(python -c 'import json,sys; print(len(json.loads(sys.argv[1])["include"]))' "$matrix")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Selected $count pending module(s):"
+          python bulk/compute_matrix.py "${args[@]/--format matrix/--format table}" || true
+
+      - name: Fail if nothing to encode
+        if: ${{ steps.compute.outputs.count == '0' }}
+        run: |
+          echo "::warning::No pending worklist entries match this dispatch." >&2
+          # Not a hard failure: a scheduled run with an empty queue is normal.
+          exit 0
+
+  encode:
+    name: encode
+    needs: dispatch
+    if: ${{ needs.dispatch.outputs.count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Independent modules: one red module must not cancel the others.
+      fail-fast: false
+      # Cap parallelism at 4 to stay well under OpenAI rate limits and keep
+      # engine builds cheap.
+      max-parallel: 4
+      matrix:
+        item: ${{ fromJSON(needs.dispatch.outputs.matrix).include }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout rules repository (leaf dir MUST be named rulespec-us)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # BULK_ENCODE_TOKEN so the PR push/creation triggers the required
+          # validate CI (the default GITHUB_TOKEN would not).
+          token: ${{ secrets.BULK_ENCODE_TOKEN }}
+
+      - name: Guard - workspace must be named rulespec-us
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="$(basename "$GITHUB_WORKSPACE")"
+          if [ "$base" != "rulespec-us" ]; then
+            echo "::error::--apply resolver requires the checkout leaf dir to be 'rulespec-us' (got '$base')." >&2
+            exit 1
+          fi
+          echo "Workspace leaf dir: $base"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.26.1"
+          cache: false
+
+      - name: Resolve pinned RuleSpec toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(
+              Path(".axiom/workflow-toolchain.toml").read_text()
+          )
+          t = data["workflow_toolchain"]
+          ref_keys = (
+              "axiom_encode_ref",
+              "axiom_rules_engine_ref",
+              "axiom_corpus_ref",
+          )
+          for key in ref_keys:
+              value = t.get(key)
+              if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{40}", value) is None:
+                  raise SystemExit(f"{key} must be a full lowercase commit SHA")
+              print(f"{key}={value}")
+          version = t.get("axiom_encode_version")
+          if not isinstance(version, str) or re.fullmatch(r"[0-9]+(?:\.[0-9]+){2}", version) is None:
+              raise SystemExit("axiom_encode_version must be a semantic version")
+          print(f"axiom_encode_version={version}")
+
+          evidence = tomllib.loads(Path(".axiom/toolchain.toml").read_text())
+          if set(evidence) != {"toolchain"}:
+              raise SystemExit("evidence toolchain must contain only [toolchain]")
+          policy = evidence["toolchain"]
+          expected = {
+              "axiom_corpus_release",
+              "axiom_corpus_release_content_sha256",
+              "validation_waiver_set_sha256",
+          }
+          if not isinstance(policy, dict) or set(policy) != expected:
+              raise SystemExit("evidence toolchain has an invalid schema")
+          release = policy["axiom_corpus_release"]
+          content_sha = policy["axiom_corpus_release_content_sha256"]
+          if not isinstance(release, str) or re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", release) is None:
+              raise SystemExit("axiom_corpus_release must be an immutable release name")
+          if not isinstance(content_sha, str) or re.fullmatch(r"[0-9a-f]{64}", content_sha) is None:
+              raise SystemExit("axiom_corpus_release_content_sha256 must be a lowercase sha256")
+          print(f"axiom_corpus_release={release}")
+          print(f"axiom_corpus_release_content_sha256={content_sha}")
+          PY
+          echo "Resolved toolchain:"
+          grep -E 'axiom_(encode|rules_engine|corpus)_ref|axiom_encode_version' "$GITHUB_OUTPUT" || true
+
+      - name: Checkout axiom-encode (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-encode
+          ref: ${{ steps.toolchain.outputs.axiom_encode_ref }}
+          path: _axiom/axiom-encode
+
+      - name: Checkout axiom-rules-engine (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-rules-engine
+          ref: ${{ steps.toolchain.outputs.axiom_rules_engine_ref }}
+          path: _axiom/axiom-rules-engine
+
+      - name: Checkout axiom-corpus (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: TheAxiomFoundation/axiom-corpus
+          ref: ${{ steps.toolchain.outputs.axiom_corpus_ref }}
+          path: _axiom/axiom-corpus
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Cache axiom-rules-engine build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: _axiom/axiom-rules-engine
+
+      - name: Install pinned axiom-encode
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+          python -m pip install -e _axiom/axiom-encode
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages"
+          python -m pip install --target "$RUNNER_TEMP/axiom-verification-site-packages" \
+            _axiom/axiom-encode
+          # The protected runtime imports axiom_encode from a root-owned copy of
+          # the exact Git checkout so apply manifests retain verifiable commit
+          # provenance. Dependencies remain in the isolated site-packages tree.
+          rm -rf "$RUNNER_TEMP/axiom-verification-site-packages/axiom_encode"
+
+      - name: Fetch pinned signed corpus release object from public registry
+        shell: bash
+        env:
+          SUPABASE_URL: https://swocpijqqahhuwtuahwc.supabase.co
+          SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_ANON_KEY" || {
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY repository variable is required" >&2
+            exit 1
+          }
+          destination="$GITHUB_WORKSPACE/_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          mkdir -p "$(dirname "$destination")"
+          url="${SUPABASE_URL%/}/rest/v1/release_objects?select=release_object&release_name=eq.${RELEASE_NAME}&content_sha256=eq.${RELEASE_CONTENT_SHA256}&limit=2"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            --header "apikey: $SUPABASE_ANON_KEY" \
+            --header "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            --header "Accept-Profile: corpus" \
+            --output "$destination.tmp" "$url"
+          python - "$destination.tmp" "$RELEASE_NAME" "$RELEASE_CONTENT_SHA256" <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          path, expected_name, expected_sha = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+          try:
+              rows = json.loads(path.read_bytes())
+          except (OSError, json.JSONDecodeError) as exc:
+              raise SystemExit(f"Corpus release acquisition error: invalid JSON: {exc}")
+          if not isinstance(rows, list) or len(rows) != 1:
+              raise SystemExit(
+                  "Corpus release acquisition error: public registry did not return "
+                  "exactly one immutable object"
+              )
+          payload = rows[0].get("release_object") if isinstance(rows[0], dict) else None
+          if not isinstance(payload, dict):
+              raise SystemExit("Corpus release acquisition error: missing release object")
+          if payload.get("release") != expected_name:
+              raise SystemExit("Corpus release acquisition error: release name mismatch")
+          content = payload.get("content")
+          if not isinstance(content, dict):
+              raise SystemExit("Corpus release acquisition error: missing content object")
+          actual = hashlib.sha256(json.dumps(
+              content, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+          ).encode()).hexdigest()
+          if payload.get("content_sha256") != actual or actual != expected_sha:
+              raise SystemExit(
+                  f"Corpus release acquisition error: content sha256 mismatch "
+                  f"({actual} != {expected_sha})"
+              )
+          destination = path.with_suffix("")
+          destination.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+          path.unlink()
+          PY
+
+      - name: Authenticate signed corpus provenance commit
+        shell: bash
+        env:
+          RELEASE_NAME: ${{ steps.toolchain.outputs.axiom_corpus_release }}
+          RELEASE_CONTENT_SHA256: ${{ steps.toolchain.outputs.axiom_corpus_release_content_sha256 }}
+          AXIOM_CORPUS_SHA: ${{ steps.toolchain.outputs.axiom_corpus_ref }}
+        run: |
+          set -euo pipefail
+          object="_axiom/axiom-corpus/releases/$RELEASE_NAME/$RELEASE_CONTENT_SHA256.json"
+          release_commit="$(python - "$object" <<'PY'
+          import json
+          import sys
+          print(json.load(open(sys.argv[1]))["content"]["git"]["commit"])
+          PY
+          )"
+          if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Signed release provenance is not a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          default_branch="$(git -C _axiom/axiom-corpus ls-remote --symref origin HEAD | sed -n 's#^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$#\1#p')"
+          test -n "$default_branch"
+          git -C _axiom/axiom-corpus fetch --no-tags origin \
+            "+refs/heads/$default_branch:refs/remotes/origin/$default_branch"
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "refs/remotes/origin/$default_branch" || {
+              echo "Signed release provenance $release_commit is not on the corpus default branch" >&2
+              exit 1
+            }
+          git -C _axiom/axiom-corpus merge-base --is-ancestor \
+            "$release_commit" "$AXIOM_CORPUS_SHA" || {
+              echo "Corpus checkout $AXIOM_CORPUS_SHA predates signed release provenance $release_commit" >&2
+              exit 1
+            }
+
+      - name: Build axiom-rules-engine
+        working-directory: _axiom/axiom-rules-engine
+        run: cargo build --verbose
+
+      - name: Expose engine and sibling checkouts
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine/target/debug" >> "$GITHUB_PATH"
+          # Sibling layout the resolver's default checkout discovery expects.
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" "$GITHUB_WORKSPACE/../axiom-rules-engine"
+          ln -sfn "$GITHUB_WORKSPACE/_axiom/axiom-corpus" "$GITHUB_WORKSPACE/../axiom-corpus"
+
+      - name: Provision protected signing supervisor
+        shell: bash
+        env:
+          TRUST_APPLY_ROOT: ${{ vars.AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY }}
+          TRUST_EVAL_ROOT: ${{ vars.AXIOM_ENCODE_EVAL_SIGNING_PUBLIC_KEY }}
+          TRUST_CORPUS_RELEASE_ROOT: ${{ vars.AXIOM_CORPUS_RELEASE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          pushd _axiom/axiom-encode >/dev/null
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            ./cmd/axiom-encode-signing-supervisor
+          CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags='-buildid=' \
+            -o "$RUNNER_TEMP/axiom-encode-apply-signer" \
+            ./cmd/axiom-encode-apply-signer
+          popd >/dev/null
+          sudo rm -rf /opt/axiom-verification
+          sudo "$(command -v python)" \
+            _axiom/axiom-encode/scripts/provision_verification_supervisor.py \
+            --destination /opt/axiom-verification \
+            --supervisor "$RUNNER_TEMP/axiom-encode-signing-supervisor" \
+            --site-packages "$RUNNER_TEMP/axiom-verification-site-packages" \
+            --apply-root "$TRUST_APPLY_ROOT" \
+            --eval-root "$TRUST_EVAL_ROOT" \
+            --corpus-release-root "$TRUST_CORPUS_RELEASE_ROOT"
+          sudo cp -a _axiom/axiom-encode \
+            /opt/axiom-verification/python/axiom-encode-checkout
+          sudo install -m 0755 "$(command -v git)" \
+            /opt/axiom-verification/python/bin/git.real
+          sudo tee /opt/axiom-verification/python/bin/git >/dev/null <<'EOF'
+          #!/bin/sh
+          exec /opt/axiom-verification/python/bin/git.real \
+            -c safe.directory=/opt/axiom-verification/python/axiom-encode-checkout "$@"
+          EOF
+          sudo chmod 0755 /opt/axiom-verification/python/bin/git
+          sudo chown -R 0:0 /opt/axiom-verification
+          sudo chmod -R go-w /opt/axiom-verification
+          sudo chown root:root /opt
+          sudo chmod go-w /opt
+
+      - name: Require merged queue dependencies
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CITATION: ${{ matrix.item.citation }}
+          REQUIRED_CITATIONS: ${{ toJSON(matrix.item.requires_merged_citations) }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r dependency; do
+            slug="$(python -c \
+              'import sys; from bulk.compute_matrix import citation_slug; print(citation_slug(sys.argv[1]))' \
+              "$dependency")"
+            open_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+              --head "bulk/$slug" --json number --jq 'length')"
+            if [ "$open_count" -ne 0 ]; then
+              echo "::error::$CITATION is waiting for the open dependency PR for $dependency." >&2
+              exit 1
+            fi
+            merge_commit="$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
+              --head "bulk/$slug" --limit 100 --json mergedAt,mergeCommit \
+              --jq 'sort_by(.mergedAt) | last | .mergeCommit.oid // ""')"
+            if [ -z "$merge_commit" ]; then
+              echo "::error::$CITATION is waiting for merged dependency $dependency." >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$merge_commit" HEAD; then
+              echo "::error::$CITATION dependency $dependency is not present in checked-out HEAD; dispatch again from updated main." >&2
+              exit 1
+            fi
+          done < <(jq -r '.[]' <<< "$REQUIRED_CITATIONS")
+
+      - name: Prepare reviewed encode context
+        shell: bash
+        env:
+          ALLOW_CONTEXT: ${{ toJSON(matrix.item.allow_context) }}
+        run: |
+          set -euo pipefail
+          jq -r '.[]' <<< "$ALLOW_CONTEXT" > "$RUNNER_TEMP/allow-context"
+          date +%s > "$RUNNER_TEMP/encode-start"
+
+      # Keep the signing secret on a single-purpose step. This shell performs
+      # only built-in argument assembly and immediately execs the hardened
+      # launcher, so no unrelated child process inherits the key.
+      - name: Encode --apply through protected signer
+        shell: bash
+        env:
+          CITATION: ${{ matrix.item.citation }}
+          BACKEND: ${{ matrix.item.backend }}
+          MODEL: ${{ matrix.item.model }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets.AXIOM_ENCODE_APPLY_SIGNING_KEY }}
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          encode_args=(
+            encode "$CITATION"
+            --backend "$BACKEND" --model "$MODEL"
+            --policy-repo-path "$GITHUB_WORKSPACE"
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus"
+            --output "$RUNNER_TEMP/encode-out"
+            --apply --no-sync
+          )
+          while IFS= read -r context; do
+            encode_args+=(--allow-context "$GITHUB_WORKSPACE/$context")
+          done < "$RUNNER_TEMP/allow-context"
+
+          # --- Encode + apply (writes main YAML, companion test, signed manifest) ---
+          # `--apply` validates the generated main file, companion test, and
+          # direct dependents in a temporary overlay before installing. It exits
+          # non-zero and writes nothing on validation failure -> fail-closed.
+          exec "$RUNNER_TEMP/axiom-encode-apply-signer" run \
+            --scope apply_ed25519 \
+            --key-env AXIOM_ENCODE_APPLY_SIGNING_KEY \
+            --supervisor /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/axiom-encode-checkout/src \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/axiom-encode-checkout/src/axiom_encode \
+            --expected-github-repository TheAxiomFoundation/rulespec-us \
+            --allowed-workflow-ref TheAxiomFoundation/rulespec-us/.github/workflows/bulk-encode.yml@refs/heads/main \
+            --allowed-event-name workflow_dispatch \
+            --allowed-event-name schedule \
+            -- /opt/axiom-verification/axiom-encode "${encode_args[@]}"
+
+      - name: Discover applied artifacts and run the gate battery
+        id: encode
+        shell: bash
+        env:
+          CITATION: ${{ matrix.item.citation }}
+          PROGRAM_SCOPE_SYNC: ${{ toJSON(matrix.item.program_scope_sync) }}
+          AXIOM_CORPUS_REPO: ${{ github.workspace }}/_axiom/axiom-corpus
+          AXIOM_RULESPEC_REPO_ROOTS: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          start="$(<"$RUNNER_TEMP/encode-start")"
+          end=$(date +%s)
+          echo "wall_seconds=$((end - start))" >> "$GITHUB_OUTPUT"
+          echo "Encode wall time: $((end - start))s"
+
+          # Fail closed unless the reviewed helper finds exactly one generated
+          # module, its companion test, and the matching signed apply manifest.
+          # The helper also binds the generated module to the requested citation
+          # and rejects outputs written under the frozen legacy manual root.
+          mapfile -t applied < <(
+            python bulk/applied_artifacts.py \
+              --repo "$GITHUB_WORKSPACE" \
+              --citation "$CITATION"
+          )
+          if [ "${#applied[@]}" -ne 3 ]; then
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "::error::Could not identify the exact applied artifacts for $CITATION." >&2
+            exit 1
+          fi
+
+          module="${applied[0]}"
+          test_file="${applied[1]}"
+          manifest_rel="${applied[2]}"
+          juris="${module%%/*}"
+          echo "module=$module" >> "$GITHUB_OUTPUT"
+          echo "test_file=$test_file" >> "$GITHUB_OUTPUT"
+          echo "manifest_rel=$manifest_rel" >> "$GITHUB_OUTPUT"
+          echo "Applied module: $module"
+          echo "Applied manifest: $manifest_rel"
+
+          composition_files=()
+          if [ "$PROGRAM_SCOPE_SYNC" != "null" ]; then
+            program_spec="$(jq -r '.program_spec' <<< "$PROGRAM_SCOPE_SYNC")"
+            scope="$(jq -r '.scope' <<< "$PROGRAM_SCOPE_SYNC")"
+            scope_args=(
+              program-scope-sync --repo "$GITHUB_WORKSPACE"
+              --program-spec "$program_spec" --scope "$scope"
+            )
+            while IFS= read -r value; do
+              scope_args+=(--add "$value")
+            done < <(jq -r '.add[]?' <<< "$PROGRAM_SCOPE_SYNC")
+            while IFS= read -r value; do
+              scope_args+=(--remove "$value")
+            done < <(jq -r '.remove[]?' <<< "$PROGRAM_SCOPE_SYNC")
+            axiom-encode "${scope_args[@]}"
+            composition_files+=("$program_spec")
+          fi
+
+          # Regenerate the provision -> rules reverse index so the committed
+          # .axiom/index/provisions_to_rules.json reflects the new module; the
+          # reverse-index CI check fails on a stale index. This is a generated
+          # artifact (not guarded RuleSpec), safe to write here.
+          index_file=".axiom/index/provisions_to_rules.json"
+          if [ -f "$GITHUB_WORKSPACE/tests/generate_reverse_index.py" ]; then
+            (cd "$GITHUB_WORKSPACE" && python tests/generate_reverse_index.py)
+          fi
+
+          # Declare the module's unmapped executable outputs in the
+          # oracle-coverage pending lane, using the same pinned encoder as
+          # generation. The changed-file oracle-coverage gate reclassifies
+          # declared outputs from `unmapped` to `pending_classification`, so this
+          # is what lets a new-state module's PR pass the required validate check
+          # instead of hanging on `... : unmapped`. `sync` rewrites
+          # oracle-coverage-pending.yaml to exactly the repo's current unmapped
+          # set; it is a no-op when the module's outputs are already mapped.
+          pending_file="oracle-coverage-pending.yaml"
+          axiom-encode oracle-coverage-pending sync \
+            --root "$GITHUB_WORKSPACE" \
+            --source bulk || {
+              echo "::error::oracle-coverage-pending sync failed for $CITATION." >&2
+              exit 1
+            }
+
+          # --- Gate battery (fail-closed pre-check; mirrors PR CI order) ---
+          # 1. guard-generated: applied files must carry a valid signed manifest.
+          # Stage ONLY the applied module, its companion test, its signed
+          # manifest, the regenerated reverse index, and the pending-lane
+          # declaration -- never `git add -A`, which would commit the _axiom/
+          # sibling checkouts and build artifacts.
+          git -C "$GITHUB_WORKSPACE" add -- \
+            "$module" "$test_file" "$manifest_rel" "$index_file" \
+            "${composition_files[@]}"
+          # Keep the pending declaration only when it has entries (a new unmapped
+          # output) or is already tracked. A fully-mapped module syncs an empty
+          # declaration; committing that empty repo-root file would needlessly
+          # flip the PR to full-matrix validation, so drop it and stay scoped.
+          if [ -f "$GITHUB_WORKSPACE/$pending_file" ]; then
+            if grep -q -- '- legal_id:' "$GITHUB_WORKSPACE/$pending_file" \
+               || git -C "$GITHUB_WORKSPACE" ls-files --error-unmatch "$pending_file" >/dev/null 2>&1; then
+              git -C "$GITHUB_WORKSPACE" add -- "$pending_file"
+            else
+              rm -f "$GITHUB_WORKSPACE/$pending_file"
+            fi
+          fi
+          git -C "$GITHUB_WORKSPACE" -c user.email=bulk-encode@axiom \
+            -c user.name="bulk-encode" commit -q -m "wip: $CITATION"
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/axiom-encode-checkout/src \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/axiom-encode-checkout/src/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode guard-generated \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref "origin/${{ github.event.repository.default_branch }}" \
+            --head-ref HEAD \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --expected-encoder-checkout "$GITHUB_WORKSPACE/_axiom/axiom-encode"
+
+          # 2. validate (deterministic CI tier; no reviewers).
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/axiom-encode-checkout/src \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/axiom-encode-checkout/src/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode validate \
+            "$GITHUB_WORKSPACE/$module" --skip-reviewers \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine"
+
+          # 3. proof-validate (explicit proof trees + source claims).
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/axiom-encode-checkout/src \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/axiom-encode-checkout/src/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode proof-validate \
+            "$GITHUB_WORKSPACE/$module" \
+            --corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus"
+
+          # 4. companion test. Only value expectation mismatches are classified
+          #    as the known #1060 generated-fixture ceiling. Discovery, schema,
+          #    engine, supervisor, and every other failure remain hard failures.
+          set +e
+          test_json="$RUNNER_TEMP/companion.json"
+          test_err="$RUNNER_TEMP/companion.err"
+          /opt/axiom-verification/axiom-encode-signing-supervisor \
+            --trusted-signing-roots /opt/axiom-verification/signing-trust-roots.json \
+            --trusted-python-runtime-root /opt/axiom-verification/python \
+            --trusted-python-import-root /opt/axiom-verification/python/axiom-encode-checkout/src \
+            --trusted-python-import-root /opt/axiom-verification/python/lib/python3.13/site-packages \
+            --trusted-python-package-root /opt/axiom-verification/python/axiom-encode-checkout/src/axiom_encode \
+            -- /opt/axiom-verification/axiom-encode test \
+            --root "$GITHUB_WORKSPACE/$juris" \
+            --axiom-rules-engine-path "$GITHUB_WORKSPACE/_axiom/axiom-rules-engine" \
+            --json "${test_file#"$juris"/}" >"$test_json" 2>"$test_err"
+          test_status=$?
+          set -e
+          cat "$test_json"
+          cat "$test_err" >&2
+
+          if [ "$test_status" -eq 0 ]; then
+            echo "status=green" >> "$GITHUB_OUTPUT"
+            echo "Companion tests passed."
+          elif python - "$test_json" <<'PY'
+          import json
+          import re
+          import sys
+
+          try:
+              payload = json.load(open(sys.argv[1]))
+          except (OSError, json.JSONDecodeError):
+              raise SystemExit(1)
+          failures = payload.get("failures") if isinstance(payload, dict) else None
+          value_mismatch = re.compile(
+              r"^[^:]+(?:\[[0-9]+\])?: expected .+, got .+$"
+          )
+          if (
+              payload.get("success") is not False
+              or not isinstance(failures, list)
+              or not failures
+              or any(
+                  not isinstance(item, dict)
+                  or not isinstance(item.get("message"), str)
+                  or value_mismatch.fullmatch(item["message"]) is None
+                  for item in failures
+              )
+          ):
+              raise SystemExit(1)
+          PY
+          then
+            echo "status=needs-fixtures" >> "$GITHUB_OUTPUT"
+            echo "::warning::Companion value fixtures mismatch for $CITATION (#1060 ceiling). Marking needs-fixtures; the draft requires an encoder fix and rerun." >&2
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "::error::Companion test failed outside the #1060 value-fixture class for $CITATION." >&2
+            exit "$test_status"
+          fi
+
+      - name: Assemble PR body
+        id: prbody
+        # Only assemble/open a PR when the local gate battery actually passed.
+        # `status` is written `green`/`needs-fixtures` only after guard-generated
+        # + validate + proof-validate run; an apply failure writes `failed` and a
+        # guard/validate/proof failure exits the encode step BEFORE `status` is
+        # written, so in every non-passing case this condition is false and no PR
+        # body is assembled. (`needs-fixtures` is a soft companion-test fail and
+        # still opens the PR by design.) Replaces an `always() && module != ''`
+        # guard that assembled and pushed gate-failing generations
+        # (rulespec-uk#104 D2 / rulespec-us#605).
+        if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
+        shell: bash
+        env:
+          CITATION: ${{ matrix.item.citation }}
+          MODULE: ${{ steps.encode.outputs.module }}
+          TEST_FILE: ${{ steps.encode.outputs.test_file }}
+          MANIFEST_REL: ${{ steps.encode.outputs.manifest_rel }}
+          ENC_STATUS: ${{ steps.encode.outputs.status }}
+          WALL: ${{ steps.encode.outputs.wall_seconds }}
+          MODEL: ${{ matrix.item.model }}
+          BACKEND: ${{ matrix.item.backend }}
+          ACCEPTANCE_CRITERIA: ${{ matrix.item.acceptance_criteria }}
+        run: |
+          set -euo pipefail
+          body="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "## Bulk-encoded module"
+            echo
+            echo "- Citation: \`$CITATION\`"
+            echo "- Module: \`$MODULE\`"
+            echo "- Encoder: \`$BACKEND:$MODEL\` (toolchain-pinned axiom-encode ${{ steps.toolchain.outputs.axiom_encode_version }})"
+            echo "- Encode wall time: ${WALL}s"
+            echo "- Local gate status: **$ENC_STATUS**"
+            echo
+            echo "Produced by \`axiom-encode encode $CITATION --apply\` in the bulk-encode dispatcher"
+            echo "(\`.github/workflows/bulk-encode.yml\`). Values are the encoder's; this PR is plumbing."
+            echo
+            echo "### Manifest summary"
+            echo '```json'
+            # Use the exact signed manifest already bound to this module and
+            # citation by bulk/applied_artifacts.py. Basenames are not unique.
+            manifest="$(cat "$GITHUB_WORKSPACE/$MANIFEST_REL")"
+            echo "$manifest" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(json.dumps({k:d.get(k) for k in ["citation","model","backend","run_id","axiom_encode_version","applied_files"]}, indent=2))' 2>/dev/null || echo "$manifest"
+            echo '```'
+            echo
+            echo "### Local gate battery output"
+            echo '```'
+            echo "guard-generated: pass (signed apply manifest present)"
+            echo "validate:        pass"
+            echo "proof-validate:  pass"
+            if [ "$ENC_STATUS" = "green" ]; then
+              echo "companion test:  pass"
+            else
+              echo "companion test:  needs-fixtures (#1060 ceiling) - follow-up fixture pass required"
+            fi
+            echo '```'
+            echo
+            echo "The authoritative gate is the required \`validate / validate\` check on this PR."
+            echo
+            echo "### Acceptance criteria"
+            echo
+            echo "$ACCEPTANCE_CRITERIA"
+            echo
+            echo "This PR remains draft until the independent review/fix cycle is complete."
+          } > "$body"
+          echo "path=$body" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR for independent review
+        # Same gate-battery guard as "Assemble PR body": never force-push the
+        # bulk branch or open a PR for an encode whose gate
+        # battery did not pass. Under the old `always() && module != ''` guard a
+        # guard/validate/proof failure (which sets `module` but leaves `status`
+        # unwritten) still force-pushed the broken commit
+        # (rulespec-uk#104 D2 / rulespec-us#605).
+        if: ${{ steps.encode.outputs.status == 'green' || steps.encode.outputs.status == 'needs-fixtures' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.BULK_ENCODE_TOKEN }}
+          CITATION: ${{ matrix.item.citation }}
+          SLUG: ${{ matrix.item.slug }}
+          ENC_STATUS: ${{ steps.encode.outputs.status }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          branch="bulk/$SLUG"
+
+          # Retry a command through transient GitHub API failures (the PR
+          # mutations below occasionally hit a 502/503 from the GraphQL API; an
+          # unattended weekly drain must self-heal rather than drop the module
+          # until the next run). Backs off; not applied to `gh pr reopen`, whose
+          # failure is a meaningful signal (orphaned head -> fresh-PR fallback).
+          retry() {
+            local n=1 max=5 delay=5
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::\`$*\` failed after $max attempts." >&2
+                return 1
+              fi
+              echo "attempt $n/$max failed; retrying in ${delay}s: $*" >&2
+              sleep "$delay"; n=$((n + 1)); delay=$((delay * 2))
+            done
+          }
+
+          # Ensure the bulk-encode label exists.
+          gh label create bulk-encode --repo "$GITHUB_REPOSITORY" \
+            --color 1f6feb --description "Opened by the bulk-encode dispatcher" 2>/dev/null || true
+
+          title="Encode $CITATION (bulk)"
+          if [ "$ENC_STATUS" = "needs-fixtures" ]; then
+            title="Encode $CITATION (bulk, needs-fixtures)"
+          fi
+
+          # Reconcile the PR for this branch BEFORE touching the branch. A prior
+          # run may have left a CLOSED PR for bulk/<slug>. It must be reopened,
+          # but GitHub pins a closed PR to its head SHA and refuses to reopen
+          # once that head has
+          # been force-updated (`reopenPullRequest` returns "Could not open the
+          # pull request"). The force-push therefore MUST happen after the reopen,
+          # not before, so the closed head still matches the branch at reopen
+          # time. If the branch was already orphaned by an earlier failed run,
+          # reopen is impossible; open a fresh PR instead -- GitHub permits a new
+          # PR from a branch whose prior PR is closed.
+          # Query every state through the bounded retry wrapper. An empty JSON
+          # object is an explicit not-found result; API failures remain failures
+          # and cannot be mistaken for permission to mutate the branch.
+          pr_json="$(retry gh pr list --repo "$GITHUB_REPOSITORY" \
+            --state all --head "$branch" --limit 100 \
+            --json state,updatedAt \
+            --jq 'sort_by(.updatedAt) | last // {}')"
+          pr_state="$(jq -r '.state // ""' <<< "$pr_json")"
+          if [ "$pr_state" = "MERGED" ]; then
+            echo "::warning::$CITATION already has a merged PR on $branch; skipping stale pending queue entry before branch mutation." >&2
+            exit 0
+          fi
+          if [ "$pr_state" = "CLOSED" ]; then
+            if gh pr reopen "$branch" --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
+              echo "Reopened closed PR for $branch."
+            else
+              echo "::warning::Closed PR for $branch cannot be reopened (head orphaned by a prior force-push); opening a fresh PR." >&2
+              pr_state=""
+            fi
+          fi
+
+          # Push the applied commit onto the bulk branch. This updates the open or
+          # just-reopened PR, or stages the branch for a fresh PR below.
+          git -C "$GITHUB_WORKSPACE" -c user.email=bulk-encode@axiom \
+            -c user.name="bulk-encode" commit --amend -q \
+            -m "Encode $CITATION via bulk dispatcher" \
+            -m "" \
+            -m "Produced by axiom-encode encode $CITATION --apply (backend ${{ matrix.item.backend }}, model ${{ matrix.item.model }})." \
+            -m "" \
+            -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+          git -C "$GITHUB_WORKSPACE" push -f origin "HEAD:$branch"
+
+          if [ -z "$pr_state" ]; then
+            retry gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base "$DEFAULT_BRANCH" --head "$branch" \
+              --title "$title" \
+              --body-file "${{ steps.prbody.outputs.path }}" \
+              --label bulk-encode --draft
+          else
+            retry gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body-file "${{ steps.prbody.outputs.path }}" \
+              --add-label bulk-encode
+          fi
+
+          # Generated PRs remain draft until an independent reviewer reports no
+          # actionable findings. Reused PRs can retain an auto-merge request
+          # from the legacy workflow, so explicitly remove it before restoring
+          # and verifying the draft state.
+          pr_json="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json isDraft,autoMergeRequest)"
+          if [ "$(jq -r '.autoMergeRequest != null' <<< "$pr_json")" = "true" ]; then
+            retry gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto
+          fi
+          is_draft="$(jq -r .isDraft <<< "$pr_json")"
+          if [ "$is_draft" != "true" ]; then
+            retry gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo
+          fi
+          if ! gh pr view "$branch" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,autoMergeRequest \
+            --jq '.isDraft == true and .autoMergeRequest == null' | grep -qx true; then
+            echo "::error::$branch is not a draft with auto-merge disabled." >&2
+            exit 1
+          fi
+
+          echo "Draft PR opened for $CITATION on branch $branch (status: $ENC_STATUS; review required)."

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -52,6 +52,9 @@ jobs:
   dispatch:
     name: dispatch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
       count: ${{ steps.compute.outputs.count }}
@@ -73,9 +76,23 @@ jobs:
         env:
           BATCH: ${{ inputs.batch }}
           LIMIT: ${{ inputs.limit || '8' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          args=(--status pending --format matrix --limit "$LIMIT")
+          # Fetch every PR state before applying the dispatch limit. Exact bulk
+          # branches with an open or merged PR are removed from consideration,
+          # so stale pending entries cannot repeatedly consume the first slots
+          # and starve later queue work. Closed, unmerged PRs remain eligible for
+          # the workflow's reviewed reopen/recreate recovery path.
+          gh api --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/pulls?state=all&per_page=100" \
+            > "$RUNNER_TEMP/pulls.json"
+          args=(
+            --status pending --format matrix --limit "$LIMIT"
+            --exclude-prs "$RUNNER_TEMP/pulls.json"
+            --repo-full-name "$GITHUB_REPOSITORY"
+          )
           if [ -n "$BATCH" ]; then
             args+=(--batch "$BATCH")
           fi
@@ -83,7 +100,7 @@ jobs:
           count="$(python -c 'import json,sys; print(len(json.loads(sys.argv[1])["include"]))' "$matrix")"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Selected $count pending module(s):"
+          echo "Selected $count pending module(s) without an open or merged bulk PR:"
           python bulk/compute_matrix.py "${args[@]/--format matrix/--format table}" || true
 
       - name: Fail if nothing to encode
@@ -644,7 +661,7 @@ jobs:
               raise SystemExit(1)
           failures = payload.get("failures") if isinstance(payload, dict) else None
           value_mismatch = re.compile(
-              r"^.+(?:\[[0-9]+\])?: expected .+, got .+$"
+              r"^(?:[a-z]{2}(?:-[a-z0-9-]+)?:[^#\s]+#[^:\s]+|[^:\s]+)(?:\[[0-9]+\])?: expected .+, got .+$"
           )
           if (
               payload.get("success") is not False

--- a/.github/workflows/bulk-encode.yml
+++ b/.github/workflows/bulk-encode.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: "8"
+      citation:
+        description: "Exact worklist citation to encode or refresh in its existing draft PR."
+        required: false
+        type: string
+        default: ""
   schedule:
     # Weekly, off-peak, after the corpus/oracle cadence. Picks up any entries
     # still `pending` in the worklist without a human dispatch.
@@ -76,12 +81,13 @@ jobs:
         shell: bash
         env:
           BATCH: ${{ inputs.batch }}
+          CITATION: ${{ inputs.citation }}
           LIMIT: ${{ inputs.limit || '8' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # Fetch every PR state before applying the dispatch limit. Exact bulk
-          # branches with an open or merged PR are removed from consideration,
+          # branches with an open or merged PR are removed from queue consideration,
           # so stale pending entries cannot repeatedly consume the first slots
           # and starve later queue work. Closed, unmerged PRs remain eligible for
           # the workflow's reviewed reopen/recreate recovery path.
@@ -94,19 +100,28 @@ jobs:
             "/repos/$GITHUB_REPOSITORY/issues?state=open&labels=bulk-encode-failed&per_page=100" \
             > "$RUNNER_TEMP/failure-issues.json"
           args=(
-            --status pending --format matrix --limit "$LIMIT"
+            --format matrix
             --exclude-prs "$RUNNER_TEMP/pulls.json"
             --exclude-failure-issues "$RUNNER_TEMP/failure-issues.json"
             --repo-full-name "$GITHUB_REPOSITORY"
           )
-          if [ -n "$BATCH" ]; then
-            args+=(--batch "$BATCH")
+          if [ -n "$CITATION" ]; then
+            # An explicit citation is the reviewed regeneration route. It may
+            # update an existing open draft, while compute_matrix continues to
+            # block merged branches, unresolved dependencies, and open failure
+            # holds. The exact filter also caps the matrix to one entry.
+            args+=(--status any --only-citation "$CITATION" --limit 1)
+          else
+            args+=(--status pending --limit "$LIMIT")
+            if [ -n "$BATCH" ]; then
+              args+=(--batch "$BATCH")
+            fi
           fi
           matrix="$(python bulk/compute_matrix.py "${args[@]}")"
           count="$(python -c 'import json,sys; print(len(json.loads(sys.argv[1])["include"]))' "$matrix")"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Selected $count ready module(s) without an active PR or hard-failure hold:"
+          echo "Selected $count ready module(s) without a blocking merge or hard-failure hold:"
           python bulk/compute_matrix.py "${args[@]/--format matrix/--format table}" || true
 
       - name: Fail if nothing to encode

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -18,14 +18,11 @@ provisions to queue.
 | `.axiom/workflow-toolchain.toml` | Immutable checkout SHAs used by CI and generation. |
 | `bulk/local_drain.py` | Legacy recovery runner. Do not use it for signed apply with the current broker-only encoder. |
 | `bulk/applied_artifacts.py` | Validates the module, companion test, and signed manifest written by one encoder apply. |
-| `.github/workflows/bulk-encode.yml` | Fail-closed stub until the protected activation PR enables brokered generation. |
+| `.github/workflows/bulk-encode.yml` | Protected brokered cloud dispatcher for signed generation. |
 
 ## Running it
 
-Cloud generation is temporarily disabled by the protected migration base. The
-activation PR replaces the fail-closed stub only after this queue and runner
-support has passed review. After activation, dispatch from the Actions tab
-(**Bulk encode -> Run workflow**) or the CLI:
+Dispatch from the Actions tab (**Bulk encode -> Run workflow**) or the CLI:
 
 ```bash
 # Encode the first 8 pending batch-A entries:
@@ -35,7 +32,7 @@ gh workflow run bulk-encode.yml -f batch=A -f limit=8 --repo TheAxiomFoundation/
 gh workflow run bulk-encode.yml -f limit=12 --repo TheAxiomFoundation/rulespec-us
 ```
 
-After activation, the `schedule` trigger runs weekly and drains any remaining
+The `schedule` trigger runs weekly and drains any remaining
 `pending` entries with no human action. Parallelism is capped at 4
 (`max-parallel`) to stay under OpenAI rate limits; a top-level `concurrency`
 group serialises whole dispatches so two runs never fight over the same
@@ -43,7 +40,7 @@ group serialises whole dispatches so two runs never fight over the same
 
 ### Review-safe generation
 
-Once activated, signed apply runs only in the main-branch `bulk-encode.yml`
+Signed apply runs only in the main-branch `bulk-encode.yml`
 workflow. The workflow provisions a root-owned Python runtime and launches the
 current encoder through `axiom-encode-apply-signer`; the private key is consumed
 by the external signer and never reaches the encoder process. `allow_context`
@@ -63,9 +60,9 @@ then regenerated with `encode --apply`.
 | `AXIOM_ENCODE_APPLY_SIGNING_KEY` | Consumed only by the protected external signer. It must match `AXIOM_ENCODE_APPLY_SIGNING_PUBLIC_KEY`; the encoder never receives it. |
 | `BULK_ENCODE_TOKEN` | A `repo`+`workflow`-scoped token used to push the branch and open the draft PR. **Required**: PRs opened by the default `GITHUB_TOKEN` do **not** trigger the `pull_request` event, so required validation would never run. This token makes the PR a real event that triggers CI. |
 
-## Activated workflow
+## Workflow
 
-The protected activation PR supplies these jobs after the feature PR lands:
+The protected workflow supplies these jobs:
 
 1. **dispatch** — installs PyYAML, runs `compute_matrix.py --status pending`
    (optionally `--batch`, `--limit`), and emits the matrix.

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -64,13 +64,16 @@ then regenerated with `encode --apply`.
 
 The protected workflow supplies these jobs:
 
-1. **dispatch** — installs PyYAML, fetches all PR states, then runs
+1. **dispatch** — installs PyYAML, fetches all PR and hard-failure issue states,
+   then runs
    `compute_matrix.py --status pending` (optionally `--batch`, `--limit`) and
    emits the matrix. Entries whose exact `bulk/<slug>` branch already has an
-   open or merged PR are excluded before the limit is applied, so a stale
-   `pending` status cannot starve later queue entries. Closed, unmerged PRs stay
-   eligible for the workflow's reopen/recreate recovery path. Dispatch limits
-   are constrained to GitHub's `0..256` matrix capacity.
+   open or merged PR, an unresolved queue dependency, or an open
+   `bulk-encode-failed` issue are excluded before the limit is applied. This
+   keeps stale, blocked, and failed entries from starving later queue work.
+   Closed, unmerged PRs stay eligible for the workflow's reopen/recreate
+   recovery path. Dispatch limits are constrained to GitHub's `0..256` matrix
+   capacity.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.
@@ -87,6 +90,9 @@ The protected workflow supplies these jobs:
      `.axiom/encoding-manifests/**/<sec>.json`.
    - Runs the gate battery in PR-CI order: `guard-generated` (manifest present),
      `validate --skip-reviewers`, `proof-validate`, then the companion `test`.
+   - Creates or refreshes a `bulk-encode-failed` issue when apply or a hard gate
+     fails. The open issue is durable retry state; closing it permits a fresh
+     dispatch after triage.
    - Opens `bulk/<slug>` as a draft with the acceptance criteria, manifest
      summary, and gate output in the PR body. It never enables auto-merge.
 
@@ -105,11 +111,13 @@ Set in `worklist.yaml`. The runner reads `pending`; humans/follow-ups own the re
 | `needs-fixtures` | Encoded + applied, but the gpt-5.5 companion fixtures hit the #1060 ceiling. The draft PR remains open for an encoder fix and rerun. |
 | `pr-open` | A draft PR exists and is waiting for its review/fix cycle and CI. |
 | `merged` | The PR merged to main. Terminal success. |
-| `failed` | Encode or a non-fixture gate failed. Needs human triage. Never auto-retried, never merged. |
+| `failed` | Encode or a non-fixture gate failed. An open `bulk-encode-failed` issue blocks automatic retry until triage; reconcile the worklist in a reviewable follow-up. Never merged. |
 
 Statuses are updated by committing to `worklist.yaml` (a reviewable diff), not by
 silent CI mutation. `compute_matrix.py --set-status <citation> <status>` is a
-local convenience.
+local convenience. Hard cloud failures additionally use an open issue as
+immediate durable retry state, because a status PR is not effective until it is
+reviewed and merged.
 
 ## The fixture-split follow-up loop
 

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -64,8 +64,12 @@ then regenerated with `encode --apply`.
 
 The protected workflow supplies these jobs:
 
-1. **dispatch** — installs PyYAML, runs `compute_matrix.py --status pending`
-   (optionally `--batch`, `--limit`), and emits the matrix.
+1. **dispatch** — installs PyYAML, fetches all PR states, then runs
+   `compute_matrix.py --status pending` (optionally `--batch`, `--limit`) and
+   emits the matrix. Entries whose exact `bulk/<slug>` branch already has an
+   open or merged PR are excluded before the limit is applied, so a stale
+   `pending` status cannot starve later queue entries. Closed, unmerged PRs stay
+   eligible for the workflow's reopen/recreate recovery path.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -42,10 +42,12 @@ group serialises whole dispatches so two runs never fight over the same
 
 Signed apply runs only in the main-branch `bulk-encode.yml`
 workflow. The workflow provisions a root-owned Python runtime and launches the
-current encoder through `axiom-encode-apply-signer`; the private key is consumed
-by the external signer and never reaches the encoder process. `allow_context`
-and `program_scope_sync` metadata travel with each durable queue entry, so a
-restarted job reconstructs the same reviewed command without hand edits.
+   current encoder through `axiom-encode-apply-signer`; the private key is consumed
+   by the external signer and never reaches the encoder process. `allow_context`
+   and `program_scope_sync` metadata travel with each durable queue entry. The
+   entry's reviewed acceptance criteria are passed to the encoder through
+   `--review-findings`, so a restarted or review-triggered regeneration
+   reconstructs the same corrective command without hand edits.
 
 Every generated PR must complete the independent review/fix cycle and current
 CI before merge. RuleSpec YAML and companion fixtures are never hand-edited;

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -69,7 +69,8 @@ The protected workflow supplies these jobs:
    emits the matrix. Entries whose exact `bulk/<slug>` branch already has an
    open or merged PR are excluded before the limit is applied, so a stale
    `pending` status cannot starve later queue entries. Closed, unmerged PRs stay
-   eligible for the workflow's reopen/recreate recovery path.
+   eligible for the workflow's reopen/recreate recovery path. Dispatch limits
+   are constrained to GitHub's `0..256` matrix capacity.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.

--- a/bulk/README.md
+++ b/bulk/README.md
@@ -74,6 +74,11 @@ The protected workflow supplies these jobs:
    Closed, unmerged PRs stay eligible for the workflow's reopen/recreate
    recovery path. Dispatch limits are constrained to GitHub's `0..256` matrix
    capacity.
+   A manual dispatch can set `citation` to one exact worklist citation to
+   regenerate its existing open draft after review or a `needs-fixtures`
+   result. This explicit path still blocks merged branches, unresolved
+   dependencies, and open hard-failure issues; close the failure issue after
+   triage before retrying.
 2. **encode** (one leg per module, ≤4 parallel):
    - Checks out the repo into a leaf dir named exactly `rulespec-us` (the
      `--apply` resolver requirement) using `BULK_ENCODE_TOKEN`.
@@ -128,7 +133,8 @@ runner marks the module `needs-fixtures` and still opens a draft PR so the
 encoded module and failure are reviewable.
 
 A follow-up pass fixes the encoder prompt, harness, source material, or other
-root cause and reruns `encode --apply`; generated fixtures are never hand-edited
+root cause and dispatches the exact worklist `citation` to rerun `encode
+--apply`; generated fixtures are never hand-edited
 or back-filled to make a test pass. Once the regenerated artifacts pass review
 and CI, the PR can merge. Update the worklist entry to `pr-open`, then `merged`.
 

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -44,6 +44,20 @@ WORKLIST = Path(__file__).resolve().parent / "worklist.yaml"
 
 SELECTABLE_STATUSES = {"pending", "pending-local"}
 REPO_ROOT = WORKLIST.parents[1]
+MAX_MATRIX_ENTRIES = 256
+
+
+def matrix_limit(value: str) -> int:
+    """Parse a bounded GitHub Actions matrix limit."""
+    try:
+        limit = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("limit must be an integer") from exc
+    if not 0 <= limit <= MAX_MATRIX_ENTRIES:
+        raise argparse.ArgumentTypeError(
+            f"limit must be between 0 and {MAX_MATRIX_ENTRIES}"
+        )
+    return limit
 
 
 def citation_slug(citation: str) -> str:
@@ -136,6 +150,8 @@ def select(
     *,
     excluded_slugs: set[str] | None = None,
 ) -> list[dict]:
+    if limit is not None and not 0 <= limit <= MAX_MATRIX_ENTRIES:
+        raise ValueError(f"limit must be between 0 and {MAX_MATRIX_ENTRIES}")
     out: list[dict] = []
     excluded_slugs = excluded_slugs or set()
     for entry in data["entries"]:
@@ -215,7 +231,10 @@ def main() -> int:
         "--batch", default=None, help="Restrict to a batch label (A, B, ...)."
     )
     ap.add_argument(
-        "--limit", type=int, default=None, help="Cap the number of entries."
+        "--limit",
+        type=matrix_limit,
+        default=None,
+        help=f"Cap entries between 0 and {MAX_MATRIX_ENTRIES}.",
     )
     ap.add_argument(
         "--format",

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -19,6 +19,10 @@ Usage:
   python bulk/compute_matrix.py --status pending --exclude-prs pulls.json \
     --repo-full-name TheAxiomFoundation/rulespec-us
 
+  # Explicitly refresh one reviewed draft while keeping merge/failure guards:
+  python bulk/compute_matrix.py --status any --only-citation us-ny/statute/TAX/673 \
+    --exclude-prs pulls.json --repo-full-name TheAxiomFoundation/rulespec-us
+
 The matrix shape preserves the reviewed execution metadata needed by local
 jobs, in addition to the citation/backend/model fields used by cloud jobs.
 `slug` is the branch-safe citation slug used for `bulk/<slug>` branches and the
@@ -222,6 +226,22 @@ def failed_issue_slugs(pages: object) -> set[str]:
     return slugs
 
 
+def dispatch_excluded_slugs(
+    active_slugs: set[str],
+    merged_slugs: set[str],
+    failure_slugs: set[str],
+    only_citation: str | None,
+) -> set[str]:
+    """Build queue exclusions, allowing only a guarded open-draft refresh."""
+    excluded = set(active_slugs)
+    if only_citation is not None:
+        refresh_slug = citation_slug(only_citation)
+        if refresh_slug not in merged_slugs:
+            excluded.discard(refresh_slug)
+    excluded.update(failure_slugs)
+    return excluded
+
+
 def select(
     data: dict,
     status: str,
@@ -230,12 +250,17 @@ def select(
     *,
     excluded_slugs: set[str] | None = None,
     merged_slugs: set[str] | None = None,
+    only_citation: str | None = None,
 ) -> list[dict]:
     if limit is not None and not 0 <= limit <= MAX_MATRIX_ENTRIES:
         raise ValueError(f"limit must be between 0 and {MAX_MATRIX_ENTRIES}")
     out: list[dict] = []
     excluded_slugs = excluded_slugs or set()
+    citation_found = False
     for entry in data["entries"]:
+        if only_citation is not None and entry.get("citation") != only_citation:
+            continue
+        citation_found = True
         if status != "any" and entry.get("status") != status:
             continue
         if batch and str(entry.get("batch", "")).upper() != batch.upper():
@@ -303,6 +328,8 @@ def select(
                 "program_scope_sync": program_scope_sync,
             }
         )
+    if only_citation is not None and not citation_found:
+        raise ValueError(f"citation not found: {only_citation}")
     if limit is not None:
         out = out[:limit]
     return out
@@ -359,6 +386,14 @@ def main() -> int:
         help="Open failure issues from `gh api --paginate --slurp`.",
     )
     ap.add_argument(
+        "--only-citation",
+        default=None,
+        help=(
+            "Select one exact worklist citation. Its open PR may be refreshed, "
+            "but merged PR and hard-failure exclusions still apply."
+        ),
+    )
+    ap.add_argument(
         "--find-pr-branch",
         default=None,
         help="Print the latest exact-repository PR record for this branch.",
@@ -411,16 +446,18 @@ def main() -> int:
 
     if bool(args.exclude_prs) != bool(args.repo_full_name):
         raise SystemExit("--exclude-prs and --repo-full-name must be used together")
-    excluded_slugs: set[str] = set()
+    active_slugs: set[str] = set()
     merged_slugs: set[str] | None = None
     pages = None
     if args.exclude_prs:
         try:
             pages = json.loads(args.exclude_prs.read_text(encoding="utf-8"))
-            excluded_slugs = active_pr_slugs(pages, args.repo_full_name)
+            active_slugs = active_pr_slugs(pages, args.repo_full_name)
             merged_slugs = merged_pr_slugs(pages, args.repo_full_name)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise SystemExit(f"could not read pull request exclusions: {exc}") from exc
+    if args.only_citation is not None and merged_slugs is None:
+        raise SystemExit("--only-citation requires --exclude-prs")
     if args.find_pr_branch:
         if pages is None:
             raise SystemExit("--find-pr-branch requires --exclude-prs")
@@ -440,15 +477,22 @@ def main() -> int:
         return 0
     if args.find_pr_state:
         raise SystemExit("--find-pr-state requires --find-pr-branch")
+    failure_slugs: set[str] = set()
     if args.exclude_failure_issues:
         try:
             issue_pages = json.loads(
                 args.exclude_failure_issues.read_text(encoding="utf-8")
             )
-            excluded_slugs.update(failed_issue_slugs(issue_pages))
+            failure_slugs = failed_issue_slugs(issue_pages)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise SystemExit(f"could not read failure issue exclusions: {exc}") from exc
 
+    excluded_slugs = dispatch_excluded_slugs(
+        active_slugs,
+        merged_slugs or set(),
+        failure_slugs,
+        args.only_citation,
+    )
     selected = select(
         data,
         args.status,
@@ -456,6 +500,7 @@ def main() -> int:
         args.limit,
         excluded_slugs=excluded_slugs,
         merged_slugs=merged_slugs,
+        only_citation=args.only_citation,
     )
 
     if args.format == "count":

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -109,6 +109,59 @@ def entry_allow_context(entry: dict) -> list[str]:
     return values
 
 
+def _paged_mappings(pages: object, label: str):
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ValueError(f"{label} response must be a list of pages")
+    for page in pages:
+        for item in page:
+            if not isinstance(item, dict):
+                raise ValueError(f"{label} pages must contain mappings")
+            yield item
+
+
+def _exact_repo_pulls(pages: object, repo_full_name: str):
+    for pull in _paged_mappings(pages, "pull request"):
+        head = pull.get("head")
+        repo = head.get("repo") if isinstance(head, dict) else None
+        if isinstance(repo, dict) and repo.get("full_name") == repo_full_name:
+            yield pull
+
+
+def _pull_state(pull: dict) -> str:
+    if pull.get("merged_at") is not None:
+        return "MERGED"
+    state = pull.get("state")
+    return state.upper() if isinstance(state, str) else ""
+
+
+def latest_exact_pr(pages: object, repo_full_name: str, branch: str) -> dict:
+    """Return the latest PR for an exact repository and head branch."""
+    matches = []
+    for pull in _exact_repo_pulls(pages, repo_full_name):
+        head = pull.get("head")
+        if not isinstance(head, dict) or head.get("ref") != branch:
+            continue
+        number = pull.get("number")
+        if not isinstance(number, int) or number <= 0:
+            raise ValueError("matching pull request has no positive number")
+        matches.append(pull)
+    if not matches:
+        return {}
+    pull = max(
+        matches,
+        key=lambda item: (
+            str(item.get("updated_at") or ""),
+            int(item["number"]),
+        ),
+    )
+    merge_commit = pull.get("merge_commit_sha")
+    return {
+        "number": pull["number"],
+        "state": _pull_state(pull),
+        "merge_commit": merge_commit if isinstance(merge_commit, str) else "",
+    }
+
+
 def active_pr_slugs(pages: object, repo_full_name: str) -> set[str]:
     """Return bulk slugs already represented by an open or merged PR.
 
@@ -116,29 +169,49 @@ def active_pr_slugs(pages: object, repo_full_name: str) -> set[str]:
     used. Closed, unmerged PRs remain eligible so the workflow can exercise its
     reviewed reopen/recreate recovery path.
     """
-    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
-        raise ValueError("pull request response must be a list of pages")
-
     slugs: set[str] = set()
-    for page in pages:
-        for pull in page:
-            if not isinstance(pull, dict):
-                raise ValueError("pull request pages must contain mappings")
-            head = pull.get("head")
-            if not isinstance(head, dict):
-                continue
-            repo = head.get("repo")
-            ref = head.get("ref")
-            if (
-                not isinstance(repo, dict)
-                or repo.get("full_name") != repo_full_name
-                or not isinstance(ref, str)
-                or not ref.startswith("bulk/")
-            ):
-                continue
-            state = pull.get("state")
-            if state == "open" or pull.get("merged_at") is not None:
-                slugs.add(ref.removeprefix("bulk/"))
+    for pull in _exact_repo_pulls(pages, repo_full_name):
+        head = pull.get("head")
+        ref = head.get("ref") if isinstance(head, dict) else None
+        if (
+            isinstance(ref, str)
+            and ref.startswith("bulk/")
+            and _pull_state(pull) in {"OPEN", "MERGED"}
+        ):
+            slugs.add(ref.removeprefix("bulk/"))
+    return slugs
+
+
+def merged_pr_slugs(pages: object, repo_full_name: str) -> set[str]:
+    """Return exact repository bulk slugs whose PR has merged."""
+    slugs: set[str] = set()
+    for pull in _exact_repo_pulls(pages, repo_full_name):
+        head = pull.get("head")
+        ref = head.get("ref") if isinstance(head, dict) else None
+        if (
+            isinstance(ref, str)
+            and ref.startswith("bulk/")
+            and _pull_state(pull) == "MERGED"
+        ):
+            slugs.add(ref.removeprefix("bulk/"))
+    return slugs
+
+
+def failed_issue_slugs(pages: object) -> set[str]:
+    """Return citations held by an open workflow-created hard-failure issue."""
+    prefix = "Bulk encode hard failure: "
+    slugs: set[str] = set()
+    for issue in _paged_mappings(pages, "issue"):
+        title = issue.get("title")
+        if (
+            issue.get("state") == "open"
+            and "pull_request" not in issue
+            and isinstance(title, str)
+            and title.startswith(prefix)
+        ):
+            citation = title.removeprefix(prefix).strip()
+            if citation:
+                slugs.add(citation_slug(citation))
     return slugs
 
 
@@ -149,6 +222,7 @@ def select(
     limit: int | None,
     *,
     excluded_slugs: set[str] | None = None,
+    merged_slugs: set[str] | None = None,
 ) -> list[dict]:
     if limit is not None and not 0 <= limit <= MAX_MATRIX_ENTRIES:
         raise ValueError(f"limit must be between 0 and {MAX_MATRIX_ENTRIES}")
@@ -167,6 +241,11 @@ def select(
                 f"{entry.get('citation')}: requires_merged_citations must be "
                 "a list of non-empty strings"
             )
+        if merged_slugs is not None and any(
+            citation_slug(dependency) not in merged_slugs
+            for dependency in dependencies
+        ):
+            continue
         program_scope_sync = entry.get("program_scope_sync")
         if program_scope_sync is not None and not isinstance(program_scope_sync, dict):
             raise ValueError(
@@ -266,6 +345,17 @@ def main() -> int:
         default=None,
         help="Repository whose exact bulk branches may be excluded.",
     )
+    ap.add_argument(
+        "--exclude-failure-issues",
+        type=Path,
+        default=None,
+        help="Open failure issues from `gh api --paginate --slurp`.",
+    )
+    ap.add_argument(
+        "--find-pr-branch",
+        default=None,
+        help="Print the latest exact-repository PR record for this branch.",
+    )
     args = ap.parse_args()
 
     if args.status not in SELECTABLE_STATUSES | {"any"}:
@@ -309,12 +399,31 @@ def main() -> int:
     if bool(args.exclude_prs) != bool(args.repo_full_name):
         raise SystemExit("--exclude-prs and --repo-full-name must be used together")
     excluded_slugs: set[str] = set()
+    merged_slugs: set[str] | None = None
+    pages = None
     if args.exclude_prs:
         try:
             pages = json.loads(args.exclude_prs.read_text(encoding="utf-8"))
             excluded_slugs = active_pr_slugs(pages, args.repo_full_name)
+            merged_slugs = merged_pr_slugs(pages, args.repo_full_name)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise SystemExit(f"could not read pull request exclusions: {exc}") from exc
+    if args.find_pr_branch:
+        if pages is None:
+            raise SystemExit("--find-pr-branch requires --exclude-prs")
+        try:
+            print(json.dumps(latest_exact_pr(pages, args.repo_full_name, args.find_pr_branch)))
+        except ValueError as exc:
+            raise SystemExit(f"could not identify exact pull request: {exc}") from exc
+        return 0
+    if args.exclude_failure_issues:
+        try:
+            issue_pages = json.loads(
+                args.exclude_failure_issues.read_text(encoding="utf-8")
+            )
+            excluded_slugs.update(failed_issue_slugs(issue_pages))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise SystemExit(f"could not read failure issue exclusions: {exc}") from exc
 
     selected = select(
         data,
@@ -322,6 +431,7 @@ def main() -> int:
         args.batch,
         args.limit,
         excluded_slugs=excluded_slugs,
+        merged_slugs=merged_slugs,
     )
 
     if args.format == "count":

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -15,6 +15,10 @@ Usage:
   # Read one field (used by the runner to look up backend/model per entry):
   python bulk/compute_matrix.py --get us-ny/statute/TAX/673 --field model
 
+  # Cloud dispatch: exclude exact bulk branches with an open or merged PR:
+  python bulk/compute_matrix.py --status pending --exclude-prs pulls.json \
+    --repo-full-name TheAxiomFoundation/rulespec-us
+
 The matrix shape preserves the reviewed execution metadata needed by local
 jobs, in addition to the citation/backend/model fields used by cloud jobs.
 `slug` is the branch-safe citation slug used for `bulk/<slug>` branches and the
@@ -91,8 +95,49 @@ def entry_allow_context(entry: dict) -> list[str]:
     return values
 
 
-def select(data: dict, status: str, batch: str | None, limit: int | None) -> list[dict]:
+def active_pr_slugs(pages: object, repo_full_name: str) -> set[str]:
+    """Return bulk slugs already represented by an open or merged PR.
+
+    The GitHub REST API returns one list per page when ``gh api --slurp`` is
+    used. Closed, unmerged PRs remain eligible so the workflow can exercise its
+    reviewed reopen/recreate recovery path.
+    """
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ValueError("pull request response must be a list of pages")
+
+    slugs: set[str] = set()
+    for page in pages:
+        for pull in page:
+            if not isinstance(pull, dict):
+                raise ValueError("pull request pages must contain mappings")
+            head = pull.get("head")
+            if not isinstance(head, dict):
+                continue
+            repo = head.get("repo")
+            ref = head.get("ref")
+            if (
+                not isinstance(repo, dict)
+                or repo.get("full_name") != repo_full_name
+                or not isinstance(ref, str)
+                or not ref.startswith("bulk/")
+            ):
+                continue
+            state = pull.get("state")
+            if state == "open" or pull.get("merged_at") is not None:
+                slugs.add(ref.removeprefix("bulk/"))
+    return slugs
+
+
+def select(
+    data: dict,
+    status: str,
+    batch: str | None,
+    limit: int | None,
+    *,
+    excluded_slugs: set[str] | None = None,
+) -> list[dict]:
     out: list[dict] = []
+    excluded_slugs = excluded_slugs or set()
     for entry in data["entries"]:
         if status != "any" and entry.get("status") != status:
             continue
@@ -140,6 +185,9 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                     f"{entry.get('citation')}: program_scope_sync must add or "
                     "remove at least one module"
                 )
+        slug = citation_slug(entry["citation"])
+        if slug in excluded_slugs:
+            continue
         out.append(
             {
                 "citation": entry["citation"],
@@ -147,7 +195,7 @@ def select(data: dict, status: str, batch: str | None, limit: int | None) -> lis
                 "backend": entry_backend(data, entry),
                 "model": entry_model(data, entry),
                 "acceptance_criteria": entry.get("note", ""),
-                "slug": citation_slug(entry["citation"]),
+                "slug": slug,
                 "allow_context": entry_allow_context(entry),
                 "requires_merged_citations": dependencies,
                 "program_scope_sync": program_scope_sync,
@@ -187,6 +235,17 @@ def main() -> int:
         metavar=("CITATION", "STATUS"),
         default=None,
         help="LOCAL ONLY: set an entry's status in place.",
+    )
+    ap.add_argument(
+        "--exclude-prs",
+        type=Path,
+        default=None,
+        help="GitHub REST pull pages from `gh api --paginate --slurp`.",
+    )
+    ap.add_argument(
+        "--repo-full-name",
+        default=None,
+        help="Repository whose exact bulk branches may be excluded.",
     )
     args = ap.parse_args()
 
@@ -228,7 +287,23 @@ def main() -> int:
                 return 0
         raise SystemExit(f"citation not found: {args.get}")
 
-    selected = select(data, args.status, args.batch, args.limit)
+    if bool(args.exclude_prs) != bool(args.repo_full_name):
+        raise SystemExit("--exclude-prs and --repo-full-name must be used together")
+    excluded_slugs: set[str] = set()
+    if args.exclude_prs:
+        try:
+            pages = json.loads(args.exclude_prs.read_text(encoding="utf-8"))
+            excluded_slugs = active_pr_slugs(pages, args.repo_full_name)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise SystemExit(f"could not read pull request exclusions: {exc}") from exc
+
+    selected = select(
+        data,
+        args.status,
+        args.batch,
+        args.limit,
+        excluded_slugs=excluded_slugs,
+    )
 
     if args.format == "count":
         print(len(selected))

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -134,12 +134,19 @@ def _pull_state(pull: dict) -> str:
     return state.upper() if isinstance(state, str) else ""
 
 
-def latest_exact_pr(pages: object, repo_full_name: str, branch: str) -> dict:
+def latest_exact_pr(
+    pages: object,
+    repo_full_name: str,
+    branch: str,
+    required_state: str | None = None,
+) -> dict:
     """Return the latest PR for an exact repository and head branch."""
     matches = []
     for pull in _exact_repo_pulls(pages, repo_full_name):
         head = pull.get("head")
         if not isinstance(head, dict) or head.get("ref") != branch:
+            continue
+        if required_state is not None and _pull_state(pull) != required_state:
             continue
         number = pull.get("number")
         if not isinstance(number, int) or number <= 0:
@@ -356,6 +363,12 @@ def main() -> int:
         default=None,
         help="Print the latest exact-repository PR record for this branch.",
     )
+    ap.add_argument(
+        "--find-pr-state",
+        choices=["OPEN", "CLOSED", "MERGED"],
+        default=None,
+        help="With --find-pr-branch, restrict the selected PR state.",
+    )
     args = ap.parse_args()
 
     if args.status not in SELECTABLE_STATUSES | {"any"}:
@@ -412,10 +425,21 @@ def main() -> int:
         if pages is None:
             raise SystemExit("--find-pr-branch requires --exclude-prs")
         try:
-            print(json.dumps(latest_exact_pr(pages, args.repo_full_name, args.find_pr_branch)))
+            print(
+                json.dumps(
+                    latest_exact_pr(
+                        pages,
+                        args.repo_full_name,
+                        args.find_pr_branch,
+                        args.find_pr_state,
+                    )
+                )
+            )
         except ValueError as exc:
             raise SystemExit(f"could not identify exact pull request: {exc}") from exc
         return 0
+    if args.find_pr_state:
+        raise SystemExit("--find-pr-state requires --find-pr-branch")
     if args.exclude_failure_issues:
         try:
             issue_pages = json.loads(

--- a/bulk/compute_matrix.py
+++ b/bulk/compute_matrix.py
@@ -144,7 +144,7 @@ def latest_exact_pr(
     branch: str,
     required_state: str | None = None,
 ) -> dict:
-    """Return the latest PR for an exact repository and head branch."""
+    """Return the active or latest PR for an exact repository and head branch."""
     matches = []
     for pull in _exact_repo_pulls(pages, repo_full_name):
         head = pull.get("head")
@@ -161,6 +161,7 @@ def latest_exact_pr(
     pull = max(
         matches,
         key=lambda item: (
+            {"OPEN": 2, "MERGED": 1}.get(_pull_state(item), 0),
             str(item.get("updated_at") or ""),
             int(item["number"]),
         ),

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -630,3 +630,103 @@ def test_local_runner_requires_review_before_merge() -> None:
     assert "Local signed generation is disabled" in local_drain
     assert '"AXIOM_ENCODE_APPLY_SIGNING_KEY": signing_key()' not in local_drain
     assert "find-generic-password" not in local_drain
+
+
+def test_cloud_apply_uses_protected_signer_and_exact_artifact_discovery() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    encode_job = workflow.split("\n  encode:\n", 1)[1]
+    signing_step = workflow.split(
+        "- name: Encode --apply through protected signer", 1
+    )[1].split("- name: Discover applied artifacts", 1)[0]
+
+    assert 'python-version: "3.13"' in encode_job
+    assert 'go-version: "1.26.1"' in encode_job
+    assert "pull-requests: read" in encode_job
+    assert "Fetch pinned signed corpus release object from public registry" in encode_job
+    assert "rest/v1/release_objects?select=release_object" in encode_job
+    assert "NEXT_PUBLIC_SUPABASE_ANON_KEY" in encode_job
+    assert "git merge-base --is-ancestor" in encode_job
+    assert "python bulk/applied_artifacts.py" in encode_job
+    assert '--citation "$CITATION"' in encode_job
+    assert "git status --porcelain" not in encode_job
+    assert 'echo "manifest_rel=$manifest_rel"' in encode_job
+    assert "MANIFEST_REL: ${{ steps.encode.outputs.manifest_rel }}" in encode_job
+    assert 'manifest="$(cat "$GITHUB_WORKSPACE/$MANIFEST_REL")"' in encode_job
+    assert "find \"$GITHUB_WORKSPACE\" -path '*/.axiom/encoding-manifests/*'" not in encode_job
+    assert "Require merged queue dependencies" in encode_job
+    assert "Prepare reviewed encode context" in encode_job
+    assert "AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets." in signing_step
+    assert 'exec "$RUNNER_TEMP/axiom-encode-apply-signer" run' in signing_step
+    assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in signing_step
+    assert "| tee" not in signing_step
+    assert "jq " not in signing_step
+    assert "\n          python " not in signing_step
+
+
+def test_cloud_bulk_prs_remain_draft_without_auto_merge() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+
+    assert "--label bulk-encode --draft" in workflow
+    assert 'gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo' in workflow
+    assert 'gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto' in workflow
+    assert "--auto --squash" not in workflow
+    assert ".autoMergeRequest == null" in workflow
+    state_lookup = workflow.index('pr_json="$(retry gh pr list')
+    merged_guard = workflow.index('if [ "$pr_state" = "MERGED" ]; then')
+    branch_push = workflow.index('push -f origin "HEAD:$branch"')
+    assert state_lookup < merged_guard < branch_push
+    assert '--state all --head "$branch"' in workflow
+    assert "API failures remain failures" in workflow
+    assert "skipping stale pending queue entry before branch mutation" in workflow
+
+
+def test_cloud_companion_failure_classification_is_fail_closed() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    gate_step = workflow.split(
+        "- name: Discover applied artifacts and run the gate battery", 1
+    )[1].split("- name: Assemble PR body", 1)[0]
+
+    assert '--json "${test_file#"$juris"/}"' in gate_step
+    assert 'payload.get("success") is not False' in gate_step
+    assert "value_mismatch.fullmatch" in gate_step
+    assert 'echo "status=needs-fixtures"' in gate_step
+    assert 'echo "status=failed"' in gate_step
+    assert 'exit "$test_status"' in gate_step
+
+
+def test_cloud_gate_battery_uses_protected_current_command_plane() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    gate_step = workflow.split(
+        "- name: Discover applied artifacts and run the gate battery", 1
+    )[1].split("- name: Assemble PR body", 1)[0]
+
+    assert gate_step.count(
+        "/opt/axiom-verification/axiom-encode-signing-supervisor"
+    ) == 4
+    assert '--corpus-path "$GITHUB_WORKSPACE/_axiom/axiom-corpus"' in gate_step
+    assert "--expected-encoder-checkout" in gate_step
+    assert "--axiom-rules-engine-path" in gate_step
+    assert '--root "$GITHUB_WORKSPACE/$juris"' in gate_step
+    assert 'program-scope-sync --repo "$GITHUB_WORKSPACE"' in gate_step
+
+
+def test_bulk_workflow_pins_every_third_party_action() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    action_refs = {
+        line.strip().removeprefix("uses: ").split(" #", 1)[0]
+        for line in workflow.splitlines()
+        if line.strip().startswith("uses: ")
+    }
+
+    assert action_refs == {
+        "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+        "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16",
+        "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+        "dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30",
+        "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4",
+    }

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -727,6 +728,18 @@ def test_cloud_companion_failure_classification_is_fail_closed() -> None:
     assert '--json "${test_file#"$juris"/}"' in gate_step
     assert 'payload.get("success") is not False' in gate_step
     assert "value_mismatch.fullmatch" in gate_step
+    pattern_match = re.search(
+        r'value_mismatch = re\.compile\(\s*r"([^"]+)"', gate_step
+    )
+    assert pattern_match is not None
+    value_mismatch = re.compile(pattern_match.group(1))
+    assert value_mismatch.fullmatch(
+        "us:statutes/26/61#gross_income: expected 10, got 12"
+    )
+    assert value_mismatch.fullmatch(
+        "us:policies/example#amounts[2]: expected 10, got 12"
+    )
+    assert value_mismatch.fullmatch("missing output amount; got []") is None
     assert 'echo "status=needs-fixtures"' in gate_step
     assert 'echo "status=failed"' in gate_step
     assert 'exit "$test_status"' in gate_step

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -31,6 +31,7 @@ discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
 select = _compute_matrix.select
 active_pr_slugs = _compute_matrix.active_pr_slugs
 failed_issue_slugs = _compute_matrix.failed_issue_slugs
+dispatch_excluded_slugs = _compute_matrix.dispatch_excluded_slugs
 latest_exact_pr = _compute_matrix.latest_exact_pr
 matrix_limit = _compute_matrix.matrix_limit
 merged_pr_slugs = _compute_matrix.merged_pr_slugs
@@ -576,6 +577,64 @@ def test_matrix_excludes_active_prs_before_applying_limit() -> None:
     assert [item["citation"] for item in selected] == ["us-sc/manual/page-165"]
 
 
+def test_matrix_explicit_citation_selects_only_reviewed_draft() -> None:
+    data = {
+        "entries": [
+            {"citation": "us-sc/manual/page-163", "status": "pr-open"},
+            {"citation": "us-sc/manual/page-165", "status": "pending"},
+        ]
+    }
+
+    selected = select(
+        data,
+        "any",
+        None,
+        1,
+        excluded_slugs=set(),
+        merged_slugs=set(),
+        only_citation="us-sc/manual/page-163",
+    )
+
+    assert [item["citation"] for item in selected] == ["us-sc/manual/page-163"]
+
+
+def test_matrix_explicit_citation_still_honors_exclusions() -> None:
+    citation = "us-sc/manual/page-163"
+    data = {"entries": [{"citation": citation, "status": "needs-fixtures"}]}
+
+    selected = select(
+        data,
+        "any",
+        None,
+        1,
+        excluded_slugs={"us-sc-manual-page-163"},
+        merged_slugs=set(),
+        only_citation=citation,
+    )
+
+    assert selected == []
+
+
+def test_explicit_refresh_bypasses_only_its_open_pr_exclusion() -> None:
+    citation = "us-sc/manual/page-163"
+    slug = "us-sc-manual-page-163"
+
+    assert dispatch_excluded_slugs({slug}, set(), set(), citation) == set()
+    assert dispatch_excluded_slugs({slug}, {slug}, set(), citation) == {slug}
+    assert dispatch_excluded_slugs({slug}, set(), {slug}, citation) == {slug}
+
+
+def test_matrix_explicit_citation_must_exist() -> None:
+    with pytest.raises(ValueError, match="citation not found"):
+        select(
+            {"entries": []},
+            "any",
+            None,
+            1,
+            only_citation="us-sc/manual/page-163",
+        )
+
+
 def test_matrix_excludes_blocked_dependencies_before_applying_limit() -> None:
     data = {
         "entries": [
@@ -975,6 +1034,18 @@ def test_cloud_dispatch_filters_dependencies_before_matrix_limit() -> None:
         root / "bulk/compute_matrix.py"
     ).read_text()
     assert '--find-pr-state MERGED' in workflow
+
+
+def test_cloud_dispatch_can_refresh_one_open_draft() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    compute_step = workflow.split("- name: Compute matrix from worklist", 1)[1].split(
+        "- name: Fail if nothing to encode", 1
+    )[0]
+
+    assert 'CITATION: ${{ inputs.citation }}' in compute_step
+    assert 'args+=(--status any --only-citation "$CITATION" --limit 1)' in compute_step
+    assert "dispatch_excluded_slugs" in Path(root / "bulk/compute_matrix.py").read_text()
 
 
 def test_cloud_companion_failure_classification_is_fail_closed() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -979,6 +979,8 @@ def test_cloud_apply_uses_protected_signer_and_exact_artifact_discovery() -> Non
     assert "find \"$GITHUB_WORKSPACE\" -path '*/.axiom/encoding-manifests/*'" not in encode_job
     assert "Require merged queue dependencies" in encode_job
     assert "Prepare reviewed encode context" in encode_job
+    assert 'REVIEW_FINDINGS: ${{ matrix.item.acceptance_criteria }}' in encode_job
+    assert 'encode_args+=(--review-findings "$RUNNER_TEMP/review-findings.md")' in signing_step
     assert "AXIOM_ENCODE_APPLY_SIGNING_KEY: ${{ secrets." in signing_step
     assert 'exec "$RUNNER_TEMP/axiom-encode-apply-signer" run' in signing_step
     assert "--key-env AXIOM_ENCODE_APPLY_SIGNING_KEY" in signing_step

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -30,7 +30,10 @@ changed_paths = _applied_artifacts.changed_paths
 discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
 select = _compute_matrix.select
 active_pr_slugs = _compute_matrix.active_pr_slugs
+failed_issue_slugs = _compute_matrix.failed_issue_slugs
+latest_exact_pr = _compute_matrix.latest_exact_pr
 matrix_limit = _compute_matrix.matrix_limit
+merged_pr_slugs = _compute_matrix.merged_pr_slugs
 
 
 def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
@@ -573,6 +576,23 @@ def test_matrix_excludes_active_prs_before_applying_limit() -> None:
     assert [item["citation"] for item in selected] == ["us-sc/manual/page-165"]
 
 
+def test_matrix_excludes_blocked_dependencies_before_applying_limit() -> None:
+    data = {
+        "entries": [
+            {
+                "citation": "us-sc/manual/page-165",
+                "status": "pending",
+                "requires_merged_citations": ["us-sc/manual/page-163"],
+            },
+            {"citation": "us-sc/manual/page-159", "status": "pending"},
+        ]
+    }
+
+    selected = select(data, "pending", None, 1, merged_slugs=set())
+
+    assert [item["citation"] for item in selected] == ["us-sc/manual/page-159"]
+
+
 @pytest.mark.parametrize("limit", [-1, 257])
 def test_matrix_rejects_out_of_range_limit(limit: int) -> None:
     with pytest.raises(ValueError, match="between 0 and 256"):
@@ -637,6 +657,90 @@ def test_active_pr_slugs_excludes_open_and_merged_exact_repo_branches() -> None:
 def test_active_pr_slugs_rejects_unexpected_api_shape() -> None:
     with pytest.raises(ValueError, match="list of pages"):
         active_pr_slugs({"state": "open"}, "TheAxiomFoundation/rulespec-us")
+
+
+def test_latest_exact_pr_ignores_same_branch_from_fork() -> None:
+    pages = [
+        [
+            {
+                "number": 900,
+                "state": "closed",
+                "merged_at": "2026-07-15T12:00:00Z",
+                "updated_at": "2026-07-15T12:00:00Z",
+                "merge_commit_sha": "a" * 40,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "someone/fork"},
+                },
+            },
+            {
+                "number": 901,
+                "state": "open",
+                "merged_at": None,
+                "updated_at": "2026-07-15T11:00:00Z",
+                "merge_commit_sha": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+        ]
+    ]
+
+    assert latest_exact_pr(
+        pages,
+        "TheAxiomFoundation/rulespec-us",
+        "bulk/us-sc-manual-page-163",
+    ) == {"number": 901, "state": "OPEN", "merge_commit": ""}
+
+
+def test_merged_pr_slugs_uses_exact_repository() -> None:
+    pages = [
+        [
+            {
+                "state": "closed",
+                "merged_at": "2026-07-15T12:00:00Z",
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "state": "closed",
+                "merged_at": "2026-07-15T12:00:00Z",
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-165",
+                    "repo": {"full_name": "someone/fork"},
+                },
+            },
+        ]
+    ]
+
+    assert merged_pr_slugs(pages, "TheAxiomFoundation/rulespec-us") == {
+        "us-sc-manual-page-163"
+    }
+
+
+def test_failed_issue_slugs_only_reads_open_hard_failure_issues() -> None:
+    pages = [
+        [
+            {
+                "state": "open",
+                "title": "Bulk encode hard failure: us-sc/manual/page-163",
+            },
+            {
+                "state": "closed",
+                "title": "Bulk encode hard failure: us-sc/manual/page-165",
+            },
+            {
+                "state": "open",
+                "title": "Bulk encode hard failure: us-sc/manual/page-159",
+                "pull_request": {"url": "https://api.github.test/pulls/1"},
+            },
+        ]
+    ]
+
+    assert failed_issue_slugs(pages) == {"us-sc-manual-page-163"}
 
 
 @pytest.mark.parametrize("status", ["pr-open", "needs-fixtures", "failed", "merged"])
@@ -793,17 +897,45 @@ def test_cloud_bulk_prs_remain_draft_without_auto_merge() -> None:
     workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
 
     assert "--label bulk-encode --draft" in workflow
-    assert 'gh pr ready "$branch" --repo "$GITHUB_REPOSITORY" --undo' in workflow
-    assert 'gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --disable-auto' in workflow
+    assert 'gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo' in workflow
+    assert 'gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --disable-auto' in workflow
     assert "--auto --squash" not in workflow
     assert ".autoMergeRequest == null" in workflow
-    state_lookup = workflow.index('pr_json="$(retry gh pr list')
+    state_lookup = workflow.index('pr_json="$(python bulk/compute_matrix.py')
     merged_guard = workflow.index('if [ "$pr_state" = "MERGED" ]; then')
     branch_push = workflow.index('push -f origin "HEAD:$branch"')
     assert state_lookup < merged_guard < branch_push
-    assert '--state all --head "$branch"' in workflow
-    assert "API failures remain failures" in workflow
+    assert '--find-pr-branch "$branch"' in workflow
+    assert 'gh pr reopen "$pr_number"' in workflow
+    assert 'gh pr edit "$pr_number"' in workflow
+    assert 'gh pr view "$pr_number"' in workflow
     assert "skipping stale pending queue entry before branch mutation" in workflow
+
+
+def test_cloud_dispatch_persists_and_excludes_hard_failures() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+
+    assert "issues: write" in workflow
+    assert "--exclude-failure-issues" in workflow
+    assert "Bulk encode hard failure: $CITATION" in workflow
+    assert "steps.apply.outcome == 'failure'" in workflow
+    assert "steps.encode.outcome == 'failure'" in workflow
+    assert "close this issue to permit a fresh run" in workflow
+
+
+def test_cloud_dispatch_filters_dependencies_before_matrix_limit() -> None:
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
+    compute_step = workflow.split("- name: Compute matrix from worklist", 1)[1].split(
+        "- name: Fail if nothing to encode", 1
+    )[0]
+
+    assert '--exclude-prs "$RUNNER_TEMP/pulls.json"' in compute_step
+    assert '--limit "$LIMIT"' in compute_step
+    assert "merged_slugs=merged_slugs" in Path(
+        root / "bulk/compute_matrix.py"
+    ).read_text()
 
 
 def test_cloud_companion_failure_classification_is_fail_closed() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -789,6 +789,41 @@ def test_latest_exact_pr_can_select_merged_before_newer_closed_pr() -> None:
     ) == {"number": 901, "state": "MERGED", "merge_commit": "a" * 40}
 
 
+def test_latest_exact_pr_prefers_open_before_newer_closed_pr() -> None:
+    pages = [
+        [
+            {
+                "number": 901,
+                "state": "open",
+                "merged_at": None,
+                "updated_at": "2026-07-15T11:00:00Z",
+                "merge_commit_sha": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "number": 902,
+                "state": "closed",
+                "merged_at": None,
+                "updated_at": "2026-07-15T12:00:00Z",
+                "merge_commit_sha": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+        ]
+    ]
+
+    assert latest_exact_pr(
+        pages,
+        "TheAxiomFoundation/rulespec-us",
+        "bulk/us-sc-manual-page-163",
+    ) == {"number": 901, "state": "OPEN", "merge_commit": ""}
+
+
 def test_merged_pr_slugs_uses_exact_repository() -> None:
     pages = [
         [

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -992,21 +992,25 @@ def test_cloud_bulk_prs_remain_draft_without_auto_merge() -> None:
     workflow = (root / ".github/workflows/bulk-encode.yml").read_text()
 
     assert "--label bulk-encode --draft" in workflow
-    assert 'gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo' in workflow
-    assert 'gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --disable-auto' in workflow
+    assert 'gh pr ready "$number" --repo "$GITHUB_REPOSITORY" --undo' in workflow
+    assert 'gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --disable-auto' in workflow
     assert "--auto --squash" not in workflow
     assert ".autoMergeRequest == null" in workflow
     state_lookup = workflow.index('pr_json="$(python bulk/compute_matrix.py')
     merged_guard = workflow.index('if [ "$pr_state" = "MERGED" ]; then')
+    pre_push_hardening = workflow.index('harden_pr_for_review "$pr_number"')
     branch_push = workflow.index('push -f origin "HEAD:$branch"')
-    assert state_lookup < merged_guard < branch_push
+    assert state_lookup < merged_guard < pre_push_hardening < branch_push
     assert '--find-pr-branch "$branch"' in workflow
     assert "retry fetch_reconcile_pulls" in workflow
     assert 'mv "$temporary" "$RUNNER_TEMP/reconcile-pulls.json"' in workflow
     assert 'gh pr reopen "$pr_number"' in workflow
     assert 'gh pr edit "$pr_number"' in workflow
-    assert 'gh pr view "$pr_number"' in workflow
+    assert 'gh pr view "$number"' in workflow
     assert "skipping stale pending queue entry before branch mutation" in workflow
+    assert "trap rollback_reopened_pr EXIT" in workflow
+    assert 'retry gh pr close "$pr_number"' in workflow
+    assert "refresh_complete=true" in workflow
 
 
 def test_cloud_dispatch_persists_and_excludes_hard_failures() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -28,6 +28,7 @@ _local_drain = _load_bulk_module("local_drain")
 changed_paths = _applied_artifacts.changed_paths
 discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
 select = _compute_matrix.select
+active_pr_slugs = _compute_matrix.active_pr_slugs
 
 
 def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
@@ -551,6 +552,74 @@ def test_matrix_preserves_context_for_cloud_entry() -> None:
     assert selected[0]["allow_context"] == ["us/regulations/7-cfr/273/9.yaml"]
 
 
+def test_matrix_excludes_active_prs_before_applying_limit() -> None:
+    data = {
+        "entries": [
+            {"citation": "us-sc/manual/page-163", "status": "pending"},
+            {"citation": "us-sc/manual/page-165", "status": "pending"},
+        ]
+    }
+
+    selected = select(
+        data,
+        "pending",
+        None,
+        1,
+        excluded_slugs={"us-sc-manual-page-163"},
+    )
+
+    assert [item["citation"] for item in selected] == ["us-sc/manual/page-165"]
+
+
+def test_active_pr_slugs_excludes_open_and_merged_exact_repo_branches() -> None:
+    pages = [
+        [
+            {
+                "state": "open",
+                "merged_at": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "state": "closed",
+                "merged_at": "2026-07-15T12:00:00Z",
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-165",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "state": "closed",
+                "merged_at": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-159",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "state": "open",
+                "merged_at": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-159",
+                    "repo": {"full_name": "someone/fork"},
+                },
+            },
+        ]
+    ]
+
+    assert active_pr_slugs(pages, "TheAxiomFoundation/rulespec-us") == {
+        "us-sc-manual-page-163",
+        "us-sc-manual-page-165",
+    }
+
+
+def test_active_pr_slugs_rejects_unexpected_api_shape() -> None:
+    with pytest.raises(ValueError, match="list of pages"):
+        active_pr_slugs({"state": "open"}, "TheAxiomFoundation/rulespec-us")
+
+
 @pytest.mark.parametrize("status", ["pr-open", "needs-fixtures", "failed", "merged"])
 def test_matrix_preserves_context_after_local_status_transition(status: str) -> None:
     data = {
@@ -739,6 +808,8 @@ def test_cloud_companion_failure_classification_is_fail_closed() -> None:
     assert value_mismatch.fullmatch(
         "us:policies/example#amounts[2]: expected 10, got 12"
     )
+    assert value_mismatch.fullmatch("amount[2]: expected 10, got 12")
+    assert value_mismatch.fullmatch("compile failed: expected token, got eof") is None
     assert value_mismatch.fullmatch("missing output amount; got []") is None
     assert 'echo "status=needs-fixtures"' in gate_step
     assert 'echo "status=failed"' in gate_step

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib.util
 import json
 import re
@@ -29,6 +30,7 @@ changed_paths = _applied_artifacts.changed_paths
 discover_applied_artifacts = _applied_artifacts.discover_applied_artifacts
 select = _compute_matrix.select
 active_pr_slugs = _compute_matrix.active_pr_slugs
+matrix_limit = _compute_matrix.matrix_limit
 
 
 def _write_manifest(path: Path, citation: str, applied_paths: set[str]) -> None:
@@ -569,6 +571,23 @@ def test_matrix_excludes_active_prs_before_applying_limit() -> None:
     )
 
     assert [item["citation"] for item in selected] == ["us-sc/manual/page-165"]
+
+
+@pytest.mark.parametrize("limit", [-1, 257])
+def test_matrix_rejects_out_of_range_limit(limit: int) -> None:
+    with pytest.raises(ValueError, match="between 0 and 256"):
+        select({"entries": []}, "pending", None, limit)
+
+
+@pytest.mark.parametrize("value", ["-1", "257", "not-an-integer"])
+def test_matrix_limit_parser_rejects_unsafe_values(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="limit must"):
+        matrix_limit(value)
+
+
+def test_matrix_limit_parser_accepts_github_capacity_bounds() -> None:
+    assert matrix_limit("0") == 0
+    assert matrix_limit("256") == 256
 
 
 def test_active_pr_slugs_excludes_open_and_merged_exact_repo_branches() -> None:

--- a/tests/test_bulk_applied_artifacts.py
+++ b/tests/test_bulk_applied_artifacts.py
@@ -694,6 +694,42 @@ def test_latest_exact_pr_ignores_same_branch_from_fork() -> None:
     ) == {"number": 901, "state": "OPEN", "merge_commit": ""}
 
 
+def test_latest_exact_pr_can_select_merged_before_newer_closed_pr() -> None:
+    pages = [
+        [
+            {
+                "number": 901,
+                "state": "closed",
+                "merged_at": "2026-07-15T11:00:00Z",
+                "updated_at": "2026-07-15T11:00:00Z",
+                "merge_commit_sha": "a" * 40,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+            {
+                "number": 902,
+                "state": "closed",
+                "merged_at": None,
+                "updated_at": "2026-07-15T12:00:00Z",
+                "merge_commit_sha": None,
+                "head": {
+                    "ref": "bulk/us-sc-manual-page-163",
+                    "repo": {"full_name": "TheAxiomFoundation/rulespec-us"},
+                },
+            },
+        ]
+    ]
+
+    assert latest_exact_pr(
+        pages,
+        "TheAxiomFoundation/rulespec-us",
+        "bulk/us-sc-manual-page-163",
+        "MERGED",
+    ) == {"number": 901, "state": "MERGED", "merge_commit": "a" * 40}
+
+
 def test_merged_pr_slugs_uses_exact_repository() -> None:
     pages = [
         [
@@ -906,6 +942,8 @@ def test_cloud_bulk_prs_remain_draft_without_auto_merge() -> None:
     branch_push = workflow.index('push -f origin "HEAD:$branch"')
     assert state_lookup < merged_guard < branch_push
     assert '--find-pr-branch "$branch"' in workflow
+    assert "retry fetch_reconcile_pulls" in workflow
+    assert 'mv "$temporary" "$RUNNER_TEMP/reconcile-pulls.json"' in workflow
     assert 'gh pr reopen "$pr_number"' in workflow
     assert 'gh pr edit "$pr_number"' in workflow
     assert 'gh pr view "$pr_number"' in workflow
@@ -936,6 +974,7 @@ def test_cloud_dispatch_filters_dependencies_before_matrix_limit() -> None:
     assert "merged_slugs=merged_slugs" in Path(
         root / "bulk/compute_matrix.py"
     ).read_text()
+    assert '--find-pr-state MERGED' in workflow
 
 
 def test_cloud_companion_failure_classification_is_fail_closed() -> None:

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -89,7 +89,9 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         assert value not in repository_checks
 
     bulk_encode = (ROOT / ".github/workflows/bulk-encode.yml").read_text()
-    assert "disabled pending reviewed activation" in bulk_encode
-    assert "exit 1" in bulk_encode
-    assert "axiom_encode.cli encode" not in bulk_encode
-    assert "schedule:" not in bulk_encode
+    assert '.axiom/workflow-toolchain.toml").read_text()' in bulk_encode
+    assert "steps.toolchain.outputs.axiom_encode_ref" in bulk_encode
+    assert "axiom-encode-apply-signer" in bulk_encode
+    assert "python bulk/applied_artifacts.py" in bulk_encode
+    assert "--label bulk-encode --draft" in bulk_encode
+    assert "--auto --squash" not in bulk_encode


### PR DESCRIPTION
## Summary

- activate the protected, toolchain-pinned signed bulk encoder workflow
- keep one generated RuleSpec module per draft PR and require independent review before merge
- make queue selection durable across open/merged PRs, dependencies, hard failures, and explicit reviewed regeneration
- synchronize canonical ProgramSpec, reverse-index, and oracle-coverage artifacts through supported encoder commands

## Stack

- depends on #928 (`codex/bulk-review-runner-hardening`)
- #928 depends on #927 and the protected canonical-layout migration
- keep this PR draft until the stack lands and hosted CI is current

## Review/Fix Cycle

Independent review was repeated after every substantive fix. Findings addressed across the cycle:

- canonical fixture IDs and source aliases
- active-PR starvation and matrix bounds
- exact repository PR reconciliation and merged dependency enforcement
- durable hard-failure holds and retry-safe paginated fetches
- exact merged-PR lookup when newer closed PRs exist
- explicit guarded regeneration of open generated drafts
- pre-push draft/auto-merge hardening and rollback of failed reopened-PR refreshes

Final independent review: no actionable correctness defects in the activation workflow, matrix filtering, dependency checks, failure persistence, or draft-PR hardening.

## Checks

- `uv run --python 3.13 --with pytest --with pyyaml pytest -q`: 90 passed, 1 existing unmanifested-module warning
- focused bulk/freeze suite: 69 passed
- `uv run ruff check bulk/compute_matrix.py tests/test_bulk_applied_artifacts.py`
- actionlint 1.7.7 and 1.7.12
- `git diff --check`

Generated RuleSpec and fixtures are never edited manually; workflow generation uses the pinned `axiom-encode encode <citation> --apply` path.