### PR TITLE
Preapprove canonical Louisiana validation gaps

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -10892,6 +10892,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-la/statutes/47/294.yaml":
+    pending:
+      fingerprint: "sha256:02f6b6dbf9bd17cb76dce830bcddbc8695c631ec244513d8740c1f521f77c623"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-la/statutes/47/295.yaml":
+    pending:
+      fingerprint: "sha256:a9a2d03308c41243b17ef9b63942011b2b308c016412eca9cf2038879773a7df"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-la/statutes/47/297/4.yaml":
+    pending:
+      fingerprint: "sha256:8b4f0cba996fed710fb646c79ae3adf022cf80b10ba839a29ffafdf2a5a7b6dd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-la/statutes/47/297/8.yaml":
+    pending:
+      fingerprint: "sha256:df3e187a4f59ce8f89de6c9e8a6b880aec0f07fd99769432be9fcdfa27ba8392"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-la/statutes/47:294.yaml":
     pending:
       fingerprint: "sha256:95f9824e34d0164cc571a8f15aa9f4a8664e4b4450cf87f0de9391b72037d907"


### PR DESCRIPTION
## Summary

- preapprove the four canonical Louisiana statute paths that inherit existing source-grounding debt during PR #911
- use exact fingerprints produced by the pinned `axiom-encode` validator against the signed corpus release
- retain the legacy colon-path pending records until the migration consumes the canonical records and removes the obsolete paths

These records are `pending`; they do not waive current validation failures on `main`. PR #911 will consume each exact record as a metadata-preserving `pending` to `active` transition.

## Cycle

- Independent review: pending
- Actionable findings: pending

## Checks

- `python -m pytest -q` (`54 passed`, one expected unmanifested-module warning)
- strict YAML comparison against `origin/main`: exactly four additions, zero changed entries, zero removals
- `git diff --check`