### PR TITLE
Encode Medicaid community engagement gaps

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/552.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/552.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/552.test.yaml",
+      "sha256": "264092f51da1d7f62d57199b37d82a2f4a35a9558001e4e1f804cca00de3d7dc"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/552.yaml",
+      "sha256": "97d60f73fc264b92afbb20d3a9ab4da582df5885ff998c57bccf3712b5389576"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/552",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.436280+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/552.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "97d60f73fc264b92afbb20d3a9ab4da582df5885ff998c57bccf3712b5389576",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "663130c5f50f23c7bed37fe6a77928cecd5feab717cd3b042b44b78eec54cfdf"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.311009+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "77b89ce4cc5ca8b869ff5c691c111f7424a1155202c311a0a2b6275cc1a16f03",
+    "prior_signature": "462770d9b8b62f36a5a11cb3d2094fbbcb40db7a5d6f747969c6e4a0858e7b67",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.317547+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "09d300bd49ec94c8c44c8618ca8bb8cb782b3e1b2934b63617d42063839df32e",
+      "prior_signature": "2466354cda0335fededcb3a285d59800fc119d80b15c0a7c3ddb1cd3d9438549",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:54.453911+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "d55cc6ab9fe4671b2dba1d09b9e909af2ca3e55b09e35c3e7a87abe544d6a22d",
+        "prior_signature": "506ba9ba9fe7970b121f3b678d852a0f79a4d9ec03f4028d244157da2ada2398",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.074402+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "5bce8df83ad20a8669931699981f0336ca8b4d70c0f37cb4bdcda4ddd8b1e067",
+          "prior_signature": "6c228f77c4921886afb23184bbca08a3601fcaee287c09f66a58924d7168426e",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.857090+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "81514d184f1d0e55a0c3450e7c5d544bee31acefe1abc7651e8a7d3fb687e363",
+            "prior_signature": "2e43527dc25bfbde78d1679378f9c02b0626614dbe7505c88b07ede4d3ec410f",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/555.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/555.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/555.test.yaml",
+      "sha256": "9fef11777f7734f304c6c7b5d31c79f9eba470d977ed56b188858227d7e8c5ec"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/555.yaml",
+      "sha256": "86c12a96d468df9946f973e13dd8a828514462e7272949520ff81ae9f47e9199"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/555",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.445933+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/555.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "86c12a96d468df9946f973e13dd8a828514462e7272949520ff81ae9f47e9199",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8348a53136e7c3014877383cd6e30872373d246372ccd5cddda12e2bb9063f1c"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.317118+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6f03f3d7b37956a658ee614381e420511368e4421df322f570480dea29889589",
+    "prior_signature": "9376b55f04e65f0235b848090319b48e579991a7e40a136912b89ef59636a92d",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.340269+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "81abbe1e00c8b8c76e0dbad271a4ae9b595f01c11d1cfdc56f2a9ef242925c28",
+      "prior_signature": "6275efff91362d0eebc2a6aee608ed99bcc8087f0b0d66dd472f96e9b9edbcf0",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:54.480826+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "2c4dd3a4d3444b282a77949e728f4bae0e978f62ccaa19c9a4636a1208ec3b99",
+        "prior_signature": "d02db49d815eea24413c4b13a49eb55460562c0b9265fe83aeeac5ad71b77977",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.076633+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "57d09f2d238655ae31e3e7fab704b8321d3509ff21022c327210f5175420535e",
+          "prior_signature": "c964edffac88357812748cb1392869d99695121509709f70a1dd3cd00f11aafe",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.861152+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "319ee6f500d1c9a8dc73402df84a25b8fdbf9d63d4a5630f227bcb208cd6afd4",
+            "prior_signature": "33788d342d40da768d3a53a9892a854d5d6b4c225ab71c2714bbb21aeb746fa3",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/557.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/557.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/557.test.yaml",
+      "sha256": "ad943e894237688ca5e76f4e1c2125a33c7434cb175240a68305f299ec2b4cf3"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/557.yaml",
+      "sha256": "9593c24858e105cd1a3155a328d0b129ca56881e955b68b76d20070ead8849fb"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/557",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.452166+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/557.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "9593c24858e105cd1a3155a328d0b129ca56881e955b68b76d20070ead8849fb",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aad17c7e7de9c4f74c9762338a95e7f4996b2087335a0189fa28a9a39eea8926"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.321262+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "fb3713341168ad9fed41d4f6761a24117241e797549e58ff792744bc4c2bf3c7",
+    "prior_signature": "2d1896611caace0599546b98f77598ba93290689df5db26e34ac476eee6c85b1",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.361278+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "d601d6713dc38c672d490abe11b62d72e3cca4c18401f032501de1e0c0b99920",
+      "prior_signature": "c99d50deb0e904349a4ec68c52565e975648658c32b3e54ce34d934f5321dc5a",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:54.500808+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "ff8fc862a3360c4f2e5f78682df4ba43e1354e9771cf71ca2f693c94101ca9f7",
+        "prior_signature": "c12647c185f81edb0ca69270da1cb9ba39a842372c07790184323cb67029c2a6",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.082158+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "99cd48288117305106cac2b332684949132b2867cd4afef98d3592d06d09c338",
+          "prior_signature": "38ba969c7547e34b0948275fdb587fd66b46f234d6dcddea2e820d2d32040c8b",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.862460+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "aa2cc8dbb3bd97e99f502401bd2e7dc3c0e894fbb0d2b6cb600ff8333bfdb278",
+            "prior_signature": "b3d429eed9bea3e7a9e9b3afd1425ece1813737a4cf8edaf5a28a4cdc1d48c24",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/558.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/558.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/558.test.yaml",
+      "sha256": "1b6126384fe2dba6656b2f5b7450eab5f6c7f119e9ce394e8ad6937abf3836b2"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/558.yaml",
+      "sha256": "21df6e278201328e209b831d7780a8e60f6e44c552cacab2c9fcf76f12c70b90"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/558",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.458438+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/558.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "21df6e278201328e209b831d7780a8e60f6e44c552cacab2c9fcf76f12c70b90",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fae7734df74b98def78a496060695cdbdabec76eb0db898b5d266d21367f4a3b"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.322748+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "16ad40cc21f6aa930eebb54754f386381a9df823d1df790e77cfc002a58590dc",
+    "prior_signature": "6e9498f6c2100d11ad743fbb9dac1b77cead3f8ff2b5cc2af56ee01bb8b7c11d",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.383287+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "8b47bb321f12154a49204a8ac8ed6d7d1993d7fbaf421e486a6fde9607d62251",
+      "prior_signature": "359142a71558669010b894a420e41c694d7d830a9b2a690d5eb6912c8f843fea",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:55.117589+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "bd7395ca71230686b8c1d805971b8202633eae26b2284a3b7e481928f30b37e8",
+        "prior_signature": "2394c4cd55ceff268260a2401ceb3bdb240630cb78644a3c24d8a8e02139efaf",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.083292+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "5d6d80ef1e655113b1711d9b7b09459568b1287426c248aa187605a475ba50c8",
+          "prior_signature": "5955b25e1cd410d20bef133dd72ddeeedad4a9bfb1450aa19253174c62eef19b",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.865525+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "e81d965558ee0280e3b1a715c51b3aff371d8af9aa7d8e4ecd5880d024a99fe0",
+            "prior_signature": "706332965468665f502093b5d4e608310105b9ee4f3cd6f14429e197bacc1811",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/559.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/559.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/559.test.yaml",
+      "sha256": "b8a7a2932ade5feee8e2e2a48ed79e417b407e97d264221130559a1490d5adc7"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/559.yaml",
+      "sha256": "f8c72e649756362570983de2f7f8f4ddc8d81186e6ebb131d770d98a14c0c7a6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/559",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.465434+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/559.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "f8c72e649756362570983de2f7f8f4ddc8d81186e6ebb131d770d98a14c0c7a6",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4dbe279fde18e162f7b1ef2ab53908ea5e84679147f0f280137ce4e784b2f8f8"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.324399+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "b9d66880c1a02d1ab00a57716def48619b1fa8a2a357bfecc6d9831fd88de47a",
+    "prior_signature": "369801ca9e255dd23f4fe938c57a7a8d4caadacfa404e74d9da1c711ac9df237",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.398743+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "29a6b24e1becd37713caf6287dfcddc0a1cd0dd624425aaa1de3579c5ec8d3e5",
+      "prior_signature": "319732695774f11794cabf1758c9edc4af0266a9366fcf7aecbdce18eb607fa1",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:55.171120+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "671cc87e539f737712b1281ae0f01296df4a3cc5b9960fbf16d7a2887261fbf6",
+        "prior_signature": "22c6c21392e8dab0989528b5e783daa8fbb563f2ed06868af8e659f13e45ef54",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.084317+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "24b7febceeaba5119c3de8044a1b853ee08d148da1c58711ebe4e1145995f0a8",
+          "prior_signature": "3795b904fdac55bfa440798d2f7f36e38608b5e9b3a8be3cb2e1db7fe678f62b",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.866887+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "c39c1b2824dac8571d904e61cc2ba71b57c3e7fb016a1431a6d57d7c3683dd99",
+            "prior_signature": "5888c558d978ecb9549d308e1f44dc0c8da8453d7fd6cf09fe17e8a9e7c6066a",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/561.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/561.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/561.test.yaml",
+      "sha256": "fe43d9d56acf75a25b58198de6ff01295ef0f51b3bde968c9873fa98d95cc654"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/561.yaml",
+      "sha256": "b6e80128899e0c380bf2af67b22664e7c05bb7aa3ce40beadb192031c9bb3d8e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/561",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.472250+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/561.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "b6e80128899e0c380bf2af67b22664e7c05bb7aa3ce40beadb192031c9bb3d8e",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "aceb0a2351d728680a24d05f2811778bc23fd08a9ebfdac71f7d8b6feda6e31d"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.325514+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6f87014976678660f1a8e65a861d168cfc93977b3f29c2149fee55320d1c416d",
+    "prior_signature": "8729b8ad7d60c63bca239b88ca9e5874f790149515b5ef5ce7ebaac73c4db7c6",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.409206+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "4b2052521868fee14d1c3f60722557b32879dc127776351217f70efab51cc14e",
+      "prior_signature": "f11569501f516b954a532e3db216f0cfbc3d428c58b9ed4ffbc74a788cd4bb2f",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:55.214505+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "51d3641f51c7365eebdd612f2501c25713ece0f212c1425aa3f66aac10b08897",
+        "prior_signature": "035fe1f446a0fdde577d3ece43db3f93853774f17cfa530e31c50b0813fa3611",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.085202+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "1a6b2667ae7e8a9749714f4eb2e1e70ad3eb2fc40878abcd6aa4e5dccccaf959",
+          "prior_signature": "325033f1fd83c78f4f28e2f1a631e84c42df2d84398d3dd3c8a016b9a6a98a08",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.868143+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "bdd65edd072c4334521dd03e26b709698e1a546f99962dfde8212b8e3b2fba4c",
+            "prior_signature": "1e462c30035417c8e0f24f6b905f42ce0981acf93147ae40b97cb45f1f09db3c",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/563.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/563.json
@@ -1,0 +1,86 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/563.test.yaml",
+      "sha256": "7e3a3810b020dc3e39e36f59fb06675d6ff2fd5258b7083416642e22e063fe4f"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/563.yaml",
+      "sha256": "fa7ad92f2e14410b39f3ad1e7ef380f3e69cc2e44426497cc019cd0cb92cf236"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/42-cfr/435/563",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T17:29:04.478185+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/563.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "fa7ad92f2e14410b39f3ad1e7ef380f3e69cc2e44426497cc019cd0cb92cf236",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c8a68fb8f7ce26c40d2b085ab8ed46b2fea9850537b661552b784e47cadeda3f"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.326691+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "9252f6c2e0f7f588c8ede5d825c85d32737119b8e87747b22c11819ee519afee",
+    "prior_signature": "3c7399576d683474fb8d149524569cb6a2f534c8a6f009c701d28f1d0ec7e6d4",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.427960+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "e751d539fea02b2decca7bb6e9d07200cb6fdc86ae0cae7a5db7c0368ea91469",
+      "prior_signature": "d956236a3c5f9cf0122d407debfd6de799103ed0ffee1b65e2559a31b1edc9dc",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:55.231963+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "efd1aa13e38ea68991907bbcdac59d6420dabda25f5fa650acf71c78ecd8b9e5",
+        "prior_signature": "789bc1dd725d2ebec3ff874f592aad299fad43b2360619975eed411d2ff74281",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.086312+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "3d9d45365130dd6b3852408301ef6d906ab2414341a6e92122e604e5512c6816",
+          "prior_signature": "c57c440aab0be3c58826d237782ca915a3f435b4c4488edd86f4ba3011ebe844",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.869133+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "e6bc49bdc45f3762d2e4507534c4528fc35bbf8c63aab77b99b624bf45423fd2",
+            "prior_signature": "78b806c3dd8f11a41c5dde13897959d879e5a6036ed25c9bf9ddeebf97c192b6",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/statutes/42/1396a/xx.json
+++ b/.axiom/encoding-manifests/us/statutes/42/1396a/xx.json
@@ -1,41 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us/statutes/42/1396a/xx.yaml",
-      "sha256": "48ae645b26d1e6987bbf379424d1a96db6871830473d4671eb786cc3fad6c75c"
+      "path": "us/statutes/42/1396a/xx.test.yaml",
+      "sha256": "15d9056fb28e894ce391d0fb5bd101ef8bceb476acd5288bdc7e49d7a2115f89"
     },
     {
-      "path": "us/statutes/42/1396a/xx.test.yaml",
-      "sha256": "0b4152b2675da74a10ec8d7b7a37cbeacce9e8fbe3299f8032a0e0bd51a240be"
+      "path": "us/statutes/42/1396a/xx.yaml",
+      "sha256": "b387ca2b62e96b93cb4e7c2f6277a2c83b2dc311327c318e10142d281c4ea047"
     }
   ],
   "axiom_encode_git": {
-    "commit": "444ff74879cef2c61cc61f8a726d7b8090086629",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.971",
-    "version_commit": "444ff74879cef2c61cc61f8a726d7b8090086629"
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.971",
-  "backend": "deterministic",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
   "citation": "us:statutes/42/1396a/xx",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-29T10:38:25.722651+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4azmdtsa/deterministic-repair/us/statutes/42/1396a/xx.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4azmdtsa",
-  "generated_output_sha256": "48ae645b26d1e6987bbf379424d1a96db6871830473d4671eb786cc3fad6c75c",
+  "generated_at": "2026-07-20T17:29:04.484275+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/statutes/42/1396a/xx.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
+  "generated_output_sha256": "b387ca2b62e96b93cb4e7c2f6277a2c83b2dc311327c318e10142d281c4ea047",
   "generation_prompt_sha256": null,
-  "model": "source-child-corpus-path-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b29fbd51f20a5f7d314cef9f9cfd643689b24af9480208529aa082f907a625c1"
+    "value": "d5313a53c4adc1157f74266e81ab16fc9658f1a7b65a8300fea57337e3aa03e8"
   },
-  "tool": "axiom-encode repair-source-child-corpus-paths",
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-20T17:25:29.328264+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "10bf4ed915db639b65eb0489f598a1607e61c0889aa1aac80bf3645d14f9d7a4",
+    "prior_signature": "175f4fa072f6404589696e149a792d99221bfffd3eadd8c58113f56009614f77",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-20T17:24:35.443786+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "20caf78d507f42cf7066f901a33854fe41185403f11ddf64a4c65493fbb93958",
+      "prior_signature": "5430048690f4efe9b26c1bcf2bf3ad5f020bcd8888a7363822d00cb3285affab",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-20T17:22:55.239835+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "2df72a4c8984bf02b9516f8801803416358e2507fbdec5be7beac960b9597a2f",
+        "prior_signature": "fb9482398795d8f978efb8705d6c4b2ea5aba44f46252ed052564bc9c936238a",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-20T17:21:52.087705+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "5ccfbb83f90eec26c12f4b8545061c3a524e2276b31e47e8cb8594d063287977",
+          "prior_signature": "9175dcf95707b0cfc97afcbd95cb79227185fbedb39d3034f0099d5bb2449f18",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-20T17:18:52.874327+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "143ed0e5ffbea6de1cd6426d39b2bbd6895cdf851806019a6a2da4b76890b910",
+            "prior_signature": "595b085cb966e20e5f875af9ee6f7d9814dd7ddc893e5a89298c3444afb5f725",
+            "run_id": null,
+            "supersedes": {
+              "backend": "deterministic",
+              "generated_at": "2026-06-29T10:38:25.722651+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "8414d31ab6b244bb77420d65e40845b12ca87b257da2cf7e4475cabeb4c5564b",
+              "prior_signature": "7ee34c4f4d0206f60b27ff8dcd9ca972f9e93900479b3c0a0fcb35728e36ae10",
+              "run_id": "deterministic-repair",
+              "tool": "axiom-encode repair-source-child-corpus-paths"
+            },
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -32718,7 +32718,8 @@
       {
         "module": "us/regulations/42-cfr/435/563.yaml",
         "via": [
-          "module"
+          "module",
+          "proof_atom"
         ]
       }
     ],

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -15866,12 +15866,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us/regulations/42-cfr/435/552.yaml":
-    pending:
-      fingerprint: "sha256:b2eed30773675a1ca8ea17f160bf884794ed1035df34afd2937c8807d47c4969"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us/regulations/42-cfr/435/553.yaml":
     pending:
       fingerprint: "sha256:484dca39e45028d844efa6e8fe3c8e2d5895c65be8a6a9a8adbd88e836371b8a"
@@ -15884,33 +15878,9 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us/regulations/42-cfr/435/555.yaml":
-    pending:
-      fingerprint: "sha256:437c33ce375500099ed2ab5aa71b23a201b6ccb22bd98ed1f0241824d38b3506"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us/regulations/42-cfr/435/556.yaml":
     pending:
       fingerprint: "sha256:49182810d73c7ca0e3bccf89a4cb9c1cea7b9c7027727de5a0a75f906589bf2b"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/regulations/42-cfr/435/557.yaml":
-    pending:
-      fingerprint: "sha256:caf66bf153fcbcef0abed3b6f2bd549e4bc8880824a2caed6d6b39e4c4ba957c"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/regulations/42-cfr/435/558.yaml":
-    pending:
-      fingerprint: "sha256:306ba700bd8cc97418ea619458733ef0c8e3333b1cd46bed19d1dc7a0ae3c11a"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/regulations/42-cfr/435/559.yaml":
-    pending:
-      fingerprint: "sha256:5ef13e78cb4ff6b4db8de89a7d30705e286ed64cf65ae421ec62f4a09070eaa2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15920,21 +15890,9 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us/regulations/42-cfr/435/561.yaml":
-    pending:
-      fingerprint: "sha256:d00804b8f948c442e55126c6773003e93c62839dd79ee50e607e3d330ec28b19"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us/regulations/42-cfr/435/562.yaml":
     pending:
       fingerprint: "sha256:fcf3949186ecb1483765f59cc6d740530e863186123ba0822bdb6e258f80f7bc"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/regulations/42-cfr/435/563.yaml":
-    pending:
-      fingerprint: "sha256:58c5b84d06295fb5625fc0fc3b6b0c0363cd66dd28abfb255807ece74c28a7c1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18491,12 +18449,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/42/1396a/m.yaml":
     pending:
       fingerprint: "sha256:b9643cd38a66873d1d02a6590188c65d509aa9361f39ebe552d23cf70b1f2025"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/statutes/42/1396a/xx.yaml":
-    pending:
-      fingerprint: "sha256:85050e41ac9ec7188f376002f6841617db3dc6f5fdb7bf7be30a596b59efd07d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"

--- a/us/regulations/42-cfr/435/552.test.yaml
+++ b/us/regulations/42-cfr/435/552.test.yaml
@@ -32,6 +32,7 @@
     us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 80
     us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 0
     us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 80
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
     us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: not_holds
@@ -68,6 +69,7 @@
     us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 60
     us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 20
     us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 160
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
     us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
@@ -102,6 +104,7 @@
     us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 0
     us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 51.96
     us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 131.96
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
     us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: not_holds
@@ -133,5 +136,35 @@
   output:
     us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
     us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 0
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: not_holds
     us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: holds
+- name: half_time_education_blocks_combined_activity_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/552#input.applicable_federal_minimum_wage_requirement: 10
+    us:regulations/42-cfr/435/552#input.individual_monthly_income: 100
+    us:regulations/42-cfr/435/552#input.agency_uses_income_based_work_hours_calculation: false
+    us:regulations/42-cfr/435/552#input.agency_lacks_documentation_of_hours_worked: false
+    us:regulations/42-cfr/435/552#input.agency_uses_reasonable_method_to_allocate_work_hours_between_household_members: false
+    us:regulations/42-cfr/435/552#input.documented_work_hours: 40
+    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_less_than_half_time: false
+    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: false
+    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 0
+    us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 0
+    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 40
+    us:regulations/42-cfr/435/552#input.work_program_participation_hours: 0
+    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: true
+  output:
+    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 80
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: not_holds
+    us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: not_holds

--- a/us/regulations/42-cfr/435/552.yaml
+++ b/us/regulations/42-cfr/435/552.yaml
@@ -203,6 +203,25 @@ rules:
         formula: |-
           work_hours_for_community_engagement + community_service_hours_completed + work_program_participation_hours + less_than_half_time_educational_program_hours
 
+  - name: educational_program_hours_may_be_combined_with_other_activity
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.552(a)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/552
+              excerpt: "States are not permitted to combine educational program hours with another activity if the individual is enrolled in an educational program at least half-time."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not individual_enrolled_in_educational_program_at_least_half_time
+
   - name: work_hours_path_demonstrates_community_engagement
     kind: derived
     entity: Person
@@ -360,6 +379,12 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
+              target: us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity
+              output: educational_program_hours_may_be_combined_with_other_activity
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
               target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
               output: monthly_community_engagement_hours_requirement
               hash: sha256:local
@@ -367,6 +392,7 @@ rules:
       - effective_from: '0001-01-01'
         formula: |-
           applicable_individual
+          and educational_program_hours_may_be_combined_with_other_activity
           and combined_activity_hours_for_community_engagement >= monthly_community_engagement_hours_requirement
 
   - name: monthly_income_path_demonstrates_community_engagement

--- a/us/regulations/42-cfr/435/555.test.yaml
+++ b/us/regulations/42-cfr/435/555.test.yaml
@@ -199,3 +199,54 @@
     us:regulations/42-cfr/435/555#outside_community_medical_travel_short_term_hardship_event: not_holds
     us:regulations/42-cfr/435/555#short_term_hardship_event: not_holds
     us:regulations/42-cfr/435/555#community_engagement_deemed_demonstrated_for_short_term_hardship: not_holds
+- name: individual_request_hardship_process_requires_all_notices_and_appeal_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 35
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/555#input.state_elected_short_term_hardship_exception_option: true
+    ? us:regulations/42-cfr/435/555#input.request_for_inpatient_or_similar_acuity_hardship_exception_made_by_applicable_individual_or_representative
+    : true
+    ? us:regulations/42-cfr/435/555#input.request_for_outside_community_medical_travel_hardship_exception_made_by_applicable_individual_or_representative
+    : false
+    us:regulations/42-cfr/435/555#input.notice_of_hardship_request_method_provided: true
+    us:regulations/42-cfr/435/555#input.notice_of_hardship_request_timeframe_provided: true
+    us:regulations/42-cfr/435/555#input.timely_hardship_request_process_provided: true
+    us:regulations/42-cfr/435/555#input.notice_of_state_hardship_determination_provided: true
+    us:regulations/42-cfr/435/555#input.adverse_hardship_determination_appeal_process_provided: false
+  output:
+    us:regulations/42-cfr/435/555#short_term_hardship_notice_required: holds
+    us:regulations/42-cfr/435/555#individual_request_hardship_event_process_required: holds
+    us:regulations/42-cfr/435/555#individual_request_hardship_event_process_complete: not_holds
+- name: individual_request_hardship_process_complete_with_all_required_steps
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 35
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/555#input.state_elected_short_term_hardship_exception_option: true
+    ? us:regulations/42-cfr/435/555#input.request_for_inpatient_or_similar_acuity_hardship_exception_made_by_applicable_individual_or_representative
+    : true
+    ? us:regulations/42-cfr/435/555#input.request_for_outside_community_medical_travel_hardship_exception_made_by_applicable_individual_or_representative
+    : false
+    us:regulations/42-cfr/435/555#input.notice_of_hardship_request_method_provided: true
+    us:regulations/42-cfr/435/555#input.notice_of_hardship_request_timeframe_provided: true
+    us:regulations/42-cfr/435/555#input.timely_hardship_request_process_provided: true
+    us:regulations/42-cfr/435/555#input.notice_of_state_hardship_determination_provided: true
+    us:regulations/42-cfr/435/555#input.adverse_hardship_determination_appeal_process_provided: true
+  output:
+    us:regulations/42-cfr/435/555#individual_request_hardship_event_process_required: holds
+    us:regulations/42-cfr/435/555#individual_request_hardship_event_process_complete: holds

--- a/us/regulations/42-cfr/435/555.yaml
+++ b/us/regulations/42-cfr/435/555.yaml
@@ -335,3 +335,81 @@ rules:
           state_elected_short_term_hardship_exception_option
           and applicable_individual
           and short_term_hardship_event
+
+  - name: short_term_hardship_notice_required
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.555(c)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/regulation/42/435/555
+              excerpt: "If the agency elects the option described in paragraph (a) of this section, it must provide ... Notice regarding how the applicable individual can demonstrate that they meet a short-term hardship exception."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          state_elected_short_term_hardship_exception_option
+          and applicable_individual
+
+  - name: individual_request_hardship_event_process_required
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.555(c)(2), (d)(1), (d)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/regulation/42/435/555
+              excerpt: "For the circumstances in paragraphs (d)(1) and (4) of this section, the State must also provide"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          state_elected_short_term_hardship_exception_option
+          and applicable_individual
+          and (
+            request_for_inpatient_or_similar_acuity_hardship_exception_made_by_applicable_individual_or_representative
+            or request_for_outside_community_medical_travel_hardship_exception_made_by_applicable_individual_or_representative
+          )
+
+  - name: individual_request_hardship_event_process_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.555(c)(2)(i)-(v)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/555
+              excerpt: "Notice of the method ... Notice of the timeframe ... A timely process ... Notice to the applicable individual of the State's determination ... A process under which the applicable individual ... can appeal an adverse determination."
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/555#individual_request_hardship_event_process_required
+              output: individual_request_hardship_event_process_required
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            not individual_request_hardship_event_process_required
+          )
+          or (
+            notice_of_hardship_request_method_provided
+            and notice_of_hardship_request_timeframe_provided
+            and timely_hardship_request_process_provided
+            and notice_of_state_hardship_determination_provided
+            and adverse_hardship_determination_appeal_process_provided
+          )

--- a/us/regulations/42-cfr/435/557.test.yaml
+++ b/us/regulations/42-cfr/435/557.test.yaml
@@ -180,3 +180,31 @@
     us:regulations/42-cfr/435/557#specified_excluded_status_reverification_barred_between_redeterminations: holds
     us:regulations/42-cfr/435/557#automatic_short_term_hardship_exception_required_for_area_event: holds
     us:regulations/42-cfr/435/557#secretary_service_new_data_source_connection_timely: not_holds
+- name: first_redetermination_medical_frailty_reverification_requires_reliable_information_or_documentation
+  period: 2028-02
+  input:
+    ? us:regulations/42-cfr/435/557#input.first_regularly_scheduled_redetermination_after_medical_frailty_status_determined_by_statement_or_other_information
+    : true
+    ? us:regulations/42-cfr/435/557#input.medical_frailty_or_special_medical_needs_status_verified_using_reliable_information
+    : false
+    ? us:regulations/42-cfr/435/557#input.reliable_information_available_to_state_not_sufficient_for_medical_frailty_status_verification
+    : true
+    ? us:regulations/42-cfr/435/557#input.medical_frailty_or_special_medical_needs_status_verified_using_documentation_submitted_by_or_on_behalf_of_individual
+    : false
+  output:
+    us:regulations/42-cfr/435/557#medical_frailty_status_first_redetermination_reverification_required: holds
+    us:regulations/42-cfr/435/557#medical_frailty_status_first_redetermination_reverification_complete: not_holds
+- name: first_redetermination_medical_frailty_reverification_complete_with_documentation
+  period: 2028-02
+  input:
+    ? us:regulations/42-cfr/435/557#input.first_regularly_scheduled_redetermination_after_medical_frailty_status_determined_by_statement_or_other_information
+    : true
+    ? us:regulations/42-cfr/435/557#input.medical_frailty_or_special_medical_needs_status_verified_using_reliable_information
+    : false
+    ? us:regulations/42-cfr/435/557#input.reliable_information_available_to_state_not_sufficient_for_medical_frailty_status_verification
+    : true
+    ? us:regulations/42-cfr/435/557#input.medical_frailty_or_special_medical_needs_status_verified_using_documentation_submitted_by_or_on_behalf_of_individual
+    : true
+  output:
+    us:regulations/42-cfr/435/557#medical_frailty_status_first_redetermination_reverification_required: holds
+    us:regulations/42-cfr/435/557#medical_frailty_status_first_redetermination_reverification_complete: holds

--- a/us/regulations/42-cfr/435/557.yaml
+++ b/us/regulations/42-cfr/435/557.yaml
@@ -289,6 +289,59 @@ rules:
             or individual_resides_in_secretary_approved_unemployment_exception_county_or_equivalent
           )
 
+  - name: medical_frailty_status_first_redetermination_reverification_required
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.557(f)(1)(ii)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/557
+              excerpt: "At the individual's first regularly scheduled redetermination after such status was determined using the individual's statement provided under penalty of perjury or other information"
+    versions:
+      - effective_from: '2028-01-01'
+        formula: |-
+          first_regularly_scheduled_redetermination_after_medical_frailty_status_determined_by_statement_or_other_information
+
+  - name: medical_frailty_status_first_redetermination_reverification_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.557(f)(1)(ii)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/557
+              excerpt: "the agency must verify that the individual is medically frail or otherwise has special medical needs using reliable information available to the State, or, if reliable information available to the State is not sufficient for verification, using documentation submitted by or on behalf of the individual"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/557#medical_frailty_status_first_redetermination_reverification_required
+              output: medical_frailty_status_first_redetermination_reverification_required
+              hash: sha256:local
+    versions:
+      - effective_from: '2028-01-01'
+        formula: |-
+          (
+            not medical_frailty_status_first_redetermination_reverification_required
+          )
+          or (
+            medical_frailty_or_special_medical_needs_status_verified_using_reliable_information
+            or (
+              reliable_information_available_to_state_not_sufficient_for_medical_frailty_status_verification
+              and medical_frailty_or_special_medical_needs_status_verified_using_documentation_submitted_by_or_on_behalf_of_individual
+            )
+          )
+
   - name: secretary_service_new_data_source_connection_timely
     kind: derived
     entity: Person

--- a/us/regulations/42-cfr/435/558.test.yaml
+++ b/us/regulations/42-cfr/435/558.test.yaml
@@ -69,6 +69,23 @@
   output:
     us:regulations/42-cfr/435/558#state_must_reconsider_magi_eligibility_after_reconsideration_period_submission: holds
     us:regulations/42-cfr/435/558#agency_must_not_restrict_reapplication_after_noncompliance_denial_or_disenrollment: holds
+- name: medically_frail_status_reverification_due_after_twelve_months
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/558#input.individual_has_medically_frail_or_special_medical_needs_status: true
+    ? us:regulations/42-cfr/435/558#input.months_since_medically_frail_or_special_medical_needs_status_last_verified
+    : 12
+  output:
+    us:regulations/42-cfr/435/558#medically_frail_status_reverification_interval_months: 12
+    us:regulations/42-cfr/435/558#agency_must_reverify_medically_frail_or_special_medical_needs_status: holds
+- name: medically_frail_status_reverification_not_due_before_twelve_months
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/558#input.individual_has_medically_frail_or_special_medical_needs_status: true
+    ? us:regulations/42-cfr/435/558#input.months_since_medically_frail_or_special_medical_needs_status_last_verified
+    : 11
+  output:
+    us:regulations/42-cfr/435/558#agency_must_reverify_medically_frail_or_special_medical_needs_status: not_holds
 - name: auto_output_unable_to_verify_community_engagement_at_renewal
   period:
     period_kind: tax_year

--- a/us/regulations/42-cfr/435/558.yaml
+++ b/us/regulations/42-cfr/435/558.yaml
@@ -45,6 +45,24 @@ rules:
         formula: |-
           5
 
+  - name: medically_frail_status_reverification_interval_months
+    kind: parameter
+    dtype: Count
+    unit: month
+    source: 42 CFR 435.558
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/42/435/558
+              excerpt: "the agency must reverify this status at least every 12 months"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          12
+
   - name: unable_to_verify_community_engagement_at_application
     kind: derived
     entity: Person
@@ -463,6 +481,32 @@ rules:
       - effective_from: '0001-01-01'
         formula: |-
           prior_denial_or_disenrollment_for_noncompliance_under_this_section
+
+  - name: agency_must_reverify_medically_frail_or_special_medical_needs_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.558
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/regulation/42/435/558
+              excerpt: "the agency must reverify this status at least every 12 months"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/558#medically_frail_status_reverification_interval_months
+              output: medically_frail_status_reverification_interval_months
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          individual_has_medically_frail_or_special_medical_needs_status
+          and months_since_medically_frail_or_special_medical_needs_status_last_verified >= medically_frail_status_reverification_interval_months
 
   - name: state_must_reconsider_magi_eligibility_after_reconsideration_period_submission
     kind: derived

--- a/us/regulations/42-cfr/435/559.test.yaml
+++ b/us/regulations/42-cfr/435/559.test.yaml
@@ -23,7 +23,6 @@
     us:regulations/42-cfr/435/559#input.medical_assistance_furnished_on_or_after_mandatory_implementation_date: true
     us:regulations/42-cfr/435/559#input.state_elected_early_implementation_under_state_plan_or_section_1115: false
     us:regulations/42-cfr/435/559#input.individual_demonstrated_community_engagement_under_sections_435_552_and_435_556: true
-    us:regulations/42-cfr/435/559#input.individual_deemed_to_have_demonstrated_community_engagement_under_section_435_555: false
     us:regulations/42-cfr/435/559#input.beneficiary_enrolled_as_of_state_implementation_date: true
     us:regulations/42-cfr/435/559#input.renewal_is_first_renewal_initiated_on_or_after_state_implementation_date: true
   output:
@@ -56,7 +55,6 @@
     us:regulations/42-cfr/435/559#input.medical_assistance_furnished_on_or_after_mandatory_implementation_date: true
     us:regulations/42-cfr/435/559#input.state_elected_early_implementation_under_state_plan_or_section_1115: false
     us:regulations/42-cfr/435/559#input.individual_demonstrated_community_engagement_under_sections_435_552_and_435_556: false
-    us:regulations/42-cfr/435/559#input.individual_deemed_to_have_demonstrated_community_engagement_under_section_435_555: false
     us:regulations/42-cfr/435/559#input.beneficiary_enrolled_as_of_state_implementation_date: true
     us:regulations/42-cfr/435/559#input.renewal_is_first_renewal_initiated_on_or_after_state_implementation_date: true
   output:
@@ -88,7 +86,6 @@
     us:regulations/42-cfr/435/559#input.medical_assistance_furnished_on_or_after_mandatory_implementation_date: false
     us:regulations/42-cfr/435/559#input.state_elected_early_implementation_under_state_plan_or_section_1115: true
     us:regulations/42-cfr/435/559#input.individual_demonstrated_community_engagement_under_sections_435_552_and_435_556: false
-    us:regulations/42-cfr/435/559#input.individual_deemed_to_have_demonstrated_community_engagement_under_section_435_555: false
     us:regulations/42-cfr/435/559#input.beneficiary_enrolled_as_of_state_implementation_date: false
     us:regulations/42-cfr/435/559#input.renewal_is_first_renewal_initiated_on_or_after_state_implementation_date: true
   output:
@@ -121,7 +118,7 @@
     us:regulations/42-cfr/435/559#input.medical_assistance_furnished_on_or_after_mandatory_implementation_date: true
     us:regulations/42-cfr/435/559#input.state_elected_early_implementation_under_state_plan_or_section_1115: false
     us:regulations/42-cfr/435/559#input.individual_demonstrated_community_engagement_under_sections_435_552_and_435_556: false
-    us:regulations/42-cfr/435/559#input.individual_deemed_to_have_demonstrated_community_engagement_under_section_435_555: false
+    us:regulations/42-cfr/435/555#input.state_elected_short_term_hardship_exception_option: false
     us:regulations/42-cfr/435/559#input.beneficiary_enrolled_as_of_state_implementation_date: true
     us:regulations/42-cfr/435/559#input.renewal_is_first_renewal_initiated_on_or_after_state_implementation_date: false
   output:

--- a/us/regulations/42-cfr/435/559.yaml
+++ b/us/regulations/42-cfr/435/559.yaml
@@ -9,6 +9,7 @@ module:
 imports:
   - us:regulations/42-cfr/435/551#applicable_individual
   - us:regulations/42-cfr/435/553#community_engagement_mandatory_exception_applies
+  - us:regulations/42-cfr/435/555#community_engagement_deemed_demonstrated_for_short_term_hardship
 rules:
   - name: community_engagement_requirement_applies_as_condition_of_eligibility
     kind: derived
@@ -69,12 +70,18 @@ rules:
               target: us:regulations/42-cfr/435/553#community_engagement_mandatory_exception_applies
               output: community_engagement_mandatory_exception_applies
               hash: sha256:fdd2ff369baed1aaa28f9ee342d34194d2f9c498c0c9be67001aac2960bcfef5
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/555#community_engagement_deemed_demonstrated_for_short_term_hardship
+              output: community_engagement_deemed_demonstrated_for_short_term_hardship
+              hash: sha256:86c12a96d468df9946f973e13dd8a828514462e7272949520ff81ae9f47e9199
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           individual_demonstrated_community_engagement_under_sections_435_552_and_435_556
           or community_engagement_mandatory_exception_applies
-          or individual_deemed_to_have_demonstrated_community_engagement_under_section_435_555
+          or community_engagement_deemed_demonstrated_for_short_term_hardship
 
   - name: community_engagement_condition_of_eligibility_satisfied
     kind: derived

--- a/us/regulations/42-cfr/435/561.test.yaml
+++ b/us/regulations/42-cfr/435/561.test.yaml
@@ -52,3 +52,50 @@
     us:regulations/42-cfr/435/561#input.cms_requests_increased_outreach_due_to_monitoring_or_compliance_information: true
   output:
     us:regulations/42-cfr/435/561#periodic_outreach_notice_required: holds
+- name: required_outreach_notice_incomplete_without_additional_modality
+  period: 2027-01
+  input:
+    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: true
+    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project: false
+    us:regulations/42-cfr/435/561#input.demonstration_project_coverage_is_minimum_essential_coverage_equivalent: false
+    us:regulations/42-cfr/435/561#input.individual_age: 18
+    us:regulations/42-cfr/435/561#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
+    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement
+    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
+    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
+    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: false
+  output:
+    us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: holds
+    us:regulations/42-cfr/435/561#outreach_notice_content_complete: holds
+    us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete: not_holds
+    us:regulations/42-cfr/435/561#outreach_notice_complete: not_holds
+- name: required_outreach_notice_complete_with_content_and_modalities
+  period: 2027-01
+  input:
+    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: true
+    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project: false
+    us:regulations/42-cfr/435/561#input.demonstration_project_coverage_is_minimum_essential_coverage_equivalent: false
+    us:regulations/42-cfr/435/561#input.individual_age: 18
+    us:regulations/42-cfr/435/561#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
+    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement
+    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
+    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
+    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: true
+  output:
+    us:regulations/42-cfr/435/561#outreach_notice_content_complete: holds
+    us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete: holds
+    us:regulations/42-cfr/435/561#outreach_notice_complete: holds

--- a/us/regulations/42-cfr/435/561.yaml
+++ b/us/regulations/42-cfr/435/561.yaml
@@ -166,3 +166,83 @@ rules:
           or short_term_hardship_event_becomes_available_or_is_effectuated
           or state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
           or cms_requests_increased_outreach_due_to_monitoring_or_compliance_information
+
+  - name: outreach_notice_content_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.561(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/561
+              excerpt: "The notice required under paragraph (a) of this section must be provided in a manner consistent with Sec. 435.905(b) and include information on"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          outreach_notice_provided_consistent_with_section_435_905_b
+          and outreach_notice_explains_how_to_comply_with_community_engagement_requirement
+          and outreach_notice_explains_consequences_of_noncompliance
+          and outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
+
+  - name: outreach_notice_delivery_modalities_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.561(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/561
+              excerpt: "The notice must be provided to the individual-- (1) By regular mail, or, if elected by the individual, in an electronic format ...; and (2) In one or more of the following additional modalities"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          outreach_notice_provided_by_regular_mail_or_elected_electronic_format
+          and outreach_notice_provided_by_at_least_one_additional_modality
+
+  - name: outreach_notice_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.561(c), (d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required
+              output: community_engagement_outreach_notice_required
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/561#outreach_notice_content_complete
+              output: outreach_notice_content_complete
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete
+              output: outreach_notice_delivery_modalities_complete
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            not community_engagement_outreach_notice_required
+          )
+          or (
+            outreach_notice_content_complete
+            and outreach_notice_delivery_modalities_complete
+          )

--- a/us/regulations/42-cfr/435/563.test.yaml
+++ b/us/regulations/42-cfr/435/563.test.yaml
@@ -1,1 +1,25 @@
-[]
+- name: section_1115_project_waiver_must_not_be_approved
+  period: 2027-01
+  input:
+    ? us:regulations/42-cfr/435/563#input.section_1115_demonstration_project_waives_community_engagement_provisions_in_whole_or_in_part
+    : true
+  output:
+    us:regulations/42-cfr/435/563#cms_must_not_approve_section_1115_demonstration_project_waiver: holds
+- name: section_1115_implementation_requires_full_section_1902_xx_compliance
+  period: 2027-01
+  input:
+    ? us:regulations/42-cfr/435/563#input.state_implements_community_engagement_provisions_through_section_1115_demonstration_authority
+    : true
+    us:regulations/42-cfr/435/563#input.state_ensures_compliance_with_each_section_1902_xx_requirement: false
+  output:
+    us:regulations/42-cfr/435/563#state_section_1115_community_engagement_compliance_required: holds
+    us:regulations/42-cfr/435/563#state_section_1115_community_engagement_compliance_complete: not_holds
+- name: section_1115_implementation_complete_with_full_section_1902_xx_compliance
+  period: 2027-01
+  input:
+    ? us:regulations/42-cfr/435/563#input.state_implements_community_engagement_provisions_through_section_1115_demonstration_authority
+    : true
+    us:regulations/42-cfr/435/563#input.state_ensures_compliance_with_each_section_1902_xx_requirement: true
+  output:
+    us:regulations/42-cfr/435/563#state_section_1115_community_engagement_compliance_required: holds
+    us:regulations/42-cfr/435/563#state_section_1115_community_engagement_compliance_complete: holds

--- a/us/regulations/42-cfr/435/563.yaml
+++ b/us/regulations/42-cfr/435/563.yaml
@@ -15,3 +15,69 @@ rules:
       basis:
         delegation: us:statutes/42/1396a/xx#state_must_apply_community_engagement_requirement
     source: 42 CFR 435.563
+
+  - name: cms_must_not_approve_section_1115_demonstration_project_waiver
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.563(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/563
+              excerpt: "CMS will not approve a section 1115 demonstration project that waives, in whole or in part, the community engagement provisions of section 1902(xx) of the Act."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          section_1115_demonstration_project_waives_community_engagement_provisions_in_whole_or_in_part
+
+  - name: state_section_1115_community_engagement_compliance_required
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.563(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/regulation/42/435/563
+              excerpt: "A State implementing the community engagement provisions of section 1902(xx) of the Act through section 1115 demonstration authority must ensure compliance with each of the requirements of section 1902(xx) of the Act."
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          state_implements_community_engagement_provisions_through_section_1115_demonstration_authority
+
+  - name: state_section_1115_community_engagement_compliance_complete
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.563(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/563#state_section_1115_community_engagement_compliance_required
+              output: state_section_1115_community_engagement_compliance_required
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/563
+              excerpt: "must ensure compliance with each of the requirements of section 1902(xx) of the Act"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            not state_section_1115_community_engagement_compliance_required
+          )
+          or state_ensures_compliance_with_each_section_1902_xx_requirement

--- a/us/statutes/42/1396a/xx.test.yaml
+++ b/us/statutes/42/1396a/xx.test.yaml
@@ -97,6 +97,37 @@
     us:statutes/42/1396a/xx#optional_hardship_deeming_applies: holds
     us:statutes/42/1396a/xx#deemed_to_have_demonstrated_community_engagement: holds
     us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: holds
+- name: state_may_waive_verification_for_deemed_community_engagement
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 0
+    us:statutes/42/1396a/xx#input.monthly_community_service_hours: 0
+    us:statutes/42/1396a/xx#input.monthly_work_program_hours: 0
+    us:statutes/42/1396a/xx#input.enrolled_in_educational_program_at_least_half_time: false
+    us:statutes/42/1396a/xx#input.monthly_combined_engagement_activity_hours: 0
+    us:statutes/42/1396a/xx#input.monthly_income: 0
+    us:statutes/42/1396a/xx#input.applicable_minimum_wage_hourly_rate: 10
+    us:statutes/42/1396a/xx#input.seasonal_worker: false
+    us:statutes/42/1396a/xx#input.average_monthly_income_over_preceding_6_months: 0
+    us:statutes/42/1396a/xx#input.was_specified_excluded_individual_for_part_or_all_of_month: false
+    us:statutes/42/1396a/xx#input.was_under_age_19_for_part_or_all_of_month: true
+    us:statutes/42/1396a/xx#input.was_entitled_to_or_enrolled_for_medicare_part_a_or_b_for_part_or_all_of_month: false
+    us:statutes/42/1396a/xx#input.was_described_in_subsection_a_10_A_i_I_through_VII_for_part_or_all_of_month: false
+    us:statutes/42/1396a/xx#input.was_inmate_of_public_institution_during_3_month_period_ending_first_day_of_month: false
+    us:statutes/42/1396a/xx#input.state_plan_provides_optional_short_term_hardship_deeming: false
+    us:statutes/42/1396a/xx#input.received_high_acuity_services_for_part_or_all_of_month: false
+    us:statutes/42/1396a/xx#input.county_has_presidential_emergency_or_disaster_for_part_or_all_of_month: false
+    us:statutes/42/1396a/xx#input.county_unemployment_rate: 0.04
+    us:statutes/42/1396a/xx#input.national_unemployment_rate: 0.04
+    ? us:statutes/42/1396a/xx#input.individual_or_dependent_must_travel_outside_community_for_extended_medically_necessary_services
+    : false
+    us:statutes/42/1396a/xx#input.individual_requested_hardship_deeming: false
+    ? us:statutes/42/1396a/xx#input.state_elects_not_to_require_verification_for_deemed_community_engagement
+    : true
+    us:statutes/26/3304#input.business_is_educational_institution_in_any_state: false
+  output:
+    us:statutes/42/1396a/xx#deemed_to_have_demonstrated_community_engagement: holds
+    us:statutes/42/1396a/xx#state_may_waive_verification_for_deemed_community_engagement: holds
 - name: specified_excluded_person_is_not_applicable_individual
   period: 2027-01
   input:

--- a/us/statutes/42/1396a/xx.yaml
+++ b/us/statutes/42/1396a/xx.yaml
@@ -230,6 +230,25 @@ rules:
     formula: 'mandatory_community_engagement_deeming_applies
 
       or optional_hardship_deeming_applies'
+- name: state_may_waive_verification_for_deemed_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 USC 1396a(xx)(3)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/42/1396a/xx
+          excerpt: may elect to not require an individual to verify information resulting in such deeming
+  versions:
+  - effective_from: '2026-12-31'
+    formula: 'state_elects_not_to_require_verification_for_deemed_community_engagement
+
+      and deemed_to_have_demonstrated_community_engagement'
 - name: demonstrated_community_engagement_for_month
   kind: derived
   entity: Person


### PR DESCRIPTION
## Summary
- Encode remaining Medicaid community-engagement source-law gaps surfaced by the dashboard across 42 CFR 435.552, 435.555, 435.557, 435.558, 435.559, 435.561, 435.563, and 42 USC 1396a(xx).
- Add focused RuleSpec tests for the new education-combination bar, hardship process duties, medical-frailty reverification, outreach notice requirements, section 1115 compliance, and statutory verification-waiver option.
- Refresh encoding manifests, reverse index entries, and remove the now-resolved pending validation-gap records for the touched modules.

## Validation
- `uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode validate --skip-reviewers <8 touched modules>`
- `uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode test --root /Users/pavelmakarchuk/rulespec-us <8 companion test files>`
- `AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode guard-generated --repo /Users/pavelmakarchuk/rulespec-us --base-ref origin/main --head-ref HEAD --json`
- `python -m pytest tests/test_repository_layout.py tests/test_encoding_manifests.py tests/test_reverse_index.py -q`
- `ruby -e 'require "yaml"; YAML.load_file("known-validation-gaps.yaml")'`
- GitHub CI: build, generated-guard, reverse-index, source-staleness, waiver-change-guard, and all validation shards except `us-sc` pass.

## CI blocker
- `validate / validate (us-sc)` fails before module validation with `target-pass workflow run does not match evidence`. The failing evidence is `.axiom/target-validation-passes.json` on protected `main`, not this PR; GitHub API now returns `pull_requests: []` for recorded run `29466984289`, while the reusable workflow requires exactly one PR record.
- The only modules covered by that stale evidence, `us-sc/policies/dss/snap-policy-manual/page-215.yaml` and `page-345.yaml`, pass local pinned validation directly. Because the workflow reads target-pass evidence from `PR_BASE_SHA`, this PR cannot remove or update that evidence for CI; `main` or the reusable workflow needs a separate fix.

## Notes
- The focused manifest/index suite passes with the existing warning about unrelated unmanifested modules outside the manifest-sync guard.
- Latest pushed head: `09f80976`.
