### PR TITLE
Encode Alabama 2026 individual income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-al/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-al/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-al/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "e44fea2c0cd3b112e6a94fa181f75367df5d7cebc8206cdf6b88610c4e30eeb4"
+      "sha256": "7501b8953a75f009e8934de66f544b91bf80af1c066ced35372fc0aa4836b1ce"
     },
     {
       "path": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "883da84df072a7b523eb5c2ce5c1d4a720224c00ab00ea8d95f84b9b423a6263"
+      "sha256": "dea63ecf9c151fd5590ff62dc19ce1f98807695c725399be70058b07a41a8494"
     }
   ],
   "axiom_encode_git": {
-    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1195",
-    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1195",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-al:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T02:09:18.252630+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbrdf5e1b/sign-applied-files/us-al/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpbrdf5e1b",
-  "generated_output_sha256": "883da84df072a7b523eb5c2ce5c1d4a720224c00ab00ea8d95f84b9b423a6263",
+  "generated_at": "2026-07-22T02:14:42.873887+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgjtobin5/sign-applied-files/us-al/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgjtobin5",
+  "generated_output_sha256": "dea63ecf9c151fd5590ff62dc19ce1f98807695c725399be70058b07a41a8494",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c9cce6a7c6279a7c683dda4a34ae4112f037cc87c869f1c411dd7dc606953976"
+    "value": "313d3b9238ff2b8455ddbf36e35ff2e650fe0902f4fb47854ec5be2207b877e1"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-09T02:09:18.252630+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "905be300e0f5e857115867555ef29556470eb073336c963ca05990fc4c7b9e2e",
+    "prior_signature": "c9cce6a7c6279a7c683dda4a34ae4112f037cc87c869f1c411dd7dc606953976",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -1032,13 +1032,6 @@
     ],
     "us-al/statute/40-18-15": [
       {
-        "module": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-al/statutes/40-18-15.yaml",
         "via": [
           "module",
@@ -1047,12 +1040,6 @@
       }
     ],
     "us-al/statute/40-18-19": [
-      {
-        "module": "us-al/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      },
       {
         "module": "us-al/statutes/40-18-19.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -5798,12 +5798,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-al/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:8000ea0c123d5555a4178082e78d071ef0e45a0a0f9951df55926eb7d3b1b7fc"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-al/regulations/660-4/1/01/block-1.yaml":
     pending:
       fingerprint: "sha256:a4c62ea708f74f3896bab3962af1abd5b5cbd9a349c2429ecb3157f8c7928355"

--- a/us-al/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-al/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,119 +1,76 @@
-# Fixtures are hand-computed at the 2026 tax year (the expected values are the
-# author's own shown arithmetic from the supplied schedule, which axiom-encode
-# test proves equal the engine output to full decimal precision, not an oracle
-# read-back). Alabama liability = the section 40-18-5 graduated tax on Alabama
-# taxable income (Alabama AGI - the section 40-18-15 deductions and section
-# 40-18-19 exemptions) less the supplied nonrefundable exemption credit (zero for
-# Alabama). The supplied schedule collapses the 2/4-per-cent lower brackets into
-# the cumulative tax at the 3,000-dollar top-bracket floor (6,000 joint) — 110
-# dollars single, 220 dollars joint — expressed as an effective first-bracket
-# rate of 0.0366667 (110 / 3,000), plus the 5-per-cent excess rate above the
-# floor. The supplied personal exemption is the full Alabama subtraction from AGI
-# to taxable income (standard/optional deduction, the 40-18-15(a)(1) federal
-# income tax deduction, and the 40-18-19 personal and dependent exemptions),
-# calibrated to PolicyEngine al_taxable_income. All grid filers are above the
-# 3,000/6,000-dollar top-bracket floor.
-- name: single_30000
-  # taxable 30000-5720 = 24280. Schedule: 0.0366667*3000 + 0.05*(24280-3000)
-  # = 110.0001 + 1064 = 1174.0001. No Alabama exemption credit: liability 1174.0001.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Fixtures are independently hand-computed from Ala. Code § 40-18-5. The two
+# inputs are completed-return Alabama taxable income and the caller's legal
+# classification that the married-joint schedule applies.
+- name: negative nonjoint taxable income is floored
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 30000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 5720
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: -1000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: false
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '24280'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '1174.0001'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '1174.0001'
-- name: single_60000
-  # taxable 48890. Schedule 110.0001 + 0.05*45890 = 2404.5001. Liability 2404.5001.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '0'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '0'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '0'
+- name: nonjoint at first bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 60000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 11110
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 500
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: false
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '48890'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '2404.5001'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '2404.5001'
-- name: single_150000
-  # taxable 112291. Schedule 110.0001 + 0.05*109291 = 5574.5501. Liability 5574.5501.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '10'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '10'
+- name: nonjoint one dollar into second bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 150000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 37709
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 3000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 501
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: false
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '112291'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '5574.5501'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '5574.5501'
-- name: married_60000
-  # Married filing jointly, spouse income 0. taxable 49160. Schedule
-  # 0.0366667*6000 + 0.05*(49160-6000) = 220.0002 + 2158 = 2378.0002.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '10.04'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '10.04'
+- name: nonjoint at second bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 60000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 10840
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 3000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: false
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '49160'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '2378.0002'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '2378.0002'
-- name: married_120000
-  # taxable 97780. Schedule 220.0002 + 0.05*91780 = 4809.0002. Liability 4809.0002.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '110'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '110'
+- name: nonjoint one dollar into third bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 120000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 22220
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 3001
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: false
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '97780'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '4809.0002'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '4809.0002'
-- name: married_300000
-  # taxable 231293. Schedule 220.0002 + 0.05*225293 = 11484.6502. Liability 11484.6502.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '110.05'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '110.05'
+- name: joint at first bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_adjusted_gross_income: 300000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_personal_exemption: 68707
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_no_tax_threshold: 6000
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_first_bracket_rate: 0.0366667
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_excess_rate: 0.05
-    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_supplied_exemption_credit: 0
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 1000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: true
   output:
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_taxable_income: '231293'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '11484.6502'
-    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '11484.6502'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '20'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '20'
+- name: joint one dollar into second bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 1001
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: true
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '20.04'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '20.04'
+- name: joint at second bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 6000
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: true
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '220'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '220'
+- name: joint one dollar into third bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_state_taxable_income: 6001
+    us-al:policies/income_tax/pilot_liability_pipeline#input.al_pit_pilot_joint_schedule_applies: true
+  output:
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_schedule_tax: '220.05'
+    us-al:policies/income_tax/pilot_liability_pipeline#al_pit_pilot_income_tax_liability: '220.05'

--- a/us-al/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-al/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,90 +3,197 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-al/statute/40-18-5
-      - us-al/statute/40-18-15
-      - us-al/statute/40-18-19
+    corpus_citation_path: us-al/statute/40-18-5
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-al/statute/40-18-5
-        - us-al/statute/40-18-15
-        - us-al/statute/40-18-19
       rationale: |-
-        This pipeline computes the Alabama section 40-18-5 individual income-tax
-        liability for the ordinary resident wage-earner slice: the graduated tax
-        on Alabama taxable income (Alabama adjusted gross income less the section
-        40-18-15 deductions and the section 40-18-19 personal and dependent
-        exemptions). The encoded 40-18-5 module carries the statutory schedule —
-        two per cent on the first 500 dollars of taxable income (1,000 for a
-        joint return), four per cent on the next 2,500 dollars (5,000 joint), and
-        five per cent on taxable income over 3,000 dollars (6,000 joint). Every
-        filer on this grid is above the 3,000/6,000-dollar top-bracket floor, so
-        the liability is the cumulative lower-bracket tax at that floor (110
-        dollars single, 220 dollars joint) plus five per cent of the excess.
-        To reach a liability comparable to PolicyEngine al_income_tax to the cent,
-        the amounts this pipeline needs are declared caller-supplied inputs: the
-        top-bracket floor, the effective first-bracket rate that reproduces the
-        cumulative 2/4-per-cent tax at that floor, and the five-per-cent excess
-        rate, plus a single supplied subtraction standing for the section
-        40-18-15 deductions (Alabama uses the optional/standard deduction and,
-        under 40-18-15(a)(1), a deduction for federal income tax paid) together
-        with the section 40-18-19 personal and dependent exemptions. Alabama
-        allows no per-exemption tax credit, so the supplied exemption credit is
-        zero on this grid. The pipeline adds no numeric literals of its own; it
-        wires the graduated-tax mechanics only. The 40-18-15 deduction and
-        40-18-19 exemption amounts are supplied here pending their own executable
-        encodings, mirroring the California pilot's supplied standard deduction
-        and personal exemption credit.
+        Alabama Code section 40-18-5 supplies the complete individual-income-
+        tax schedule: one schedule for single, head-of-family, and separate
+        returns and a wider schedule for married persons filing jointly. This
+        narrow composition accepts completed-return Alabama taxable income and
+        a caller-supplied indicator that the joint schedule applies. The caller
+        boundary preserves filing-status classification and all upstream
+        adjusted-gross-income, deduction, exemption, residency, and allocation
+        decisions. Credits and filing obligations are outside this before-
+        nonrefundable-credit schedule calculation.
   summary: |-
-    Composed Alabama individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Alabama adjusted gross income into the section 40-18-5 graduated tax on
-    Alabama taxable income, so an end-to-end comparison against PolicyEngine
-    (al_income_tax_before_refundable_credits) and TAXSIM (siitax) does not
-    require the caller to supply the 40-18-5 bracket application. It wires:
-    Alabama taxable income (Alabama AGI less the supplied section 40-18-15
-    deductions and section 40-18-19 exemptions); the graduated tax as the
-    supplied first-bracket effective rate on taxable income up to the supplied
-    3,000/6,000-dollar top-bracket floor plus the supplied five-per-cent excess
-    rate above it, which reproduces the statutory "two per cent of the first 500
-    dollars, four per cent of the next 2,500 dollars, and five per cent of the
-    excess over 3,000 dollars" form for filers above the top-bracket floor; and
-    that tax less the supplied nonrefundable exemption credit (zero for Alabama),
-    floored at zero. It deliberately models only the ordinary resident wage
-    earner above the top-bracket floor. Alabama AGI, filing status, the
-    top-bracket floor, the bracket rates, the deduction/exemption subtraction,
-    and the exemption credit are supplied inputs; PolicyEngine is compared at the
-    2026 tax year and TAXSIM at its latest 2024 law year, with the 2024-to-2026
-    deduction/exemption vintage dispositioned rather than absorbed by tolerance.
+    Composed Alabama individual-income-tax schedule for tax year 2026. It
+    accepts one TaxUnit-level completed-return Alabama taxable-income boundary
+    plus a joint-schedule indicator, floors taxable income at zero, and applies
+    Alabama Code section 40-18-5 before nonrefundable credits. The closest
+    PolicyEngine-US 1.752.2 target is
+    `al_income_tax_before_non_refundable_credits`, whose formula applies the
+    same statutory brackets to `al_taxable_income` based on filing status.
+    PolicyEngine maps its federal surviving-spouse status to the joint schedule;
+    the oracle projector must therefore classify both its JOINT and
+    SURVIVING_SPOUSE statuses as joint-schedule cases while leaving that
+    upstream status adaptation outside this legal schedule module. On all 1,632
+    positive-weight Alabama tax units in the certified 2024 Populace routed to
+    tax year 2026, this calculation is within the campaign tolerance for every
+    unit. Alabama's filing thresholds are not imported: the target itself does
+    not read a must-file variable, and all 159 Alabama units below the published
+    adjusted-gross-income filing thresholds had zero target tax. All rules are
+    bounded to tax year 2026.
 rules:
+  - name: al_pit_pilot_first_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Ala. Code § 40-18-5(1)(a) and (2)(a), first marginal rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Two percent of taxable income not in excess of five hundred dollars ($500)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.02'
+
+  - name: al_pit_pilot_second_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Ala. Code § 40-18-5(1)(b) and (2)(b), second marginal rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Four percent of taxable income in excess of five hundred dollars ($500) and not in excess of three thousand dollars ($3,000)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.04'
+
+  - name: al_pit_pilot_third_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Ala. Code § 40-18-5(1)(c) and (2)(c), third marginal rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Five percent of taxable income in excess of three thousand dollars ($3,000)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.05'
+
+  - name: al_pit_pilot_nonjoint_first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(a), nonjoint first-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of five hundred dollars ($500)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '500'
+
+  - name: al_pit_pilot_nonjoint_second_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ala. Code § 40-18-5(1)(b), nonjoint second-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of three thousand dollars ($3,000)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '3000'
+
+  - name: al_pit_pilot_joint_first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(a), joint first-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of one thousand dollars ($1,000)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1000'
+
+  - name: al_pit_pilot_joint_second_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Ala. Code § 40-18-5(2)(b), joint second-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "not in excess of six thousand dollars ($6,000)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '6000'
+
   - name: al_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 40-18-15 and 40-18-19, Alabama taxable income after the supplied deductions and exemptions
+    source: Ala. Code § 40-18-5, supplied completed-return Alabama taxable income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-al/statute/40-18-15
-              excerpt: "the following items shall be deductible"
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "Two percent of taxable income not in excess of five hundred dollars ($500)."
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, al_pit_pilot_adjusted_gross_income - al_pit_pilot_supplied_personal_exemption)
+        effective_to: '2026-12-31'
+        formula: max(0, al_pit_pilot_state_taxable_income)
+
   - name: al_pit_pilot_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 40-18-5, graduated tax as the supplied first-bracket rate up to the top-bracket floor plus the supplied excess rate above it
+    source: Ala. Code § 40-18-5, graduated tax selected by return status
     metadata:
       proof:
         atoms:
@@ -94,19 +201,32 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "5% of taxable income over $3,000"
+              excerpt: "For a single person, head of family, or married persons filing separate returns"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-al/statute/40-18-5
+              excerpt: "For married persons filing a joint return"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          al_pit_pilot_supplied_first_bracket_rate * min(al_pit_pilot_taxable_income, al_pit_pilot_supplied_no_tax_threshold)
-          + al_pit_pilot_supplied_excess_rate * max(0, al_pit_pilot_taxable_income - al_pit_pilot_supplied_no_tax_threshold)
+          if al_pit_pilot_joint_schedule_applies:
+            al_pit_pilot_first_rate * min(al_pit_pilot_taxable_income, al_pit_pilot_joint_first_bracket_ceiling)
+            + al_pit_pilot_second_rate * min(max(0, al_pit_pilot_taxable_income - al_pit_pilot_joint_first_bracket_ceiling), al_pit_pilot_joint_second_bracket_ceiling - al_pit_pilot_joint_first_bracket_ceiling)
+            + al_pit_pilot_third_rate * max(0, al_pit_pilot_taxable_income - al_pit_pilot_joint_second_bracket_ceiling)
+          else:
+            al_pit_pilot_first_rate * min(al_pit_pilot_taxable_income, al_pit_pilot_nonjoint_first_bracket_ceiling)
+            + al_pit_pilot_second_rate * min(max(0, al_pit_pilot_taxable_income - al_pit_pilot_nonjoint_first_bracket_ceiling), al_pit_pilot_nonjoint_second_bracket_ceiling - al_pit_pilot_nonjoint_first_bracket_ceiling)
+            + al_pit_pilot_third_rate * max(0, al_pit_pilot_taxable_income - al_pit_pilot_nonjoint_second_bracket_ceiling)
+
   - name: al_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 40-18-5 graduated tax less the supplied nonrefundable exemption credit, floored at zero
+    source: Ala. Code § 40-18-5, income tax before nonrefundable credits
     metadata:
       proof:
         atoms:
@@ -114,8 +234,8 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "There shall be levied, collected, and paid a tax"
+              excerpt: "The tax levied and imposed by Section 40-18-2 shall be computed as follows"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, al_pit_pilot_schedule_tax - al_pit_pilot_supplied_exemption_credit)
+        effective_to: '2026-12-31'
+        formula: max(0, al_pit_pilot_schedule_tax)


### PR DESCRIPTION
## Summary

- replaces the supplied-schedule Alabama pilot with the complete schedule in Alabama Code section 40-18-5
- accepts completed-return `al_taxable_income` plus the reviewed joint-width schedule Boolean
- treats both JOINT and SURVIVING_SPOUSE as the joint-width upstream filing-status adaptation and bounds all policy rules to 2026

## Certified Populace parity

Full unsampled certified Populace against PE-US 1.752.2 `al_income_tax_before_non_refundable_credits`: 1,632 positive-weight Alabama tax units; weight 2,571,800.23285324; max absolute difference $0.2000000002; max relative difference 5.1378e-8; weighted MAE 0.0000424236; zero differences above $1 and zero outside $0.01 absolute OR 1e-7 relative tolerance. The six surviving-spouse units are material: misclassifying them as nonjoint would produce a maximum $40.00005 difference.

## Review cycle and checks

Independent semantic review was CLEAN at `0251e91fff9573570e4dfe1b322d6ac565954e6a`; it verified the official schedule, all five statuses, surviving-spouse behavior, fail-closed dates, full-Populace parity, manifests, and focused gates. After merging current main through Oklahoma #970, Alabama module/test/manifest bytes remained identical.

Fresh CI exposed one metadata issue: the now-valid module still carried its protected-base `pending` waiver. Commit `bcb73048c39d464b6b4ed00e35ecd332ee56f367` removes only that obsolete live waiver while retaining immutable historical fingerprint evidence. A second independent exact-head review was CLEAN and confirmed no manifest, index, oracle-ledger, or historical-evidence edit was required.

Exact-head checks: validation passed; proof validation passed with 11 atoms and 0/4 missing money atoms; 9 fixtures passed; pending ledger 1,588 declared / 0 stale / 0 problems; reverse index 3,942 provisions / 4,674 edges / 4,433 modules; generated guard passed; full unsampled 16-ready-state national run compared 25,859 units with zero mismatches and zero errors. Fresh exact-head CI is fully green.