### PR TITLE
Pin validation workflow metadata fix

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@b4ee8522c893e391118248886593f6b4d8be5f9a # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@9c00090688e2c2ba704e7e25ff417b9319bd3228 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- Update the repository checks workflow to use TheAxiomFoundation/.github reusable validation workflow commit `9c00090688e2c2ba704e7e25ff417b9319bd3228`.
- That reusable workflow preserves target-pass evidence verification when GitHub no longer returns historical run-level `pull_requests` metadata.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/repository-checks.yml")'`

## Context
- This is separated from PR #945 because the validation workflow intentionally rejects changing `known-validation-gaps.yaml` and caller workflows in the same PR.
