### PR TITLE
Encode Oklahoma 2026 individual income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ok/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ok/policies/income_tax/pilot_liability_pipeline.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "e4508f456c5f70e5aef4b0ab4004061461c365d4aaf236f5d1e93b65cd26cc14"
+      "sha256": "0c6e24a2868d6d200020223fd27cccc0e45cd6bb36ef017c0201bda33d889ef9"
     },
     {
       "path": "us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "3556a34142fe3525aca3cb06ff254300549ec8c9dd82fc34782b64e175ab8c25"
+      "sha256": "0eb5ff34a3087e3bd0121ce161e5065bc8eccf75491830cc4b4e5f9ea5576cea"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ok:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T02:11:55.632490+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpyefc3hmb/sign-applied-files/us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpyefc3hmb",
-  "generated_output_sha256": "3556a34142fe3525aca3cb06ff254300549ec8c9dd82fc34782b64e175ab8c25",
+  "generated_at": "2026-07-22T02:30:04.741948+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbsysc8ch/sign-applied-files/us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbsysc8ch",
+  "generated_output_sha256": "0eb5ff34a3087e3bd0121ce161e5065bc8eccf75491830cc4b4e5f9ea5576cea",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,78 +34,96 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "773ec774b6d0be3252e87b75e1df695d5617899e9363a81f0e6086065bd4d4e0"
+    "value": "fb49820f8d1e6ab58f6aa527d71c1d981f1ddd0d3c0fdefe7f95bd81d138df3f"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:45:46.881964+00:00",
+    "generated_at": "2026-07-22T02:29:06.807065+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "4a810e1965b28bc99904b954098d71dd927e4bec8ea3b36a62404d1b5871ffe8",
-    "prior_signature": "67a2d65fcb2065b5acc3c199aec047af8d4de4f42f8db870ed3df5af15a17d03",
+    "manifest_sha256": "1f7af2410d45be479e2407d32014d516cc32cf87ba2fddbdf489972688767c3b",
+    "prior_signature": "0ef97682786135a7eab4f3bbbff6403a7b5ace94fdb800541e7c3569bdc37371",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-21T15:44:47.911266+00:00",
+      "generated_at": "2026-07-22T02:11:55.632490+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "3b149725775f94da69236f2eae5bf5fdc445825ed1e8aec61da3779319f41e48",
-      "prior_signature": "d1631c49a1a40be5f6c8af11f142c58496c47188749ed4f077a7ea300fb03471",
+      "manifest_sha256": "d66e33977db821d26f599737389738adf50d105bce8b3c514eee0eea46cb38c4",
+      "prior_signature": "773ec774b6d0be3252e87b75e1df695d5617899e9363a81f0e6086065bd4d4e0",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:48:15.203574+00:00",
+        "generated_at": "2026-07-21T15:45:46.881964+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "1bb0acf67ec39a2bb6f93db02f9555527646dc75c4571d7afb98e45ada11dd2b",
-        "prior_signature": "298bced8e72bef9cefe1e7d3490da3da6439b721803dc4f498f4bec6a6909885",
+        "manifest_sha256": "4a810e1965b28bc99904b954098d71dd927e4bec8ea3b36a62404d1b5871ffe8",
+        "prior_signature": "67a2d65fcb2065b5acc3c199aec047af8d4de4f42f8db870ed3df5af15a17d03",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:22:02.270138+00:00",
+          "generated_at": "2026-07-21T15:44:47.911266+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "625cbc167f17fcd343c48143ff584a0c526e294ca0e8103906b5e57a798febd8",
-          "prior_signature": "85dc34c353548fa3e01b41251884a0860d31f0f09b8b70af6cbdc3e680a36f0a",
+          "manifest_sha256": "3b149725775f94da69236f2eae5bf5fdc445825ed1e8aec61da3779319f41e48",
+          "prior_signature": "d1631c49a1a40be5f6c8af11f142c58496c47188749ed4f077a7ea300fb03471",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T15:09:31.553039+00:00",
+            "generated_at": "2026-07-16T15:48:15.203574+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "f584a64f52616513a9f54d72ab3f4ce876385bd48bb0e4ca779c75f844e0ff6a",
-            "prior_signature": "0f39379c3781cb3bf0b9f391c9013011d692aa47118e40779cb329b40d7b6486",
+            "manifest_sha256": "1bb0acf67ec39a2bb6f93db02f9555527646dc75c4571d7afb98e45ada11dd2b",
+            "prior_signature": "298bced8e72bef9cefe1e7d3490da3da6439b721803dc4f498f4bec6a6909885",
             "run_id": null,
             "supersedes": {
               "backend": "manual",
-              "generated_at": "2026-07-16T14:52:20.239638+00:00",
+              "generated_at": "2026-07-16T15:22:02.270138+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "87ad67f555aebc450baa83b6017c912072768e5491b9aafcda22ad65fc4c2989",
-              "prior_signature": "5ecc323104afe65d7f9a3345245a213bad6e587617051a53eb00ebe31c79758f",
+              "manifest_sha256": "625cbc167f17fcd343c48143ff584a0c526e294ca0e8103906b5e57a798febd8",
+              "prior_signature": "85dc34c353548fa3e01b41251884a0860d31f0f09b8b70af6cbdc3e680a36f0a",
               "run_id": null,
               "supersedes": {
                 "backend": "manual",
-                "generated_at": "2026-07-16T14:39:34.876106+00:00",
+                "generated_at": "2026-07-16T15:09:31.553039+00:00",
                 "generation_prompt_sha256": null,
-                "manifest_sha256": "1b5351dddf63fee446ffa8c4692db9e5b2c9f2ed03a9f7d3ebbdea5389d4f7fe",
-                "prior_signature": "0403a3e855e43e2b79626da1280816d38e9f9928956f4b23c28301118dfacdad",
+                "manifest_sha256": "f584a64f52616513a9f54d72ab3f4ce876385bd48bb0e4ca779c75f844e0ff6a",
+                "prior_signature": "0f39379c3781cb3bf0b9f391c9013011d692aa47118e40779cb329b40d7b6486",
                 "run_id": null,
                 "supersedes": {
                   "backend": "manual",
-                  "generated_at": "2026-07-16T14:29:10.637770+00:00",
+                  "generated_at": "2026-07-16T14:52:20.239638+00:00",
                   "generation_prompt_sha256": null,
-                  "manifest_sha256": "d86d4da44357e7ad339a52867b8308a9ffd3119ed7a62f111997992570d23dc1",
-                  "prior_signature": "b0a3c2fde998fb20b115d19e636b80ce74ecd79a83fb201e75ab7cfb66eb15a9",
+                  "manifest_sha256": "87ad67f555aebc450baa83b6017c912072768e5491b9aafcda22ad65fc4c2989",
+                  "prior_signature": "5ecc323104afe65d7f9a3345245a213bad6e587617051a53eb00ebe31c79758f",
                   "run_id": null,
                   "supersedes": {
                     "backend": "manual",
-                    "generated_at": "2026-07-15T14:31:12.054363+00:00",
+                    "generated_at": "2026-07-16T14:39:34.876106+00:00",
                     "generation_prompt_sha256": null,
-                    "manifest_sha256": "8237be0a59b1f2c3af16dd6c1b5e8614703337c2460304cf689ef1cd77431706",
-                    "prior_signature": "428d9c44aadba11e4d72359aeab9bcc9fc3d1076aeb2cbe78e6020df887f3bd3",
+                    "manifest_sha256": "1b5351dddf63fee446ffa8c4692db9e5b2c9f2ed03a9f7d3ebbdea5389d4f7fe",
+                    "prior_signature": "0403a3e855e43e2b79626da1280816d38e9f9928956f4b23c28301118dfacdad",
                     "run_id": null,
                     "supersedes": {
                       "backend": "manual",
-                      "generated_at": "2026-07-15T14:18:32.185188+00:00",
+                      "generated_at": "2026-07-16T14:29:10.637770+00:00",
                       "generation_prompt_sha256": null,
-                      "manifest_sha256": "1f4768b744afc64998fb0336ccd1b283b4225706c95536540b9570b9cd4c462a",
-                      "prior_signature": "d326098a4e1e31187b357ff57b16a47a55e205e3c4594e6486a6afda15e705db",
+                      "manifest_sha256": "d86d4da44357e7ad339a52867b8308a9ffd3119ed7a62f111997992570d23dc1",
+                      "prior_signature": "b0a3c2fde998fb20b115d19e636b80ce74ecd79a83fb201e75ab7cfb66eb15a9",
                       "run_id": null,
+                      "supersedes": {
+                        "backend": "manual",
+                        "generated_at": "2026-07-15T14:31:12.054363+00:00",
+                        "generation_prompt_sha256": null,
+                        "manifest_sha256": "8237be0a59b1f2c3af16dd6c1b5e8614703337c2460304cf689ef1cd77431706",
+                        "prior_signature": "428d9c44aadba11e4d72359aeab9bcc9fc3d1076aeb2cbe78e6020df887f3bd3",
+                        "run_id": null,
+                        "supersedes": {
+                          "backend": "manual",
+                          "generated_at": "2026-07-15T14:18:32.185188+00:00",
+                          "generation_prompt_sha256": null,
+                          "manifest_sha256": "1f4768b744afc64998fb0336ccd1b283b4225706c95536540b9570b9cd4c462a",
+                          "prior_signature": "d326098a4e1e31187b357ff57b16a47a55e205e3c4594e6486a6afda15e705db",
+                          "run_id": null,
+                          "tool": "axiom-encode sign-applied-files"
+                        },
+                        "tool": "axiom-encode sign-applied-files"
+                      },
                       "tool": "axiom-encode sign-applied-files"
                     },
                     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ok/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ok/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "ce3a6a1c9cf599d2e964de60686c62d2e8b7490ec3bb11794e4175804faedbf8"
+      "sha256": "e4508f456c5f70e5aef4b0ab4004061461c365d4aaf236f5d1e93b65cd26cc14"
     },
     {
       "path": "us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "55399b30512866a3f5235935906d439d09f303fcfe8fc2dfc209b4918243d6a0"
+      "sha256": "3556a34142fe3525aca3cb06ff254300549ec8c9dd82fc34782b64e175ab8c25"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-ok:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.881964+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "55399b30512866a3f5235935906d439d09f303fcfe8fc2dfc209b4918243d6a0",
+  "generated_at": "2026-07-22T02:11:55.632490+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpyefc3hmb/sign-applied-files/us-ok/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpyefc3hmb",
+  "generated_output_sha256": "3556a34142fe3525aca3cb06ff254300549ec8c9dd82fc34782b64e175ab8c25",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,71 +34,80 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "67a2d65fcb2065b5acc3c199aec047af8d4de4f42f8db870ed3df5af15a17d03"
+    "value": "773ec774b6d0be3252e87b75e1df695d5617899e9363a81f0e6086065bd4d4e0"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.911266+00:00",
+    "generated_at": "2026-07-21T15:45:46.881964+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "3b149725775f94da69236f2eae5bf5fdc445825ed1e8aec61da3779319f41e48",
-    "prior_signature": "d1631c49a1a40be5f6c8af11f142c58496c47188749ed4f077a7ea300fb03471",
+    "manifest_sha256": "4a810e1965b28bc99904b954098d71dd927e4bec8ea3b36a62404d1b5871ffe8",
+    "prior_signature": "67a2d65fcb2065b5acc3c199aec047af8d4de4f42f8db870ed3df5af15a17d03",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.203574+00:00",
+      "generated_at": "2026-07-21T15:44:47.911266+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "1bb0acf67ec39a2bb6f93db02f9555527646dc75c4571d7afb98e45ada11dd2b",
-      "prior_signature": "298bced8e72bef9cefe1e7d3490da3da6439b721803dc4f498f4bec6a6909885",
+      "manifest_sha256": "3b149725775f94da69236f2eae5bf5fdc445825ed1e8aec61da3779319f41e48",
+      "prior_signature": "d1631c49a1a40be5f6c8af11f142c58496c47188749ed4f077a7ea300fb03471",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.270138+00:00",
+        "generated_at": "2026-07-16T15:48:15.203574+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "625cbc167f17fcd343c48143ff584a0c526e294ca0e8103906b5e57a798febd8",
-        "prior_signature": "85dc34c353548fa3e01b41251884a0860d31f0f09b8b70af6cbdc3e680a36f0a",
+        "manifest_sha256": "1bb0acf67ec39a2bb6f93db02f9555527646dc75c4571d7afb98e45ada11dd2b",
+        "prior_signature": "298bced8e72bef9cefe1e7d3490da3da6439b721803dc4f498f4bec6a6909885",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:31.553039+00:00",
+          "generated_at": "2026-07-16T15:22:02.270138+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "f584a64f52616513a9f54d72ab3f4ce876385bd48bb0e4ca779c75f844e0ff6a",
-          "prior_signature": "0f39379c3781cb3bf0b9f391c9013011d692aa47118e40779cb329b40d7b6486",
+          "manifest_sha256": "625cbc167f17fcd343c48143ff584a0c526e294ca0e8103906b5e57a798febd8",
+          "prior_signature": "85dc34c353548fa3e01b41251884a0860d31f0f09b8b70af6cbdc3e680a36f0a",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T14:52:20.239638+00:00",
+            "generated_at": "2026-07-16T15:09:31.553039+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "87ad67f555aebc450baa83b6017c912072768e5491b9aafcda22ad65fc4c2989",
-            "prior_signature": "5ecc323104afe65d7f9a3345245a213bad6e587617051a53eb00ebe31c79758f",
+            "manifest_sha256": "f584a64f52616513a9f54d72ab3f4ce876385bd48bb0e4ca779c75f844e0ff6a",
+            "prior_signature": "0f39379c3781cb3bf0b9f391c9013011d692aa47118e40779cb329b40d7b6486",
             "run_id": null,
             "supersedes": {
               "backend": "manual",
-              "generated_at": "2026-07-16T14:39:34.876106+00:00",
+              "generated_at": "2026-07-16T14:52:20.239638+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "1b5351dddf63fee446ffa8c4692db9e5b2c9f2ed03a9f7d3ebbdea5389d4f7fe",
-              "prior_signature": "0403a3e855e43e2b79626da1280816d38e9f9928956f4b23c28301118dfacdad",
+              "manifest_sha256": "87ad67f555aebc450baa83b6017c912072768e5491b9aafcda22ad65fc4c2989",
+              "prior_signature": "5ecc323104afe65d7f9a3345245a213bad6e587617051a53eb00ebe31c79758f",
               "run_id": null,
               "supersedes": {
                 "backend": "manual",
-                "generated_at": "2026-07-16T14:29:10.637770+00:00",
+                "generated_at": "2026-07-16T14:39:34.876106+00:00",
                 "generation_prompt_sha256": null,
-                "manifest_sha256": "d86d4da44357e7ad339a52867b8308a9ffd3119ed7a62f111997992570d23dc1",
-                "prior_signature": "b0a3c2fde998fb20b115d19e636b80ce74ecd79a83fb201e75ab7cfb66eb15a9",
+                "manifest_sha256": "1b5351dddf63fee446ffa8c4692db9e5b2c9f2ed03a9f7d3ebbdea5389d4f7fe",
+                "prior_signature": "0403a3e855e43e2b79626da1280816d38e9f9928956f4b23c28301118dfacdad",
                 "run_id": null,
                 "supersedes": {
                   "backend": "manual",
-                  "generated_at": "2026-07-15T14:31:12.054363+00:00",
+                  "generated_at": "2026-07-16T14:29:10.637770+00:00",
                   "generation_prompt_sha256": null,
-                  "manifest_sha256": "8237be0a59b1f2c3af16dd6c1b5e8614703337c2460304cf689ef1cd77431706",
-                  "prior_signature": "428d9c44aadba11e4d72359aeab9bcc9fc3d1076aeb2cbe78e6020df887f3bd3",
+                  "manifest_sha256": "d86d4da44357e7ad339a52867b8308a9ffd3119ed7a62f111997992570d23dc1",
+                  "prior_signature": "b0a3c2fde998fb20b115d19e636b80ce74ecd79a83fb201e75ab7cfb66eb15a9",
                   "run_id": null,
                   "supersedes": {
                     "backend": "manual",
-                    "generated_at": "2026-07-15T14:18:32.185188+00:00",
+                    "generated_at": "2026-07-15T14:31:12.054363+00:00",
                     "generation_prompt_sha256": null,
-                    "manifest_sha256": "1f4768b744afc64998fb0336ccd1b283b4225706c95536540b9570b9cd4c462a",
-                    "prior_signature": "d326098a4e1e31187b357ff57b16a47a55e205e3c4594e6486a6afda15e705db",
+                    "manifest_sha256": "8237be0a59b1f2c3af16dd6c1b5e8614703337c2460304cf689ef1cd77431706",
+                    "prior_signature": "428d9c44aadba11e4d72359aeab9bcc9fc3d1076aeb2cbe78e6020df887f3bd3",
                     "run_id": null,
+                    "supersedes": {
+                      "backend": "manual",
+                      "generated_at": "2026-07-15T14:18:32.185188+00:00",
+                      "generation_prompt_sha256": null,
+                      "manifest_sha256": "1f4768b744afc64998fb0336ccd1b283b4225706c95536540b9570b9cd4c462a",
+                      "prior_signature": "d326098a4e1e31187b357ff57b16a47a55e205e3c4594e6486a6afda15e705db",
+                      "run_id": null,
+                      "tool": "axiom-encode sign-applied-files"
+                    },
                     "tool": "axiom-encode sign-applied-files"
                   },
                   "tool": "axiom-encode sign-applied-files"

--- a/us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -2,16 +2,6 @@
 # section 2355(D), as enacted by HB 2764. The wide schedule applies to joint,
 # surviving-spouse, and head-of-household filers; all other statuses use the
 # single/separate schedule.
-- name: negative other-schedule taxable income is floored
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: -100
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
-  output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '0'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0'
-
 - name: other schedule at zero-bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:

--- a/us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ok/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,70 +1,113 @@
-# PolicyEngine 4.18.9 supplies Oklahoma taxable income and the active 2026
-# section 2355(D) bracket. The displayed expected amounts are hand arithmetic.
-- name: single_30000
-  # 109.25 + 4.5%*(22,650-7,200) = 804.50.
+# Independently hand-computed from the tax-year-2026 schedules in 68 O.S.
+# section 2355(D), as enacted by HB 2764. The wide schedule applies to joint,
+# surviving-spouse, and head-of-household filers; all other statuses use the
+# single/separate schedule.
+- name: negative other-schedule taxable income is floored
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 22650
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 109.25
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 7200
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: -100
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '22650'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '804.5'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '804.5'
-- name: single_60000
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '0'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0'
+
+- name: other schedule at zero-bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 52650
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 109.25
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 7200
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 3750
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '52650'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '2154.5'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '2154.5'
-- name: single_150000
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '3750'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0'
+
+- name: other schedule one dollar into second bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 142650
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 109.25
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 7200
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 3751
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '142650'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '6204.5'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '6204.5'
-- name: married_60000
-  # 218.50 + 4.5%*(45,300-14,400) = 1,609.00.
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '3751'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0.025'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0.025'
+
+- name: other schedule at second-bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 45300
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 218.5
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 14400
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 4900
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '45300'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '1609'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '1609'
-- name: married_120000
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '4900'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '28.75'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '28.75'
+
+- name: other schedule at third-bracket ceiling
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 105300
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 218.5
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 14400
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 7200
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '105300'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '4309'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '4309'
-- name: married_300000
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '7200'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '109.25'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '109.25'
+
+- name: other schedule in top bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_taxable_income: 285300
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_base: 218.5
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_bracket_floor: 14400
-    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_supplied_marginal_rate: 0.045
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 100000
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: false
   output:
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '285300'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '12409'
-    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '12409'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '100000'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '4285.25'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '4285.25'
+
+- name: wide schedule at zero-bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 7500
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: true
+  output:
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '7500'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0'
+
+- name: wide schedule one dollar into second bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 7501
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: true
+  output:
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '7501'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '0.025'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '0.025'
+
+- name: wide schedule at second-bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 9800
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: true
+  output:
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '9800'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '57.5'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '57.5'
+
+- name: wide schedule at third-bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 14400
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: true
+  output:
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '14400'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '218.5'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '218.5'
+
+- name: wide schedule in top bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_state_taxable_income: 100000
+    us-ok:policies/income_tax/pilot_liability_pipeline#input.ok_pit_pilot_filing_status_uses_wide_schedule: true
+  output:
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_taxable_income: '100000'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_schedule_tax: '4070.5'
+    us-ok:policies/income_tax/pilot_liability_pipeline#ok_pit_pilot_income_tax_liability: '4070.5'

--- a/us-ok/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ok/policies/income_tax/pilot_liability_pipeline.yaml
@@ -22,7 +22,8 @@ module:
         closed outside that year.
   summary: |-
     Composed Oklahoma individual-income-tax schedule for tax year 2026 before
-    credits. It accepts completed-return Oklahoma taxable income plus the one
+    credits. It accepts nonnegative completed-return Oklahoma taxable income
+    plus the one
     filing-status branch required by section 2355(D): single/separate versus
     joint/surviving-spouse/head-of-household. It makes no independent claim
     about upstream adjusted gross income, deductions, exemptions, nonresident
@@ -34,7 +35,9 @@ module:
     error $0.460000001, weighted MAE $0.0000483071, zero units above $1, and
     zero units outside $0.01 or 1e-7 relative tolerance. Completed-return
     Oklahoma taxable income is therefore sufficient when paired with the
-    statutory filing-status schedule branch.
+    statutory filing-status schedule branch. The defensive zero floor is an
+    identity over that declared nonnegative caller boundary, not a separate
+    legal parameter or transformation.
 rules:
   - name: ok_pit_pilot_second_bracket_rate
     kind: parameter
@@ -219,7 +222,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: 68 O.S. section 2355(D), supplied completed-return Oklahoma taxable income floored at zero
+    source: 68 O.S. section 2355(D), supplied nonnegative completed-return Oklahoma taxable income defensively normalized at zero
     metadata:
       proof:
         atoms:
@@ -289,14 +292,14 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
-        formula: max(0, ok_pit_pilot_schedule_tax)
+        formula: ok_pit_pilot_schedule_tax
 inputs:
   - name: ok_pit_pilot_state_taxable_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Completed-return Oklahoma taxable income supplied by the caller as an upstream oracle boundary.
+    description: Nonnegative completed-return Oklahoma taxable income supplied by the caller as an upstream oracle boundary.
   - name: ok_pit_pilot_filing_status_uses_wide_schedule
     entity: TaxUnit
     dtype: Boolean

--- a/us-ok/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ok/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,36 +5,221 @@ module:
   source_verification:
     corpus_citation_path: us-ok/statute/68-2355
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-ok/statute/68-2355
       rationale: |-
-        The staged 2026-05-10 primary text of 68 O.S. 2355(D) supplies the four
-        rate bands effective in tax year 2026: zero, 2.5, 3.5, and 4.5 percent,
-        with doubled band widths for joint filers. This candidate accepts
-        Oklahoma taxable income and the applicable bracket base, floor, and rate
-        as declared inputs because this rate section does not prove the upstream
-        deduction and exemption computation. It
-        applies no later subsection (E) reduction,
-        because the supplied 2026 PolicyEngine schedule reflects the subsection
-        (D) rates and no triggering certification is represented in the oracle.
+        Enrolled Oklahoma House Bill 2764 amended 68 O.S. section 2355(D)
+        effective November 1, 2025. It fixes the tax-year-2026 individual
+        schedules at zero, 2.5, 3.5, and 4.5 percent, with doubled band widths
+        for joint, surviving-spouse, and head-of-household filers. Section
+        2355(E) makes a later 0.25-percentage-point reduction effective only on
+        January 1 following a final State Board of Equalization certification;
+        the act directs the first real analysis to the December 2026 and
+        February 2027 meetings. The Oklahoma Tax Commission's official 2025
+        legislative summary independently publishes the same 2026 brackets.
+        This module therefore encodes only the fixed 2026 schedule and fails
+        closed outside that year.
   summary: |-
-    Candidate Oklahoma 2026 individual income-tax liability pipeline for an
-    ordinary full-year resident wage earner. It normalizes supplied Oklahoma
-    taxable income and applies the supplied active 68 O.S. 2355(D) bracket in
-    base-plus-marginal form, before credits. Its exact PolicyEngine 4.18.9 analog
-    is `ok_income_tax_before_credits` on the six-case childless age-40 resident
-    wage grid: single at $30,000/$60,000/$150,000 and one-earner joint at
-    $60,000/$120,000/$300,000. PolicyEngine supplies the taxable-income and
-    schedule inputs; outputs are independently hand-computed.
+    Composed Oklahoma individual-income-tax schedule for tax year 2026 before
+    credits. It accepts completed-return Oklahoma taxable income plus the one
+    filing-status branch required by section 2355(D): single/separate versus
+    joint/surviving-spouse/head-of-household. It makes no independent claim
+    about upstream adjusted gross income, deductions, exemptions, nonresident
+    apportionment, nonresident-alien treatment, tax-table rounding, or credits.
+    PolicyEngine-US 1.752.2 has the same direct dependency graph:
+    ok_taxable_income and filing_status feed ok_income_tax_before_credits. On
+    all 1,292 positive-weight Oklahoma tax units in the certified 2024
+    Populace routed to tax year 2026, this legal schedule had maximum absolute
+    error $0.460000001, weighted MAE $0.0000483071, zero units above $1, and
+    zero units outside $0.01 or 1e-7 relative tolerance. Completed-return
+    Oklahoma taxable income is therefore sufficient when paired with the
+    statutory filing-status schedule branch.
 rules:
+  - name: ok_pit_pilot_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 68 O.S. section 2355(D)(1)(b) and (2)(b), 2026 second-bracket rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "2.5% tax on the next $1,150.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.025'
+
+  - name: ok_pit_pilot_third_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 68 O.S. section 2355(D)(1)(c) and (2)(c), 2026 third-bracket rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "3.5% tax on next $2,300.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.035'
+
+  - name: ok_pit_pilot_top_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 68 O.S. section 2355(D)(1)(d) and (2)(d), 2026 top-bracket rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "4.5% tax on the remainder"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.045'
+
+  - name: ok_pit_pilot_other_zero_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(1)(a), single/separate zero-bracket ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "0% tax on first $3,750.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '3750'
+
+  - name: ok_pit_pilot_other_second_bracket_width
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(1)(b), single/separate second-bracket width
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "2.5% tax on the next $1,150.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1150'
+
+  - name: ok_pit_pilot_other_third_bracket_width
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(1)(c), single/separate third-bracket width
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "3.5% tax on next $2,300.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2300'
+
+  - name: ok_pit_pilot_wide_zero_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(2)(a), joint/HOH/survivor zero-bracket ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "0% tax on first $7,500.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '7500'
+
+  - name: ok_pit_pilot_wide_second_bracket_width
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(2)(b), joint/HOH/survivor second-bracket width
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "2.5% tax on the next $2,300.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2300'
+
+  - name: ok_pit_pilot_wide_third_bracket_width
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D)(2)(c), joint/HOH/survivor third-bracket width
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "3.5% tax on next $4,600.00 or part thereof"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '4600'
+
   - name: ok_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 68 O.S. 2355(D), supplied Oklahoma taxable income
+    source: 68 O.S. section 2355(D), supplied completed-return Oklahoma taxable income floored at zero
     metadata:
       proof:
         atoms:
@@ -45,14 +230,54 @@ rules:
               excerpt: "a tax is hereby imposed upon the Oklahoma taxable income of every resident or nonresident individual"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, ok_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, ok_pit_pilot_state_taxable_income)
+
   - name: ok_pit_pilot_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 68 O.S. 2355(D), supplied active bracket base plus marginal tax
+    source: 68 O.S. section 2355(D), enacted four-band 2026 filing-status schedules
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "Single individuals and married individuals filing separately"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "Married individuals filing jointly and surviving spouse"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ok/statute/68-2355
+              excerpt: "heads of households as defined in the Internal Revenue Code of 1986, as amended"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ok_pit_pilot_filing_status_uses_wide_schedule:
+            ok_pit_pilot_second_bracket_rate * min(max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_wide_zero_bracket_ceiling), ok_pit_pilot_wide_second_bracket_width)
+            + ok_pit_pilot_third_bracket_rate * min(max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_wide_zero_bracket_ceiling - ok_pit_pilot_wide_second_bracket_width), ok_pit_pilot_wide_third_bracket_width)
+            + ok_pit_pilot_top_bracket_rate * max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_wide_zero_bracket_ceiling - ok_pit_pilot_wide_second_bracket_width - ok_pit_pilot_wide_third_bracket_width)
+          else:
+            ok_pit_pilot_second_bracket_rate * min(max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_other_zero_bracket_ceiling), ok_pit_pilot_other_second_bracket_width)
+            + ok_pit_pilot_third_bracket_rate * min(max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_other_zero_bracket_ceiling - ok_pit_pilot_other_second_bracket_width), ok_pit_pilot_other_third_bracket_width)
+            + ok_pit_pilot_top_bracket_rate * max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_other_zero_bracket_ceiling - ok_pit_pilot_other_second_bracket_width - ok_pit_pilot_other_third_bracket_width)
+
+  - name: ok_pit_pilot_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 68 O.S. section 2355(D), individual income tax before credits
     metadata:
       proof:
         atoms:
@@ -63,24 +288,17 @@ rules:
               excerpt: "For tax year 2026 and for subsequent tax years subject to rate reductions as provided by subsection E of this section"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          ok_pit_pilot_supplied_bracket_base
-          + ok_pit_pilot_supplied_marginal_rate * max(0, ok_pit_pilot_taxable_income - ok_pit_pilot_supplied_bracket_floor)
-  - name: ok_pit_pilot_income_tax_liability
-    kind: derived
+        effective_to: '2026-12-31'
+        formula: max(0, ok_pit_pilot_schedule_tax)
+inputs:
+  - name: ok_pit_pilot_state_taxable_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 68 O.S. 2355(D) tax before credits
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ok/statute/68-2355
-              excerpt: "4.5% tax on the remainder"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: ok_pit_pilot_schedule_tax
+    description: Completed-return Oklahoma taxable income supplied by the caller as an upstream oracle boundary.
+  - name: ok_pit_pilot_filing_status_uses_wide_schedule
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True for married-joint, surviving-spouse, or head-of-household filing status; false for single or married-separate.


### PR DESCRIPTION
## Summary

- replaces the supplied-schedule Oklahoma pilot with the enacted 2026 four-band schedules in 68 O.S. section 2355(D)
- accepts completed-return `ok_taxable_income` and the reviewed wide-schedule filing-status Boolean as distinct upstream boundaries
- bounds every rule to 2026 and fails closed in adjacent years

## Certified Populace parity

Full unsampled certified Populace, PE-US 1.752.2 target `ok_income_tax_before_credits`: 1,292 positive-weight Oklahoma tax units; weight 1,997,014.2823715578; max absolute difference $0.4600000009; max relative difference 5.6921e-8; weighted MAE 0.0000483071; zero differences above $1 and zero outside $0.01 absolute OR 1e-7 relative tolerance.

## Review cycle and checks

Initial independent review found an unsupported caller-boundary floor claim. The input is now explicitly nonnegative, the validator-required defensive floor is documented as an identity over that boundary, the unsupported negative fixture was removed, and final liability is a direct schedule alias. Repeat independent review is CLEAN at exact semantic SHA `7bbf90168b128bda5d8e0dcae15b742c03525acd`, with no actionable findings.

After review the branch merged current main through Arizona #967; Oklahoma files and signed manifest remain byte-identical to the reviewed SHA. Focused validation passed; proof validation passed with 14 atoms and 0/6 missing money atoms; 10 fixtures passed; pending ledger 1,588 declared / 0 stale / 0 problems; reverse index 3,942 provisions / 4,676 edges / 4,433 modules; diff and worktree clean.

Draft until fresh exact-head CI is green and current.