### PR TITLE
Pin corpus for Ohio 2026 income tax source

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "abeab6a9f4ec432eb8fb7bb131f561cb3bcf6181"
+axiom_corpus_ref = "588580d508856960453bee044d4dab8c5c5216db"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

Advance only the pinned axiom-corpus commit from `abeab6a9f4ec432eb8fb7bb131f561cb3bcf6181` to `588580d508856960453bee044d4dab8c5c5216db`, which contains the independently reviewed Ohio H.B. 96 source needed by the follow-up RuleSpec promotion.

This intentionally lands separately from the Ohio validation-waiver retirement, as required by the trust-input CI guard.

## Checks

- TOML parse: pass
- exact corpus commit exists and is an ancestor of merged axiom-corpus main `ac53ae2db44ec2475f9cf18d6e95431a27debdc5`
- only the `axiom_corpus_ref` value changes
- no RuleSpec, waiver, workflow, or other trust input changes
- diff check and worktree: clean

## Review cycle

Independent exact-head review is CLEAN at `765b3154a74585d5dc5f58911ac468115d6f844e`. The reviewer also verified the reusable workflow classifies this isolated change as `corpus-only` / `changed-corpus-toolchain-bump`.