### PR TITLE
Fix SC SNAP upstream placement imports

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-215.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-215.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-215.test.yaml",
+      "sha256": "d864cb32920b13bcec3a24732b6c774af4e752eeebf6b9aeaf8b3018b13978b5"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-215.yaml",
+      "sha256": "7090d4dfa6b3fb96713825b7688fc9ed8a99d2c3d353da6a75831d78a76a019f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-215",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T23:05:26.935278+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-215.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji",
+  "generated_output_sha256": "7090d4dfa6b3fb96713825b7688fc9ed8a99d2c3d353da6a75831d78a76a019f",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a67bb1c1edd0a8bb7108a5c48e14499eae71b03da490446c801eafcc573eb0a9"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-345.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-345.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-345.test.yaml",
+      "sha256": "01f7a606eef95a1573428b8bc5def1ca335f1894fd6e74b01012d8e3fceb774d"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-345.yaml",
+      "sha256": "8bd2cb1bc29663658047d2fd9ff44e42e8f5e5ed9bdb2832c2da0ca2cb3443f9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-345",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T23:05:26.937124+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-345.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji",
+  "generated_output_sha256": "8bd2cb1bc29663658047d2fd9ff44e42e8f5e5ed9bdb2832c2da0ca2cb3443f9",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b372a089c45b8575c91b99e7c4416c310917665da0751ebf2d946f306d7e9ac6"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-385.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-385.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-385.yaml",
+      "sha256": "736494991e780ce6977ec08292030bd51e9323e770bf8ececeb5b2db55eab06e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/axiom-encode-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-385",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-20T23:05:26.937910+00:00",
+  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-385.yaml",
+  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmplmu1scji",
+  "generated_output_sha256": "736494991e780ce6977ec08292030bd51e9323e770bf8ececeb5b2db55eab06e",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3876ea1f3da7417c76b2d77df77c4519766de87f04f5e9bb61a1e04888843b7e"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/us-sc/policies/dss/snap-policy-manual/page-215.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-215.test.yaml
@@ -7,7 +7,6 @@
   input:
     us-sc:policies/dss/snap-policy-manual/page-215#input.adverse_action_notice_days_from_mail_to_effective: 10
   output:
-    us-sc:policies/dss/snap-policy-manual/page-215#minimum_advance_notice_days: 10
     us-sc:policies/dss/snap-policy-manual/page-215#adverse_action_notice_timely: holds
 - name: untimely_notice_below_minimum_advance_days
   period:

--- a/us-sc/policies/dss/snap-policy-manual/page-215.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-215.yaml
@@ -10,23 +10,6 @@ module:
     - output: us-sc:policies/dss/snap-policy-manual/page-215#adverse_action_advance_notice_required
       reason: Section 16.1 makes the notice duty subject to exemptions in Section 16.2, but Section 16.2 is not available in copied context.
 rules:
-  - name: minimum_advance_notice_days
-    kind: parameter
-    dtype: Integer
-    source: SNAP Manual Chapter 16.1, Use of Notice
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-215
-              excerpt: "at least 10 days"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          10
-
   - name: adverse_action_notice_timely
     kind: derived
     entity: Household
@@ -43,9 +26,9 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us-sc:policies/dss/snap-policy-manual/page-215#minimum_advance_notice_days
+              target: us-ma:regulations/106-cmr/366/200/block-1#minimum_advance_notice_days
               output: minimum_advance_notice_days
-              hash: sha256:local
+              hash: sha256:06d3edd364dbf98d59c4fe6f873a0b37566c3aebb5991d8ec01fc8f2d2e2582f
     versions:
       - effective_from: '0001-01-01'
         formula: |-
@@ -93,3 +76,6 @@ rules:
           and notice_explains_availability_of_continued_benefits
           and notice_explains_household_liability_for_overissuances_if_hearing_decision_adverse
           and (not free_legal_representation_available or notice_advises_availability_of_free_legal_representation)
+
+imports:
+  - us-ma:regulations/106-cmr/366/200/block-1#minimum_advance_notice_days

--- a/us-sc/policies/dss/snap-policy-manual/page-345.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-345.test.yaml
@@ -6,7 +6,6 @@
     us-sc:policies/dss/snap-policy-manual/page-345#input.person_age_years: 18
     us-sc:policies/dss/snap-policy-manual/page-345#input.household_has_dependent_under_abawd_dependent_age_limit_exclusive: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-345#abawd_minimum_age: 18
     us-sc:policies/dss/snap-policy-manual/page-345#abawd_maximum_age_exclusive: 65
     us-sc:policies/dss/snap-policy-manual/page-345#abawd_dependent_age_limit_exclusive: 14
     us-sc:policies/dss/snap-policy-manual/page-345#able_bodied_adult_without_dependents: holds

--- a/us-sc/policies/dss/snap-policy-manual/page-345.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-345.yaml
@@ -7,23 +7,6 @@ module:
   summary: |-
     ABAWD means a SNAP household member who is an able-bodied adult at least 18 but under 65, and without dependents under 14 in the household. Adequate notice includes stated elements and allows participants ten days from mailing to contest agency action.
 rules:
-  - name: abawd_minimum_age
-    kind: parameter
-    dtype: Integer
-    source: SNAP Manual 345, Glossary, "Able-bodied Adult Without Dependents (ABAWD)"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-345
-              excerpt: "at least 18 years of age"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          18
-
   - name: abawd_maximum_age_exclusive
     kind: parameter
     dtype: Integer
@@ -91,9 +74,9 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us-sc:policies/dss/snap-policy-manual/page-345#abawd_minimum_age
+              target: us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age
               output: abawd_minimum_age
-              hash: sha256:local
+              hash: sha256:165a85d01c0d43f0b77cb46d023ce6a1023956e842f56766a2d8c9eea7991321
           - path: versions[0].formula
             kind: import
             import:
@@ -139,3 +122,6 @@ rules:
           and notice_states_availability_of_continued_snap_benefits
           and notice_states_household_liability_for_overissuances_if_adverse_hearing_decision
           and contest_period_days_allowed_from_mailing_date >= adequate_notice_contest_period_days
+
+imports:
+  - us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age

--- a/us-sc/policies/dss/snap-policy-manual/page-385.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-385.yaml
@@ -40,9 +40,9 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
-          target: us-sc:policies/dss/snap-policy-manual/page-345#abawd_minimum_age
+          target: us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age
           output: abawd_minimum_age
-          hash: sha256:9e0e085f695d7ebac00250805699ad53b449d1c81b594e3fba1e8590dc5b4215
+          hash: sha256:165a85d01c0d43f0b77cb46d023ce6a1023956e842f56766a2d8c9eea7991321
       - path: versions[0].formula
         kind: import
         import:
@@ -57,4 +57,4 @@ rules:
 
       and person_age_years < abawd_upper_age_exclusive'
 imports:
-- us-sc:policies/dss/snap-policy-manual/page-345#abawd_minimum_age
+- us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age


### PR DESCRIPTION
## Summary
- remove South Carolina local executable copies of upstream SNAP parameters
- import the canonical Massachusetts parameter targets instead
- update dependent SC SNAP proof import wiring and companion tests
- add signed encoding manifests covering the repaired files

## Validation
- ruby YAML parse for touched modules/tests
- AXIOM_RULESPEC_REPO_ROOTS=/tmp/rulespec-us-sc-upstream:/tmp/rulespec-us-sc-upstream uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode validate --skip-reviewers page-215/page-345/page-385
- uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode test --root /tmp/rulespec-us-sc-upstream page-215/page-345/page-385 companion tests: 12 cases passed
- AXIOM_ENCODE_APPLY_SIGNING_KEY=... uv run --directory /tmp/axiom-encode-3869d66d --python 3.13 axiom-encode guard-generated --repo /tmp/rulespec-us-sc-upstream --base-ref origin/main --head-ref HEAD --json
- us-sc/policies/dss/snap-policy-manual validation subset passed

Note: a local all-us-sc sweep also reports unrelated existing non-SNAP source-verification failures in us-sc/statutes/12-6-520.yaml and two CMS eligibility modules; this PR is scoped to the SNAP upstream-placement failures exposed in #945 CI.