### PR TITLE
Bump PIT validation engine and corpus pins

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -3,7 +3,7 @@
 # file trigger full-repository revalidation.
 [toolchain]
 axiom_encode_version = "0.2.1200"
-axiom_rules_engine_ref = "474f82db158c3513f87ccaeedbd7c6a6512e3717"
+axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
 axiom_corpus_ref = "a6ef35176a5d094c3f3c49e96c9a1b3d06207996"
 # Canonical-targets checkout for cross-repo validation. This remains on

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -3,9 +3,9 @@
 # file trigger full-repository revalidation.
 [toolchain]
 axiom_encode_version = "0.2.1200"
-axiom_rules_engine_ref = "e19f1b7573c74512f20a6b71a0c55dbbf333d41b"
+axiom_rules_engine_ref = "474f82db158c3513f87ccaeedbd7c6a6512e3717"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "f66b3628a97c96bb0ab71809434ecaf84b6ad091"
+axiom_corpus_ref = "a6ef35176a5d094c3f3c49e96c9a1b3d06207996"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.github/workflows/program-artifacts.yml
+++ b/.github/workflows/program-artifacts.yml
@@ -15,6 +15,7 @@ on:
       - "tools/**"
       - "us/**"
       - "us-*/**"
+      - ".axiom/toolchain.toml"
       - ".github/workflows/program-artifacts.yml"
   push:
     branches: [main]
@@ -23,12 +24,13 @@ on:
       - "tools/**"
       - "us/**"
       - "us-*/**"
+      - ".axiom/toolchain.toml"
       - ".github/workflows/program-artifacts.yml"
 
 env:
   # Toolchain pins — bump deliberately; they define artifact provenance.
   AXIOM_COMPOSE_REF: fabe0b3b3fd6e90d3e8f075516f9b668f524f711
-  AXIOM_RULES_ENGINE_REF: e19f1b7573c74512f20a6b71a0c55dbbf333d41b
+  AXIOM_RULES_ENGINE_REF: 474f82db158c3513f87ccaeedbd7c6a6512e3717
 
 jobs:
   build:

--- a/.github/workflows/program-artifacts.yml
+++ b/.github/workflows/program-artifacts.yml
@@ -30,7 +30,7 @@ on:
 env:
   # Toolchain pins — bump deliberately; they define artifact provenance.
   AXIOM_COMPOSE_REF: fabe0b3b3fd6e90d3e8f075516f9b668f524f711
-  AXIOM_RULES_ENGINE_REF: 474f82db158c3513f87ccaeedbd7c6a6512e3717
+  AXIOM_RULES_ENGINE_REF: ffd8213271947b0189a9dd61a055c1e0e78908a0
 
 jobs:
   build:

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1571
+ceiling: 1584
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -2105,6 +2105,45 @@ entries:
 - legal_id: us-wv:statutes/11-21-3#unincorporated_organization_subject_to_article_tax
   source: bulk
   since: '2026-07-08'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_benefit
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_earned_income
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_countable_unearned_income
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_gross_monthly_income
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_household_member_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_household_residency_and_citizenship_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_initial_month_issued_allotment
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_member_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_monthly_household_income
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_residency_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_ssn_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_student_eligible
+  source: manual
+  since: '2026-07-21'
+- legal_id: us:policies/usda/snap/state-plan-composition#snap_work_requirement_eligible
+  source: manual
+  since: '2026-07-21'
 - legal_id: us:regulations/7-cfr/247/9/b#adjunctively_income_eligible_for_csfp
   source: bulk
   since: '2026-07-09'

--- a/tools/build_program_artifacts.py
+++ b/tools/build_program_artifacts.py
@@ -38,9 +38,9 @@ from pathlib import Path
 import yaml
 
 MANIFEST_FORMAT_VERSION = 1
-# The compiled-artifact format generation (rulespec/v1). Bumped only on a
+# The compiled-artifact format generation. Bumped only on a
 # breaking artifact-format change; the engine negotiates against it on load.
-ARTIFACT_SCHEMA_VERSION = 1
+ARTIFACT_SCHEMA_VERSION = 2
 # The fixed, tested lower bound an artifact requires of the engine. A floor, not
 # the building engine's version — any engine >= this that supports the artifact
 # schema can load it. Raise only when an emitted feature demands a newer engine.

--- a/tools/tests/test_manifest_provenance.py
+++ b/tools/tests/test_manifest_provenance.py
@@ -62,9 +62,10 @@ def test_engine_build_sha_unknown_returns_empty(tmp_path, monkeypatch):
 
 def test_build_compat_contract_shape_and_floor():
     compat = bpa.build_compat(engine_version="0.1.0", engine_sha="e19f1b75cafe")
-    assert compat["artifact_schema"] == 1
+    assert compat["artifact_schema"] == 2
     # Provenance carries the real build sha; gating carries the FIXED floor,
-    # not the building version (so older schema-1 engines aren't rejected).
+    # not the building version. Artifact readers separately require the exact
+    # schema generation, so v1 and v2 engines fail closed across this boundary.
     assert compat["built_by_engine"] == {"version": "0.1.0", "git_sha": "e19f1b75cafe"}
     assert compat["requires_engine"]["min_version"] == bpa.MIN_ENGINE_VERSION == "0.1.0"
     assert compat["requires_engine"]["capabilities"] == []


### PR DESCRIPTION
## Summary
- pin the Axiom rules engine to maintenance merge `ffd8213271947b0189a9dd61a055c1e0e78908a0`, which adds inclusive RuleSpec `effective_to` and compiled artifact v2 while preserving the currently pinned encoder's legacy root and source-metadata compatibility
- pin the corpus to merged commit `a6ef35176a5d094c3f3c49e96c9a1b3d06207996`, containing the Georgia, Michigan, and Pennsylvania PIT sources
- make toolchain-pin changes trigger all-program artifact publication and stamp artifact schema v2

## Motivation
These pins are shared prerequisites for the 2026 state-income-tax campaign. The old engine silently extended bounded 2026 parameters into 2027, while the engine mainline also includes unrelated strict migrations incompatible with the current encoder and RuleSpec corpus. The maintenance backport isolates the required temporal behavior.

## Validation
- exact engine and corpus merge SHAs asserted locally; workflow and toolchain engine pins match
- focused artifact tooling tests: 8 passed
- `python -m compileall`: passed
- `git diff --check`: passed
- full 52-jurisdiction validation matrix and all-program artifact build running on the exact pins

## Review cycle
- initial independent review found that the artifact publisher did not react to the toolchain pin and still stamped schema v1; fixed both findings and repeated review clean
- the first engine-main pin then exposed legacy incompatibilities across the full matrix; PR returned to draft and the isolated maintenance backport was created
- exact head `4d46127e` independently re-reviewed after repinning to the maintenance merge: no actionable findings
- PR remains draft until every matrix/artifact check is green

## Upstream review
- axiom-rules-engine PR #108 passed an independent review-fix-repeat cycle plus Rust, Python, wasm32, and wasm package/node CI before merge
- corpus PRs #455 and #457 each passed review-fix cycles and full CI before merge

## Final pending-ledger cycle
- the first full matrix exposed 13 federal SNAP composition outputs that are unmapped only under the legacy pinned classifier
- exact head `e5313bc2` declares those 13, retains 27 Missouri entries still required by that classifier, and sets the ceiling to the exact 1,584 unique declarations
- exact pinned ratchet check: 1,584 declared/applied, zero stale, zero problems
- independent repeat review of `e5313bc2`: no actionable findings