### PR TITLE
Pin stale target-pass workflow fix

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@9c00090688e2c2ba704e7e25ff417b9319bd3228 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@799195b2ca85c8106fcee001ead074fa99e2feef # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- Update the repository checks workflow to use TheAxiomFoundation/.github reusable validation workflow commit `799195b2ca85c8106fcee001ead074fa99e2feef`.
- That workflow stops consuming target-pass evidence when the current protected base toolchain has drifted from the historical target-pass run, so affected modules are validated normally instead of failing before validation.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/repository-checks.yml")'`

## Context
- Follow-up to #946. This is separated from Medicaid PR #945 because waiver changes and caller-workflow changes must land independently.
