### PR TITLE
Re-encode North Carolina section 105-153.7

### DIFF
--- a/.axiom/encoding-manifests/us-nc/statutes/105/105-153/7.json
+++ b/.axiom/encoding-manifests/us-nc/statutes/105/105-153/7.json
@@ -1,51 +1,99 @@
 {
   "applied_files": [
     {
-      "path": "us-nc/statutes/105/105-153/7.test.yaml",
-      "sha256": "dc4a570c92fbbb5f20db4bffbb2a20ae1766f91c312696c7bfc7512626be350e"
+      "path": "us-nc/statutes/105/105-153/7.yaml",
+      "sha256": "a40d46759fb1362865ab09cd4470f13729af1739b11ee91dde0fef8a08e5acc7"
     },
     {
-      "path": "us-nc/statutes/105/105-153/7.yaml",
-      "sha256": "c0306fd55fd67ea700a1abdc65cdbfa473c781522aa15e9f4d2b4fecc2277e0d"
+      "path": "us-nc/statutes/105/105-153/7.test.yaml",
+      "sha256": "6672253116bdfad0dfa1fd51fcc5d947741db210d70c2266b3201b8792f54b46"
+    },
+    {
+      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "33655045f43f6e3762a5cbfd464b55a36690212d9c2dc484979354a7038c91ba"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "763af71c504ef09cce2a4bf63c978007ff90718a",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1314",
+    "version_commit": "763af71c504ef09cce2a4bf63c978007ff90718a"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-nc:statutes/105/105-153/7",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T21:19:50.569450+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpno48f1gb/sign-applied-files/us-nc/statutes/105/105-153/7.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpno48f1gb",
-  "generated_output_sha256": "c0306fd55fd67ea700a1abdc65cdbfa473c781522aa15e9f4d2b4fecc2277e0d",
-  "generation_prompt_sha256": null,
-  "manual_exception": "composition",
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1314",
+  "backend": "openai",
+  "citation": "us-nc/statute/105/105-153.7",
+  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-nc-statute-105-105-153.7/workspace/context-manifest.json",
+  "context_manifest_sha256": "ed9cf1a8dbcb7af63a3203099e8737b81e83b82f651329b486a5b9034d7abd5b",
+  "generated_at": "2026-07-22T05:27:40.939384+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/105/105-153/7.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated",
+  "generated_output_sha256": "a40d46759fb1362865ab09cd4470f13729af1739b11ee91dde0fef8a08e5acc7",
+  "generation_prompt_sha256": "997702ca72ae2a4898222a5c7cef1d338f78a51dc5db9534c2670ec5cadd30f4",
+  "model": "gpt-5.6-terra",
+  "run_id": "8614d20a",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "f4a8d0dc57402d3e4acb9108710191195e61e3b30cdfed99f7d01f667eaa00ea"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
+    "value": "xqIiZBgKdJhKyMfLFB5IYEyGZ77Cv5BypM/Hf2BRByXyLB3dIHENurRfiOllCwOnio8wLuBmZQeZyNZ371cbAw=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-21T21:03:48.367156+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "93d73b40bc2797fde7d4f6d2b088a4a43d0ae43ef5f7850a48946755e3f360ff",
-    "prior_signature": "920e96c2a1a79ed65ed479bbec88bec4ee1062fc6fce7ecf37a8a65219227a9b",
-    "run_id": null,
-    "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-22-current",
+    "corpus_release_content_sha256": "7b1c6c0ec237dc3767f770fbb30178d6857bbe43fd4d952f57ebfc8409874bcc",
+    "corpus_release_selector_sha256": "2edc30670f498a7f56b74024023c032f0e834643d6483bbd48fb11830f946d67",
+    "corpus_source": "local",
+    "expression_date": "2026-07-13",
+    "generation_input_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+    "provision_file": "data/corpus/provisions/us-nc/statute/2026-07-13-recovery.jsonl",
+    "provision_file_sha256": "671d105b274dc6d7bd7faeadceecf6aa2f5850444d2785c5e752e6e5604c1bb7",
+    "requested_corpus_citation_path": "us-nc/statute/105/105-153.7",
+    "resolved_corpus_citation_path": "us-nc/statute/105/105-153.7",
+    "resolved_text_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+    "row": {
+      "body_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+      "citation_path": "us-nc/statute/105/105-153.7",
+      "document_class": "statute",
+      "expression_date": "2026-07-13",
+      "jurisdiction": "us-nc",
+      "line_number": 53,
+      "provision_file": "data/corpus/provisions/us-nc/statute/2026-07-13-recovery.jsonl",
+      "provision_file_sha256": "671d105b274dc6d7bd7faeadceecf6aa2f5850444d2785c5e752e6e5604c1bb7",
+      "record_id": "87e8f1e6-2622-55a3-8c79-7b0bd039d804",
+      "source_as_of": "2026-07-13",
+      "source_path": "sources/us-nc/statute/2026-07-13-recovery/official-documents/us-nc-code-105",
+      "version": "2026-07-13-recovery"
+    },
+    "rulespec_root": "rulespec-us/us-nc",
+    "source_as_of": "2026-07-13",
+    "source_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-nc-statute-105-105-153.7.json",
+  "trace_sha256": "20640ada57990ba188fa1bbdbba60c9f1d20660b6574a54fd2b7159019c6a0d0",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "763af71c504ef09cce2a4bf63c978007ff90718a",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1314"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "761152b26049d478762ccc8798c3a76a375cfe1f55361e573a9c4f88434c9440",
+      "pre_apply_file_count": 1013,
+      "rulespec_root": "rulespec-us/us-nc",
+      "toolchain_contract_sha256": "83c488562d3b860c021867e505618d8ddc283fc1d51be1ff2d6323ff9922d2e8",
+      "validation_waiver_set_sha256": "bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3"
 }

--- a/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,64 +4,76 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-nc/statute/105/105-153.7
-  summary: |-
-    Composed North Carolina individual income-tax pipeline for the 2026
+    source_sha256: e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6
+  summary: 'Composed North Carolina individual income-tax pipeline for the 2026
+
     before-credit target. It accepts one TaxUnit-level completed-return North
+
     Carolina taxable-income boundary, floors it at zero, and applies the rate
+
     imported from the encoded section 105-153.7 module. It deliberately excludes
+
     all credits and makes no independent claim about the upstream federal and
+
     state adjustment chain. The imported rate is policy-bearing; zero is only
+
     the nonnegative taxable-income floor. Because subsection (a1) may change
+
     the rate beginning in 2027, both rules are bounded to tax year 2026. This
-    narrow boundary is suitable for comparison with PolicyEngine's
+
+    narrow boundary is suitable for comparison with PolicyEngine''s
+
     nc_taxable_income feeding nc_income_tax_before_credits for full-year
-    resident tax units.
+
+    resident tax units.'
 imports:
-  - us-nc:statutes/105/105-153/7#individual_income_tax_rate
+- us-nc:statutes/105/105-153/7#individual_income_tax_rate
 rules:
-  - name: nc_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: N.C. Gen. Stat. 105-153.7, supplied completed-return state taxable income floored at zero
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "A tax is imposed for each taxable year on the North Carolina taxable income of every individual"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          max(0, nc_pit_pilot_state_taxable_income)
-  - name: nc_pit_pilot_income_tax_liability
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: N.C. Gen. Stat. 105-153.7(a), the 3.99 per cent flat tax on North Carolina taxable income before credits
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
-              output: individual_income_tax_rate
-              hash: sha256:c0306fd55fd67ea700a1abdc65cdbfa473c781522aa15e9f4d2b4fecc2277e0d
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "the tax is a percentage of the taxpayer's North Carolina taxable income computed as follows"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          nc_pit_pilot_taxable_income * individual_income_tax_rate
+- name: nc_pit_pilot_taxable_income
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: N.C. Gen. Stat. 105-153.7, supplied completed-return state taxable income
+    floored at zero
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: A tax is imposed for each taxable year on the North Carolina taxable
+            income of every individual
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: max(0, nc_pit_pilot_state_taxable_income)
+- name: nc_pit_pilot_income_tax_liability
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: N.C. Gen. Stat. 105-153.7(a), the 3.99 per cent flat tax on North Carolina
+    taxable income before credits
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
+          output: individual_income_tax_rate
+          hash: sha256:a40d46759fb1362865ab09cd4470f13729af1739b11ee91dde0fef8a08e5acc7
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: the tax is a percentage of the taxpayer's North Carolina taxable
+            income computed as follows
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: nc_pit_pilot_taxable_income * individual_income_tax_rate

--- a/us-nc/statutes/105/105-153/7.test.yaml
+++ b/us-nc/statutes/105/105-153/7.test.yaml
@@ -18,7 +18,7 @@
     us-nc:statutes/105/105-153/7#input.taxable_period_months: 12
   output:
     us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: holds
-- name: withholding tables do not apply to short period section 443 accounting change return
+- name: withholding tables do not apply to qualifying short period section 443 return
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -29,3 +29,15 @@
     us-nc:statutes/105/105-153/7#input.taxable_period_months: 11
   output:
     us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: not_holds
+- name: withholding tables apply to a short period not caused by section 443 accounting
+    change
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-nc:statutes/105/105-153/7#input.secretary_has_provided_withholding_tables: true
+    us-nc:statutes/105/105-153/7#input.files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period: false
+    us-nc:statutes/105/105-153/7#input.taxable_period_months: 11
+  output:
+    us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: holds

--- a/us-nc/statutes/105/105-153/7.yaml
+++ b/us-nc/statutes/105/105-153/7.yaml
@@ -4,100 +4,84 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-nc/statute/105/105-153.7
-  summary: |-
-    A tax is imposed for each taxable year on the North Carolina taxable income of every individual. The fixed subsection (a) schedule sets the rate at 3.99% after 2025. Subsection (a1) can reduce that rate beginning in 2027 if annual revenue triggers are met, so the rate and individual-tax calculation in this module are deliberately bounded to tax year 2026 and later years are deferred. The Secretary may provide withholding tables; the tables do not apply to an individual filing a return under Code section 443(a)(1) for a period of less than 12 months due to an annual accounting period change or to an estate or trust.
+    source_sha256: e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6
+  summary: '"A tax is imposed for each taxable year on the North Carolina taxable
+    income of every individual." "After 2025 3.99%." "The Secretary may provide tables
+    that compute the amount of tax due for a taxable year under this Part."'
 rules:
-  - name: individual_income_tax_rate
-    kind: parameter
-    dtype: Rate
-    period: Year
-    source: N.C. Gen. Stat. § 105-153.7(a)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: table_cell
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              table:
-                header: "Taxable Years Beginning Tax"
-                row: "After 2025"
-                column: "Tax"
-              excerpt: "After 2025 3.99%"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          0.0399
-
-  - name: short_period_return_month_count
-    kind: parameter
-    dtype: Count
-    period: Year
-    source: N.C. Gen. Stat. § 105-153.7(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "for a period of less than 12 months"
-    versions:
-      - effective_from: '2014-01-01'
-        formula: |-
-          12
-
-  - name: individual_income_tax
-    kind: derived
-    entity: Person
-    dtype: Money
-    period: Year
-    unit: USD
-    source: N.C. Gen. Stat. § 105-153.7(a)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "A tax is imposed ... on the North Carolina taxable income of every individual"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
-              output: individual_income_tax_rate
-              hash: sha256:local
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          max(0, north_carolina_taxable_income) * individual_income_tax_rate
-
-  - name: withholding_tables_apply_to_individual
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Year
-    source: N.C. Gen. Stat. § 105-153.7(b)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: predicate
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "The Secretary may provide tables ... The tables do not apply to an individual who files a return under section 443(a)(1) ... for a period of less than 12 months"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-nc:statutes/105/105-153/7#short_period_return_month_count
-              output: short_period_return_month_count
-              hash: sha256:local
-    versions:
-      - effective_from: '2014-01-01'
-        formula: |-
-          secretary_has_provided_withholding_tables
-          and not files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period
-          and taxable_period_months >= short_period_return_month_count
+- name: individual_income_tax_rate
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: N.C. Gen. Stat. § 105-153.7(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: table_cell
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          table:
+            header: Taxable Years Beginning Tax
+            row: After 2025
+            column: Tax
+          excerpt: After 2025 3.99%
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '0.0399'
+- name: short_period_return_month_count
+  kind: parameter
+  dtype: Count
+  period: Year
+  source: N.C. Gen. Stat. § 105-153.7(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: for a period of less than 12 months
+  versions:
+  - effective_from: '2014-01-01'
+    formula: '12'
+- name: individual_income_tax
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: N.C. Gen. Stat. § 105-153.7(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: A tax is imposed for each taxable year on the North Carolina taxable
+            income of every individual.
+  versions:
+  - effective_from: '2026-01-01'
+    formula: max(0, north_carolina_taxable_income) * individual_income_tax_rate
+- name: withholding_tables_apply_to_individual
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: N.C. Gen. Stat. § 105-153.7(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: The tables do not apply to an individual who files a return under
+            section 443(a)(1) of the Code for a period of less than 12 months due
+            to a change in the individual's annual accounting period
+  versions:
+  - effective_from: '2014-01-01'
+    formula: "secretary_has_provided_withholding_tables\nand not (\n  files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period\n\
+      \  and taxable_period_months < short_period_return_month_count\n)"


### PR DESCRIPTION
## Summary
- regenerate `us-nc/statute/105/105-153.7` through the protected encoder apply lane
- replace its legacy manual-attestation manifest with signed v5 provenance
- repair the exact corpus proof excerpt and refresh the dependent NC liability pipeline hash
- add the missing short-period withholding-table case

## Provenance
- protected run: `TheAxiomFoundation/axiom-encode` Actions run `29893673823`
- encoder commit: `763af71c504ef09cce2a4bf63c978007ff90718a`
- RuleSpec base: `52467ee7d99f4aa31882dfa7ec16835db2613eb3`
- corpus commit: `c5af541326e024e04cb533bbf5709ae04e6305f6`
- rules-engine commit: `05eac9d2f89dabe5c6673176260762cef3a58f47`
- downloaded artifact checksums verified against `SHA256SUMS`

## Checks
- protected encoder generation, review, validation, provenance guard, and packaging: passed
- `git diff --check`: passed
- `uv run --python 3.13 --with pytest --with pyyaml python -m pytest tests/test_encoding_manifests.py tests/test_legacy_rulespec_freeze.py tests/test_repository_layout.py tests/test_program_specs.py tests/test_reverse_index.py`: 43 passed

## Review cycle
- pending independent exact-head RuleSpec review
