### PR TITLE
Compose Colorado income-tax pilot liability pipeline (39-22-104)

### DIFF
--- a/.axiom/encoding-manifests/us-co/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-co/policies/income_tax/pilot_liability_pipeline.json
@@ -1,0 +1,60 @@
+{
+  "applied_files": [
+    {
+      "path": "us-co/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "8c9dd37468f36c3ab1529de0b493d19ab740f49d844e95df6145b5ad8c01cc27"
+    },
+    {
+      "path": "us-co/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "3d1af043b44c6d6dfba556ced4a2c889d07e18b960248b6ca87a21669781a869"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-co:policies/income_tax/pilot_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-18T13:12:07.616764+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj9tytoc7/sign-applied-files/us-co/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj9tytoc7",
+  "generated_output_sha256": "3d1af043b44c6d6dfba556ced4a2c889d07e18b960248b6ca87a21669781a869",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "48da31200a426721b1c7f932cb79b19ef998fad34a68f18fed82508617317b60"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-18T13:10:56.290881+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "99638800f8f36eb0e694ad6cf28adc964c8e1b6572475b5e2e0b1acd59433dc0",
+    "prior_signature": "f9d315246117333cc715bf514357bbceda4ce55c6aacd3cef9b8f578d196a573",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-18T13:10:48.217128+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "3a5f58336880b3f652d99ef55e74f843bf30a354989ee78c3e23356142b4081c",
+      "prior_signature": "1cffdc43f5f838e777065472a5a474d4eb8767c9826fa8775496e267198f8a4c",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -10172,6 +10172,12 @@
     ],
     "us-co/statute/39/39-22-104": [
       {
+        "module": "us-co/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-co/statutes/39/39-22-104.yaml",
         "via": [
           "module"

--- a/us-co/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-co/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,0 +1,99 @@
+# Fixtures are hand-computed at the 2026 tax year (shown arithmetic proved
+# equal to engine output by axiom-encode test, not an oracle read-back).
+# Colorado liability = the imported 39-22-104(1.7)(c) flat rate (0.044 for
+# taxable years commencing on or after January 1, 2022) times Colorado taxable
+# income: section 63 federal taxable income (the supplied AGI less the supplied
+# federal deductions, calibrated to the PolicyEngine 2026 standard deduction —
+# 16,100 single / 32,200 joint) plus the supplied subsection (3) additions less
+# the supplied subsection (4) subtractions, floored at zero. The supplied
+# aggregates stand in for the encoded-but-uncomposed subsection (3)/(4) chains
+# and are zero on this ordinary wage-earner grid; the subsection (3)
+# deduction-limitation addback that binds at the 300,000-dollar joint case is
+# out of this pilot slice and recorded in the oracle suite's dispositions.
+- name: single_30000
+  # taxable max(0, 30000 - 16100) = 13900. Liability 0.044 * 13900 = 611.6.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 30000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '13900'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '611.6'
+- name: single_60000
+  # taxable max(0, 60000 - 16100) = 43900. Liability 0.044 * 43900 = 1931.6.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 60000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '43900'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1931.6'
+- name: single_150000
+  # taxable max(0, 150000 - 16100) = 133900. Liability 0.044 * 133900 = 5891.6.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 150000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '133900'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '5891.6'
+- name: joint_60000
+  # taxable max(0, 60000 - 32200) = 27800. Liability 0.044 * 27800 = 1223.2.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 60000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '27800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1223.2'
+- name: joint_120000
+  # taxable max(0, 120000 - 32200) = 87800. Liability 0.044 * 87800 = 3863.2.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 120000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '87800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '3863.2'
+- name: joint_300000
+  # taxable max(0, 300000 - 32200) = 267800. Liability 0.044 * 267800 = 11783.2.
+  # PolicyEngine additionally applies the 39-22-104(3) deduction-limitation
+  # addback at this AGI; that definitional gap lives in the oracle suite's
+  # dispositions, not in this pilot's supplied aggregates.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 300000
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '267800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '11783.2'

--- a/us-co/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-co/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,0 +1,82 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-co/statute/39/39-22-104
+      - us-co/statute/39/39-22-627
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-co/statute/39/39-22-104
+        - us-co/statute/39/39-22-627
+      rationale: |-
+        This pipeline computes the Colorado section 39-22-104 individual
+        income-tax liability before credits for the ordinary resident slice:
+        the flat tax prescribed by subsection (1.7)(c) — four and forty
+        one-hundredths percent for taxable years commencing on or after
+        January 1, 2022 — applied to Colorado taxable income, which
+        subsection (2) defines as federal taxable income modified by the
+        subsection (3) additions and subsection (4) subtractions. The rate is
+        imported from the encoded 39-22-104(1.7)(c) module rather than
+        restated, so this pipeline adds no numeric literals of its own.
+        The caller supplies adjusted gross income and the federal
+        deductions that take it to section 63 federal taxable income (the
+        subsection (1.7)(c) base is federal taxable income "as determined
+        pursuant to section 63 of the internal revenue code"), plus single
+        aggregate subsection (3) addition and subsection (4) subtraction
+        amounts, pending executable composition of those chains: their child
+        modules are individually encoded, but the 39-22-104 aggregate parent
+        defers composition across their distinct legal entities and adjusted
+        federal taxable-income bases (see its deferred_outputs), mirroring
+        the Alabama and California pilots' supplied-deduction pattern. The
+        section 39-22-627 temporary rate reduction is a distinct
+        revenue-triggered mechanism and is out of scope for this pilot slice.
+imports:
+  - us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate
+rules:
+  - name: co_pit_pilot_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 39-22-104 subsection 2, section 63 federal taxable income from the supplied adjusted gross income and federal deductions, modified by the supplied additions and subtractions, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "the federal taxable income shall be modified as provided in"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          max(0, co_pit_pilot_adjusted_gross_income - co_pit_pilot_supplied_federal_deductions + co_pit_pilot_supplied_additions - co_pit_pilot_supplied_subtractions)
+  - name: co_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 39-22-104 subsection 1.7 paragraph c, the four and forty one-hundredths percent tax imposed on modified federal taxable income for taxable years commencing on or after January 1, 2022, via the imported encoded rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate
+              output: individual_estate_trust_income_tax_rate
+              hash: sha256:4d1715dc9dea486e37a50708f2079aff7b235a5b6de816188cf3ef437c6401b1
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "a tax of four and forty one-hundredths percent is imposed"
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          individual_estate_trust_income_tax_rate * co_pit_pilot_taxable_income


### PR DESCRIPTION
Composes the first Colorado income-tax pipeline (`us-co/policies/income_tax/pilot_liability_pipeline`), following the AL/ID/KY composed-pipeline pattern from #773: the 39-22-104(1.7)(c) flat tax (four and forty one-hundredths percent, 2022+) on Colorado taxable income. The rate is **imported from the encoded 39-22-104/1.7/c module with a pinned hash** — the pipeline adds no numeric literals of its own; federal taxable income and aggregate subsection (3)/(4) modifications are caller-supplied pending composition of the encoded chains (the 104 parent defers those aggregates). The 39-22-627 temporary-rate mechanism is cited and explicitly scoped out. Validate + proof-validate + 4/4 engine companion cases + layout pytest green locally. This is the Axiom side of the axiom-oracles#274 us-co income-tax comparison suite (vs PolicyEngine co_income_tax_before_non_refundable_credits and TAXSIM state 8).

**Release-cut note (.github#39 rule 7):** citations resolve within the `us-rulespec-2026-07-17` cut (art-22 scope already included; no widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
