### PR TITLE
Promote Kansas 2026 personal income-tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ks/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ks/policies/income_tax/pilot_liability_pipeline.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "c2cf69bdad85d076427564ae085c0a3c7a09cdf9ada7917ef44c0891d456ab2d"
+      "sha256": "81ce710ad885cd59e738c072f8e361eb0eebba6172353dd620f7e847518be926"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ks:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T23:12:17.706331+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp45p4m64r/sign-applied-files/us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp45p4m64r",
-  "generated_output_sha256": "c2cf69bdad85d076427564ae085c0a3c7a09cdf9ada7917ef44c0891d456ab2d",
+  "generated_at": "2026-07-21T23:47:19.276171+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_inmm91l/sign-applied-files/us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_inmm91l",
+  "generated_output_sha256": "81ce710ad885cd59e738c072f8e361eb0eebba6172353dd620f7e847518be926",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,43 +34,52 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "d27716108c3aa8fcb60b0d1527d44ff60d3e97fabbbd6932fa5cd1876f353c20"
+    "value": "14a5304a1cb2c425f26dc4bf932cb99e62a9595929406c22d2889345eb7baf4e"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:45:46.872287+00:00",
+    "generated_at": "2026-07-21T23:12:17.706331+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "e7b93b1aa7079d526a48771708ebad3bd62702148ed2c399417e3e5a60d8283b",
-    "prior_signature": "93663a609bf32767fffe2973e17c7f3412aeb04c22d2fc27bbd7387c41899d6b",
+    "manifest_sha256": "2ca7ed9897d420e1c9e41c5b733372ca5236696a099db30f4307df411910b74d",
+    "prior_signature": "d27716108c3aa8fcb60b0d1527d44ff60d3e97fabbbd6932fa5cd1876f353c20",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-21T15:44:47.901762+00:00",
+      "generated_at": "2026-07-21T15:45:46.872287+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "4b432414a7c81f0ae8f0cbeee60e5719ecea8355c5c9a452297ce9ab723fd7d8",
-      "prior_signature": "0119a36b22135771e4ae0323e6061197e475504319258f53a7fba91d060fcfaf",
+      "manifest_sha256": "e7b93b1aa7079d526a48771708ebad3bd62702148ed2c399417e3e5a60d8283b",
+      "prior_signature": "93663a609bf32767fffe2973e17c7f3412aeb04c22d2fc27bbd7387c41899d6b",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:48:15.199285+00:00",
+        "generated_at": "2026-07-21T15:44:47.901762+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "e0e9816702b562cdd15c840ac92a2abb86ac73bf0a190f48b3ce0a425abf84c0",
-        "prior_signature": "5e67a2f00f0bab2b9e38d5410a04a69f4d70df516dc7e905d3e4cc02248874d3",
+        "manifest_sha256": "4b432414a7c81f0ae8f0cbeee60e5719ecea8355c5c9a452297ce9ab723fd7d8",
+        "prior_signature": "0119a36b22135771e4ae0323e6061197e475504319258f53a7fba91d060fcfaf",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:22:02.266948+00:00",
+          "generated_at": "2026-07-16T15:48:15.199285+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "eabb87afef80f4b957f1b5f32455869af2e5d2860e941141ab351f313b44d126",
-          "prior_signature": "6357b9c57571f4ad33eec29b748c1658710495c297c39aa01568ba88d0e3cfa0",
+          "manifest_sha256": "e0e9816702b562cdd15c840ac92a2abb86ac73bf0a190f48b3ce0a425abf84c0",
+          "prior_signature": "5e67a2f00f0bab2b9e38d5410a04a69f4d70df516dc7e905d3e4cc02248874d3",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T15:09:30.955876+00:00",
+            "generated_at": "2026-07-16T15:22:02.266948+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "4080a71d7e8da9128792e8c4c050c95bd5a2bbf912faa93dad8f57d2b838217d",
-            "prior_signature": "60d547ff5dcca24a8fe9396f75610e33fe96046007a99e3ae016d2a9d99a4d92",
+            "manifest_sha256": "eabb87afef80f4b957f1b5f32455869af2e5d2860e941141ab351f313b44d126",
+            "prior_signature": "6357b9c57571f4ad33eec29b748c1658710495c297c39aa01568ba88d0e3cfa0",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-16T15:09:30.955876+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "4080a71d7e8da9128792e8c4c050c95bd5a2bbf912faa93dad8f57d2b838217d",
+              "prior_signature": "60d547ff5dcca24a8fe9396f75610e33fe96046007a99e3ae016d2a9d99a4d92",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ks/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ks/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-ks/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "df22d14d795ee3807dff88d93ff10f84a1be539ebf8078d86495842a128a9f23"
+      "sha256": "524533b1ebb3c8baa6ca63050f8442d3037da414b97ca3db4bb1c450f45e9a5f"
     },
     {
       "path": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "435c7ba568fc650c78356cf9538c581ce19f04ccc5796ba2f33a95f4afd25c01"
+      "sha256": "c2cf69bdad85d076427564ae085c0a3c7a09cdf9ada7917ef44c0891d456ab2d"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-ks:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.872287+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "435c7ba568fc650c78356cf9538c581ce19f04ccc5796ba2f33a95f4afd25c01",
+  "generated_at": "2026-07-21T23:12:17.706331+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp45p4m64r/sign-applied-files/us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp45p4m64r",
+  "generated_output_sha256": "c2cf69bdad85d076427564ae085c0a3c7a09cdf9ada7917ef44c0891d456ab2d",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,36 +34,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "93663a609bf32767fffe2973e17c7f3412aeb04c22d2fc27bbd7387c41899d6b"
+    "value": "d27716108c3aa8fcb60b0d1527d44ff60d3e97fabbbd6932fa5cd1876f353c20"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.901762+00:00",
+    "generated_at": "2026-07-21T15:45:46.872287+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "4b432414a7c81f0ae8f0cbeee60e5719ecea8355c5c9a452297ce9ab723fd7d8",
-    "prior_signature": "0119a36b22135771e4ae0323e6061197e475504319258f53a7fba91d060fcfaf",
+    "manifest_sha256": "e7b93b1aa7079d526a48771708ebad3bd62702148ed2c399417e3e5a60d8283b",
+    "prior_signature": "93663a609bf32767fffe2973e17c7f3412aeb04c22d2fc27bbd7387c41899d6b",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.199285+00:00",
+      "generated_at": "2026-07-21T15:44:47.901762+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "e0e9816702b562cdd15c840ac92a2abb86ac73bf0a190f48b3ce0a425abf84c0",
-      "prior_signature": "5e67a2f00f0bab2b9e38d5410a04a69f4d70df516dc7e905d3e4cc02248874d3",
+      "manifest_sha256": "4b432414a7c81f0ae8f0cbeee60e5719ecea8355c5c9a452297ce9ab723fd7d8",
+      "prior_signature": "0119a36b22135771e4ae0323e6061197e475504319258f53a7fba91d060fcfaf",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.266948+00:00",
+        "generated_at": "2026-07-16T15:48:15.199285+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "eabb87afef80f4b957f1b5f32455869af2e5d2860e941141ab351f313b44d126",
-        "prior_signature": "6357b9c57571f4ad33eec29b748c1658710495c297c39aa01568ba88d0e3cfa0",
+        "manifest_sha256": "e0e9816702b562cdd15c840ac92a2abb86ac73bf0a190f48b3ce0a425abf84c0",
+        "prior_signature": "5e67a2f00f0bab2b9e38d5410a04a69f4d70df516dc7e905d3e4cc02248874d3",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:30.955876+00:00",
+          "generated_at": "2026-07-16T15:22:02.266948+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "4080a71d7e8da9128792e8c4c050c95bd5a2bbf912faa93dad8f57d2b838217d",
-          "prior_signature": "60d547ff5dcca24a8fe9396f75610e33fe96046007a99e3ae016d2a9d99a4d92",
+          "manifest_sha256": "eabb87afef80f4b957f1b5f32455869af2e5d2860e941141ab351f313b44d126",
+          "prior_signature": "6357b9c57571f4ad33eec29b748c1658710495c297c39aa01568ba88d0e3cfa0",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-16T15:09:30.955876+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "4080a71d7e8da9128792e8c4c050c95bd5a2bbf912faa93dad8f57d2b838217d",
+            "prior_signature": "60d547ff5dcca24a8fe9396f75610e33fe96046007a99e3ae016d2a9d99a4d92",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18751,6 +18751,15 @@
         ]
       }
     ],
+    "us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1": [
+      {
+        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ks/guidance/khpa/policy-memo/2007-05-01/state-supplemental-payment-program": [
       {
         "module": "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml",
@@ -18783,31 +18792,6 @@
         "via": [
           "module",
           "proof_atom"
-        ]
-      }
-    ],
-    "us-ks/statute/79-32-110": [
-      {
-        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      }
-    ],
-    "us-ks/statute/79-32-110c": [
-      {
-        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      }
-    ],
-    "us-ks/statute/79-32-116": [
-      {
-        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
         ]
       }
     ],

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18795,6 +18795,22 @@
         ]
       }
     ],
+    "us-ks/statute/79-32-110c": [
+      {
+        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
+    "us-ks/statute/79-32-116": [
+      {
+        "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
     "us-ky/statute/11/141.020": [
       {
         "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "a6ef35176a5d094c3f3c49e96c9a1b3d06207996"
+axiom_corpus_ref = "5b9e638b71f15e5f0c4d2abab53030c73fb50e38"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1587
+ceiling: 1589
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1584
+ceiling: 1588
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -350,12 +350,24 @@ entries:
 - legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-16'
+- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_joint_lower_bracket_ceiling
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_lower_rate
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_other_lower_bracket_ceiling
+  source: manual
+  since: '2026-07-21'
 - legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax
   source: manual
   since: '2026-07-16'
 - legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income
   source: manual
   since: '2026-07-16'
+- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_upper_rate
+  source: manual
+  since: '2026-07-21'
 - legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-09'

--- a/us-ks/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ks/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,79 +1,75 @@
-# Expected values are independently hand-computed from K.S.A. 79-32,110(a)'s
-# schedule effective for tax year 2024 and thereafter. Supplied taxable-income
-# inputs are PolicyEngine's completed-return ks_taxable_income values for the
-# standard 2026 wage grid. The four upper-bracket results differ from
-# ks_income_tax_before_credits by $0.0038 because PolicyEngine starts the upper
-# marginal rate at $23,001/$46,001; the statute instead supplies the exact
-# cumulative bases at $23,000/$46,000.
-- name: single_30000
-  # 5.2% * 17,235 = 896.22.
+# Fixtures are independently hand-computed from the tax-year-2026 schedules in
+# K.S.A. 79-32,110(a), as confirmed by the Kansas Department of Revenue's 2026
+# Form K-40ES. The supplied boundary is completed-return Kansas taxable income.
+- name: negative nonjoint taxable income is floored
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 17235
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 0
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 0
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.052
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: -1000
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: false
   output:
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '17235'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '896.22'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '896.22'
-- name: single_60000
-  # 1,196 + 5.58% * (47,235 - 23,000) = 2,548.313.
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '0'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '0'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '0'
+- name: nonjoint at lower bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 47235
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 1196
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 23000
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.0558
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 23000
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: false
   output:
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '47235'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '2548.313'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '2548.313'
-- name: single_150000
-  # 1,196 + 5.58% * (137,235 - 23,000) = 7,570.313.
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '23000'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '1196'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '1196'
+- name: nonjoint one dollar above lower bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 137235
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 1196
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 23000
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.0558
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 23001
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: false
+  output:
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '23001'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '1196.0558'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '1196.0558'
+- name: nonjoint upper bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 137235
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: false
   output:
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '137235'
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '7570.313'
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '7570.313'
-- name: married_60000
-  # 5.2% * 33,440 = 1,738.88.
+- name: joint zero taxable income
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 33440
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 0
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 0
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.052
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 0
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: true
   output:
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '33440'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '1738.88'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '1738.88'
-- name: married_120000
-  # 2,392 + 5.58% * (93,440 - 46,000) = 5,039.152.
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '0'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '0'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '0'
+- name: joint at lower bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 93440
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 2392
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 46000
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.0558
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 46000
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: true
+  output:
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '46000'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '2392'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '2392'
+- name: joint one dollar above lower bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 46001
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: true
+  output:
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '46001'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '2392.0558'
+    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '2392.0558'
+- name: joint upper bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_state_taxable_income: 93440
+    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_filing_status_joint: true
   output:
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '93440'
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '5039.152'
     us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '5039.152'
-- name: married_300000
-  # 2,392 + 5.58% * (273,440 - 46,000) = 15,083.152.
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_taxable_income: 273440
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_base: 2392
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_bracket_floor: 46000
-    us-ks:policies/income_tax/pilot_liability_pipeline#input.ks_pit_pilot_supplied_marginal_rate: 0.0558
-  output:
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income: '273440'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax: '15083.152'
-    us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability: '15083.152'

--- a/us-ks/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ks/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,10 +3,7 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-ks/statute/79-32-110
-      - us-ks/statute/79-32-110c
-      - us-ks/statute/79-32-116
+    corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
     upstream_source_check:
       status: official_parameter_source
       checked_paths:
@@ -14,51 +11,51 @@ module:
         - us-ks/statute/79-32-110c
         - us-ks/statute/79-32-116
       rationale: |-
-        K.S.A. 79-32,110(a) imposes tax on Kansas taxable income and supplies
-        the schedules effective for tax year 2024 and thereafter: joint filers
-        pay 5.2 percent through $46,000 and $2,392 plus 5.58 percent of excess
-        over $46,000; other individuals pay 5.2 percent through $23,000 and
-        $1,196 plus 5.58 percent of excess over $23,000. The Kansas Department
-        of Revenue's official 2026 Form K-40ES, revised August 26, 2025,
-        publishes those same schedules for tax year 2026. Section 79-32,110c
-        creates an annual rate-reduction mechanism, so this module is bounded
-        to 2026 rather than carrying the verified schedule into a later year.
-        Section 79-32,116 defines Kansas taxable income. This narrow composition
-        accepts only completed-return Kansas taxable income and whether the
-        taxpayer files jointly. Deductions, exemptions, special income classes,
-        credits, nonresident apportionment, and future section 79-32,110c
-        adjustments remain outside the module.
+        K.S.A. 79-32,110(a) imposes tax on Kansas taxable income and provides
+        the underlying schedules, while 79-32,110c makes those rates subject to
+        an annual rate-reduction determination and 79-32,116 defines Kansas
+        taxable income. The Kansas Department of Revenue's official 2026 Form
+        K-40ES, revised August 26, 2025, is therefore the controlling current
+        parameter source: it publishes the schedules actually applicable for
+        tax year 2026 after the 2025 determination window. This narrow
+        composition accepts only completed-return Kansas taxable income and
+        whether the taxpayer files jointly. Deductions, exemptions, special
+        income classes, credits, nonresident apportionment, and future annual
+        rate adjustments remain outside the module.
   summary: |-
     Composed Kansas resident individual-income-tax schedule for tax year 2026.
     It accepts one TaxUnit-level completed-return Kansas taxable-income boundary
     plus a joint-filer flag, floors taxable income at zero, and applies the
-    verified K.S.A. 79-32,110(a) schedule before credits. The closest
-    PolicyEngine-US 1.752.2 target is `ks_income_tax_before_credits`, whose only
-    upstream policy inputs after the completed taxable-income boundary are
-    filing status and its Kansas rate table. Every positive-weight Kansas tax
-    unit in the certified 2024 Populace routed to tax year 2026 is within one
-    dollar of this statutory calculation. PolicyEngine starts each upper rate
-    at $23,001 or $46,001 and uses float32 microsimulation values; the statute
-    supplies exact cumulative bases above $23,000 or $46,000. Credits and all
-    upstream taxable-income construction are deliberately excluded.
+    official K-40ES tax-year-2026 schedule before credits. The closest
+    PolicyEngine-US 1.752.2 target is `ks_income_tax_before_credits`. Besides
+    Kansas taxable income, filing status, and the rate table, that oracle reads
+    `ks_agi` through a filing-status zero-tax threshold. On all 989
+    positive-weight Kansas tax units in the certified 2024 Populace routed to
+    tax year 2026, there were zero cases where that AGI gate suppressed a
+    positive K-40ES schedule result; every unit was within one dollar of this
+    legal calculation. The module therefore does not import the model-specific
+    zero-tax threshold. PolicyEngine starts each upper rate at $23,001 or
+    $46,001 and uses float32 microsimulation values; K-40ES supplies exact
+    cumulative bases above $23,000 or $46,000. Credits and all upstream
+    taxable-income construction are deliberately excluded.
 rules:
   - name: ks_pit_pilot_lower_rate
     kind: parameter
     dtype: Rate
     period: Year
-    source: K.S.A. 79-32,110(a), tax-year-2026 lower individual rate
+    source: Kansas 2026 Form K-40ES, tax computation schedules, lower rate
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
               table:
-                header: "The tax is"
-                row: "Not over $46,000; Not over $23,000"
-                column: "Tax"
-              excerpt: "5.2% of Kansas taxable income"
+                header: "TAX COMPUTATION SCHEDULES"
+                row: "$0.00 through $46,000; $0.00 through $23,000"
+                column: "Enter on line 6"
+              excerpt: "5.2% of line 5"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -68,19 +65,19 @@ rules:
     kind: parameter
     dtype: Rate
     period: Year
-    source: K.S.A. 79-32,110(a), tax-year-2026 upper individual rate
+    source: Kansas 2026 Form K-40ES, tax computation schedules, upper rate
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: table_cell
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
               table:
-                header: "The tax is"
+                header: "TAX COMPUTATION SCHEDULES"
                 row: "Over $46,000; Over $23,000"
-                column: "Tax"
-              excerpt: "5.58% of excess"
+                column: "Enter on line 6"
+              excerpt: "5.58% of excess over $46,000"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -91,15 +88,15 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a)(1)(B), tax-year-2026 joint lower-bracket ceiling
+    source: Kansas 2026 Form K-40ES, Schedule I joint lower-bracket ceiling
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: amount
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "Not over $46,000 | 5.2% of Kansas taxable income"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$ 0.00 $46,000"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -110,15 +107,15 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a)(2)(B), tax-year-2026 nonjoint lower-bracket ceiling
+    source: Kansas 2026 Form K-40ES, Schedule II nonjoint lower-bracket ceiling
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: amount
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "Not over $23,000 | 5.2% of Kansas taxable income"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$ 0.00 $23,000"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -130,15 +127,15 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a) and 79-32,116, supplied completed-return Kansas taxable income
+    source: Kansas 2026 Form K-40ES line 5, supplied completed-return Kansas taxable income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "a tax is hereby imposed upon the Kansas taxable income of every resident individual"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "5. Kansas taxable income (subtract line 4 from line 1)"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -150,20 +147,20 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a), resident individual schedules verified for tax year 2026
+    source: Kansas 2026 Form K-40ES, individual tax computation schedules
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "Not over $46,000 | 5.2% of Kansas taxable income Over $46,000 | $2,392 plus 5.58% of excess over $46,000"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$46,000 ................................................. $2,392 plus 5.58% of excess over $46,000"
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "Not over $23,000 | 5.2% of Kansas taxable income Over $23,000 | $1,196 plus 5.58% of excess over $23,000"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$23,000 ................................................. $1,196 plus 5.58% of excess over $23,000"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -181,15 +178,15 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a), resident individual income tax before credits
+    source: Kansas 2026 Form K-40ES line 6, income tax liability before credits
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ks/statute/79-32-110
-              excerpt: "a tax is hereby imposed upon the Kansas taxable income of every resident individual"
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "6. Estimated Kansas tax liability (use the Tax Computation Schedules below)"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'

--- a/us-ks/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ks/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,9 +3,12 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us-ks/statute/79-32-110
+    corpus_citation_paths:
+      - us-ks/statute/79-32-110
+      - us-ks/statute/79-32-110c
+      - us-ks/statute/79-32-116
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-ks/statute/79-32-110
         - us-ks/statute/79-32-110c
@@ -15,29 +18,112 @@ module:
         the schedules effective for tax year 2024 and thereafter: joint filers
         pay 5.2 percent through $46,000 and $2,392 plus 5.58 percent of excess
         over $46,000; other individuals pay 5.2 percent through $23,000 and
-        $1,196 plus 5.58 percent of excess over $23,000. Section 79-32,110c
-        establishes the later rate-reduction mechanism, and section 79-32,116
-        defines Kansas taxable income. This narrow composition accepts
-        completed-return Kansas taxable income and the active bracket's
-        cumulative base tax, floor, and marginal rate as caller-supplied
-        current-authority inputs. Deductions, exemptions, special income
-        classes, credits, and any future section 79-32,110c adjustment remain
-        outside this rate-section module.
+        $1,196 plus 5.58 percent of excess over $23,000. The Kansas Department
+        of Revenue's official 2026 Form K-40ES, revised August 26, 2025,
+        publishes those same schedules for tax year 2026. Section 79-32,110c
+        creates an annual rate-reduction mechanism, so this module is bounded
+        to 2026 rather than carrying the verified schedule into a later year.
+        Section 79-32,116 defines Kansas taxable income. This narrow composition
+        accepts only completed-return Kansas taxable income and whether the
+        taxpayer files jointly. Deductions, exemptions, special income classes,
+        credits, nonresident apportionment, and future section 79-32,110c
+        adjustments remain outside the module.
   summary: |-
-    Composed Kansas individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied completed-
-    return Kansas taxable income and applies the supplied active K.S.A.
-    79-32,110(a) bracket in cumulative-base-plus-marginal form before credits.
-    Its closest PolicyEngine 4.18.9 / PolicyEngine-US 1.752.2 analog is
-    `ks_income_tax_before_credits` on the six-case childless age-40 grid:
-    single at $30,000/$60,000/$150,000 of wages and one-earner joint at
-    $60,000/$120,000/$300,000. PolicyEngine supplies completed taxable income;
-    expected outputs are independently hand-computed from the statutory 2026
-    schedule. The four upper-bracket cases differ from PolicyEngine by less
-    than one cent because its parameter starts the upper rate at $23,001 or
-    $46,001 instead of applying the statute's cumulative base above $23,000 or
-    $46,000.
+    Composed Kansas resident individual-income-tax schedule for tax year 2026.
+    It accepts one TaxUnit-level completed-return Kansas taxable-income boundary
+    plus a joint-filer flag, floors taxable income at zero, and applies the
+    verified K.S.A. 79-32,110(a) schedule before credits. The closest
+    PolicyEngine-US 1.752.2 target is `ks_income_tax_before_credits`, whose only
+    upstream policy inputs after the completed taxable-income boundary are
+    filing status and its Kansas rate table. Every positive-weight Kansas tax
+    unit in the certified 2024 Populace routed to tax year 2026 is within one
+    dollar of this statutory calculation. PolicyEngine starts each upper rate
+    at $23,001 or $46,001 and uses float32 microsimulation values; the statute
+    supplies exact cumulative bases above $23,000 or $46,000. Credits and all
+    upstream taxable-income construction are deliberately excluded.
 rules:
+  - name: ks_pit_pilot_lower_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: K.S.A. 79-32,110(a), tax-year-2026 lower individual rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-ks/statute/79-32-110
+              table:
+                header: "The tax is"
+                row: "Not over $46,000; Not over $23,000"
+                column: "Tax"
+              excerpt: "5.2% of Kansas taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.052'
+
+  - name: ks_pit_pilot_upper_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: K.S.A. 79-32,110(a), tax-year-2026 upper individual rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-ks/statute/79-32-110
+              table:
+                header: "The tax is"
+                row: "Over $46,000; Over $23,000"
+                column: "Tax"
+              excerpt: "5.58% of excess"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0558'
+
+  - name: ks_pit_pilot_joint_lower_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: K.S.A. 79-32,110(a)(1)(B), tax-year-2026 joint lower-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/statute/79-32-110
+              excerpt: "Not over $46,000 | 5.2% of Kansas taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '46000'
+
+  - name: ks_pit_pilot_other_lower_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: K.S.A. 79-32,110(a)(2)(B), tax-year-2026 nonjoint lower-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/statute/79-32-110
+              excerpt: "Not over $23,000 | 5.2% of Kansas taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '23000'
+
   - name: ks_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
@@ -55,7 +141,8 @@ rules:
               excerpt: "a tax is hereby imposed upon the Kansas taxable income of every resident individual"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, ks_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, ks_pit_pilot_state_taxable_income)
 
   - name: ks_pit_pilot_schedule_tax
     kind: derived
@@ -63,7 +150,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: K.S.A. 79-32,110(a), schedules effective for 2024 and thereafter
+    source: K.S.A. 79-32,110(a), resident individual schedules verified for tax year 2026
     metadata:
       proof:
         atoms:
@@ -79,9 +166,14 @@ rules:
               excerpt: "Not over $23,000 | 5.2% of Kansas taxable income Over $23,000 | $1,196 plus 5.58% of excess over $23,000"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          ks_pit_pilot_supplied_bracket_base
-          + ks_pit_pilot_supplied_marginal_rate * max(0, ks_pit_pilot_taxable_income - ks_pit_pilot_supplied_bracket_floor)
+          if ks_pit_pilot_filing_status_joint:
+            ks_pit_pilot_lower_rate * min(ks_pit_pilot_taxable_income, ks_pit_pilot_joint_lower_bracket_ceiling)
+            + ks_pit_pilot_upper_rate * max(0, ks_pit_pilot_taxable_income - ks_pit_pilot_joint_lower_bracket_ceiling)
+          else:
+            ks_pit_pilot_lower_rate * min(ks_pit_pilot_taxable_income, ks_pit_pilot_other_lower_bracket_ceiling)
+            + ks_pit_pilot_upper_rate * max(0, ks_pit_pilot_taxable_income - ks_pit_pilot_other_lower_bracket_ceiling)
 
   - name: ks_pit_pilot_income_tax_liability
     kind: derived
@@ -100,4 +192,5 @@ rules:
               excerpt: "a tax is hereby imposed upon the Kansas taxable income of every resident individual"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: max(0, ks_pit_pilot_schedule_tax)


### PR DESCRIPTION
## Summary
- replace caller-supplied Kansas bracket values with the official 2026 K-40ES schedules
- encode joint and nonjoint 5.2% / 5.58% rates and $46,000 / $23,000 bracket ceilings
- bind numeric and effective-year proofs to the merged official KDOR K-40ES corpus source
- bound all policy-bearing rules and parameters to tax year 2026 because K.S.A. 79-32,110c permits annual rate reductions
- pin the merged corpus dependency and regenerate the signed apply manifest, reverse index, and oracle-pending declarations

## Certified Populace validation
Pinned dataset `populace-us-2024-f0af251-703bd81a565c-20260620T201958Z` (SHA prefix `16be6338f9d0`), routed to tax year 2026 with PolicyEngine-US 1.752.2:

- 989 positive-weight Kansas tax units; weighted 1,490,131.9739
- target: `ks_income_tax_before_credits`
- maximum absolute error: $0.9008000008761883
- maximum relative error: 3.208160854591692e-06
- units and weighted units over $1: 0 / 0
- PolicyEngine `ks_agi` zero-threshold gate suppressed positive K-40ES schedule results: 0 units / 0 weight
- weighted PolicyEngine total: $4,870,788,048.60
- weighted Axiom total: $4,870,790,577.13
- weighted absolute error: $2,538.73

## Checks
- deterministic RuleSpec validate: passed
- proof validation: 8 atoms; 0 missing across 2 money obligations
- companion fixtures: 8/8 passed
- signed generated-file guard: passed
- oracle-pending ratchet: 1,588 applied, 0 stale
- reverse index regenerated and stable after merging current main
- focused repository tests: 18 passed, 1 warning

## Review cycle
Independent exact-head review: CLEAN at `f238ea89c5de4ed0cba579d2498eb941f5a8d220`. The reviewer independently reproduced the certified 989-unit comparison and all focused gates. No actionable findings remain.

Keep this PR draft until current CI is fully green.