### PR TITLE
Promote Delaware 2026 income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-de/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-de/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-de/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "4413c690c058f2458cc9d60207c9b237233b44ff6208d5c1547a0bbf1e97277d"
+      "sha256": "b7a291929482c3de0165b78ec61c3ef54c96a877c6bd3097f45cffcac749037d"
     },
     {
       "path": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "3dd2a5ff7e506870d91723d46675c5e903f8fb5a2f9f35722b201673cd204156"
+      "sha256": "7b3eb7822b345b9ec1b5aea3f90e6e8c0c3159d3fb07061e019c18329abe2deb"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1196",
-    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1196",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-de:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T06:33:47.690165+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-de/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
-  "generated_output_sha256": "3dd2a5ff7e506870d91723d46675c5e903f8fb5a2f9f35722b201673cd204156",
+  "generated_at": "2026-07-22T06:40:21.702246+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp77n5ygw6/sign-applied-files/us-de/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp77n5ygw6",
+  "generated_output_sha256": "7b3eb7822b345b9ec1b5aea3f90e6e8c0c3159d3fb07061e019c18329abe2deb",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,25 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ebd844448788e57266ebb5d0a8dc678c07fad2ea1567d445092aec065722d8b2"
+    "value": "9ccdae31c8c53154f93a804ff20bc952f67b612812173e3a9c7bacd1198cf628"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-22T04:01:04.726621+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "a4b1c457bf9988375ff59c7475fd9494f165f91a268087ee3dbb0fed49abeb77",
+    "prior_signature": "db306b559de94b1bb0e95eaef63f005073728d42df249194fdfe19750c750985",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-09T06:33:47.690165+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "0e6d24f9dd15c7099f91b6b29167bed76c94158100244383c9e700f49a62c48e",
+      "prior_signature": "ebd844448788e57266ebb5d0a8dc678c07fad2ea1567d445092aec065722d8b2",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16446,13 +16446,6 @@
     ],
     "us-de/statute/30/1108": [
       {
-        "module": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-de/statutes/30/1108.yaml",
         "via": [
           "module",
@@ -16470,13 +16463,6 @@
       }
     ],
     "us-de/statute/30/1110": [
-      {
-        "module": "us-de/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-de/statutes/30/1110.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -9770,12 +9770,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-de/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:296aebdd85c4b261b018bcd1592f3b3fad9fcd306605f7bd406629046c78ad0c"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-de/policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels.yaml":
     pending:
       fingerprint: "sha256:a3fbf8126341ecef5a25984f596ccbbb0c9cb4e451064f61755ce342c577d584"

--- a/us-de/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-de/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,120 +1,98 @@
-# Fixtures are hand-computed at the 2026 tax year (the expected values are the
-# author's own shown arithmetic from the section 1102 schedule, which axiom-encode
-# test proves equal the engine output to full decimal precision, not an oracle
-# read-back). Delaware liability = the section 1102 graduated tax on Delaware
-# taxable income (Delaware AGI - the section 1108 standard deduction: 3,250 single
-# / 6,500 joint) less the section 1110 personal credit (110 per exemption). Each
-# case supplies the cumulative tax at its bracket floor, the floor, and the
-# bracket marginal rate: floor 25,000 / base 1,001 / 5.55 per cent for the
-# 5.55-per-cent bracket (cumulative 0 + .022*3000 + .039*5000 + .048*10000 +
-# .052*5000 = 1,001 at 25,000), and floor 60,000 / base 2,943.5 / 6.6 per cent for
-# the top bracket (1,001 + .0555*35000 = 2,943.5 at 60,000). PolicyEngine
-# de_income_tax_before_refundable_credits matches to the cent.
-- name: single_30000
-  # taxable 30000-3250 = 26750. Schedule 1001 + 0.0555*(26750-25000) = 1001 + 97.125
-  # = 1098.125. Less 110 personal credit: liability 988.125.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Expected amounts are independent decimal arithmetic from 30 Del. C.
+# section 1102(a)(14), not PolicyEngine output read-back. The seven individual
+# cases cover the zero band and every positive statutory marginal band. The
+# final two cases exercise both values of PolicyEngine's computed
+# lower-pre-credit-tax branch selector and relation aggregation across two
+# included taxpayers plus one excluded person.
+- name: zero_band_through_2000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 30000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 1500
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '26750'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '1098.125'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '988.125'
-- name: single_60000
-  # taxable 56750. Schedule 1001 + 0.0555*(56750-25000) = 1001 + 1762.125 = 2763.125.
-  # Less 110: liability 2653.125.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_taxable_income: '1500'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '0'
+
+- name: first_positive_band
+  # 2.2% * (3,500 - 2,000) = 33.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 60000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 3500
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '56750'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '2763.125'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '2653.125'
-- name: single_150000
-  # taxable 146750. Top bracket: 2943.5 + 0.066*(146750-60000) = 2943.5 + 5725.5
-  # = 8669.0. Less 110: liability 8559.0.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '33'
+
+- name: second_positive_band
+  # 2.2% * 3,000 + 3.9% * 2,500 = 163.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 150000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 3250
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 110
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 7500
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '146750'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '8669'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '8559'
-- name: married_60000
-  # MFJ, spouse income 0. taxable 60000-6500 = 53500. Schedule 1001 + 0.0555*(53500-25000)
-  # = 1001 + 1581.75 = 2582.75. Less 220 (two exemptions): liability 2362.75.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '163.5'
+
+- name: third_positive_band
+  # 66 + 195 + 4.8% * 5,000 = 501.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 60000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 25000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 1001
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.0555
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 15000
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '53500'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '2582.75'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '2362.75'
-- name: married_120000
-  # taxable 113500. Top bracket: 2943.5 + 0.066*(113500-60000) = 2943.5 + 3531 = 6474.5.
-  # Less 220: liability 6254.5.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '501'
+
+- name: fourth_positive_band
+  # 66 + 195 + 480 + 5.2% * 2,500 = 871.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 120000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 22500
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '113500'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '6474.5'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '6254.5'
-- name: married_300000
-  # taxable 293500. Top bracket: 2943.5 + 0.066*(293500-60000) = 2943.5 + 15411 = 18354.5.
-  # Less 220: liability 18134.5.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '871'
+
+- name: fifth_positive_band
+  # Cumulative tax at 25,000 is 1,001; 1,001 + 5.55% * 15,000 = 1,833.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_adjusted_gross_income: 300000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_standard_deduction: 6500
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_floor: 60000
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_bracket_base: 2943.5
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_marginal_rate: 0.066
-    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_nonrefundable_credit: 220
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 40000
   output:
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_taxable_income: '293500'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_schedule_tax: '18354.5'
-    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '18134.5'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '1833.5'
+
+- name: top_band
+  # Cumulative tax at 60,000 is 2,943.5; 2,943.5 + 6.6% * 40,000 = 5,583.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 100000
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_schedule_tax: '5583.5'
+
+- name: strict_lower_individual_tax_selects_separate_branch
+  # Separate: schedule(70,000) + schedule(30,000) = 3,603.5 + 1,278.5 = 4,882.
+  # Combined: schedule(100,000) = 5,583.5. Strictly lower individual tax selects 4,882.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#relation.de_pit_pilot_taxpayer_of_tax_unit:
+      - us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_taxpayer_is_included: true
+        us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 70000
+      - us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_taxpayer_is_included: true
+        us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 30000
+      - us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_taxpayer_is_included: false
+        us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 100000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_combined_taxable_income: 100000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_files_separately: true
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_return_tax: '4882'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_combined_taxable_income: '100000'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_combined_return_tax: '5583.5'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '4882'
+
+- name: nonlower_individual_tax_selects_combined_branch
+  # Separate: schedule(50,000) + schedule(30,000) = 2,388.5 + 1,278.5 = 3,667.
+  # Combined: schedule(70,000) = 3,603.5. Individual tax is not lower, so the selector uses 3,603.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-de:policies/income_tax/pilot_liability_pipeline#relation.de_pit_pilot_taxpayer_of_tax_unit:
+      - us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_taxpayer_is_included: true
+        us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 50000
+      - us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_taxpayer_is_included: true
+        us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_separate_taxable_income: 30000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_supplied_combined_taxable_income: 70000
+    us-de:policies/income_tax/pilot_liability_pipeline#input.de_pit_pilot_files_separately: false
+  output:
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_separate_return_tax: '3667'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_combined_return_tax: '3603.5'
+    us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability: '3603.5'

--- a/us-de/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-de/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,119 +3,292 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-de/statute/30/1102
-      - us-de/statute/30/1108
-      - us-de/statute/30/1110
+    corpus_citation_path: us-de/statute/30/1102
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-de/statute/30/1102
-        - us-de/statute/30/1108
-        - us-de/statute/30/1110
       rationale: |-
-        This pipeline computes the Delaware section 1102 individual income-tax
-        liability for the ordinary resident wage-earner slice: the graduated tax
-        on Delaware taxable income (Delaware adjusted gross income less the
-        section 1108 standard deduction) less the section 1110 personal credits.
-        The encoded 1102 module carries the statutory rate schedule — zero on the
-        first 2,000 dollars, 2.2 per cent to 5,000, 3.9 per cent to 10,000, 4.8
-        per cent to 20,000, 5.2 per cent to 25,000, 5.55 per cent to 60,000, and
-        6.6 per cent above 60,000 — and those bracket boundaries are fixed in
-        statute (Delaware does not index them). Because the six-case grid crosses
-        the 5.55-per-cent and 6.6-per-cent brackets, each case supplies the
-        cumulative tax at its bracket floor, that floor, and the bracket's
-        marginal rate, so the schedule reproduces the graduated tax as the
-        supplied cumulative base plus the supplied marginal rate on taxable income
-        above the floor. To reach a liability comparable to PolicyEngine
-        de_income_tax to the cent, the amounts this pipeline needs are declared
-        caller-supplied inputs: the section 1108 standard deduction (3,250 dollars
-        single, 6,500 dollars joint), the per-case bracket floor, the cumulative
-        base tax at that floor, the bracket marginal rate, and the section 1110
-        personal credit (110 dollars per exemption — 110 single, 220 for the
-        two-exemption joint filer). The pipeline adds no numeric literals of its
-        own; it wires the graduated-tax mechanics only. The section 1108 standard
-        deduction and section 1110 personal-credit provisions are supplied here
-        pending their own executable encodings, mirroring the California pilot's
-        supplied standard deduction and personal exemption credit.
+        Delaware Code section 1102(a)(14) supplies the complete current
+        individual-income-tax schedule. This narrow component accepts
+        completed-return taxable-income candidates for the separate-return and
+        combined-return methods plus PolicyEngine's computed
+        `de_files_separately` lower-pre-credit-tax branch selector as explicit
+        upstream facts. In pinned PolicyEngine-US 1.752.2 that selector is true
+        exactly when aggregate individual pre-credit schedule tax is strictly
+        less than combined pre-credit schedule tax; a tie selects the combined
+        branch. It is not represented as a taxpayer election. This module
+        therefore does not reconstruct adjusted gross income, deductions,
+        exemptions, residency, allocation, or that computed branch selector.
+        Credits, the separate lump-sum-distribution tax, and the subsection (d)
+        Director-prescribed tax-table substitution are outside this
+        subsection (a)(14) rate-schedule calculation. The prescribed tables
+        are not present in the certified source slice.
+  deferred_outputs:
+    - output: us-de:statutes/30/1102/d#tax_table_tax_amount
+      reason: |-
+        Section 1102(d) substitutes Director-prescribed tables for qualifying
+        incomes. Those tables are not supplied by the certified source slice,
+        so this module exposes only the exact subsection (a)(14) schedule
+        amount compared by the pinned PolicyEngine target.
+      source_values:
+        - us-de:policies/income_tax/pilot_liability_pipeline#de_pit_pilot_income_tax_liability
   summary: |-
-    Composed Delaware individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Delaware adjusted gross income into the section 1102 graduated tax on Delaware
-    taxable income less the section 1110 personal credits, so an end-to-end
-    comparison against PolicyEngine (de_income_tax_before_refundable_credits) and
-    TAXSIM (siitax) does not require the caller to supply the 1102 bracket
-    application or the 1110 credit. It wires: Delaware taxable income (Delaware
-    AGI less the supplied section 1108 standard deduction); the graduated tax as
-    the supplied cumulative base tax at the case's bracket floor plus the supplied
-    marginal rate on taxable income above that floor, which reproduces the
-    statutory 0/2.2/3.9/4.8/5.2/5.55/6.6-per-cent schedule for filers above the
-    floor; and that tax less the supplied section 1110 personal credit, floored at
-    zero. It deliberately models only the ordinary resident wage earner and
-    excludes the section 1109 itemized-deduction election, the lump-sum and
-    business schedules, and the refundable/earned-income credits, all of which are
-    zero for the childless wage-earner grid. Delaware AGI, filing status, the
-    standard deduction, the bracket floor, base, and marginal rate, and the
-    personal credit are supplied inputs; Delaware's brackets are fixed in statute,
-    so this pipeline is compared against PolicyEngine at 2026 and against TAXSIM's
-    latest 2024 law year with the 2024-to-2026 vintage dispositioned rather than
-    absorbed by tolerance.
+    Composed Delaware subsection (a)(14) individual-income-tax rate schedule
+    for tax year 2026 before nonrefundable credits and before any subsection
+    (d) prescribed-tax-table substitution. For every included taxpayer it applies the fixed
+    section 1102(a)(14) schedule to supplied completed-return separate taxable
+    income, aggregates those amounts to the tax unit, and applies the same
+    schedule to supplied completed-return combined taxable income. The final
+    output selects the branch identified by the caller-supplied representation
+    of PolicyEngine's computed `de_files_separately` flag: true exactly when
+    aggregate individual pre-credit schedule tax is strictly less than combined
+    pre-credit schedule tax, with ties using the combined branch. This is not an
+    actual taxpayer election. It is the narrowest non-circular boundary for
+    PolicyEngine-US 1.752.2: `de_taxable_income_indv` and
+    `de_taxable_income_joint` are upstream of the compared schedule variables,
+    while no Delaware tax output is fed back as an input. For the certified 2024
+    Populace routed to tax year 2026, independently computing that strict
+    lower-tax selector covers all 936 positive-weight Delaware tax units,
+    including 124 separate-branch and 812 combined-branch selections. Against
+    `de_income_tax_before_non_refundable_credits_unit`, maximum absolute error
+    is $0.231999999844, maximum relative error is 7.76694402e-8, weighted MAE
+    is $0.0000864010142, no unit differs by more than $1, and no unit is outside
+    the campaign tolerance of $0.01 absolute or 1e-7 relative. Every statutory
+    band is represented in both candidate-income branches. All rules fail
+    closed outside tax year 2026.
 rules:
-  - name: de_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
+  - name: de_pit_pilot_taxpayer_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: de_pit_pilot_taxpayer_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+
+  - name: de_pit_pilot_first_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), first positive marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "2.2% of taxable income in excess of $2,000 but not in excess of $5,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.022'}]
+
+  - name: de_pit_pilot_second_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), second marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "3.9% of taxable income in excess of $5,000 but not in excess of $10,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.039'}]
+
+  - name: de_pit_pilot_third_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), third marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "4.8% of taxable income in excess of $10,000 but not in excess of $20,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.048'}]
+
+  - name: de_pit_pilot_fourth_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), fourth marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "5.2% of taxable income in excess of $20,000 but not in excess of $25,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.052'}]
+
+  - name: de_pit_pilot_fifth_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), fifth marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "5.55% of taxable income in excess of $25,000 but not in excess of $60,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0555'}]
+
+  - name: de_pit_pilot_top_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 30 Del. C. section 1102(a)(14), top marginal rate
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "6.6% of taxable income in excess of $60,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.066'}]
+
+  - name: de_pit_pilot_zero_bracket_ceiling
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: 1102 and 1108, Delaware taxable income after the supplied standard deduction
+    source: 30 Del. C. section 1102(a)(14), first positive-rate floor
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "taxable income in excess of $2,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2000'}]
+
+  - name: de_pit_pilot_first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), first positive bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "not in excess of $5,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '5000'}]
+
+  - name: de_pit_pilot_second_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), second bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "not in excess of $10,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '10000'}]
+
+  - name: de_pit_pilot_third_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), third bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "not in excess of $20,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '20000'}]
+
+  - name: de_pit_pilot_fourth_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), fourth bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "not in excess of $25,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '25000'}]
+
+  - name: de_pit_pilot_fifth_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), fifth bracket ceiling
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "not in excess of $60,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '60000'}]
+
+  - name: de_pit_pilot_separate_taxable_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), supplied completed-return separate taxable income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
-            source:
-              corpus_citation_path: us-de/statute/30/1108
-              excerpt: "the standard deduction of a resident individual"
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "taxable income in excess of $2,000"}
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, de_pit_pilot_adjusted_gross_income - de_pit_pilot_supplied_standard_deduction)
-  - name: de_pit_pilot_schedule_tax
+        effective_to: '2026-12-31'
+        formula: max(0, de_pit_pilot_supplied_separate_taxable_income)
+
+  - name: de_pit_pilot_separate_schedule_tax
     kind: derived
-    entity: TaxUnit
+    entity: Person
     dtype: Money
     period: Year
     unit: USD
-    source: 1102, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    source: 30 Del. C. section 1102(a)(14), graduated schedule on separate taxable income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
-            source:
-              corpus_citation_path: us-de/statute/30/1102
-              excerpt: "tax table income"
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "For taxable years beginning after December 31, 2013, the amount of tax shall be determined as follows"}
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          de_pit_pilot_supplied_bracket_base
-          + de_pit_pilot_supplied_marginal_rate * max(0, de_pit_pilot_taxable_income - de_pit_pilot_supplied_bracket_floor)
+          de_pit_pilot_first_rate * min(max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_zero_bracket_ceiling), de_pit_pilot_first_bracket_ceiling - de_pit_pilot_zero_bracket_ceiling)
+          + de_pit_pilot_second_rate * min(max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_first_bracket_ceiling), de_pit_pilot_second_bracket_ceiling - de_pit_pilot_first_bracket_ceiling)
+          + de_pit_pilot_third_rate * min(max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_second_bracket_ceiling), de_pit_pilot_third_bracket_ceiling - de_pit_pilot_second_bracket_ceiling)
+          + de_pit_pilot_fourth_rate * min(max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_third_bracket_ceiling), de_pit_pilot_fourth_bracket_ceiling - de_pit_pilot_third_bracket_ceiling)
+          + de_pit_pilot_fifth_rate * min(max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_fourth_bracket_ceiling), de_pit_pilot_fifth_bracket_ceiling - de_pit_pilot_fourth_bracket_ceiling)
+          + de_pit_pilot_top_rate * max(0, de_pit_pilot_separate_taxable_income - de_pit_pilot_fifth_bracket_ceiling)
+
+  - name: de_pit_pilot_separate_return_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), aggregate tax for taxpayers using separate completed-return incomes
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "the amount of tax shall be determined as follows"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: sum_where(de_pit_pilot_taxpayer_of_tax_unit, de_pit_pilot_separate_schedule_tax, de_pit_pilot_taxpayer_is_included)
+
+  - name: de_pit_pilot_combined_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), supplied completed-return combined taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "taxable income in excess of $2,000"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, de_pit_pilot_supplied_combined_taxable_income)
+
+  - name: de_pit_pilot_combined_return_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 30 Del. C. section 1102(a)(14), graduated schedule on combined taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "For taxable years beginning after December 31, 2013, the amount of tax shall be determined as follows"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          de_pit_pilot_first_rate * min(max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_zero_bracket_ceiling), de_pit_pilot_first_bracket_ceiling - de_pit_pilot_zero_bracket_ceiling)
+          + de_pit_pilot_second_rate * min(max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_first_bracket_ceiling), de_pit_pilot_second_bracket_ceiling - de_pit_pilot_first_bracket_ceiling)
+          + de_pit_pilot_third_rate * min(max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_second_bracket_ceiling), de_pit_pilot_third_bracket_ceiling - de_pit_pilot_second_bracket_ceiling)
+          + de_pit_pilot_fourth_rate * min(max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_third_bracket_ceiling), de_pit_pilot_fourth_bracket_ceiling - de_pit_pilot_third_bracket_ceiling)
+          + de_pit_pilot_fifth_rate * min(max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_fourth_bracket_ceiling), de_pit_pilot_fifth_bracket_ceiling - de_pit_pilot_fourth_bracket_ceiling)
+          + de_pit_pilot_top_rate * max(0, de_pit_pilot_combined_taxable_income - de_pit_pilot_fifth_bracket_ceiling)
+
   - name: de_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 1102 graduated tax less the 1110 personal credits, floored at zero
+    source: 30 Del. C. section 1102(a)(14), schedule tax selected by the supplied PolicyEngine lower-pre-credit-tax branch flag
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
-            source:
-              corpus_citation_path: us-de/statute/30/1110
-              excerpt: "personal credits"
+            source: {corpus_citation_path: us-de/statute/30/1102, excerpt: "the amount of tax shall be determined as follows"}
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, de_pit_pilot_schedule_tax - de_pit_pilot_supplied_nonrefundable_credit)
+          if de_pit_pilot_files_separately:
+            de_pit_pilot_separate_return_tax
+          else:
+            de_pit_pilot_combined_return_tax


### PR DESCRIPTION
## Summary

Promote the Delaware 2026 individual income-tax schedule over the complete certified Populace. The RuleSpec applies the complete 30 Del. C. section 1102(a)(14) rate schedule to separate-return Person-grain taxable-income candidates and the combined TaxUnit-grain candidate, then selects the same pre-credit branch as pinned PolicyEngine-US 1.752.2.

The supplied `de_files_separately` boundary is documented precisely as PolicyEngine's computed lower-pre-credit-tax selector: aggregate individual schedule tax must be strictly less than combined schedule tax; a tie uses the combined branch. It is not represented as an actual taxpayer election.

## Entity and relation projection

- Exact relation: `de_pit_pilot_taxpayer_of_tax_unit(TaxUnit, Person)`
- Person boundary: `de_taxable_income_indv`
- TaxUnit boundary: reviewed Person-to-TaxUnit sum of `de_taxable_income_joint`
- Only PolicyEngine-certified TaxUnit heads and spouses are related/included; dependents are excluded
- Person identity, order, cardinality, and Person-to-TaxUnit membership are checked before projection
- No Delaware tax result is fed back as an input

## Certified Populace evidence

- 936 positive-weight Delaware tax units
- weighted tax units: 538,740.58326
- branch selections: 124 separate, 812 combined
- maximum absolute difference: $0.231999999844
- maximum relative difference: 7.76694402e-8
- weighted MAE: $0.0000864010142
- zero units above $1
- zero units outside $0.01 absolute OR 1e-7 relative tolerance

## Exact base and provenance

- exact base: `37424844688d4ffbc538ca499110c7c1389b7399`
- exact reviewed head: `6458ba30eb8b304b82f9c75b04d71eeb43c4612f`
- branch shape: one clean commit above the exact base
- module SHA256: `7b3eb7822b345b9ec1b5aea3f90e6e8c0c3159d3fb07061e019c18329abe2deb`
- test SHA256: `b7a291929482c3de0165b78ec61c3ef54c96a877c6bd3097f45cffcac749037d`
- signed manifest refreshed with pinned axiom-encode `3869d66d009f52258be35901edbef370e65a399c`

## Checks

- pinned validator: pass
- companion fixtures: 9/9 pass
- proof validation: 18 atoms
- money obligations: 6; zero missing
- validation-gap ratchet: resolved Delaware waiver retired; validation pass
- reverse index: current (3,942 provisions / 4,668 edges / 4,433 modules)
- focused repository tests: 18 passed
- diff check and worktree: clean
- secure signed exact-base generated-artifact guard: pass

## Review cycle

The first independent exact-head review found two actionable presentation/provenance issues: the branch needed to be a single commit above the exact Connecticut base, and documentation incorrectly described PolicyEngine's computed branch selector as a taxpayer election. Both were fixed, the signed manifest was refreshed, and every focused gate was rerun. Independent exact-head rereview is CLEAN at `6458ba30eb8b304b82f9c75b04d71eeb43c4612f`.
