### PR TITLE
Promote Utah PIT to full-Populace taxable-income boundary

### DIFF
--- a/.axiom/encoding-manifests/us-ut/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ut/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "5375027a2c17eb6836a7e90eb3090d979a49660f16d1300c1c882d39a2e2f867"
+      "sha256": "05abe440c3f5d658e91bd778ee93fec7c805cfaa31aeab8036145a5b25ce01ae"
     },
     {
       "path": "us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "899232480598ae76d2538bf56914a6b7903a79897df9aa8f565812beb03fafcf"
+      "sha256": "18a20c68d731ee1084c5692bf689c4beaebc21d8b92ccee7c6361a78656c0160"
     }
   ],
   "axiom_encode_git": {
-    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1195",
-    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1195",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ut:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-08T23:55:46.263429+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpm2y984en/sign-applied-files/us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpm2y984en",
-  "generated_output_sha256": "899232480598ae76d2538bf56914a6b7903a79897df9aa8f565812beb03fafcf",
+  "generated_at": "2026-07-21T19:07:30.960921+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwt_sksec/sign-applied-files/us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwt_sksec",
+  "generated_output_sha256": "18a20c68d731ee1084c5692bf689c4beaebc21d8b92ccee7c6361a78656c0160",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6da8de822754af81e95a6d66e16ff59d00ea0bd29c8ba8c1a345167544965cc9"
+    "value": "87d124f64d5f4eae0f13219d7b8c7109e4d9dbb75fe630438f3e5f9b352c4a59"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-08T23:55:46.263429+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "cebcbe438caa8bc15753339132b7013a6ebce9baf37556d02a1151e30504c91e",
+    "prior_signature": "6da8de822754af81e95a6d66e16ff59d00ea0bd29c8ba8c1a345167544965cc9",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -15398,12 +15398,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ut/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:4f7a2ac0d5f232e0148d1b42b5fcd2214bc1a323e77874568a733c9337725e47"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ut/regulations/admin-rules/r986/200/204.yaml":
     pending:
       fingerprint: "sha256:52faa006ef535266c4c09a165ebad40a64d906c77cb811ee857db405cb524a8d"

--- a/us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ut/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,11 +1,32 @@
 # Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
 # expected values are the author's own shown arithmetic from the supplied
 # schedule, not an oracle read-back). Utah liability = Utah Code 59-10-104(2)
-# flat 4.45 per cent (H.B. 106 of 2025) on Utah taxable income = supplied Utah
-# AGI less the supplied subtractions (zero for the resident wage earner, whose
-# Utah taxable income is federal AGI). This before-credit core excludes the
+# flat 4.45 per cent (H.B. 106 of 2025) on supplied completed-return Utah
+# taxable income. This before-credit core excludes the
 # section 59-10-1018 taxpayer tax credit, so it equals PolicyEngine's
 # ut_income_tax_before_credits exactly.
+- name: zero_taxable_income
+  # taxable 0. Tax 0.0445*0 = 0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 0
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '0'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '0'
+- name: negative_taxable_income_is_floored
+  # The completed-return boundary may be negative; the taxable base and tax are 0.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: -1000
+  output:
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '0'
+    us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '0'
 - name: single_30k
   # taxable 30000. Tax 0.0445*30000 = 1335.
   period:
@@ -13,9 +34,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 30000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 30000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '30000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '1335'
@@ -26,9 +45,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 60000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 60000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '60000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '2670'
@@ -39,9 +56,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 150000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 150000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '150000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '6675'
@@ -52,9 +67,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 60000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 60000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '60000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '2670'
@@ -65,9 +78,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 120000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 120000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '120000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '5340'
@@ -78,9 +89,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_adjusted_gross_income: 300000
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_subtractions: 0
-    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_supplied_rate: 0.0445
+    us-ut:policies/income_tax/pilot_liability_pipeline#input.ut_pit_pilot_state_taxable_income: 300000
   output:
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_taxable_income: '300000'
     us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability: '13350'

--- a/us-ut/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ut/policies/income_tax/pilot_liability_pipeline.yaml
@@ -13,41 +13,28 @@ module:
         - us-ut/statute/59-10-1018
       rationale: |-
         This pipeline computes the Utah Code 59-10-104 flat individual income tax
-        on Utah taxable income for the ordinary resident wage-earner slice at the
-        2026 tax year, before the section 59-10-1018 taxpayer tax credit. Section
-        59-10-104(2) imposes a single flat rate on the state taxable income of a
-        resident individual; the encoded us-ut/statutes/59-10-104 module carries
-        the rate, and the legislature reduced it to 4.45 per cent for taxable
-        years beginning in 2026 (H.B. 106 of 2025). This pipeline supplies that
-        operative 4.45 per cent rate as a declared caller-supplied
-        current-authority input so the flat application runs end to end without
-        importing the encoded rate. Utah taxable income for the resident wage
-        earner is federal adjusted gross income (Utah levies no separate standard
-        deduction; the section 59-10-1018 taxpayer tax credit, itself a function
-        of the federal deduction and personal exemptions, plays the deduction
-        role); this before-credit core supplies the taxable base and excludes the
-        section 59-10-1018 credit, which is cited as the boundary authority and
-        carried by its own encoded module. The pipeline adds no numeric literals
-        of its own; it wires the flat-tax mechanics only.
+        on Utah taxable income for full-year resident tax units at the 2026 tax
+        year, before the section 59-10-1018 taxpayer tax credit. Section
+        59-10-104(2) imposes a single flat rate on a resident individual's state
+        taxable income. The caller supplies that completed-return state taxable
+        income as the explicit upstream boundary; this module does not claim to
+        reconstruct the federal and Utah adjustments that produce the boundary.
+        The encoded us-ut/statutes/59-10-104 module supplies the operative 4.45
+        per cent rate, which this pipeline imports instead of accepting from the
+        caller. The section 59-10-1018 credit and all other credits remain outside
+        this before-credit target. The pipeline adds no policy-bearing numeric
+        literal of its own; zero is only the nonnegative taxable-income floor.
   summary: |-
-    Composed Utah individual income-tax liability pipeline for the oracle slice
-    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Utah
-    adjusted gross income into the Utah Code 59-10-104(2) flat tax, so an
-    end-to-end comparison against PolicyEngine (ut_income_tax_before_credits) and
-    TAXSIM (siitax) does not require the caller to supply the section 59-10-104
-    rate. It wires: Utah taxable income (AGI less any supplied subtractions, zero
-    for this wage slice); and the liability as the flat 4.45 per cent rate on
-    that taxable income. Because Utah levies a single statutory rate on this
-    slice, the composed liability equals PolicyEngine's before-credit value
-    exactly. It deliberately excludes the section 59-10-1018 taxpayer tax credit
-    (the phased-out credit that PolicyEngine nets in
-    ut_income_tax_before_non_refundable_credits), the section 59-10-1002 through
-    59-10-1044 credits, the at-home-parent and retirement credits, and the
-    business-income and part-year mechanics, all supplied as zero or omitted for
-    this slice. Utah AGI, the subtractions, and the flat rate are supplied
-    inputs; the legislature sets the rate by session law (4.45 per cent for
-    2026), so this 2026 pipeline is compared against PolicyEngine at 2026 and
-    against TAXSIM's latest 2024 law year with the rate vintage dispositioned.
+    Composed Utah individual income-tax pipeline for the 2026 before-credit
+    target. It accepts one TaxUnit-level completed-return Utah taxable-income
+    boundary, floors it at zero, and applies the rate imported from the encoded
+    Utah Code 59-10-104 module. It deliberately excludes the section 59-10-1018
+    taxpayer tax credit and all other credits, and it makes no independent claim
+    about the upstream federal or Utah adjustment chain. This narrow boundary is
+    suitable for comparison with PolicyEngine's ut_taxable_income feeding
+    ut_income_tax_before_credits for full-year resident tax units.
+imports:
+  - us-ut:statutes/59-10-104#resident_individual_income_tax_rate
 rules:
   - name: ut_pit_pilot_taxable_income
     kind: derived
@@ -55,7 +42,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: Utah Code 59-10-104, Utah taxable income after any supplied subtractions
+    source: Utah Code 59-10-104, supplied completed-return state taxable income floored at zero
     metadata:
       proof:
         atoms:
@@ -67,7 +54,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          max(0, ut_pit_pilot_adjusted_gross_income - ut_pit_pilot_supplied_subtractions)
+          max(0, ut_pit_pilot_state_taxable_income)
   - name: ut_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
@@ -79,6 +66,12 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
+              output: resident_individual_income_tax_rate
+              hash: sha256:a6a9d878c99572670d08eb55745c3357b16d2fde709cd1b4be9a17bbab08b703
+          - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us-ut/statute/59-10-104
@@ -86,4 +79,4 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          ut_pit_pilot_taxable_income * ut_pit_pilot_supplied_rate
+          ut_pit_pilot_taxable_income * resident_individual_income_tax_rate


### PR DESCRIPTION
## Summary

- replace Utah PIT caller-supplied AGI, subtraction, and rate slots with one completed-return Utah taxable-income boundary
- import the encoded Utah Code 59-10-104 4.45% rate with an exact proof hash
- add zero and negative-boundary fixtures while retaining the six positive cases
- keep scope explicit: full-year resident routing, before credits, with no claim to reconstruct the upstream adjustment chain

## Full-Populace evidence

Pinned certified US Populace (2024), evaluated at tax year 2026:
- 1,251 positive-weight Utah tax units
- 0 mismatches over the $1 contract tolerance
- maximum absolute difference: $0.568
- 12 negative and 23 zero taxable-income boundaries covered by the nonnegative floor

## Checks

- pinned axiom-encode validate --skip-reviewers: pass
- proof-validate --require-money-atoms: pass (3 atoms, 0 missing)
- companion RuleSpec tests: pass (8/8)
- compile with pinned axiom-rules-engine: pass
- reverse-index freshness: pass
- repository focused tests: pass
- signed apply-manifest guard: pass
- git diff --check: pass

## Review cycle

Independent review completed after the final fixture changes. No actionable findings remained; source fidelity, scope honesty, import pin, proof tree, and all fixtures were checked.