### PR TITLE
Promote Vermont 2026 income tax over certified Populace

### DIFF
--- a/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
@@ -1,6 +1,10 @@
 {
   "applied_files": [
     {
+      "path": "us-vt/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "7cad7a87efa3cbf1b94e175c10a376ff135707bb9498cace41cb0e6bcb784a34"
+    },
+    {
       "path": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
       "sha256": "3394d120b89d002a73d295396e5f45c75aba3886645ba9171320c3f1cd191c39"
     }
@@ -17,9 +21,9 @@
   "citation": "us-vt:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T05:01:43.460913+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp3_n4k8e/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp3_n4k8e",
+  "generated_at": "2026-07-22T05:05:23.282428+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp609h23jw/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp609h23jw",
   "generated_output_sha256": "3394d120b89d002a73d295396e5f45c75aba3886645ba9171320c3f1cd191c39",
   "generation_prompt_sha256": null,
   "model": "",
@@ -29,43 +33,52 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3de11c2ba0e0f9ccde1bfea9ee6b8ba022e967133ee1f375b49d7bb1679e53ec"
+    "value": "8a4f23c9755f63c66ce03a987386b774a5fcf71db80f48f7f4cafaef10b5661f"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T04:40:46.847673+00:00",
+    "generated_at": "2026-07-22T05:01:43.460913+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "d9c9aa6a1c94bc16a4af424dc85d72c664c198c5b05ee41e9391ce6d76513a17",
-    "prior_signature": "30da78141fd08e305140d793780feb10ac0543fa6588618822b7b525d9acbb62",
+    "manifest_sha256": "76153e446ffc308a74419dbc929351353e8c65179da525a0c9510aae0d136ea8",
+    "prior_signature": "3de11c2ba0e0f9ccde1bfea9ee6b8ba022e967133ee1f375b49d7bb1679e53ec",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-21T15:45:46.886935+00:00",
+      "generated_at": "2026-07-22T04:40:46.847673+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "17dde453f3840f7c42efbe4112d4ee7c0591d1786b5e223015c78047e900bd78",
-      "prior_signature": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63",
+      "manifest_sha256": "d9c9aa6a1c94bc16a4af424dc85d72c664c198c5b05ee41e9391ce6d76513a17",
+      "prior_signature": "30da78141fd08e305140d793780feb10ac0543fa6588618822b7b525d9acbb62",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-21T15:44:47.916434+00:00",
+        "generated_at": "2026-07-21T15:45:46.886935+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
-        "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
+        "manifest_sha256": "17dde453f3840f7c42efbe4112d4ee7c0591d1786b5e223015c78047e900bd78",
+        "prior_signature": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T16:58:36.943154+00:00",
+          "generated_at": "2026-07-21T15:44:47.916434+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
-          "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
+          "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
+          "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T16:11:49.938310+00:00",
+            "generated_at": "2026-07-16T16:58:36.943154+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
-            "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+            "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
+            "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-16T16:11:49.938310+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
+              "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-vt/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "5fbf91683a49aef2443e14b51350d1cd975a2d2a6f8f03465f6696a51c81320c"
+      "sha256": "7cad7a87efa3cbf1b94e175c10a376ff135707bb9498cace41cb0e6bcb784a34"
     },
     {
       "path": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "c94fca8cb10b19ded82dde2538e7b31d1b5b18bc6cb68b96df8aa084008a08d8"
+      "sha256": "be8d87e3ce5b4a053fdde551202b9d1116085a1d4e099bbd7932f019e44643d1"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-vt:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.886935+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "c94fca8cb10b19ded82dde2538e7b31d1b5b18bc6cb68b96df8aa084008a08d8",
+  "generated_at": "2026-07-22T04:40:46.847673+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplaezmcls/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplaezmcls",
+  "generated_output_sha256": "be8d87e3ce5b4a053fdde551202b9d1116085a1d4e099bbd7932f019e44643d1",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,29 +33,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63"
+    "value": "30da78141fd08e305140d793780feb10ac0543fa6588618822b7b525d9acbb62"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.916434+00:00",
+    "generated_at": "2026-07-21T15:45:46.886935+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
-    "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
+    "manifest_sha256": "17dde453f3840f7c42efbe4112d4ee7c0591d1786b5e223015c78047e900bd78",
+    "prior_signature": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T16:58:36.943154+00:00",
+      "generated_at": "2026-07-21T15:44:47.916434+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
-      "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
+      "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
+      "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T16:11:49.938310+00:00",
+        "generated_at": "2026-07-16T16:58:36.943154+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
-        "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+        "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
+        "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-16T16:11:49.938310+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
+          "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-vt/policies/income_tax/pilot_liability_pipeline.json
@@ -1,12 +1,8 @@
 {
   "applied_files": [
     {
-      "path": "us-vt/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "7cad7a87efa3cbf1b94e175c10a376ff135707bb9498cace41cb0e6bcb784a34"
-    },
-    {
       "path": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "be8d87e3ce5b4a053fdde551202b9d1116085a1d4e099bbd7932f019e44643d1"
+      "sha256": "3394d120b89d002a73d295396e5f45c75aba3886645ba9171320c3f1cd191c39"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +17,10 @@
   "citation": "us-vt:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T04:40:46.847673+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplaezmcls/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplaezmcls",
-  "generated_output_sha256": "be8d87e3ce5b4a053fdde551202b9d1116085a1d4e099bbd7932f019e44643d1",
+  "generated_at": "2026-07-22T05:01:43.460913+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp3_n4k8e/sign-applied-files/us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpp3_n4k8e",
+  "generated_output_sha256": "3394d120b89d002a73d295396e5f45c75aba3886645ba9171320c3f1cd191c39",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,36 +29,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "30da78141fd08e305140d793780feb10ac0543fa6588618822b7b525d9acbb62"
+    "value": "3de11c2ba0e0f9ccde1bfea9ee6b8ba022e967133ee1f375b49d7bb1679e53ec"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:45:46.886935+00:00",
+    "generated_at": "2026-07-22T04:40:46.847673+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "17dde453f3840f7c42efbe4112d4ee7c0591d1786b5e223015c78047e900bd78",
-    "prior_signature": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63",
+    "manifest_sha256": "d9c9aa6a1c94bc16a4af424dc85d72c664c198c5b05ee41e9391ce6d76513a17",
+    "prior_signature": "30da78141fd08e305140d793780feb10ac0543fa6588618822b7b525d9acbb62",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-21T15:44:47.916434+00:00",
+      "generated_at": "2026-07-21T15:45:46.886935+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
-      "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
+      "manifest_sha256": "17dde453f3840f7c42efbe4112d4ee7c0591d1786b5e223015c78047e900bd78",
+      "prior_signature": "24f2170942dee03c07e9a49914bb4399df521860d97ff271c335c0fd22bfaa63",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T16:58:36.943154+00:00",
+        "generated_at": "2026-07-21T15:44:47.916434+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
-        "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
+        "manifest_sha256": "710d1f413521fe7185d922f701a55e389d69162ceefa479380916c98c60f4917",
+        "prior_signature": "f33faf3bf5908fb455f0428ef05a12debe5517cb731b3951f90d2f90eda17180",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T16:11:49.938310+00:00",
+          "generated_at": "2026-07-16T16:58:36.943154+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
-          "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+          "manifest_sha256": "c34fb9a07d519ea7dc1aca18d5f93c4fc172bb2eec579f9a5ef0f1ffb95ec8d5",
+          "prior_signature": "9540175de609c7d98f46a925af176384718bd0e68130401dfb50d393d47b8b48",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-16T16:11:49.938310+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "50e671e8955c25797efb3762a1e16123600a79d4c5d0e47694e11117ac4dbd62",
+            "prior_signature": "d505489fdcfcfedbd7342d362871b06889bed3857e39cd01e69ed6434bfd8b75",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -31503,25 +31503,7 @@
         ]
       }
     ],
-    "us-vt/statute/32-5811": [
-      {
-        "module": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      }
-    ],
     "us-vt/statute/32-5822": [
-      {
-        "module": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      }
-    ],
-    "us-vt/statute/32-5823": [
       {
         "module": "us-vt/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1609
+ceiling: 1611
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1946,7 +1946,13 @@ entries:
 - legal_id: us-va:statutes/58.1/58/1-339/8#poverty_guideline_percentage_limit
   source: bulk
   since: '2026-07-08'
+- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_rate
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_threshold
   source: manual
   since: '2026-07-22'
 - legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1601
+ceiling: 1598
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1946,21 +1946,15 @@ entries:
 - legal_id: us-va:statutes/58.1/58/1-339/8#poverty_guideline_percentage_limit
   source: bulk
   since: '2026-07-08'
+- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability
   source: bulk
   since: '2026-07-17'
-- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_individual_schedule_tax
-  source: bulk
-  since: '2026-07-17'
-- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_individual_taxable_income
-  source: bulk
-  since: '2026-07-17'
-- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax
-  source: bulk
-  since: '2026-07-17'
-- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income
-  source: bulk
-  since: '2026-07-17'
+- legal_id: us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-wa:policies/income_tax/pilot_liability_pipeline#wa_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-15'

--- a/us-vt/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-vt/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,121 +1,62 @@
-# PolicyEngine 4.18.9 supplies completed Vermont taxable income and the current
-# 2026 indexed section 5822 thresholds. Expected values are the shown decimal
-# arithmetic and match vt_income_tax_before_non_refundable_credits at return-
-# cent precision on all six standard cases.
-- name: individual_schedule_scope
+# Expected values below are direct decimal applications of 32 V.S.A.
+# section 5822(a)(6), independent of the PolicyEngine comparison target.
+- name: below_threshold_uses_normal_tax
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 16776.63
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 0
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 0
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.0335
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 30000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: 1567.017105
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 60000
   output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_individual_taxable_income: '16776.63'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_individual_schedule_tax: '562.017105'
-- name: single_30000
-  # 3.35% * 16,776.63 = 562.017105 (PE $562.02).
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 16776.63
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.0335
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 30000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
-  output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '16776.63'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '562.017105'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '562.017105'
-- name: single_60000
-  # 3.35% * 46,776.63 = 1,567.017105 (PE $1,567.02).
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 46776.63
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.0335
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 60000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
-  output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '46776.63'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '1567.017105'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '1567.017105'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '0'
     us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '1567.017105'
-- name: single_150000
-  # 6,437.356125 + 7.6% * (136,776.63 - 122,412.75) = 7,529.011005.
+
+- name: exactly_150000_does_not_activate_minimum
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 136776.63
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 6437.356125
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 122412.75
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.076
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: 7529.011005
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 150000
   output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '136776.63'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '7529.011005'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '7529.011005'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '0'
     us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '7529.011005'
-- name: married_60000
-  # 3.35% * 33,553.26 = 1,124.034210 (PE $1,124.03).
+
+- name: above_threshold_normal_tax_wins
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 33553.26
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 0
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.0335
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 60000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: 16008.330875
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 300000
   output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '33553.26'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '1124.03421'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '1124.03421'
-- name: married_120000
-  # 2,826.384615 + 6.6% * (93,553.26 - 84,369.69) = 3,432.500235.
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 93553.26
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 2826.384615
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 84369.69
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.066
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 120000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
-  output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '93553.26'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '3432.500235'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '3432.500235'
-- name: married_300000
-  # 10,720.012995 + 7.6% * (273,553.25 - 203,970.12) = 16,008.330875;
-  # the $9,000 minimum is smaller.
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-vt:policies/income_tax/pilot_liability_pipeline#relation.vt_pit_pilot_taxpayer_of_tax_unit:
-      - us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_taxpayer_is_included: true
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_taxable_income: 273553.25
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_base: 10720.012995
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_bracket_floor: 203970.12
-        us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_marginal_rate: 0.076
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_federal_adjusted_gross_income: 300000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_threshold: 150000
-    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_minimum_tax_rate: 0.03
-  output:
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_taxable_income: '273553.25'
-    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_schedule_tax: '16008.330875'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '16008.330875'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '9000'
     us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '16008.330875'
+
+- name: above_threshold_minimum_tax_wins
+  # Full-Populace minimum-winning case: 155,432.515625 * 3% = 4,662.97546875.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: 4345.44677734375
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 155432.515625
+  output:
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '4345.44677734375'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '4662.97546875'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '4662.97546875'
+
+- name: negative_supplied_normal_tax_is_floored
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: -25
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 100000
+  output:
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '0'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '0'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '0'
+
+- name: zero_income_and_tax
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_supplied_normal_income_tax: 0
+    us-vt:policies/income_tax/pilot_liability_pipeline#input.vt_pit_pilot_federal_adjusted_gross_income: 0
+  output:
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_normal_income_tax: '0'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_federal_agi_minimum_tax: '0'
+    us-vt:policies/income_tax/pilot_liability_pipeline#vt_pit_pilot_income_tax_liability: '0'

--- a/us-vt/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-vt/policies/income_tax/pilot_liability_pipeline.yaml
@@ -39,7 +39,62 @@ module:
     floating-point rounding. Populace contains no positive U.S.-government
     interest for Vermont, so PolicyEngine's separate `vt_amt` interest
     subtraction is not exercised or absorbed into this statutory formula.
+  deferred_outputs:
+    - output: us-vt:statutes/32-5822/b#filing_status_definitions_and_indexed_normal_tax_schedules
+      reason: |-
+        Subsection (b) defines the filing-status categories used by the normal
+        tax schedules and directs the Commissioner to publish annually indexed
+        table amounts. The certified corpus does not contain the official 2026
+        indexed tables, so this narrow composition accepts the completed
+        current-year normal income tax as an explicitly supplied upstream
+        boundary instead of reconstructing those schedules.
+    - output: us-vt:statutes/32-5822/e#nonresident_income_percentage_reduction
+      reason: |-
+        Subsection (e) applies Vermont's nonresident and part-year-resident
+        income percentage after the tax determined under subsections (a)-(d).
+        This certified-Populace comparison targets the resident before-credit
+        liability core and leaves that downstream allocation outside the
+        composition.
 rules:
+  - name: vt_pit_pilot_federal_agi_minimum_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 32 V.S.A. section 5822(a)(6), federal-AGI threshold for the minimum tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-vt/statute/32-5822
+              excerpt: "If the federal adjusted gross income of the taxpayer exceeds $150,000.00"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '150000.0'
+
+  - name: vt_pit_pilot_federal_agi_minimum_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 32 V.S.A. section 5822(a)(6), federal-AGI minimum-tax rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-vt/statute/32-5822
+              excerpt: "three percent of the taxpayer's federal adjusted gross income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.03'
+
   - name: vt_pit_pilot_normal_income_tax
     kind: derived
     entity: TaxUnit
@@ -82,8 +137,8 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if vt_pit_pilot_federal_adjusted_gross_income > 150000:
-            0.03 * vt_pit_pilot_federal_adjusted_gross_income
+          if vt_pit_pilot_federal_adjusted_gross_income > vt_pit_pilot_federal_agi_minimum_threshold:
+            vt_pit_pilot_federal_agi_minimum_rate * vt_pit_pilot_federal_adjusted_gross_income
           else: 0
 
   - name: vt_pit_pilot_income_tax_liability

--- a/us-vt/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-vt/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,111 +3,50 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-vt/statute/32-5811
-      - us-vt/statute/32-5822
-      - us-vt/statute/32-5823
+    corpus_citation_path: us-vt/statute/32-5822
     upstream_source_check:
       status: composed_from_supplied_current_authority
       checked_paths:
         - us-vt/statute/title-32
         - us-vt/statute/chapter-151
-        - us-vt/statute/32-5811
         - us-vt/statute/32-5822
-        - us-vt/statute/32-5823
       rationale: |-
-        The complete official Chapter 151 package contains the individual
-        taxable-income definition and annually inflation-adjusted exemptions
-        and deductions in section 5811, the resident-income rule in section
-        5823, and the imposition, four statutory rates, annually adjusted table
-        thresholds, and minimum-tax comparison in section 5822. The 2026 Acts
-        152 and 164 overlays are included in those canonical records. This
-        narrow composition accepts each taxpayer's completed-return Vermont
-        taxable income and current indexed active bracket's cumulative base
-        tax, floor, and marginal rate as supplied inputs because sections 5811
-        and 5822 assign annual inflation adjustment to the Commissioner. It
-        then explicitly aggregates the taxpayer amounts to the tax unit.
-        Credits, special income classes, and nonresident allocation remain
-        outside this core.
+        The certified Chapter 151 package contains the section 5822 tax
+        schedules, the four statutory rates, the Commissioner's annual
+        inflation-adjustment mandate, and the federal-AGI minimum. It does not
+        contain Commissioner-published 2026 indexed bracket amounts. This
+        narrow composition therefore accepts the completed current-year normal
+        income tax as an explicitly supplied upstream boundary and independently
+        encodes section 5822(a)(6): only when federal adjusted gross income
+        exceeds $150,000, compare normal tax with three percent of federal AGI.
+        Credits, special federal-tax additions, nonresident allocation, and the
+        annually indexed schedule calculation remain outside this composition.
   summary: |-
-    Vermont individual-income-tax liability pipeline for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes each taxpayer's supplied
-    completed-return Vermont taxable income, applies the supplied current
-    indexed section 5822 bracket in cumulative-base-plus-marginal form,
-    aggregates those amounts to the tax unit, and takes the greater of that
-    schedule tax or the statutory three-percent federal-AGI minimum when federal
-    AGI exceeds the supplied statutory threshold. The six-case
-    childless age-40 grid matches PolicyEngine 4.18.9 / PolicyEngine-US 1.752.2
-    `vt_income_tax_before_non_refundable_credits` exactly at return-cent
-    precision. Expected values are independent decimal arithmetic using the
-    live model's completed taxable incomes and current indexed thresholds; no
-    oracle output is read back into the RuleSpec formula.
+    Vermont 2026 individual income tax before nonrefundable credits for the
+    complete certified-Populace comparison scope. The module works entirely at
+    TaxUnit grain: it normalizes supplied completed-return Vermont normal income
+    tax and applies the statutory strict-over-$150,000 three-percent federal-AGI
+    minimum. No person or taxpayer aggregation is required by PolicyEngine-US
+    1.752.2, whose `vt_income_tax_before_non_refundable_credits` target is the
+    TaxUnit-level greater of `vt_normal_income_tax` and `vt_amt`.
+
+    The upstream normal-tax boundary is required because the certified corpus
+    establishes the rates and annual indexing method but not official 2026
+    indexed table amounts. Over all 922 positive-weight Vermont tax units in the
+    pinned Populace artifact, the statutory composition covers all five filing
+    statuses and has zero failures at $0.01 absolute or 1e-7 relative tolerance.
+    One tax unit selects the minimum; its $0.000117 residual is PolicyEngine
+    floating-point rounding. Populace contains no positive U.S.-government
+    interest for Vermont, so PolicyEngine's separate `vt_amt` interest
+    subtraction is not exercised or absorbed into this statutory formula.
 rules:
-  - name: vt_pit_pilot_taxpayer_of_tax_unit
-    kind: data_relation
-    data_relation:
-      predicate: vt_pit_pilot_taxpayer_of_tax_unit
-      arity: 2
-      arguments:
-        - TaxUnit
-        - Person
-
-  - name: vt_pit_pilot_individual_taxable_income
-    kind: derived
-    entity: Person
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 32 V.S.A. sections 5811(21) and 5823(a), supplied Vermont taxable income
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5811
-              excerpt: "“Taxable income” means, in the case of an individual, federal adjusted gross income"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5811
-              excerpt: "shall be adjusted annually for inflation by the Commissioner of Taxes beginning with taxable year 2018"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5823
-              excerpt: "the Vermont income of a resident individual is the adjusted gross income of the individual"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: max(0, vt_pit_pilot_supplied_taxable_income)
-
-  - name: vt_pit_pilot_taxable_income
+  - name: vt_pit_pilot_normal_income_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 32 V.S.A. sections 5811(21) and 5823(a), supplied Vermont taxable income
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5823
-              excerpt: "the Vermont income of a resident individual is the adjusted gross income of the individual"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, sum_where(vt_pit_pilot_taxpayer_of_tax_unit, vt_pit_pilot_individual_taxable_income, vt_pit_pilot_taxpayer_is_included))
-
-  - name: vt_pit_pilot_individual_schedule_tax
-    kind: derived
-    entity: Person
-    dtype: Money
-    period: Year
-    unit: USD
-    source: 32 V.S.A. section 5822(a)-(b), supplied active indexed bracket
+    source: 32 V.S.A. section 5822(a)(1)-(5), supplied completed normal income tax
     metadata:
       proof:
         atoms:
@@ -115,45 +54,18 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "A tax is imposed for each taxable year upon the taxable income earned or received in that year by every individual"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "3.35% of taxable income"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "$1,296.00 plus 6.6% of"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "$4,926.00 plus 7.6%"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "$12,659.00 plus 8.75% of"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "The amounts of taxable income shown in the tables in this section shall be adjusted annually for inflation by the Commissioner of Taxes"
+              excerpt: "the tax calculated under subdivisions (1)-(5) of this subsection"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          vt_pit_pilot_supplied_bracket_base
-          + vt_pit_pilot_supplied_marginal_rate * max(0, vt_pit_pilot_individual_taxable_income - vt_pit_pilot_supplied_bracket_floor)
+        formula: max(0, vt_pit_pilot_supplied_normal_income_tax)
 
-  - name: vt_pit_pilot_schedule_tax
+  - name: vt_pit_pilot_federal_agi_minimum_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 32 V.S.A. section 5822(a)-(b), aggregated taxpayer schedule tax
+    source: 32 V.S.A. section 5822(a)(6), three-percent federal-AGI minimum
     metadata:
       proof:
         atoms:
@@ -161,11 +73,18 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "A tax is imposed for each taxable year upon the taxable income earned or received in that year by every individual"
+              excerpt: "If the federal adjusted gross income of the taxpayer exceeds $150,000.00"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-vt/statute/32-5822
+              excerpt: "three percent of the taxpayer's federal adjusted gross income"
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          sum_where(vt_pit_pilot_taxpayer_of_tax_unit, vt_pit_pilot_individual_schedule_tax, vt_pit_pilot_taxpayer_is_included)
+          if vt_pit_pilot_federal_adjusted_gross_income > 150000:
+            0.03 * vt_pit_pilot_federal_adjusted_gross_income
+          else: 0
 
   - name: vt_pit_pilot_income_tax_liability
     kind: derived
@@ -173,7 +92,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: 32 V.S.A. section 5822(a)(6), schedule or federal-AGI minimum
+    source: 32 V.S.A. section 5822(a)(6), greater of normal tax or minimum
     metadata:
       proof:
         atoms:
@@ -182,14 +101,7 @@ rules:
             source:
               corpus_citation_path: us-vt/statute/32-5822
               excerpt: "the tax calculated under this subsection shall be the greater of"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-vt/statute/32-5822
-              excerpt: "three percent of the taxpayer’s federal adjusted gross income"
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if vt_pit_pilot_supplied_federal_adjusted_gross_income > vt_pit_pilot_supplied_minimum_tax_threshold:
-            max(vt_pit_pilot_schedule_tax, vt_pit_pilot_supplied_minimum_tax_rate * vt_pit_pilot_supplied_federal_adjusted_gross_income)
-          else: vt_pit_pilot_schedule_tax
+          max(vt_pit_pilot_normal_income_tax, vt_pit_pilot_federal_agi_minimum_tax)


### PR DESCRIPTION
## Summary

Promote the Vermont 2026 individual income-tax before-nonrefundable-credit composition over the complete certified Populace scope.

The RuleSpec accepts completed-return TaxUnit-level Vermont normal income tax as the narrow upstream boundary required by the absent official 2026 indexed tables, then independently encodes 32 V.S.A. section 5822(a)(6): strict federal AGI above $150,000, a 3% minimum, and the greater of normal tax or minimum tax.

## Certified Populace evidence

- 922 positive-weight Vermont tax units
- weighted tax units: 366,584.606693
- all five filing statuses represented
- one minimum-tax winner
- max absolute difference: $0.0001171875
- max relative difference: 2.513e-8
- weighted MAE: 7.071e-9
- zero differences outside $0.01 absolute OR 1e-7 relative tolerance

PolicyEngine-US 1.752.2 target: `vt_income_tax_before_non_refundable_credits`.

## Checks

- pinned validator: pass
- companion fixtures: 6/6 pass
- proof validation: 6 atoms; 0 of 1 money obligations missing
- pending ratchet: 1,611 declared / 1,611 applied / 0 stale
- reverse index: current
- signed exact-base guard: pass
- diff check and worktree: clean
- module SHA256: `3394d120b89d002a73d295396e5f45c75aba3886645ba9171320c3f1cd191c39`
- test SHA256: `7cad7a87efa3cbf1b94e175c10a376ff135707bb9498cace41cb0e6bcb784a34`

## Review cycle

Independent review found four actionable validation issues: embedded threshold and rate literals plus undeclared subsection (b) and (e) scope. The threshold and rate are now source-backed named parameters, both out-of-scope subsections are formally deferred with reasons, the complete branch diff was re-signed, and all focused gates were rerun.

Final independent exact-head review is CLEAN at `d685e3f4ad9973d3d252b76db0e264de026acbf3` against current main `e58c38b64a3e059aa7a60917ce069ed94118eb01`.