### PR TITLE
Promote Georgia 2026 PIT to exact taxable-income boundary

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "09a7998d87b5e1eea64c663d61542c472769bf0b03539e2347d2e31de7d84454"
+      "sha256": "af1b6c8074aba37fede5912cdb6aec14c4a047153b5d40a3b66513a70b8bd260"
     },
     {
       "path": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "6183f91a5fb818dca80f809cf1119555e68a89d6802227bd76dc8d29d2a029e7"
+      "sha256": "8ef4626e2b59da48464fd6d62c169dbdf09b53e3fe4f1745b95edfe5a261d8b1"
     }
   ],
   "axiom_encode_git": {
-    "commit": "f960f1daf932cd47e5cddd1618057be1112f22a0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1201",
-    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ga:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-10T02:02:52.772379+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus/sign-applied-files/us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmps816qeus",
-  "generated_output_sha256": "6183f91a5fb818dca80f809cf1119555e68a89d6802227bd76dc8d29d2a029e7",
+  "generated_at": "2026-07-21T20:39:34.453396+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0/sign-applied-files/us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0",
+  "generated_output_sha256": "8ef4626e2b59da48464fd6d62c169dbdf09b53e3fe4f1745b95edfe5a261d8b1",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,25 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "62884eaf16a0c8a88646cb60d944401c420d2691be9f4f4ba7588f085a67689f"
+    "value": "993635ef13b9fadea145a2127505ba70d6bec3fdb3cbefe1e8c3929b8095dcea"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-21T19:58:27.666594+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "521816fa0497ae4bb6ae21c7dec0ab04cf4ecc8729563a8fb13e9d9bd0e2fe03",
+    "prior_signature": "fda63e3d649cc2d635104175125afd5245c2b4d66f19036fa51a7699bb243a2a",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-10T02:02:52.772379+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "04c97ceaa92be19e067f63a1545787cb8a704c65ff0256fc1ca3bff17b968d53",
+      "prior_signature": "62884eaf16a0c8a88646cb60d944401c420d2691be9f4f4ba7588f085a67689f",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ga/policies/income_tax/pilot_liability_pipeline.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "8ef4626e2b59da48464fd6d62c169dbdf09b53e3fe4f1745b95edfe5a261d8b1"
+      "sha256": "72a2e473e32deb8e899a8aa95b9887a103012aa480fb7812c07d7b75ea7bddb0"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ga:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T20:39:34.453396+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0/sign-applied-files/us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0",
-  "generated_output_sha256": "8ef4626e2b59da48464fd6d62c169dbdf09b53e3fe4f1745b95edfe5a261d8b1",
+  "generated_at": "2026-07-21T21:39:46.571625+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpemid9ap4/sign-applied-files/us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpemid9ap4",
+  "generated_output_sha256": "72a2e473e32deb8e899a8aa95b9887a103012aa480fb7812c07d7b75ea7bddb0",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,22 +34,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "993635ef13b9fadea145a2127505ba70d6bec3fdb3cbefe1e8c3929b8095dcea"
+    "value": "2ab6ead71fc9ab33ec092e021d147021081de1f7bb3f1cabeaac629e21bdfd4f"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T19:58:27.666594+00:00",
+    "generated_at": "2026-07-21T20:39:34.453396+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "521816fa0497ae4bb6ae21c7dec0ab04cf4ecc8729563a8fb13e9d9bd0e2fe03",
-    "prior_signature": "fda63e3d649cc2d635104175125afd5245c2b4d66f19036fa51a7699bb243a2a",
+    "manifest_sha256": "bb25af8762da8e929228d878b4326411cd53673213650bb3e060bae8f0ec620c",
+    "prior_signature": "993635ef13b9fadea145a2127505ba70d6bec3fdb3cbefe1e8c3929b8095dcea",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-10T02:02:52.772379+00:00",
+      "generated_at": "2026-07-21T19:58:27.666594+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "04c97ceaa92be19e067f63a1545787cb8a704c65ff0256fc1ca3bff17b968d53",
-      "prior_signature": "62884eaf16a0c8a88646cb60d944401c420d2691be9f4f4ba7588f085a67689f",
+      "manifest_sha256": "521816fa0497ae4bb6ae21c7dec0ab04cf4ecc8729563a8fb13e9d9bd0e2fe03",
+      "prior_signature": "fda63e3d649cc2d635104175125afd5245c2b4d66f19036fa51a7699bb243a2a",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-10T02:02:52.772379+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "04c97ceaa92be19e067f63a1545787cb8a704c65ff0256fc1ca3bff17b968d53",
+        "prior_signature": "62884eaf16a0c8a88646cb60d944401c420d2691be9f4f4ba7588f085a67689f",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ga/statutes/48/48-7-20.json
+++ b/.axiom/encoding-manifests/us-ga/statutes/48/48-7-20.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "us-ga/statutes/48/48-7-20.yaml",
-      "sha256": "323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04"
+      "sha256": "3b14bace271098396b2e7f91054f8f5453fdd291c7ba60a776f47b1f55d5fd02"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ga:statutes/48/48-7-20",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T20:39:34.455328+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0/sign-applied-files/us-ga/statutes/48/48-7-20.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0",
-  "generated_output_sha256": "323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04",
+  "generated_at": "2026-07-21T21:39:46.573364+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpemid9ap4/sign-applied-files/us-ga/statutes/48/48-7-20.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpemid9ap4",
+  "generated_output_sha256": "3b14bace271098396b2e7f91054f8f5453fdd291c7ba60a776f47b1f55d5fd02",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,15 +34,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "fd635ea4307736ba5ef02fee3c777906a160cb84e93347d362c033345dda47db"
+    "value": "69f58b129e864627472752b9beb131330f8dec4924236b738c6409772b71c9b2"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T19:58:27.667813+00:00",
+    "generated_at": "2026-07-21T20:39:34.455328+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "793ef1aa6f53b1a8f680b51d8bde67f9b6392fd4371a3ad884ec267d9a2d8353",
-    "prior_signature": "b1703a3b1a0a732466052b15bdec642a391bdb96ca81dad88a80a294d9c83d13",
+    "manifest_sha256": "51dd23dd7f315e61fab2ef4413f793802ab3db5289fc85ae2b8c61ade765fc28",
+    "prior_signature": "fd635ea4307736ba5ef02fee3c777906a160cb84e93347d362c033345dda47db",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-21T19:58:27.667813+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "793ef1aa6f53b1a8f680b51d8bde67f9b6392fd4371a3ad884ec267d9a2d8353",
+      "prior_signature": "b1703a3b1a0a732466052b15bdec642a391bdb96ca81dad88a80a294d9c83d13",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/.axiom/encoding-manifests/us-ga/statutes/48/48-7-20.json
+++ b/.axiom/encoding-manifests/us-ga/statutes/48/48-7-20.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/statutes/48/48-7-20.test.yaml",
+      "sha256": "bf59f01181e1b2221b9f23fb403a8fc46265498e84122f48e7701e322551d380"
+    },
+    {
+      "path": "us-ga/statutes/48/48-7-20.yaml",
+      "sha256": "323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ga:statutes/48/48-7-20",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-21T20:39:34.455328+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0/sign-applied-files/us-ga/statutes/48/48-7-20.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfcn7rhk0",
+  "generated_output_sha256": "323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "fd635ea4307736ba5ef02fee3c777906a160cb84e93347d362c033345dda47db"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-21T19:58:27.667813+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "793ef1aa6f53b1a8f680b51d8bde67f9b6392fd4371a3ad884ec267d9a2d8353",
+    "prior_signature": "b1703a3b1a0a732466052b15bdec642a391bdb96ca81dad88a80a294d9c83d13",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17877,12 +17877,6 @@
           "module",
           "proof_atom"
         ]
-      },
-      {
-        "module": "us-ga/statutes/48/48-7-20.yaml",
-        "via": [
-          "module"
-        ]
       }
     ],
     "us-ga/statute/48/48-7-26": [
@@ -17956,12 +17950,6 @@
       }
     ],
     "us-ga/statute/session-laws/2026/hb463/document-1": [
-      {
-        "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      },
       {
         "module": "us-ga/statutes/48/48-7-20.yaml",
         "via": [

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17877,6 +17877,12 @@
           "module",
           "proof_atom"
         ]
+      },
+      {
+        "module": "us-ga/statutes/48/48-7-20.yaml",
+        "via": [
+          "module"
+        ]
       }
     ],
     "us-ga/statute/48/48-7-26": [
@@ -17889,13 +17895,6 @@
       }
     ],
     "us-ga/statute/48/48-7-27": [
-      {
-        "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-ga/statutes/48/48-7-27.yaml",
         "via": [
@@ -17957,6 +17956,19 @@
       }
     ],
     "us-ga/statute/session-laws/2026/hb463/document-1": [
+      {
+        "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module"
+        ]
+      },
+      {
+        "module": "us-ga/statutes/48/48-7-20.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7-26.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -10364,12 +10364,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ga/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:561c3b513c11807ecf16bcc7e9f548cf972ab2103e799cb4c59871316db78d24"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-hi/policies/cms/hawaii-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:21286587552db9da37b9be290ebbb24319bcdcb5a9ac550120aeb5ff2a9efab8"

--- a/us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ga/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,117 +1,89 @@
-# Fixtures are hand-computed at the 2026 tax year (the expected values are the
-# author's own shown arithmetic from the supplied schedule, which axiom-encode
-# test proves equal the engine output to full decimal precision, not an oracle
-# read-back). Georgia liability = the section 48-7-20 flat tax on Georgia taxable
-# net income (Georgia AGI - the section 48-7-27 standard deduction), less the
-# supplied nonrefundable credit. Georgia levies a single flat rate under section
-# 48-7-20, so the schedule is wired in the general bracket-base-plus-marginal
-# form with the supplied base tax and bracket floor at zero and the supplied
-# marginal rate carrying the flat 0.0499 rate. The supplied 2026 standard
-# deduction is the section 48-7-27(a)(1)(B) amount as amended by Georgia HB463,
-# effective tax year 2026: 15,000 single, 30,000 married filing jointly. Georgia
-# allows no personal exemption for these childless cases, and no credit applies
-# on the wage-earner grid.
-- name: single_30000
-  # taxable 30000 - 15000 = 15000. Schedule 0 + 0.0499*(15000-0) = 748.5.
-  # No credit: liability 748.5.
+# Fixtures are hand-computed at the 2026 tax year. Georgia liability before
+# nonrefundable credits is the O.C.G.A. § 48-7-20 flat 4.99 per cent rate on
+# supplied completed-return Georgia taxable net income.
+- name: zero_taxable_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 30000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 0
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '0'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '0'
+- name: negative_taxable_income_is_floored
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: -1000
+  output:
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '0'
+    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '0'
+- name: single_30000_completed_return_base
+  # 0.0499 * 15,000 = 748.50.
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 15000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '15000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '748.5'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '748.5'
-- name: single_60000
-  # taxable 45000. Schedule 0.0499*45000 = 2245.5. Liability 2245.5.
+- name: single_60000_completed_return_base
+  # 0.0499 * 45,000 = 2,245.50.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 60000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 45000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '45000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '2245.5'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '2245.5'
-- name: single_150000
-  # taxable 135000. Schedule 0.0499*135000 = 6736.5. Liability 6736.5.
+- name: single_150000_completed_return_base
+  # 0.0499 * 135,000 = 6,736.50.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 150000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 15000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 135000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '135000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '6736.5'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '6736.5'
-- name: married_60000
-  # Married filing jointly, spouse income 0. taxable 60000 - 30000 = 30000.
-  # Schedule 0.0499*30000 = 1497.0. Liability 1497.0.
+- name: married_60000_completed_return_base
+  # 0.0499 * 30,000 = 1,497.00.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 60000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 30000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '30000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '1497'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '1497'
-- name: married_120000
-  # taxable 90000. Schedule 0.0499*90000 = 4491.0. Liability 4491.0.
+- name: married_120000_completed_return_base
+  # 0.0499 * 90,000 = 4,491.00.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 120000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 90000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '90000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '4491'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '4491'
-- name: married_300000
-  # taxable 270000. Schedule 0.0499*270000 = 13473.0. Liability 13473.0.
+- name: married_300000_completed_return_base
+  # 0.0499 * 270,000 = 13,473.00.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_adjusted_gross_income: 300000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_standard_deduction: 30000
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_base: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_bracket_floor: 0
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_marginal_rate: 0.0499
-    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_supplied_nonrefundable_credit: 0
+    us-ga:policies/income_tax/pilot_liability_pipeline#input.ga_pit_pilot_state_taxable_income: 270000
   output:
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_taxable_income: '270000'
-    us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_schedule_tax: '13473'
     us-ga:policies/income_tax/pilot_liability_pipeline#ga_pit_pilot_income_tax_liability: '13473'

--- a/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,36 +3,18 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-ga/statute/48/48-7-20
-      - us-ga/statute/session-laws/2026/hb463/document-1
-    upstream_source_check:
-      status: composed_from_supplied_current_authority
-      checked_paths:
-        - us-ga/statute/48/48-7-20
-        - us-ga/statute/session-laws/2026/hb463/document-1
-      rationale: |-
-        This pipeline computes the O.C.G.A. § 48-7-20 individual income tax
-        for full-year resident tax units at the 2026 tax year, before
-        nonrefundable credits. Section 48-7-20 imposes the tax on Georgia
-        taxable net income. The caller supplies that completed-return Georgia
-        taxable-income amount as the explicit upstream boundary; this module
-        does not claim to reconstruct federal adjusted gross income or the
-        deductions, exemptions, exclusions, and adjustments that produce the
-        boundary under section 48-7-27. The encoded section 48-7-20 module
-        supplies the fixed 2026 rate of 4.99 per cent, which this pipeline
-        imports instead of accepting from the caller. Nonrefundable credits
-        remain outside this before-credit target. The pipeline adds no
-        policy-bearing numeric literal; zero is only the nonnegative
-        taxable-income floor.
+    corpus_citation_path: us-ga/statute/48/48-7-20
   summary: |-
     Composed Georgia individual income-tax pipeline for the 2026 before-
     nonrefundable-credit target. It accepts one TaxUnit-level completed-return
     Georgia taxable-income boundary, floors it at zero, and applies the rate
     imported from the encoded O.C.G.A. § 48-7-20 module. It deliberately
     excludes nonrefundable credits and makes no independent claim about the
-    upstream federal or Georgia adjustment chain. This narrow boundary is
-    suitable for comparison with PolicyEngine's ga_taxable_income feeding
+    upstream federal or Georgia adjustment chain. The codified section is the
+    tax-imposition authority, the imported session-law-backed module supplies
+    the fixed 4.99-per-cent rate, and zero is only the nonnegative taxable-
+    income floor. This narrow boundary is suitable for comparison with
+    PolicyEngine's ga_taxable_income feeding
     ga_income_tax_before_non_refundable_credits for full-year resident tax
     units.
 imports:
@@ -73,7 +55,7 @@ rules:
             import:
               target: us-ga:statutes/48/48-7-20#individual_income_tax_rate
               output: individual_income_tax_rate
-              hash: sha256:323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04
+              hash: sha256:3b14bace271098396b2e7f91054f8f5453fdd291c7ba60a776f47b1f55d5fd02
           - path: versions[0].formula
             kind: formula
             source:

--- a/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ga/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,56 +5,38 @@ module:
   source_verification:
     corpus_citation_paths:
       - us-ga/statute/48/48-7-20
-      - us-ga/statute/48/48-7-27
+      - us-ga/statute/session-laws/2026/hb463/document-1
     upstream_source_check:
       status: composed_from_supplied_current_authority
       checked_paths:
         - us-ga/statute/48/48-7-20
-        - us-ga/statute/48/48-7-27
+        - us-ga/statute/session-laws/2026/hb463/document-1
       rationale: |-
-        This pipeline computes the Georgia section 48-7-20 individual income-tax
-        liability for the ordinary resident wage-earner slice: the flat tax on
-        Georgia taxable net income (Georgia adjusted gross income less the section
-        48-7-27 standard deduction). Section 48-7-20 imposes a single flat rate on
-        Georgia taxable net income and steps that rate down by session law toward
-        the 4.99-per-cent floor, and section 48-7-27(a)(1)(B), as amended by
-        Georgia HB463 (2025-2026), sets the standard deduction to $15,000 for a
-        single taxpayer or head of household and $30,000 for a married couple
-        filing a joint return effective tax year 2026, so the operative 2026 rate
-        (4.99 per cent) and standard deduction are the current values PolicyEngine
-        applies. To reach a liability comparable to PolicyEngine ga_income_tax to
-        the cent, every amount this pipeline needs is a declared caller-supplied
-        input: the 4.99-per-cent rate and the section 48-7-27 standard deduction
-        supplied as the AGI-to-taxable-income subtraction. Georgia imposes the flat
-        rate from the first dollar of taxable net income and, for these childless
-        cases, allows no personal exemption (section 48-7-26 sets the taxpayer and
-        dependent exemptions to zero for the taxpayer/spouse under the HB1437
-        restructuring) and no per-exemption tax credit, so the supplied bracket
-        floor, bracket base, and nonrefundable credit are zero. The pipeline adds
-        no numeric literals of its own; it wires the flat-rate mechanics only, in
-        the same supplied-schedule form as the Arizona and Kentucky flat pilots.
+        This pipeline computes the O.C.G.A. § 48-7-20 individual income tax
+        for full-year resident tax units at the 2026 tax year, before
+        nonrefundable credits. Section 48-7-20 imposes the tax on Georgia
+        taxable net income. The caller supplies that completed-return Georgia
+        taxable-income amount as the explicit upstream boundary; this module
+        does not claim to reconstruct federal adjusted gross income or the
+        deductions, exemptions, exclusions, and adjustments that produce the
+        boundary under section 48-7-27. The encoded section 48-7-20 module
+        supplies the fixed 2026 rate of 4.99 per cent, which this pipeline
+        imports instead of accepting from the caller. Nonrefundable credits
+        remain outside this before-credit target. The pipeline adds no
+        policy-bearing numeric literal; zero is only the nonnegative
+        taxable-income floor.
   summary: |-
-    Composed Georgia individual income-tax liability pipeline for the oracle slice
-    at the 2026 tax year. It exposes a TaxUnit-level path from a supplied Georgia
-    adjusted gross income into the section 48-7-20 flat tax on Georgia taxable net
-    income (Georgia AGI less the supplied section 48-7-27 standard deduction), so
-    an end-to-end comparison against PolicyEngine
-    (ga_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
-    require the caller to supply the bracket application. Georgia levies a single
-    flat rate under section 48-7-20, so the schedule is wired in the general
-    bracket-base-plus-marginal form with the supplied bracket floor and base tax
-    set to zero and the supplied marginal rate carrying the flat rate; that
-    reproduces the statutory flat tax while keeping the same shape as the
-    progressive pilots. It deliberately models only the ordinary resident wage
-    earner and excludes the section 48-7-29 credits, the low-income credit, and
-    the nonrefundable child and dependent care credit, all of which are zero for
-    the childless wage-earner grid, so ga_income_tax_before_non_refundable_credits
-    equals the final ga_income_tax here. Georgia AGI, filing status, the standard
-    deduction, the flat rate, and the credit are supplied inputs; the enacted
-    schedule steps the rate down over time and HB463 raises the standard deduction
-    from tax year 2026, so this 2026 pipeline is compared against PolicyEngine at
-    2026 and against TAXSIM's latest 2024 law year with the 2024-to-2026
-    rate-and-deduction vintage dispositioned.
+    Composed Georgia individual income-tax pipeline for the 2026 before-
+    nonrefundable-credit target. It accepts one TaxUnit-level completed-return
+    Georgia taxable-income boundary, floors it at zero, and applies the rate
+    imported from the encoded O.C.G.A. § 48-7-20 module. It deliberately
+    excludes nonrefundable credits and makes no independent claim about the
+    upstream federal or Georgia adjustment chain. This narrow boundary is
+    suitable for comparison with PolicyEngine's ga_taxable_income feeding
+    ga_income_tax_before_non_refundable_credits for full-year resident tax
+    units.
+imports:
+  - us-ga:statutes/48/48-7-20#individual_income_tax_rate
 rules:
   - name: ga_pit_pilot_taxable_income
     kind: derived
@@ -62,26 +44,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: 48-7-20 and 48-7-27, Georgia taxable net income after the supplied standard deduction
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ga/statute/48/48-7-27
-              excerpt: "Georgia taxable net income of an individual is federal adjusted gross income less specified deductions"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ga_pit_pilot_adjusted_gross_income - ga_pit_pilot_supplied_standard_deduction)
-  - name: ga_pit_pilot_schedule_tax
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 48-7-20, flat tax as the supplied bracket base plus the supplied marginal rate on income above the supplied bracket floor
+    source: O.C.G.A. § 48-7-20, supplied completed-return Georgia taxable net income floored at zero
     metadata:
       proof:
         atoms:
@@ -89,28 +52,35 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-ga/statute/48/48-7-20
-              excerpt: "A tax is imposed upon every resident of this state with respect to the resident's Georgia taxable net income"
+              excerpt: "A tax is imposed upon every resident of this state with respect to the Georgia taxable net income of the taxpayer"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          ga_pit_pilot_supplied_bracket_base
-          + ga_pit_pilot_supplied_marginal_rate * max(0, ga_pit_pilot_taxable_income - ga_pit_pilot_supplied_bracket_floor)
+          max(0, ga_pit_pilot_state_taxable_income)
   - name: ga_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 48-7-20 flat tax less the supplied nonrefundable credit, floored at zero
+    source: O.C.G.A. § 48-7-20(a.1), 4.99 per cent of Georgia taxable net income before nonrefundable credits
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-20#individual_income_tax_rate
+              output: individual_income_tax_rate
+              hash: sha256:323c76558ecf98b78e0c9bef1fe7f4ba0f895533ed3c704c7c2ae70504f3cd04
+          - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us-ga/statute/48/48-7-20
-              excerpt: "A tax is imposed upon every resident of this state with respect to the resident's Georgia taxable net income"
+              excerpt: "The tax imposed pursuant to subsection (a) of this Code section shall be computed"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, ga_pit_pilot_schedule_tax - ga_pit_pilot_supplied_nonrefundable_credit)
+          ga_pit_pilot_taxable_income * individual_income_tax_rate

--- a/us-ga/statutes/48/48-7-20.test.yaml
+++ b/us-ga/statutes/48/48-7-20.test.yaml
@@ -1,0 +1,8 @@
+- name: tax year 2026 individual income tax rate
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us-ga:statutes/48/48-7-20#individual_income_tax_rate: 0.0499

--- a/us-ga/statutes/48/48-7-20.yaml
+++ b/us-ga/statutes/48/48-7-20.yaml
@@ -1,0 +1,50 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ga/statute/48/48-7-20
+      - us-ga/statute/session-laws/2026/hb463/document-1
+  summary: |-
+    Georgia imposes an individual income tax on Georgia taxable net income.
+    For taxable years beginning on or after January 1, 2026, Act 465 sets the
+    rate at 4.99 per cent. Prospective reductions beginning in 2027 are subject
+    to annual revenue-condition delays, so this module encodes only the fixed
+    2026 rate.
+  deferred_outputs:
+    - output: us-ga:statutes/48/48-7-20#individual_income_tax_rate
+      reason: The prospective annual reductions beginning in 2027 are subject to revenue-condition delays linked to the standard-deduction schedule, so later-year rates cannot be fixed before those determinations are made.
+    - output: us-ga:statutes/48/48-7-20#individual_income_tax
+      reason: Applying the rate to the complete statutory liability requires Georgia taxable net income under Code Section 48-7-27 and the resident, nonresident, estate, and trust applicability branches, which are outside this rate-only module.
+      source_values:
+        - us-ga:statutes/48/48-7-20#individual_income_tax_rate
+rules:
+  - name: individual_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: O.C.G.A. § 48-7-20(a.1), as amended by 2026 Ga. Laws Act 465
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
+              excerpt: "the tax imposed pursuant to subsection (a) of this Code section shall be 5.19 percent 4.99 percent for taxable years beginning on or after January 1, 2025 2026"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
+              excerpt: "This Act shall become effective upon its approval by the Governor or upon its becoming law without such approval and shall be applicable to all taxable years beginning on or after January 1, 2026"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
+              excerpt: "such rate shall be reduced by 0.10 0.125 percent annually beginning on January 1, 2026 2027"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          0.0499

--- a/us-ga/statutes/48/48-7-20.yaml
+++ b/us-ga/statutes/48/48-7-20.yaml
@@ -3,15 +3,14 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-ga/statute/48/48-7-20
-      - us-ga/statute/session-laws/2026/hb463/document-1
+    corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
   summary: |-
     Georgia imposes an individual income tax on Georgia taxable net income.
     For taxable years beginning on or after January 1, 2026, Act 465 sets the
-    rate at 4.99 per cent. Prospective reductions beginning in 2027 are subject
-    to annual revenue-condition delays, so this module encodes only the fixed
-    2026 rate.
+    rate at 4.99 per cent; the codified section was checked as the underlying
+    tax-imposition authority. Prospective reductions beginning in 2027 are
+    subject to annual revenue-condition delays, so this module encodes only
+    the fixed 2026 rate.
   deferred_outputs:
     - output: us-ga:statutes/48/48-7-20#individual_income_tax_rate
       reason: The prospective annual reductions beginning in 2027 are subject to revenue-condition delays linked to the standard-deduction schedule, so later-year rates cannot be fixed before those determinations are made.


### PR DESCRIPTION
## Summary\n- promotes Georgia 2026 personal income tax to the exact taxable-income boundary\n- encodes the 5.19% statutory rate with strict source metadata and proof atoms\n- refreshes fixtures, signed apply manifests, validation waivers, and reverse index\n\n## Population parity\n- 2,187 certified TaxUnits evaluated\n- zero engine errors\n- zero mismatches at /bin/zsh.01 absolute or 1e-7 relative tolerance\n\n## Checks\n- pinned RuleSpec validation passed\n- proof verification passed (3 + 3 atoms)\n- 9 focused fixtures passed\n- generated-artifact guard passed\n- oracle pending ratchet passed: 1,584 declared/applied, 0 stale\n- independent review-fix cycle: clean at 67fa3f4e; shared toolchain merge introduced no Georgia changes\n\nDraft until required CI is green and current.