### PR TITLE
Advance validation corpus pin for Arizona PIT

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "5b9e638b71f15e5f0c4d2abab53030c73fb50e38"
+axiom_corpus_ref = "abeab6a9f4ec432eb8fb7bb131f561cb3bcf6181"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- advances only `.axiom/toolchain.toml`'s `axiom_corpus_ref`
- moves from merged Kansas corpus `5b9e638b...` to its descendant Arizona-source merge `abeab6a9...`
- exposes the official 2026 Arizona 140ES citation required by draft Arizona PIT PR #967
- deliberately keeps this toolchain change separate from Arizona's waiver retirement and RuleSpec changes, as required by the repository guard

## Evidence

- old corpus pin is an ancestor of the new pin
- new pin contains `us-az/form/individual-income-tax/2026/140es-booklet/document-1`
- both Arizona 2026 rate and liability modules validate against this exact corpus commit
- `git diff --check` and worktree are clean

## Review cycle

Independent exact-commit review is in progress. This PR remains draft until review has no actionable findings and exact-head CI is fully green.
