### PR TITLE
Bump post-HR6644 corpus pin

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "a44203e9ef810e4b957240a86cb1f8a418e2f9b8"
-# Canonical-targets checkout for cross-repo validation; bump to the
-# merged monorepo SHA in the post-merge follow-up.
+axiom_corpus_ref = "77a36bc1807228e84591400b3d4409a4532e2953"
+# Canonical-targets checkout for cross-repo validation. This remains on
+# the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1518
+ceiling: 1531
 entries:
 - legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
   source: bulk
@@ -4560,5 +4560,44 @@ entries:
   source: manual
   since: '2026-07-17'
 - legal_id: us:statutes/7/1928#contract_obligation_supported_by_full_faith_and_credit
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
+  source: manual
+  since: '2026-07-17'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
   source: manual
   since: '2026-07-17'


### PR DESCRIPTION
Post-merge hygiene after the HR6644 source-law dependency encoding merge.

Updates:
- pin axiom_corpus_ref to current axiom-corpus main after the corpus merge
- keep rulespec_us_ref on the existing canonical target; bumping it requires the newer encoder/toolchain-schema migration and is intentionally not included here
- declare 13 SNAP state-plan composition outputs in oracle-coverage-pending.yaml so the current pinned encoder/oracle classifier remains green

Local checks:
- axiom-encode@3869d66 guard-generated --base-ref origin/main --head-ref HEAD
- axiom-encode@3869d66 oracle-coverage --fail-on-unmapped --fail-on-untested-comparable
- axiom-encode@3869d66 oracle-coverage-pending check
- python tests/generate_reverse_index.py && git diff --exit-code -- .axiom/index/provisions_to_rules.json

No encoding modules changed.