### PR TITLE
Promote Connecticut 2026 income tax over certified Populace

### DIFF
--- a/.axiom/encoding-manifests/us-ct/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ct/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "edca3a53e6fcd74e34abdb0cb518658ec7122dabcb08c68a4bd8d7c7d2cf4d56"
+      "sha256": "587ff581bc0c14ab152f004bb6ccd21a6a84d7fc477a50f87fed958e1aae1ee0"
     },
     {
       "path": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "3658325574ce05445cfba036d092bba5bd777af591fed342a1f48fd9f4a96481"
+      "sha256": "ca81a20af9b3752149753a9902e83301a7f10e206800e900e4a4d989391d1877"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1196",
-    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1196",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ct:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T06:33:47.689322+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
-  "generated_output_sha256": "3658325574ce05445cfba036d092bba5bd777af591fed342a1f48fd9f4a96481",
+  "generated_at": "2026-07-22T05:01:03.938970+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_efs5kul/sign-applied-files/us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_efs5kul",
+  "generated_output_sha256": "ca81a20af9b3752149753a9902e83301a7f10e206800e900e4a4d989391d1877",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "1c6c64fb596c390afbad198b4b589a16dbc0213f8202bc3ecb204aa5a0286b50"
+    "value": "6f4f7f842e34096e0f0291cbe20607352160582acd45a875e9be507ee874a5b7"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-09T06:33:47.689322+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "289f2d2760ba02035127cf25dc7861bb055163af06f5e3ece5c5c92810d3feb5",
+    "prior_signature": "1c6c64fb596c390afbad198b4b589a16dbc0213f8202bc3ecb204aa5a0286b50",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16262,27 +16262,22 @@
     ],
     "us-ct/statute/12-700": [
       {
-        "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-ct/statutes/12-700.yaml",
         "via": [
           "module"
         ]
       }
     ],
-    "us-ct/statute/12-704e": [
+    "us-ct/statute/12-700/block-1": [
       {
         "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"
         ]
-      },
+      }
+    ],
+    "us-ct/statute/12-704e": [
       {
         "module": "us-ct/statutes/12-704e.yaml",
         "via": [
@@ -16293,13 +16288,16 @@
     ],
     "us-ct/statute/12-704i": [
       {
-        "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      },
-      {
         "module": "us-ct/statutes/12-704i.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ct/statute/12-704i/block-1": [
+      {
+        "module": "us-ct/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -9704,12 +9704,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ct/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:098a215a9a04ebcd409b95f7525f39eb560311b695279a73532b2062cba6b8c7"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ct/statutes/12-700.yaml":
     pending:
       fingerprint: "sha256:d083b175999d565ab3d8767a3e8891f2d44b7c6ca8b3ccbdd4a27c4d3d8be082"

--- a/us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ct/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,106 +1,177 @@
-# Fixtures are hand-computed at the 2026 tax year (expected values are the
-# author's shown arithmetic from the supplied schedule, which axiom-encode test
-# proves equal the engine output to full decimal precision, not an oracle
-# read-back). Connecticut section 12-700 graduated tax less the net section 12-704c personal credit / section 12-700(b) 3-percent phase-out recapture (negative credit = recapture exceeds the personal credit).
-- name: single_30000
-  # taxable 15000; schedule 200 + 0.045*max(0,15000-10000) = 425; less credit 63.75 -> liability 361.25.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+- name: single_personal_credit
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 15000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 30000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 15000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 10000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 200
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.045
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 63.75
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0.15
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '15000'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_scale: '1'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '425'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_start: 56500
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_increment: 5000
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_amount: '25'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_tax_before_personal_credit: '425'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_tax_after_personal_credit: '361.25'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '361.25'
-- name: single_60000
-  # taxable 60000; schedule 2000 + 0.055*max(0,60000-50000) = 2550; less credit 232.5 -> liability 2317.5.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
+
+- name: single_low_rate_phaseout
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: &single_60_inputs
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 60000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 60000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 50000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 2000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.055
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 232.5
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0.1
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '60000'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '2550'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_addback: '25'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '2317.5'
-- name: single_150000
-  # taxable 150000; schedule 4750 + 0.06*max(0,150000-100000) = 7750; less credit -475 -> liability 8225.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: single_low_recapture
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 150000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 150000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 100000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 4750
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.06
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -475
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '150000'
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '7750'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_addback: '250'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_low_recapture: '225'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '8225'
-- name: married_60000
-  # taxable 48000; schedule 400 + 0.045*max(0,48000-20000) = 1660; less credit 166 -> liability 1494.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
+
+- name: joint_schedule_and_personal_credit
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: &joint_inputs
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 48000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 60000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 12000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 20000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 400
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.045
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: 166
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0.1
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '48000'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '1660'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '1494'
-- name: married_120000
-  # taxable 120000; schedule 4000 + 0.055*max(0,120000-100000) = 5100; less credit -200 -> liability 5300.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: joint_phaseout
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 120000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 120000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 100000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 4000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.055
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -200
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '120000'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '5100'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_addback: '200'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '5300'
-- name: married_300000
-  # taxable 300000; schedule 9500 + 0.06*max(0,300000-200000) = 15500; less credit -950 -> liability 16450.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: joint_low_recapture
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 300000
     us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 300000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_standard_deduction: 0
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_floor: 200000
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_bracket_base: 9500
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_marginal_rate: 0.06
-    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_supplied_nonrefundable_credit: -950
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
   output:
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_taxable_income: '300000'
-    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '15500'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_addback: '500'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_low_recapture: '450'
     us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '16450'
+
+- name: separate_uses_own_phaseout_start
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 20000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 50251
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '650'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_phaseout_addback: '25'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '675'
+
+- name: head_of_household_amt_and_ordered_credit_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 20000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 30000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 100
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 300
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 2500
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '500'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_tax_after_amt: '600'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_applied_property_tax_credit: '300'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_applied_stillborn_credit: '300'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '0'
+
+- name: single_all_three_recapture_tiers
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 600000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 510000
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_schedule_tax: '38240'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_low_recapture: '250'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_middle_recapture: '2700'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_high_recapture: '100'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '41540'
+
+- name: head_of_household_middle_recapture_is_not_proportional_to_single
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_state_taxable_income: 413027.21875
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_adjusted_gross_income: 413027.21875
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_head_of_household: true
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_filing_status_separate: false
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_personal_credit_rate: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_alternative_minimum_tax: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_property_tax_credit_potential: 0
+    us-ct:policies/income_tax/pilot_liability_pipeline#input.ct_pit_pilot_stillborn_credit: 0
+  output:
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_middle_recapture: '1680'
+    us-ct:policies/income_tax/pilot_liability_pipeline#ct_pit_pilot_income_tax_liability: '25778.87809375'

--- a/us-ct/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ct/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,125 +4,545 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
-      - us-ct/statute/12-700
-      - us-ct/statute/12-704e
-      - us-ct/statute/12-704i
+      - us-ct/statute/12-700/block-1
+      - us-ct/statute/12-704i/block-1
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
-        - us-ct/statute/12-700
-        - us-ct/statute/12-704e
-        - us-ct/statute/12-704i
+        - us-ct/statute/12-700/block-1
+        - us-ct/statute/12-704i/block-1
       rationale: |-
-        This pipeline computes the Connecticut section 12-700 individual
-        income-tax liability for the ordinary resident wage-earner slice: the
-        graduated tax on Connecticut taxable income (Connecticut adjusted gross
-        income less the section 12-702 personal exemption) less the net of the
-        section 12-703 personal credit and the section 12-700(b) three-per-cent
-        phase-out (benefit recapture). The section 12-700 resident tax SCHEDULE is
-        carried on main as a deferred output (its bracket table depends on upstream
-        filing-status sources not yet imported), so this pipeline supplies the
-        operative 2026 schedule directly — the 3, 5, 5.5, 6, 6.5, 6.9, and 6.99 per
-        cent brackets — exactly as the Ohio pilot supplies its indexed schedule.
-        Because the six-case grid crosses several brackets, each case supplies the
-        cumulative tax at its bracket floor, that floor, and the bracket marginal
-        rate, so the schedule reproduces the graduated tax as the supplied
-        cumulative base plus the supplied marginal rate on taxable income above the
-        floor. To reach a liability comparable to PolicyEngine ct_income_tax to the
-        cent, the amounts this pipeline needs are declared caller-supplied inputs:
-        the section 12-702 personal exemption (15,000 single / 24,000 joint,
-        phased out one dollar per dollar over the threshold, so the supplied
-        subtraction is zero in the higher-income cases), the per-case bracket
-        floor, the cumulative base tax at that floor, the bracket marginal rate,
-        and a single supplied credit standing for the NET of the section 12-703
-        personal credit (which reduces the tax at lower income) and the section
-        12-700(b) three-per-cent phase-out and tax recapture (which ADD to the tax
-        at higher income) — so the supplied credit is positive where the personal
-        credit dominates and negative where the recapture dominates. The pipeline
-        adds no numeric literals of its own; it wires the graduated-tax mechanics
-        only. The section 12-702 exemption and the section 12-703 credit / section
-        12-700(b) recapture are supplied here pending their own executable
-        encodings, mirroring the California pilot's supplied standard deduction and
-        personal exemption credit.
+        The certified current Chapter 229 capture at section 12-700 contains
+        sections 12-700 through 12-704c, including the complete 2024-and-later
+        resident schedules, low-rate phaseout, three recapture tiers,
+        alternative minimum tax, personal credit, and property-tax credit.
+        Section 12-704i separately supplies the stillborn credit. This module
+        accepts completed-return Connecticut taxable income and Connecticut
+        adjusted gross income, the filing-status classification, the personal
+        credit rate, alternative minimum tax, and the two pre-cap nonrefundable
+        credit components. None depends on the comparison target. It computes
+        every schedule, phaseout, recapture, personal-credit application, and
+        ordered nonrefundable-credit cap inside Axiom and fails closed outside
+        tax year 2026.
   summary: |-
-    Composed Connecticut individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Connecticut adjusted gross income into the section 12-700 graduated tax on
-    Connecticut taxable income, so an end-to-end comparison against PolicyEngine
-    (ct_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
-    the caller to supply the 12-700 bracket application, the section 12-703
-    personal credit, or the section 12-700(b) recapture. It wires: Connecticut
-    taxable income (Connecticut AGI less the supplied section 12-702 personal
-    exemption); the graduated tax as the supplied cumulative base tax at the
-    case's bracket floor plus the supplied marginal rate on taxable income above
-    that floor, which reproduces the statutory 3/5/5.5/6/6.5/6.9/6.99-per-cent
-    schedule for filers above the floor; and that tax less the supplied credit —
-    the net of the section 12-703 personal credit and the section 12-700(b)
-    three-per-cent phase-out / tax recapture, hence positive at lower income and
-    negative (a net addition) at higher income — floored at zero. It deliberately
-    models only the ordinary resident wage earner and excludes the property-tax
-    and earned-income credits, all zero for the childless wage-earner grid.
-    Connecticut AGI, filing status, the personal exemption, the bracket floor,
-    base, and marginal rate, and the net credit are supplied inputs; the exemption
-    and credit thresholds are indexed, so this 2026 pipeline is compared against
-    PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with the
-    indexation vintage dispositioned.
+    Connecticut 2026 resident individual income tax before refundable credits.
+    The pipeline applies all five section 12-700 filing-status schedules, the
+    low-rate phaseout, all three income-tax recapture tiers, the section 12-703
+    personal credit, section 12-700a alternative minimum tax, and the ordered
+    property-tax and stillborn nonrefundable credits. Caller boundaries are
+    completed-return Connecticut taxable income and Connecticut AGI, three
+    mutually exclusive filing-status classifications, the independently
+    computed section 12-703 personal-credit rate, Connecticut AMT, property-tax
+    credit potential, and stillborn credit before the shared liability cap.
+    The module does not reconstruct the Connecticut tax base, AMT base, or
+    underlying credit eligibility facts. PolicyEngine-US 1.752.2 exposes each
+    boundary as a distinct ancestor of
+    `ct_income_tax_before_refundable_credits`. On all 951 positive-weight
+    Connecticut tax units in the certified 2024 Populace projected to tax year
+    2026, this pipeline had maximum absolute error $0.4592000004, maximum
+    relative error 3.69725e-7, weighted MAE $0.0001407356331, zero differences
+    above $1, and zero differences outside $0.01 absolute or 1e-7 relative
+    tolerance. The run covered 483 single, 394 joint, 68 head-of-household,
+    and 6 separate units; no surviving-spouse unit appeared, while the joint
+    fixture exercises the shared statutory schedule.
 rules:
+  - name: ct_pit_pilot_rate_1
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), first rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "Not over $10,000 2.0%"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.02'}]
+  - name: ct_pit_pilot_rate_2
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), second rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 4.5% of the"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.045'}]
+  - name: ct_pit_pilot_rate_3
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), third rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 5.5% of the"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.055'}]
+  - name: ct_pit_pilot_rate_4
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), fourth rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 6.0% of the"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.06'}]
+  - name: ct_pit_pilot_rate_5
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), fifth rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 6.5% of the"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.065'}]
+  - name: ct_pit_pilot_rate_6
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), sixth rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 6.9% of the"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.069'}]
+  - name: ct_pit_pilot_rate_7
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10), top rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "plus 6.99% of the excess"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0699'}]
+
+  - name: ct_pit_pilot_single_floor_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), second-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $10,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '10000'}]
+  - name: ct_pit_pilot_single_floor_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), third-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $50,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '50000'}]
+  - name: ct_pit_pilot_single_floor_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), fourth-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $100,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '100000'}]
+  - name: ct_pit_pilot_single_floor_5
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), fifth-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $200,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '200000'}]
+  - name: ct_pit_pilot_single_floor_6
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), sixth-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $250,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '250000'}]
+  - name: ct_pit_pilot_single_floor_7
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(i), top-band floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "excess over $500,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '500000'}]
+
   - name: ct_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 12-700 and 12-702, Connecticut taxable income after the supplied personal exemption
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ct/statute/12-700
-              excerpt: "Connecticut taxable income"
+    source: Conn. Gen. Stat. 12-700, supplied completed-return Connecticut taxable income
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "Connecticut taxable income of each resident"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'max(0, ct_pit_pilot_state_taxable_income)'}]
+
+  - name: ct_pit_pilot_head_of_household_first_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-700(a)(10)(B)(i) head-of-household first-bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "Not over $16,000 2.0%"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '16000'}]
+  - name: ct_pit_pilot_joint_first_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 12-700(a)(10)(C)(i) joint first-bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "Not over $20,000 2.0%"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '20000'}]
+
+  - name: ct_pit_pilot_schedule_scale
+    kind: derived
+    entity: TaxUnit
+    dtype: Number
+    period: Year
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D), filing-status schedule widths
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "as a head of household"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "married individuals filing jointly or any person who files a return under the federal income tax for such taxable year as a surviving spouse"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "as a married individual filing separately"}}]}}
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_supplied_standard_deduction)
+        effective_to: '2026-12-31'
+        formula: 'if ct_pit_pilot_filing_status_joint_or_surviving_spouse: ct_pit_pilot_joint_first_ceiling / ct_pit_pilot_single_floor_2 else: if ct_pit_pilot_filing_status_head_of_household: ct_pit_pilot_head_of_household_first_ceiling / ct_pit_pilot_single_floor_2 else: 1'
+
   - name: ct_pit_pilot_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 12-700, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ct/statute/12-700
-              excerpt: "the tax shall be"
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D), complete seven-band schedules
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "For taxable years commencing on or after January 1, 2024, in accordance with the following schedule"}}]}}
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          ct_pit_pilot_supplied_bracket_base
-          + ct_pit_pilot_supplied_marginal_rate * max(0, ct_pit_pilot_taxable_income - ct_pit_pilot_supplied_bracket_floor)
+          ct_pit_pilot_schedule_scale * (
+            ct_pit_pilot_rate_1 * min(ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale, ct_pit_pilot_single_floor_2)
+            + ct_pit_pilot_rate_2 * min(max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_2), ct_pit_pilot_single_floor_3 - ct_pit_pilot_single_floor_2)
+            + ct_pit_pilot_rate_3 * min(max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_3), ct_pit_pilot_single_floor_4 - ct_pit_pilot_single_floor_3)
+            + ct_pit_pilot_rate_4 * min(max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_4), ct_pit_pilot_single_floor_5 - ct_pit_pilot_single_floor_4)
+            + ct_pit_pilot_rate_5 * min(max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_5), ct_pit_pilot_single_floor_6 - ct_pit_pilot_single_floor_5)
+            + ct_pit_pilot_rate_6 * min(max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_6), ct_pit_pilot_single_floor_7 - ct_pit_pilot_single_floor_6)
+            + ct_pit_pilot_rate_7 * max(0, ct_pit_pilot_taxable_income / ct_pit_pilot_schedule_scale - ct_pit_pilot_single_floor_7)
+          )
+
+  - name: ct_pit_pilot_single_phaseout_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(ii), single phaseout start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds fifty-six thousand five hundred dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '56500'}]
+  - name: ct_pit_pilot_head_phaseout_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(B)(ii), head-of-household phaseout start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds seventy-eight thousand five hundred dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '78500'}]
+  - name: ct_pit_pilot_joint_phaseout_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(C)(ii), joint phaseout start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds one hundred thousand five hundred dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '100500'}]
+  - name: ct_pit_pilot_separate_phaseout_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(D)(ii), separate phaseout start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds fifty thousand two hundred fifty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '50250'}]
+  - name: ct_pit_pilot_single_phaseout_increment
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(ii), single phaseout increment
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each five thousand dollars, or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '5000'}]
+  - name: ct_pit_pilot_head_phaseout_increment
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(B)(ii), head-of-household phaseout increment
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each four thousand dollars, or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4000'}]
+  - name: ct_pit_pilot_separate_phaseout_increment
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(D)(ii), separate phaseout increment
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each two thousand five hundred dollars, or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2500'}]
+  - name: ct_pit_pilot_single_phaseout_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Difference between 2 and 4.5 percent on the single $1,000 withdrawal band
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "reduced by one thousand dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '25'}]
+  - name: ct_pit_pilot_single_phaseout_maximum
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Complete withdrawal of the single $10,000 bottom-rate band
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "amount of the taxpayer's Connecticut taxable income to which the two-per-cent tax rate applies shall be reduced"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '250'}]
+  - name: ct_pit_pilot_single_low_recapture_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iii), low recapture start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds one hundred five thousand dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '105000'}]
+  - name: ct_pit_pilot_single_middle_recapture_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iv), middle recapture start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds two hundred thousand dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '200000'}]
+  - name: ct_pit_pilot_single_high_recapture_start
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(v), high recapture start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds five hundred thousand dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '500000'}]
+  - name: ct_pit_pilot_single_recapture_increment
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iii)-(v), recapture increment
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each five thousand dollars, or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '5000'}]
+  - name: ct_pit_pilot_single_low_recapture_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iii), low recapture amount
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "amount equal to twenty-five dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '25'}]
+  - name: ct_pit_pilot_single_middle_recapture_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iv), middle recapture amount
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "amount equal to ninety dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '90'}]
+  - name: ct_pit_pilot_single_high_recapture_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(v), high recapture amount
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "amount equal to fifty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '50'}]
+  - name: ct_pit_pilot_single_low_recapture_maximum
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iii), low recapture maximum
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "maximum payment of two hundred fifty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '250'}]
+  - name: ct_pit_pilot_single_middle_recapture_maximum
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(iv), middle recapture maximum
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "maximum payment of two thousand seven hundred dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2700'}]
+  - name: ct_pit_pilot_head_middle_recapture_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(B)(iv), head-of-household middle recapture amount
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "amount equal to one hundred forty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '140'}]
+  - name: ct_pit_pilot_head_middle_recapture_maximum
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(B)(iv), head-of-household middle recapture maximum
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "maximum payment of four thousand two hundred dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4200'}]
+  - name: ct_pit_pilot_single_high_recapture_maximum
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)(v), high recapture maximum
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "maximum payment of four hundred fifty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '450'}]
+
+  - name: ct_pit_pilot_phaseout_start
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(ii), low-rate phaseout start
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds fifty-six thousand five hundred dollars"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds seventy-eight thousand five hundred dollars"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds one hundred thousand five hundred dollars"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds fifty thousand two hundred fifty dollars"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'if ct_pit_pilot_filing_status_joint_or_surviving_spouse: ct_pit_pilot_joint_phaseout_start else: if ct_pit_pilot_filing_status_head_of_household: ct_pit_pilot_head_phaseout_start else: if ct_pit_pilot_filing_status_separate: ct_pit_pilot_separate_phaseout_start else: ct_pit_pilot_single_phaseout_start'}]
+  - name: ct_pit_pilot_phaseout_increment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(ii), low-rate phaseout increment
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each five thousand dollars, or fraction thereof"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each four thousand dollars, or fraction thereof"}}, {path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "for each two thousand five hundred dollars, or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'if ct_pit_pilot_filing_status_head_of_household: ct_pit_pilot_head_phaseout_increment else: if ct_pit_pilot_filing_status_separate: ct_pit_pilot_separate_phaseout_increment else: ct_pit_pilot_single_phaseout_increment'}]
+  - name: ct_pit_pilot_phaseout_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(ii), difference between 2 and 4.5 percent on each withdrawn band
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "the two-per-cent tax rate does not apply shall be an amount to which the four-and-one-half-per-cent tax rate shall apply"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'ct_pit_pilot_single_phaseout_amount * ct_pit_pilot_schedule_scale'}]
+  - name: ct_pit_pilot_phaseout_addback
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(ii), low-rate phaseout
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "or fraction thereof"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'min(ct_pit_pilot_single_phaseout_maximum * ct_pit_pilot_schedule_scale, ct_pit_pilot_phaseout_amount * ceil(max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_phaseout_start) / ct_pit_pilot_phaseout_increment))'}]
+
+  - name: ct_pit_pilot_low_recapture
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(iii), low-tier recapture
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds one hundred five thousand dollars shall pay"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'min(ct_pit_pilot_single_low_recapture_maximum * ct_pit_pilot_schedule_scale, ct_pit_pilot_single_low_recapture_amount * ct_pit_pilot_schedule_scale * ceil(max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_single_low_recapture_start * ct_pit_pilot_schedule_scale) / (ct_pit_pilot_single_recapture_increment * ct_pit_pilot_schedule_scale)))'}]
+  - name: ct_pit_pilot_middle_recapture
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(iv), middle-tier recapture
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds two hundred thousand dollars shall pay"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'if ct_pit_pilot_filing_status_head_of_household: min(ct_pit_pilot_head_middle_recapture_maximum, ct_pit_pilot_head_middle_recapture_amount * ceil(max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_single_middle_recapture_start * ct_pit_pilot_schedule_scale) / (ct_pit_pilot_single_recapture_increment * ct_pit_pilot_schedule_scale))) else: min(ct_pit_pilot_single_middle_recapture_maximum * ct_pit_pilot_schedule_scale, ct_pit_pilot_single_middle_recapture_amount * ct_pit_pilot_schedule_scale * ceil(max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_single_middle_recapture_start * ct_pit_pilot_schedule_scale) / (ct_pit_pilot_single_recapture_increment * ct_pit_pilot_schedule_scale)))'}]
+  - name: ct_pit_pilot_high_recapture
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10)(A)-(D)(v), high-tier recapture
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "exceeds five hundred thousand dollars shall pay"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'min(ct_pit_pilot_single_high_recapture_maximum * ct_pit_pilot_schedule_scale, ct_pit_pilot_single_high_recapture_amount * ct_pit_pilot_schedule_scale * ceil(max(0, ct_pit_pilot_adjusted_gross_income - ct_pit_pilot_single_high_recapture_start * ct_pit_pilot_schedule_scale) / (ct_pit_pilot_single_recapture_increment * ct_pit_pilot_schedule_scale)))'}]
+
+  - name: ct_pit_pilot_tax_before_personal_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700(a)(10), schedule plus phaseout and recapture
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "shall pay, in addition to the tax computed"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'ct_pit_pilot_schedule_tax + ct_pit_pilot_phaseout_addback + ct_pit_pilot_low_recapture + ct_pit_pilot_middle_recapture + ct_pit_pilot_high_recapture'}]
+  - name: ct_pit_pilot_tax_after_personal_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-703, supplied statutory personal-credit rate applied to section 12-700 tax
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "entitled to a credit in determining the amount of tax liability"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'max(0, ct_pit_pilot_tax_before_personal_credit * (1 - min(1, max(0, ct_pit_pilot_personal_credit_rate))))'}]
+  - name: ct_pit_pilot_tax_after_amt
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-700a, Connecticut minimum-tax addition
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "shall pay, in addition to the tax imposed under section 12-700, the net Connecticut minimum tax"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'ct_pit_pilot_tax_after_personal_credit + max(0, ct_pit_pilot_alternative_minimum_tax)'}]
+  - name: ct_pit_pilot_applied_property_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-704c, property-tax credit capped by tax liability
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "entitled to a credit in determining the amount of tax liability under this chapter"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'min(ct_pit_pilot_tax_after_amt, max(0, ct_pit_pilot_property_tax_credit_potential))'}]
+  - name: ct_pit_pilot_applied_stillborn_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Conn. Gen. Stat. 12-704i, stillborn credit applied after property-tax credit and capped by remaining liability
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-704i/block-1, excerpt: "credit against the tax imposed under this chapter"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'min(max(0, ct_pit_pilot_tax_after_amt - ct_pit_pilot_applied_property_tax_credit), max(0, ct_pit_pilot_stillborn_credit))'}]
   - name: ct_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 12-700 graduated tax less the supplied net 12-703 credit / 12-700(b) recapture, floored at zero
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ct/statute/12-704e
-              excerpt: "credit against the tax"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ct_pit_pilot_schedule_tax - ct_pit_pilot_supplied_nonrefundable_credit)
+    source: Chapter 229 tax after nonrefundable credits and before refundable credits
+    metadata: {proof: {atoms: [{path: 'versions[0].formula', kind: formula, source: {corpus_citation_path: us-ct/statute/12-700/block-1, excerpt: "Order of credits"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: 'max(0, ct_pit_pilot_tax_after_amt - ct_pit_pilot_applied_property_tax_credit - ct_pit_pilot_applied_stillborn_credit)'}]
+
+inputs:
+  - name: ct_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return Connecticut taxable income supplied by the caller.
+  - name: ct_pit_pilot_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return Connecticut adjusted gross income supplied for phaseout and recapture.
+  - name: ct_pit_pilot_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True only for joint or surviving-spouse filing status.
+  - name: ct_pit_pilot_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True only for head-of-household filing status.
+  - name: ct_pit_pilot_filing_status_separate
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True only for married-filing-separately status.
+  - name: ct_pit_pilot_personal_credit_rate
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    description: Independently computed section 12-703 personal-credit rate.
+  - name: ct_pit_pilot_alternative_minimum_tax
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Independently computed net Connecticut alternative minimum tax.
+  - name: ct_pit_pilot_property_tax_credit_potential
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Section 12-704c property-tax credit potential before the shared liability cap.
+  - name: ct_pit_pilot_stillborn_credit
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Section 12-704i stillborn credit before the shared liability cap.


### PR DESCRIPTION
## Summary

Promote the complete Connecticut 2026 individual income-tax before-refundable-credit pipeline over the certified Populace.

The RuleSpec encodes all five filing-status schedules, low-rate phaseout, three recapture tiers, personal credit, alternative minimum tax addition, and the ordered property-tax and stillborn nonrefundable-credit caps. The final output matches the exact PolicyEngine-US 1.752.2 TaxUnit target `ct_income_tax_before_refundable_credits`.

## Certified Populace evidence

- 951 positive-weight Connecticut tax units
- weighted tax units: 1,974,906.441571426
- filing statuses: 483 single, 394 joint, 68 head of household, 6 separate, 0 surviving-spouse observations
- max absolute difference: $0.4592000003904104
- max relative difference: 3.6972412397573344e-7
- weighted MAE: $0.00014073563312685011
- zero units above $1
- zero units outside $0.01 absolute OR 1e-7 relative tolerance

A surviving-spouse fixture covers the shared joint/surviving branch despite no positive-weight survivor observation.

## Checks

- pinned validator: pass
- companion fixtures: 10/10 pass
- proof validation: 59 atoms
- money obligations: 29; zero missing
- pending ratchet: 1,611 declared / 1,611 applied / 0 stale
- reverse index: current
- obsolete Connecticut validation waiver: retired
- signed exact-base guard: pass
- diff check and worktree: clean
- module SHA256: `ca81a20af9b3752149753a9902e83301a7f10e206800e900e4a4d989391d1877`
- test SHA256: `587ff581bc0c14ab152f004bb6ccd21a6a84d7fc477a50f87fed958e1aae1ee0`

## Review cycle

The exhaustive run initially exposed two head-of-household outliers caused by modeling the statutory middle recapture as a proportional $144 increment. The implementation was corrected to the explicit statutory $140 increment with the $4,200 maximum, a regression fixture was added, and the entire certified-Populace run was repeated with zero tolerance failures.

Independent semantic review is CLEAN, and final exact-head metadata review is CLEAN at `0e677fbaee301c5a359799951750d2908904ea56` against current main `12ff7bcc3635a7acd3ffd6ba9841126df7ae361e`.