### PR TITLE
Promote Virginia 2026 PIT over certified Populace

### DIFF
--- a/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
@@ -1,12 +1,8 @@
 {
   "applied_files": [
     {
-      "path": "us-va/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "a07e4b63fd5c8f71c0757370df387fe922e9573019fb86e8f16614c578b1dd16"
-    },
-    {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "552bc01223f8facefc662377168455571560256cee77910801728f21b31c2164"
+      "sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +17,10 @@
   "citation": "us-va:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T00:52:47.321632+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwjtklj0w/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwjtklj0w",
-  "generated_output_sha256": "552bc01223f8facefc662377168455571560256cee77910801728f21b31c2164",
+  "generated_at": "2026-07-22T01:13:23.645976+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfvzsx_zo/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfvzsx_zo",
+  "generated_output_sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,15 +30,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74"
+    "value": "d2a7bbe67b5137f57245060d712249e1087f8fc53f3b80ee0209e37f545fce18"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-08T23:52:08.083717+00:00",
+    "generated_at": "2026-07-22T00:52:47.321632+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
-    "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+    "manifest_sha256": "b47c41422cc63fca7d49e1af95215fc0aeeace643c613e9e99df80084659f177",
+    "prior_signature": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-08T23:52:08.083717+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
+      "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
@@ -1,6 +1,10 @@
 {
   "applied_files": [
     {
+      "path": "us-va/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "a07e4b63fd5c8f71c0757370df387fe922e9573019fb86e8f16614c578b1dd16"
+    },
+    {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
       "sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc"
     }
@@ -17,9 +21,9 @@
   "citation": "us-va:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T01:13:23.645976+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfvzsx_zo/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfvzsx_zo",
+  "generated_at": "2026-07-22T01:15:35.629419+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpy07q2h8r/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpy07q2h8r",
   "generated_output_sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
@@ -30,22 +34,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "d2a7bbe67b5137f57245060d712249e1087f8fc53f3b80ee0209e37f545fce18"
+    "value": "6175e617056c80a0369a93016731634dbdf5e716297e91dd7f972f2b861663b0"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T00:52:47.321632+00:00",
+    "generated_at": "2026-07-22T01:13:23.645976+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "b47c41422cc63fca7d49e1af95215fc0aeeace643c613e9e99df80084659f177",
-    "prior_signature": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74",
+    "manifest_sha256": "28185088bb6a65c0c489bdb3f55c32aec4be966ce87f78ea0c0436e4ecbb6b43",
+    "prior_signature": "d2a7bbe67b5137f57245060d712249e1087f8fc53f3b80ee0209e37f545fce18",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-08T23:52:08.083717+00:00",
+      "generated_at": "2026-07-22T00:52:47.321632+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
-      "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+      "manifest_sha256": "b47c41422cc63fca7d49e1af95215fc0aeeace643c613e9e99df80084659f177",
+      "prior_signature": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-08T23:52:08.083717+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
+        "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "242b2ed46138ba330b5a375e9104cafd025e414063e46723faa41ce8e8669e47"
+      "sha256": "a07e4b63fd5c8f71c0757370df387fe922e9573019fb86e8f16614c578b1dd16"
     },
     {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "7d06794d17d64d31cf74f856ac50c183eb4f0079a8740cb08ee96ab045f90453"
+      "sha256": "552bc01223f8facefc662377168455571560256cee77910801728f21b31c2164"
     }
   ],
   "axiom_encode_git": {
-    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1195",
-    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1195",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-va:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-08T23:52:08.083717+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy1ojycwq/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy1ojycwq",
-  "generated_output_sha256": "7d06794d17d64d31cf74f856ac50c183eb4f0079a8740cb08ee96ab045f90453",
+  "generated_at": "2026-07-22T00:52:47.321632+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwjtklj0w/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpwjtklj0w",
+  "generated_output_sha256": "552bc01223f8facefc662377168455571560256cee77910801728f21b31c2164",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e"
+    "value": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-08T23:52:08.083717+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
+    "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -31491,12 +31491,6 @@
     ],
     "us-va/statute/58.1/58.1-321": [
       {
-        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      },
-      {
         "module": "us-va/statutes/58.1/58/1-321.yaml",
         "via": [
           "module",
@@ -31505,13 +31499,6 @@
       }
     ],
     "us-va/statute/58.1/58.1-322.03": [
-      {
-        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-va/statutes/58.1/58/1-322/03.yaml",
         "via": [

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -31491,6 +31491,13 @@
     ],
     "us-va/statute/58.1/58.1-321": [
       {
+        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-va/statutes/58.1/58/1-321.yaml",
         "via": [
           "module",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -15404,12 +15404,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:a79dd05b0f88c86477ef6891dd286811b253912f395dccba976748c03a27e15b"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-va/statutes/58.1/58/1-320.yaml":
     pending:
       fingerprint: "sha256:68ffe41b2387b5a3a10040c178b3e6d0d8e1bf6a2f65b10868d33d17c512ca64"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -1676,9 +1676,6 @@ entries:
 - legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability
   source: bulk
   since: '2026-07-08'
-- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income
-  source: bulk
-  since: '2026-07-08'
 - legal_id: us-va:statutes/58.1/58/1-320#first_bracket_rate
   source: bulk
   since: '2026-07-08'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,167 +1,112 @@
-# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
-# expected values are the author's own shown arithmetic from the supplied
-# schedule, not an oracle read-back). Virginia liability = Va. Code 58.1-320
-# marginal bracket tax (2% to $3,000; 3% to $5,000; 5% to $17,000; 5.75% above)
-# on Virginia taxable income = supplied Virginia AGI less the supplied deduction
-# and personal exemptions. The bracket tax fills 720 dollars at the $17,000 floor
-# (0.02*3000 + 0.03*2000 + 0.05*12000) plus 5.75% of the excess. The supplied
-# 2026 deduction is the Va. Code 58.1-322.03 standard deduction PolicyEngine
-# applies ($8,750 single / $17,500 married filing jointly) and the supplied
-# exemption is the section 58.1-321 $930-per-filer personal exemption. Virginia
-# neither indexes its brackets nor levies a surtax on this slice, so each
-# liability equals PolicyEngine's va_income_tax_before_non_refundable_credits
-# exactly (zero residual).
-- name: single_15k_low
-  # taxable 15000-8750-930 = 5320. Tax 0.02*3000 + 0.03*2000 + 0.05*(5320-5000) = 60+60+16 = 136.
+# Hand-computed fixtures for the completed-return Virginia taxable-income and
+# filing-requirement boundaries. Section 58.1-320 imposes 2% through $3,000,
+# 3% from $3,000 through $5,000, 5% from $5,000 through $17,000, and 5.75%
+# above $17,000. The first three brackets therefore contribute $720 at the
+# $17,000 top-bracket threshold.
+- name: nonfiler_returns_zero
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 15000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 100000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: false
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '5320'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '136'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '136'
-- name: single_30k
-  # taxable 30000-8750-930 = 20320. Tax 720 + 0.0575*(20320-17000) = 720 + 190.9 = 910.9.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5492.5'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '0'
+
+- name: zero_taxable_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 30000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '20320'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '910.9'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '910.9'
-- name: single_60k
-  # taxable 50320. Tax 720 + 0.0575*(50320-17000) = 720 + 1915.9 = 2635.9.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '0'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '0'
+
+- name: first_bracket
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 60000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 1000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '50320'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '2635.9'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '2635.9'
-- name: single_150k
-  # taxable 140320. Tax 720 + 0.0575*(140320-17000) = 720 + 7090.9 = 7810.9.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '20'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '20'
+
+- name: first_bracket_boundary
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 150000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 8750
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 930
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 3000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '140320'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '7810.9'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '7810.9'
-- name: married_60k
-  # taxable 60000-17500-1860 = 40640. Tax 720 + 0.0575*(40640-17000) = 720 + 1359.3 = 2079.3.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '60'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '60'
+
+- name: second_bracket_boundary
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 60000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 5000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '40640'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '2079.3'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '2079.3'
-- name: married_120k
-  # taxable 120000-17500-1860 = 100640. Tax 720 + 0.0575*(100640-17000) = 720 + 4809.3 = 5529.3.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '120'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '120'
+
+- name: third_bracket
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 120000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 10000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '100640'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5529.3'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '5529.3'
-- name: married_300k
-  # taxable 300000-17500-1860 = 280640. Tax 720 + 0.0575*(280640-17000) = 720 + 15159.3 = 15879.3.
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '370'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '370'
+
+- name: top_bracket_boundary
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_adjusted_gross_income: 300000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_deductions: 17500
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_exemptions: 1860
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_1: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_2: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_3: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_floor_4: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_1: 0.02
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_2: 0.03
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_3: 0.05
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_supplied_bracket_rate_4: 0.0575
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 17000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_taxable_income: '280640'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '15879.3'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '15879.3'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '720'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '720'
+
+- name: top_bracket
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 20000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '892.5'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '892.5'
+
+- name: high_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 100000
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5492.5'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '5492.5'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,7 +3,9 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us-va/statute/58.1/58.1-320
+    corpus_citation_paths:
+      - us-va/statute/58.1/58.1-320
+      - us-va/statute/58.1/58.1-321
   summary: |-
     Composed Virginia individual income-tax pipeline for tax year 2026. It
     accepts two TaxUnit-level completed-return boundaries: Virginia taxable
@@ -99,7 +101,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: Va. Code 58.1-320 tax for a completed return within the supplied filing-requirement boundary, before credits
+    source: Va. Code 58.1-320 tax, subject to the Va. Code 58.1-321 no-tax and no-return threshold, before credits
     metadata:
       proof:
         atoms:
@@ -108,6 +110,11 @@ rules:
             source:
               corpus_citation_path: us-va/statute/58.1/58.1-320
               excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-va/statute/58.1/58.1-321
+              excerpt: "No tax levied pursuant to § 58.1-320 is imposed, nor any return required to be filed"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,88 +3,83 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-va/statute/58.1/58.1-320
-      - us-va/statute/58.1/58.1-322.03
-      - us-va/statute/58.1/58.1-321
-    upstream_source_check:
-      status: composed_from_supplied_current_authority
-      checked_paths:
-        - us-va/statute/58.1/58.1-320
-        - us-va/statute/58.1/58.1-322.03
-        - us-va/statute/58.1/58.1-321
-      rationale: |-
-        This pipeline computes the Va. Code section 58.1-320 progressive bracket
-        tax on Virginia taxable income for the ordinary resident wage-earner
-        slice at the 2026 tax year. Section 58.1-320 imposes 2 per cent on income
-        not over $3,000, 3 per cent on the next $2,000 to $5,000, 5 per cent from
-        $5,000 to $17,000, and 5.75 per cent above $17,000; these bracket floors
-        and rates are statutory fixed amounts (unchanged since 1990 and not
-        indexed), carried by the encoded us-va/statutes/58.1/58/1-320 module. This
-        pipeline supplies those four floors and rates as declared caller-supplied
-        current-authority inputs so the marginal application runs end to end
-        without importing the encoded bracket rules. Virginia taxable income is
-        Virginia adjusted gross income less the section 58.1-322.03 deduction and
-        the section 58.1-321 personal exemptions; the operative 2026 standard
-        deduction ($8,750 single / $17,500 married filing jointly, Va. Code
-        58.1-322.03(1) as amended) and the $930 per-exemption personal exemption
-        (section 58.1-322.03(2)/58.1-321) are supplied as declared inputs rather
-        than derived, because those amounts sit in filing-status and dependency
-        mechanics the flat slice does not carry. The pipeline adds no numeric
-        literals of its own; it wires the progressive-tax mechanics only.
+    corpus_citation_path: us-va/statute/58.1/58.1-320
   summary: |-
-    Composed Virginia individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Virginia adjusted gross income into the section 58.1-320 progressive bracket
-    tax, so an end-to-end comparison against PolicyEngine
-    (va_income_tax_before_non_refundable_credits) and TAXSIM (siitax) does not
-    require the caller to supply the section 58.1-320 bracket-application stage
-    boundaries. It wires: Virginia taxable income (AGI less the supplied
-    deduction and personal exemptions); the progressive tax as the marginal sum
-    across the four brackets (2, 3, 5, and 5.75 per cent at the $3,000 / $5,000 /
-    $17,000 floors); and the liability as that bracket tax. Because Virginia
-    neither indexes its brackets nor levies a surtax on this slice, the composed
-    liability equals PolicyEngine's before-non-refundable-credits value exactly.
-    It deliberately excludes the section 58.1-339.8 earned income tax credit and
-    every other section 58.1-332 through 58.1-339.12 credit (all non-refundable
-    or refundable and excluded from this before-credits core), the age deduction
-    and the section 58.1-322.03 child-and-dependent-care deduction (supplied as
-    part of the caller's deduction input or zero for this slice), and itemized
-    deductions. Virginia AGI, filing status, the deduction, the personal
-    exemptions, and the bracket floors and rates are supplied inputs; the
-    brackets are statutory fixed amounts, so this 2026 pipeline is compared
-    against PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with
-    the standard-deduction vintage dispositioned.
+    Composed Virginia individual income-tax pipeline for tax year 2026. It
+    accepts two TaxUnit-level completed-return boundaries: Virginia taxable
+    income and whether the return is within the Virginia filing requirement.
+    For an applicable return, it computes the section 58.1-320 marginal
+    schedule using the bracket bounds and rates imported from the encoded
+    statute module; otherwise it returns zero. The boundaries already reflect
+    the upstream federal and Virginia income, deduction, exemption, residency,
+    and filing-status mechanics, so this module makes no independent claim
+    about that chain. It deliberately targets tax before nonrefundable credits
+    and excludes every credit and payment. Both rules are bounded to 2026 so
+    adjacent years fail closed. This narrow boundary is suitable for comparison
+    with PolicyEngine's va_taxable_income and va_must_file feeding
+    va_income_tax_before_non_refundable_credits across full-year resident tax
+    units in the certified Populace.
+imports:
+  - us-va:statutes/58.1/58/1-320#first_bracket_upper_income
+  - us-va:statutes/58.1/58/1-320#first_bracket_rate
+  - us-va:statutes/58.1/58/1-320#second_bracket_upper_income
+  - us-va:statutes/58.1/58/1-320#second_bracket_rate
+  - us-va:statutes/58.1/58/1-320#third_bracket_upper_income
+  - us-va:statutes/58.1/58/1-320#third_bracket_rate
+  - us-va:statutes/58.1/58/1-320#top_bracket_rate
 rules:
-  - name: va_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Va. Code 58.1-322, Virginia taxable income after the supplied deduction and personal exemptions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-va/statute/58.1/58.1-322.03
-              excerpt: "the Virginia standard deduction"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, va_pit_pilot_adjusted_gross_income - va_pit_pilot_supplied_deductions - va_pit_pilot_supplied_exemptions)
   - name: va_pit_pilot_bracket_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Va. Code 58.1-320, progressive tax as the marginal sum across the supplied bracket floors and rates
+    source: Va. Code 58.1-320, marginal tax on supplied completed-return Virginia taxable income
     metadata:
       proof:
         atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#first_bracket_upper_income
+              output: first_bracket_upper_income
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#first_bracket_rate
+              output: first_bracket_rate
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#second_bracket_upper_income
+              output: second_bracket_upper_income
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#second_bracket_rate
+              output: second_bracket_rate
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#third_bracket_upper_income
+              output: third_bracket_upper_income
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#third_bracket_rate
+              output: third_bracket_rate
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-va:statutes/58.1/58/1-320#top_bracket_rate
+              output: top_bracket_rate
+              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
           - path: versions[0].formula
             kind: formula
             source:
@@ -92,18 +87,19 @@ rules:
               excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual as follows"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_2) - va_pit_pilot_supplied_bracket_floor_1) * va_pit_pilot_supplied_bracket_rate_1
-          + max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_3) - va_pit_pilot_supplied_bracket_floor_2) * va_pit_pilot_supplied_bracket_rate_2
-          + max(0, min(va_pit_pilot_taxable_income, va_pit_pilot_supplied_bracket_floor_4) - va_pit_pilot_supplied_bracket_floor_3) * va_pit_pilot_supplied_bracket_rate_3
-          + max(0, va_pit_pilot_taxable_income - va_pit_pilot_supplied_bracket_floor_4) * va_pit_pilot_supplied_bracket_rate_4
+          first_bracket_rate * min(va_pit_pilot_state_taxable_income, first_bracket_upper_income)
+          + second_bracket_rate * max(0, min(va_pit_pilot_state_taxable_income, second_bracket_upper_income) - first_bracket_upper_income)
+          + third_bracket_rate * max(0, min(va_pit_pilot_state_taxable_income, third_bracket_upper_income) - second_bracket_upper_income)
+          + top_bracket_rate * max(0, va_pit_pilot_state_taxable_income - third_bracket_upper_income)
   - name: va_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Va. Code 58.1-320 bracket tax, before the section 58.1-332 through 58.1-339.12 credits, for the wage-earner slice
+    source: Va. Code 58.1-320 tax for a completed return within the supplied filing-requirement boundary, before credits
     metadata:
       proof:
         atoms:
@@ -111,8 +107,21 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-va/statute/58.1/58.1-320
-              excerpt: "A tax is hereby annually imposed on the Virginia taxable income"
+              excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          va_pit_pilot_bracket_tax
+          if va_pit_pilot_must_file: va_pit_pilot_bracket_tax else: 0
+inputs:
+  - name: va_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Nonnegative completed-return Virginia taxable income supplied by the caller as an upstream oracle boundary.
+  - name: va_pit_pilot_must_file
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Whether the tax unit is within Virginia's filing requirement, supplied by the caller as an upstream applicability boundary.


### PR DESCRIPTION
## Summary

- replace the supplied-schedule Virginia pilot with the exact completed-return va_taxable_income and va_must_file boundaries
- import the section 58.1-320 bracket bounds and rates and bound both outputs to tax year 2026
- cite section 58.1-321 for the no-tax/no-return applicability branch
- refresh fixtures, signed apply manifest, reverse index, validation-gap ledger, and obsolete pending output

## Certified Populace evidence

The exact compiled pipeline was run over every positive-weight routed Virginia tax unit in the pinned certified Populace artifact (revision populace-us-2024-f0af251-703bd81a565c-20260620T201958Z, SHA-256 prefix 16be6338f9d0):

- 1,710 tax units
- weighted tax units: 4,622,741.54473568
- max absolute difference: $0.8599999994
- max relative difference: 5.7065e-8
- weighted mean absolute difference: $0.0000936737
- differences above $1: 0
- differences outside abs $0.01 OR rel 1e-7: 0

Target: PolicyEngine va_income_tax_before_non_refundable_credits. Upstream projections: va_taxable_income and va_must_file. No target-derived or residual-alignment input is used.

## Checks

- axiom-encode validate --skip-reviewers: pass
- proof-validate --require-money-atoms: pass (10 atoms)
- companion fixtures: 9 pass
- adjacent years 2025 and 2027: fail closed
- oracle pending ledger: 1,584 declared, 0 stale, 0 problems
- reverse index: 3,941 provisions, 4,676 edges, 4,432 modules, clean regeneration
- signed generated-file guard: pass
- git diff --check: pass

## Review cycle

Independent review of the initial exact head found one medium source-fidelity issue: the filing gate cited only section 58.1-320. The branch was fixed to cite section 58.1-321 and add the exact no-tax/no-return condition proof, then refreshed onto current main and re-signed. Repeat independent review of exact head c8dd7cac2908b2fb5d7b14c320fb188097942d11 is CLEAN with no actionable findings.