### PR TITLE
Compose Colorado EITC pilot pipeline (39-22-123.5, parity phase 1)

### DIFF
--- a/.axiom/encoding-manifests/us-co/policies/income_tax/eitc_pilot_pipeline.json
+++ b/.axiom/encoding-manifests/us-co/policies/income_tax/eitc_pilot_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-co/policies/income_tax/eitc_pilot_pipeline.test.yaml",
+      "sha256": "c28b9c6987b49261f99fd2125b771760a34c4de48a1a86188ee28fd5e806d410"
+    },
+    {
+      "path": "us-co/policies/income_tax/eitc_pilot_pipeline.yaml",
+      "sha256": "6337e238dde5d23d7bbdc874f9d6ea5f77c023fd080f270d1ee8add938f53f14"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-co:policies/income_tax/eitc_pilot_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-18T13:45:16.341011+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4kszos2_/sign-applied-files/us-co/policies/income_tax/eitc_pilot_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4kszos2_",
+  "generated_output_sha256": "6337e238dde5d23d7bbdc874f9d6ea5f77c023fd080f270d1ee8add938f53f14",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d4b3eac9c91f78e443c7a1edd8c4bc1e15980ac7978f030e2f516a383d12b2bd"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -10757,6 +10757,12 @@
     ],
     "us-co/statute/39/39-22-123.5": [
       {
+        "module": "us-co/policies/income_tax/eitc_pilot_pipeline.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-co/statutes/39/39-22-123.5.yaml",
         "via": [
           "module",

--- a/us-co/policies/income_tax/eitc_pilot_pipeline.test.yaml
+++ b/us-co/policies/income_tax/eitc_pilot_pipeline.test.yaml
@@ -1,0 +1,38 @@
+# Fixtures are hand-computed at the 2026 tax year (shown arithmetic proved
+# equal to engine output by axiom-encode test, not an oracle read-back).
+# Colorado EITC = the imported 39-22-123.5 base credit percentage (0.25 for
+# income tax years commencing on or after January 1, 2026) times the supplied
+# federal earned income credit. The supplied federal amounts mirror the
+# PolicyEngine 2026 federal EITC for the oracle suite's grid cases; the
+# revenue-growth adjustment regime and part-year/SSN branches are out of this
+# pilot slice.
+- name: single_parent_15000
+  # 0.25 * 4427 = 1106.75.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/eitc_pilot_pipeline#input.co_eitc_pilot_supplied_federal_eitc: 4427
+  output:
+    us-co:policies/income_tax/eitc_pilot_pipeline#co_eitc_pilot_credit: '1106.75'
+- name: childless_8000
+  # 0.25 * 632 = 158.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/eitc_pilot_pipeline#input.co_eitc_pilot_supplied_federal_eitc: 632
+  output:
+    us-co:policies/income_tax/eitc_pilot_pipeline#co_eitc_pilot_credit: '158'
+- name: no_federal_credit
+  # 0.25 * 0 = 0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/eitc_pilot_pipeline#input.co_eitc_pilot_supplied_federal_eitc: 0
+  output:
+    us-co:policies/income_tax/eitc_pilot_pipeline#co_eitc_pilot_credit: '0'

--- a/us-co/policies/income_tax/eitc_pilot_pipeline.yaml
+++ b/us-co/policies/income_tax/eitc_pilot_pipeline.yaml
@@ -1,0 +1,58 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-co/statute/39/39-22-123.5
+      - us-co/statute/39/39-22-123
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-co/statute/39/39-22-123.5
+        - us-co/statute/39/39-22-123
+      rationale: |-
+        This pipeline computes the Colorado earned income tax credit for the
+        ordinary resident full-year slice: section 39-22-123.5 allows a
+        refundable credit equal to a percentage of the federal earned income
+        credit the resident claimed — twenty-five percent for income tax
+        years commencing on or after January 1, 2026. The percentage is
+        imported from the encoded 39-22-123.5 module's base_credit_percentage
+        rule rather than restated, so this pipeline adds no numeric literals
+        of its own. The federal credit amount is a caller-supplied input (its
+        computation is federal ground outside this state pipeline). The
+        section's revenue-growth adjustment regime (percentage-point
+        increases keyed to state revenue growth, encoded in the same module)
+        and the part-year apportionment and missing-valid-SSN branches are
+        out of this pilot slice; the companion 39-22-123 legacy credit is
+        cited as the second authority of the EITC family and is likewise out
+        of scope (its own module is an honestly deferred scaffold pending
+        the enrolled session-law formula text).
+imports:
+  - us-co:statutes/39/39-22-123.5#base_credit_percentage
+rules:
+  - name: co_eitc_pilot_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 39-22-123.5, the refundable credit equal to the imported base credit percentage of the supplied federal earned income credit, floored at zero
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-co:statutes/39/39-22-123.5#base_credit_percentage
+              output: base_credit_percentage
+              hash: sha256:4b063b891583e67973bf071c32c20e86448500ebe4c876e221db19b17c372633
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-123.5
+              excerpt: "twenty-five percent of the federal credit that the resident individual claimed on the"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, co_eitc_pilot_supplied_federal_eitc) * base_credit_percentage


### PR DESCRIPTION
Second composed Colorado pipeline for the PE-parity campaign (axiom-oracles#290, phase 1): `us-co/policies/income_tax/eitc_pilot_pipeline` computes the 39-22-123.5 refundable EITC as the **imported, hash-pinned** `base_credit_percentage` from the encoded statute module (0.25 for tax years commencing on or after 2026-01-01, matching pinned PolicyEngine co_eitc exactly at 25.00% of federal) times a caller-supplied federal earned income credit. No numeric literals of its own. The revenue-growth adjustment regime (encoded in the same module) and the part-year/missing-SSN branches are documented out of this pilot slice; 39-22-123 is cited as the second authority of the EITC family. Validate + proof-validate + 3/3 engine companion cases + layout pytest green; signed with `manual_exception: composition`.

**Release-cut note (.github#39 rule 7):** citations resolve within the `us-rulespec-2026-07-17` cut (art-22 scope included; no widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
