### PR TITLE
Pin merged Georgia corpus source chain

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "77a36bc1807228e84591400b3d4409a4532e2953"
+axiom_corpus_ref = "f66b3628a97c96bb0ab71809434ecaf84b6ad091"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- pin RuleSpec validation to axiom-corpus `f66b3628a97c96bb0ab71809434ecaf84b6ad091`
- consume the merged official Georgia O.C.G.A., 2023–2026 session-law, and 2025 IT-511 source chain from axiom-corpus #437
- land the toolchain dependency separately so rulespec-us #907 can retire repaired Georgia validation debt without violating the validation-ratchet sequencing guard

## Validation

- corpus commit is merged on axiom-corpus `main`
- the dependent state-income-tax branch passes all 44 PIT pipelines against this exact corpus commit
- TOML parsing and `git diff --check` pass

## Review cycle

- independent review found no actionable findings; it confirmed one-line scope, corpus-main reachability, immutable pin appropriateness, and the required merge ordering before #907
