### PR TITLE
Promote New Mexico 2026 PIT schedule

### DIFF
--- a/.axiom/encoding-manifests/us-nm/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nm/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-nm/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "63a3d412cbb69a517d05eb7ad82ca5024c0031f0312fa6999470fe3100cda387"
+      "sha256": "c3a74cb0c046a32fb9e5779f6ac17211089619c527996eff85e07d988b0b80db"
     },
     {
       "path": "us-nm/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "e7ed60e41c08d8c31192ad420f8c29c4c0c97e2b0c255850c4901f8c9425d7b8"
+      "sha256": "fc228d9c3a405bdd042e998ecb0ffdaf5c07d7f9759cca35adfdcca990ce0fd5"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-nm:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.881121+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-nm/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "e7ed60e41c08d8c31192ad420f8c29c4c0c97e2b0c255850c4901f8c9425d7b8",
+  "generated_at": "2026-07-22T06:30:48.294646+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5pyx_2p8/sign-applied-files/us-nm/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5pyx_2p8",
+  "generated_output_sha256": "fc228d9c3a405bdd042e998ecb0ffdaf5c07d7f9759cca35adfdcca990ce0fd5",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,71 +34,98 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "20575bc05cd2b0eb5bf4fd59b9fcfe76f481122e732edf9bba95bc9bb2c33d63"
+    "value": "0a812c84443b26567af51763fb8362bdce1663c4407a437b795dc1dd7e257c19"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.910096+00:00",
+    "generated_at": "2026-07-22T06:19:21.027774+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "88e5eace6b9f0056dee5fe66d8e71549a5b696d7357bc0de794b53c26ff7efc1",
-    "prior_signature": "59b94baed4a988c5a7ff826d83af3e5c8dfe0a390d28e1ad345d5d533cd567c6",
+    "manifest_sha256": "252308f053cf2bab02f14fc25e721ff086766c497c22cd591fb4c36db0ec10cf",
+    "prior_signature": "804ba1c297b8fa7ee42591add40613ea16aa78ac289ec69cbafaf93ace78dc0c",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.203022+00:00",
+      "generated_at": "2026-07-22T03:46:42.535133+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "deff4179ecdbf358d29359669417b73221d9dfa62db91245b780aadedb9fe1d0",
-      "prior_signature": "f67a7f3e4f7b06c6ebeb1fe04de28febe8d3730ecf55d4c70115f62b079fce9e",
+      "manifest_sha256": "c554e211f468b28884a26d11cbdfc2a212ea0e6bd087c54e67e5aa1f48554c02",
+      "prior_signature": "77105b00c5e12ed2b8253e1ca7c6f402a7a27151a6662485c1cfb071ddd9c574",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.269622+00:00",
+        "generated_at": "2026-07-21T15:45:46.881121+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "6d253da9dd8f1af56467fffe57b4c81729de018d1d1aba31a9e841a5fd155ede",
-        "prior_signature": "eab92cdc3a40139fdae0b7421cd6f2ab2a8e77be82e48f0ac6b5995ce643d380",
+        "manifest_sha256": "2254df6e0bc2f08c765d511e62d47af57728ed4df3851e02ffd03db999856782",
+        "prior_signature": "20575bc05cd2b0eb5bf4fd59b9fcfe76f481122e732edf9bba95bc9bb2c33d63",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:31.552435+00:00",
+          "generated_at": "2026-07-21T15:44:47.910096+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "cd055e00ade86ee8eda4f0291fbe91b496b74ba6e29d76cf8078f947150e66fc",
-          "prior_signature": "f87261003a24833f58925219a46ac420f0080ecea630608d80b16b20c7a3143d",
+          "manifest_sha256": "88e5eace6b9f0056dee5fe66d8e71549a5b696d7357bc0de794b53c26ff7efc1",
+          "prior_signature": "59b94baed4a988c5a7ff826d83af3e5c8dfe0a390d28e1ad345d5d533cd567c6",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T14:52:20.239164+00:00",
+            "generated_at": "2026-07-16T15:48:15.203022+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "c89f5c297242a231236251f98f69829e0b19b2c0ab892dda7c900af69fa1d7a8",
-            "prior_signature": "1b9f20cd869b13d18ff8c5fcedb95214e8ecc9a93868025a6d579aa533881f12",
+            "manifest_sha256": "deff4179ecdbf358d29359669417b73221d9dfa62db91245b780aadedb9fe1d0",
+            "prior_signature": "f67a7f3e4f7b06c6ebeb1fe04de28febe8d3730ecf55d4c70115f62b079fce9e",
             "run_id": null,
             "supersedes": {
               "backend": "manual",
-              "generated_at": "2026-07-16T14:39:34.875581+00:00",
+              "generated_at": "2026-07-16T15:22:02.269622+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "7ee7e40ab427dc65058ee25490493e193505b2804204cd3f87550eee8d7eb48b",
-              "prior_signature": "07421e2af4a5916890a358b7f8c9e637ff30d0992d84414535e868aa553ff840",
+              "manifest_sha256": "6d253da9dd8f1af56467fffe57b4c81729de018d1d1aba31a9e841a5fd155ede",
+              "prior_signature": "eab92cdc3a40139fdae0b7421cd6f2ab2a8e77be82e48f0ac6b5995ce643d380",
               "run_id": null,
               "supersedes": {
                 "backend": "manual",
-                "generated_at": "2026-07-16T14:29:10.637049+00:00",
+                "generated_at": "2026-07-16T15:09:31.552435+00:00",
                 "generation_prompt_sha256": null,
-                "manifest_sha256": "a4c331a64d9c4e355a07bf0f3489ba8a7a66e727c4633b1b84f5524be9aab0ed",
-                "prior_signature": "5f0d38be6e994c3e4d64c236b82bc9061d37b9a40e95d8053c6272e1b1d85597",
+                "manifest_sha256": "cd055e00ade86ee8eda4f0291fbe91b496b74ba6e29d76cf8078f947150e66fc",
+                "prior_signature": "f87261003a24833f58925219a46ac420f0080ecea630608d80b16b20c7a3143d",
                 "run_id": null,
                 "supersedes": {
                   "backend": "manual",
-                  "generated_at": "2026-07-15T14:31:12.053915+00:00",
+                  "generated_at": "2026-07-16T14:52:20.239164+00:00",
                   "generation_prompt_sha256": null,
-                  "manifest_sha256": "cd22642f9a99de059e9f278873f5b4467e6573c741c8764acf49ca3129bbd550",
-                  "prior_signature": "d00ae9afa17b2ff9f96c7f042e7c3193d087b8a08686abe8ed3c58d4808f0a6a",
+                  "manifest_sha256": "c89f5c297242a231236251f98f69829e0b19b2c0ab892dda7c900af69fa1d7a8",
+                  "prior_signature": "1b9f20cd869b13d18ff8c5fcedb95214e8ecc9a93868025a6d579aa533881f12",
                   "run_id": null,
                   "supersedes": {
                     "backend": "manual",
-                    "generated_at": "2026-07-15T14:18:32.184762+00:00",
+                    "generated_at": "2026-07-16T14:39:34.875581+00:00",
                     "generation_prompt_sha256": null,
-                    "manifest_sha256": "aea047f8346c8f5932456ebf60ed2f8118796191cb9f2148dfe5b4561236e656",
-                    "prior_signature": "367e61178104c32066d2e4413db604d2eb500b2070186514433d355384ceb1e7",
+                    "manifest_sha256": "7ee7e40ab427dc65058ee25490493e193505b2804204cd3f87550eee8d7eb48b",
+                    "prior_signature": "07421e2af4a5916890a358b7f8c9e637ff30d0992d84414535e868aa553ff840",
                     "run_id": null,
+                    "supersedes": {
+                      "backend": "manual",
+                      "generated_at": "2026-07-16T14:29:10.637049+00:00",
+                      "generation_prompt_sha256": null,
+                      "manifest_sha256": "a4c331a64d9c4e355a07bf0f3489ba8a7a66e727c4633b1b84f5524be9aab0ed",
+                      "prior_signature": "5f0d38be6e994c3e4d64c236b82bc9061d37b9a40e95d8053c6272e1b1d85597",
+                      "run_id": null,
+                      "supersedes": {
+                        "backend": "manual",
+                        "generated_at": "2026-07-15T14:31:12.053915+00:00",
+                        "generation_prompt_sha256": null,
+                        "manifest_sha256": "cd22642f9a99de059e9f278873f5b4467e6573c741c8764acf49ca3129bbd550",
+                        "prior_signature": "d00ae9afa17b2ff9f96c7f042e7c3193d087b8a08686abe8ed3c58d4808f0a6a",
+                        "run_id": null,
+                        "supersedes": {
+                          "backend": "manual",
+                          "generated_at": "2026-07-15T14:18:32.184762+00:00",
+                          "generation_prompt_sha256": null,
+                          "manifest_sha256": "aea047f8346c8f5932456ebf60ed2f8118796191cb9f2148dfe5b4561236e656",
+                          "prior_signature": "367e61178104c32066d2e4413db604d2eb500b2070186514433d355384ceb1e7",
+                          "run_id": null,
+                          "tool": "axiom-encode sign-applied-files"
+                        },
+                        "tool": "axiom-encode sign-applied-files"
+                      },
+                      "tool": "axiom-encode sign-applied-files"
+                    },
                     "tool": "axiom-encode sign-applied-files"
                   },
                   "tool": "axiom-encode sign-applied-files"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1611
+ceiling: 1638
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1364,9 +1364,90 @@ entries:
 - legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-15'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_base
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_floor
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_rate
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_fifth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_first_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_fourth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_second_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_third_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_base
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_floor
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_rate
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_fifth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_first_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_fourth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_second_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_third_upper_bound
+  source: manual
+  since: '2026-07-21'
 - legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax
   source: manual
   since: '2026-07-15'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_base
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_floor
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_rate
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_fifth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_first_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_fourth_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_second_upper_bound
+  source: manual
+  since: '2026-07-21'
+- legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_third_upper_bound
+  source: manual
+  since: '2026-07-21'
 - legal_id: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income
   source: manual
   since: '2026-07-15'

--- a/us-nm/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nm/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,69 +1,388 @@
-# PolicyEngine 4.18.9 supplies 2026 New Mexico taxable income and each active
-# NMSA 7-2-7 bracket. Expected values are shown base-plus-marginal arithmetic.
-- name: single_30000
-  # 82.50 + 3.2%*(12,900-5,500) = 319.30.
+- name: nonpositive_single_boundary_floors_to_zero
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 12900
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 82.5
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 5500
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.032
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: -100
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '12900'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '319.3'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '319.3'
-- name: single_60000
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '0'
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '0'
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '0'
+
+- name: single_exact_first_threshold
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 43900
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 1165.5
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 33500
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.047
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 5500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '43900'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '1654.3'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '1654.3'
-- name: single_150000
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '82.5'
+
+- name: single_second_bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 133900
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 2716.5
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 66500
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.049
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 10000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '133900'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '6019.1'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '6019.1'
-- name: married_60000
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '226.5'
+
+- name: single_top_bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 27800
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 664
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 25000
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.043
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 250000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '27800'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '784.4'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '784.4'
-- name: married_120000
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '12108'
+
+- name: married_separate_middle_bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 87800
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 1739
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 50000
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.047
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 20000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '87800'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '3515.6'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '3515.6'
-- name: married_300000
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '654.5'
+
+- name: married_separate_top_bracket
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_taxable_income: 267800
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_base: 4089
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_bracket_floor: 100000
-    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_supplied_marginal_rate: 0.049
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 200000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_taxable_income: '267800'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_schedule_tax: '12311.2'
-    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '12311.2'
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '9819.5'
+
+- name: joint_head_or_surviving_middle_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 30000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '879'
+
+- name: joint_head_or_surviving_exact_fifth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 315000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '14624'
+
+- name: joint_head_or_surviving_top_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 400000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '19639'
+
+- name: single_selector_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 5500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '82.5'
+
+- name: single_selector_transition_1_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 5501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '82.532'
+
+- name: single_selector_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 16500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '434.5'
+
+- name: single_selector_transition_2_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 16501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '434.543'
+
+- name: single_selector_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 33500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '1165.5'
+
+- name: single_selector_transition_3_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 33501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '1165.547'
+
+- name: single_selector_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 66500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '2716.5'
+
+- name: single_selector_transition_4_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 66501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '2716.549'
+
+- name: single_selector_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 210000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '9748'
+
+- name: single_selector_transition_5_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 210001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_selector: 5
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '9748.059'
+
+- name: married_separate_selector_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 4000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '60'
+
+- name: married_separate_selector_transition_1_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 4001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '60.032'
+
+- name: married_separate_selector_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 12500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '332'
+
+- name: married_separate_selector_transition_2_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 12501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '332.043'
+
+- name: married_separate_selector_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 25000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '869.5'
+
+- name: married_separate_selector_transition_3_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 25001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '869.547'
+
+- name: married_separate_selector_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 50000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '2044.5'
+
+- name: married_separate_selector_transition_4_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 50001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '2044.549'
+
+- name: married_separate_selector_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 157500
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '7312'
+
+- name: married_separate_selector_transition_5_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 157501
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: true
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_selector: 5
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '7312.059'
+
+- name: joint_head_or_surviving_selector_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 8000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 0
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '120'
+
+- name: joint_head_or_surviving_selector_transition_1_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 8001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '120.032'
+
+- name: joint_head_or_surviving_selector_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 25000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 1
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '664'
+
+- name: joint_head_or_surviving_selector_transition_2_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 25001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '664.043'
+
+- name: joint_head_or_surviving_selector_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 50000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 2
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '1739'
+
+- name: joint_head_or_surviving_selector_transition_3_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 50001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '1739.047'
+
+- name: joint_head_or_surviving_selector_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 100000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 3
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '4089'
+
+- name: joint_head_or_surviving_selector_transition_4_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 100001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '4089.049'
+
+- name: joint_head_or_surviving_selector_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 315000
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 4
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '14624'
+
+- name: joint_head_or_surviving_selector_transition_5_just_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_state_taxable_income: 315001
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_married_separate: false
+    us-nm:policies/income_tax/pilot_liability_pipeline#input.nm_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_selector: 5
+    us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_income_tax_liability: '14624.059'

--- a/us-nm/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nm/policies/income_tax/pilot_liability_pipeline.yaml
@@ -9,23 +9,32 @@ module:
       checked_paths:
         - us-nm/statute/7-2-7
       rationale: |-
-        The staged 2026-05-09 primary text of NMSA 7-2-7 provides the six
-        filing-status rate bands effective for taxable years beginning on or
-        after January 1, 2025. This 2026 candidate accepts New Mexico taxable
-        income and the applicable bracket's base tax, floor, and marginal rate
-        as declared caller-supplied current-authority inputs. It adds no
-        operative numeric literals and deliberately excludes deductions,
-        exemptions, special-income adjustments, and credits outside the rate
-        section.
+        The final source-as-of-2026-05-09 text of NMSA 7-2-7 supplies the
+        complete six-band schedule effective for taxable years beginning on or
+        after January 1, 2025. This 2026 projection accepts completed-return New
+        Mexico taxable income and mutually exclusive filing-status
+        classifications as caller boundaries, then applies every statutory
+        bracket directly. It does not reconstruct New Mexico taxable income,
+        credits, or the special lump-sum amount described in subsection D. The
+        module fails closed outside 2026.
   summary: |-
-    Candidate New Mexico individual income-tax liability pipeline for the 2026
-    ordinary full-year resident wage-earner slice. It normalizes supplied New
-    Mexico taxable income and applies the active NMSA 7-2-7 bracket in
-    base-plus-marginal form. Its exact PolicyEngine 4.18.9 analog is
-    `nm_income_tax_before_non_refundable_credits` on the six-case childless
-    age-40 resident wage grid: single at $30,000/$60,000/$150,000 and one-earner
-    joint at $60,000/$120,000/$300,000. PolicyEngine supplies the taxable-income
-    and active schedule inputs; expected outputs are independently hand-computed.
+    New Mexico 2026 individual income tax before nonrefundable credits for the
+    ordinary Section 7-2-7 rate-schedule slice. The caller supplies
+    completed-return New Mexico taxable income and filing-status
+    classifications. Joint filers, heads of household, and surviving spouses
+    share the subsection A schedule; single filers use subsection B; married
+    separate filers use subsection C. Estates, trusts, credits, upstream
+    taxable-income mechanics, and subsection D lump-sum tax remain outside this
+    narrow target.
+  deferred_outputs:
+    - output: us-nm:policies/income_tax/pilot_liability_pipeline#subsection_d_lump_sum_tax
+      reason: |-
+        PolicyEngine-US 1.752.2 does not compute subsection D in the distinct
+        nm_income_tax_before_non_refundable_credits target and exposes the
+        federal Form 4972 tax rather than the underlying lump-sum amount needed
+        by the statute. That federal tax is zero for all 1,475 positive-weight
+        New Mexico TaxUnits in the certified Populace projection, so subsection
+        D cannot be activated or validated non-circularly in this campaign.
 rules:
   - name: nm_pit_pilot_taxable_income
     kind: derived
@@ -33,7 +42,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: NMSA 7-2-7, supplied New Mexico taxable income
+    source: NMSA 7-2-7, completed-return New Mexico taxable income
     metadata:
       proof:
         atoms:
@@ -44,15 +53,16 @@ rules:
               excerpt: "For taxable income:"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, nm_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, nm_pit_pilot_state_taxable_income)
+
   - name: nm_pit_pilot_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: NMSA 7-2-7, supplied active bracket base plus marginal tax
+    source: NMSA 7-2-7(A)-(C), 2026 ordinary rate schedules
     metadata:
       proof:
         atoms:
@@ -60,19 +70,626 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-nm/statute/7-2-7
-              excerpt: "The tax imposed by Section 7-2-3 NMSA 1978 shall be at the following rates for any taxable year beginning on or after January 1, 2025"
+              excerpt: "The tax shall be:"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_base
+              output: nm_pit_pilot_married_separate_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_floor
+              output: nm_pit_pilot_married_separate_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_married_separate_bracket_rate
+              output: nm_pit_pilot_married_separate_bracket_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_base
+              output: nm_pit_pilot_joint_head_or_surviving_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_floor
+              output: nm_pit_pilot_joint_head_or_surviving_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_joint_head_or_surviving_bracket_rate
+              output: nm_pit_pilot_joint_head_or_surviving_bracket_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_base
+              output: nm_pit_pilot_single_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_floor
+              output: nm_pit_pilot_single_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nm:policies/income_tax/pilot_liability_pipeline#nm_pit_pilot_single_bracket_rate
+              output: nm_pit_pilot_single_bracket_rate
+              hash: sha256:local
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          nm_pit_pilot_supplied_bracket_base
-          + nm_pit_pilot_supplied_marginal_rate * max(0, nm_pit_pilot_taxable_income - nm_pit_pilot_supplied_bracket_floor)
+          if nm_pit_pilot_filing_status_married_separate:
+              nm_pit_pilot_married_separate_bracket_base[nm_pit_pilot_married_separate_bracket_selector]
+              + nm_pit_pilot_married_separate_bracket_rate[nm_pit_pilot_married_separate_bracket_selector]
+              * max(0, nm_pit_pilot_taxable_income - nm_pit_pilot_married_separate_bracket_floor[nm_pit_pilot_married_separate_bracket_selector])
+          else:
+              if nm_pit_pilot_filing_status_joint_head_or_surviving:
+                  nm_pit_pilot_joint_head_or_surviving_bracket_base[nm_pit_pilot_joint_head_or_surviving_bracket_selector]
+                  + nm_pit_pilot_joint_head_or_surviving_bracket_rate[nm_pit_pilot_joint_head_or_surviving_bracket_selector]
+                  * max(0, nm_pit_pilot_taxable_income - nm_pit_pilot_joint_head_or_surviving_bracket_floor[nm_pit_pilot_joint_head_or_surviving_bracket_selector])
+              else:
+                  nm_pit_pilot_single_bracket_base[nm_pit_pilot_single_bracket_selector]
+                  + nm_pit_pilot_single_bracket_rate[nm_pit_pilot_single_bracket_selector]
+                  * max(0, nm_pit_pilot_taxable_income - nm_pit_pilot_single_bracket_floor[nm_pit_pilot_single_bracket_selector])
+
+  - name: nm_pit_pilot_married_separate_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: NMSA 7-2-7(C), married-separate bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "C. For married individuals filing separate returns:"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nm_pit_pilot_taxable_income <= nm_pit_pilot_married_separate_first_upper_bound: 0
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_married_separate_second_upper_bound: 1
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_married_separate_third_upper_bound: 2
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_married_separate_fourth_upper_bound: 3
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_married_separate_fifth_upper_bound: 4
+          else: 5
+
+  - name: nm_pit_pilot_married_separate_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(C), married-separate first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Not over $4,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '4000'
+
+  - name: nm_pit_pilot_married_separate_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(C), married-separate second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $4,000 but not over $12,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '12500'
+
+  - name: nm_pit_pilot_married_separate_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(C), married-separate third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $12,500 but not over $25,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000'
+
+  - name: nm_pit_pilot_married_separate_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(C), married-separate fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $25,000 but not over $50,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '50000'
+
+  - name: nm_pit_pilot_married_separate_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(C), married-separate fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $50,000 but not over $157,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '157500'
+
+  - name: nm_pit_pilot_married_separate_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_married_separate_bracket_selector
+    source: NMSA 7-2-7(C), married-separate excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection C rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 4000, 2: 12500, 3: 25000, 4: 50000, 5: 157500}
+
+  - name: nm_pit_pilot_married_separate_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_married_separate_bracket_selector
+    source: NMSA 7-2-7(C), married-separate base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection C rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 60, 2: 332, 3: 869.5, 4: 2044.5, 5: 7312}
+
+  - name: nm_pit_pilot_married_separate_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: nm_pit_pilot_married_separate_bracket_selector
+    source: NMSA 7-2-7(C), married-separate marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection C rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.015, 1: 0.032, 2: 0.043, 3: 0.047, 4: 0.049, 5: 0.059}
+
+  - name: nm_pit_pilot_joint_head_or_surviving_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "A. For married individuals filing joint returns, heads of household and surviving spouses:"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nm_pit_pilot_taxable_income <= nm_pit_pilot_joint_head_or_surviving_first_upper_bound: 0
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_joint_head_or_surviving_second_upper_bound: 1
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_joint_head_or_surviving_third_upper_bound: 2
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_joint_head_or_surviving_fourth_upper_bound: 3
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_joint_head_or_surviving_fifth_upper_bound: 4
+          else: 5
+
+  - name: nm_pit_pilot_joint_head_or_surviving_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Not over $8,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '8000'
+
+  - name: nm_pit_pilot_joint_head_or_surviving_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $8,000 but not over $25,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000'
+
+  - name: nm_pit_pilot_joint_head_or_surviving_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $25,000 but not over $50,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '50000'
+
+  - name: nm_pit_pilot_joint_head_or_surviving_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $50,000 but not over $100,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '100000'
+
+  - name: nm_pit_pilot_joint_head_or_surviving_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $100,000 but not over $315,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '315000'
+
+  - name: nm_pit_pilot_joint_head_or_surviving_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_joint_head_or_surviving_bracket_selector
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection A rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 8000, 2: 25000, 3: 50000, 4: 100000, 5: 315000}
+
+  - name: nm_pit_pilot_joint_head_or_surviving_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_joint_head_or_surviving_bracket_selector
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection A rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 120, 2: 664, 3: 1739, 4: 4089, 5: 14624}
+
+  - name: nm_pit_pilot_joint_head_or_surviving_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: nm_pit_pilot_joint_head_or_surviving_bracket_selector
+    source: NMSA 7-2-7(A), joint, head-of-household, and surviving-spouse marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection A rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.015, 1: 0.032, 2: 0.043, 3: 0.047, 4: 0.049, 5: 0.059}
+
+  - name: nm_pit_pilot_single_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: NMSA 7-2-7(B), single bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "B. For single individuals and for estates and trusts:"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nm_pit_pilot_taxable_income <= nm_pit_pilot_single_first_upper_bound: 0
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_single_second_upper_bound: 1
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_single_third_upper_bound: 2
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_single_fourth_upper_bound: 3
+          else: if nm_pit_pilot_taxable_income <= nm_pit_pilot_single_fifth_upper_bound: 4
+          else: 5
+
+  - name: nm_pit_pilot_single_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(B), single first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Not over $5,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '5500'
+
+  - name: nm_pit_pilot_single_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(B), single second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $5,500 but not over $16,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '16500'
+
+  - name: nm_pit_pilot_single_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(B), single third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $16,500 but not over $33,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '33500'
+
+  - name: nm_pit_pilot_single_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(B), single fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $33,500 but not over $66,500"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '66500'
+
+  - name: nm_pit_pilot_single_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: NMSA 7-2-7(B), single fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              excerpt: "Over $66,500 but not over $210,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '210000'
+
+  - name: nm_pit_pilot_single_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_single_bracket_selector
+    source: NMSA 7-2-7(B), single excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection B rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 5500, 2: 16500, 3: 33500, 4: 66500, 5: 210000}
+
+  - name: nm_pit_pilot_single_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nm_pit_pilot_single_bracket_selector
+    source: NMSA 7-2-7(B), single base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection B rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 82.5, 2: 434.5, 3: 1165.5, 4: 2716.5, 5: 9748}
+
+  - name: nm_pit_pilot_single_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: nm_pit_pilot_single_bracket_selector
+    source: NMSA 7-2-7(B), single marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nm/statute/7-2-7
+              table: {header: "Subsection B rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.015, 1: 0.032, 2: 0.043, 3: 0.047, 4: 0.049, 5: 0.059}
+
   - name: nm_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: NMSA 7-2-7 tax before credits
+    source: NMSA 7-2-7(A)-(C), tax before credits and subsection D
     metadata:
       proof:
         atoms:
@@ -83,5 +700,5 @@ rules:
               excerpt: "The tax shall be:"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          nm_pit_pilot_schedule_tax
+        effective_to: '2026-12-31'
+        formula: nm_pit_pilot_schedule_tax


### PR DESCRIPTION
## Summary

Promote the New Mexico 2026 ordinary individual-income-tax schedule under NMSA 7-2-7(A)-(C). The RuleSpec accepts completed-return New Mexico taxable income and mutually exclusive filing-status classifications, then applies every statutory bracket for joint/head/surviving-spouse, single, and married-separate filers.

Credits, estates and trusts, upstream taxable-income mechanics, and subsection D lump-sum tax remain outside this narrow pre-nonrefundable-credit target. The subsection D deferral is explicit and evidence-backed for the pinned PolicyEngine-US model and certified Populace.

## Certified Populace evidence

- 1,475 positive-weight New Mexico TaxUnits
- weighted TaxUnits: 1,128,605.532538854
- PolicyEngine target: `nm_income_tax_before_non_refundable_credits`
- maximum absolute difference: $0.519999999553
- maximum relative difference: 5.63842806e-8
- zero units outside $0.01 absolute OR 1e-7 relative tolerance
- all operative statutory bracket transitions have exact companion fixtures

## Exact base and provenance

- exact base: `507da67f418619f30639f652f0ecdcf5c7e8b95b`
- exact reviewed head: `b6beb4133986d2bb94470031c746bb9ac64d36f6`
- branch shape: one clean commit above the exact Delaware merge
- module SHA256: `fc228d9c3a405bdd042e998ecb0ffdaf5c07d7f9759cca35adfdcca990ce0fd5`
- test SHA256: `c3a74cb0c046a32fb9e5779f6ac17211089619c527996eff85e07d988b0b80db`
- signed manifest: pinned axiom-encode 0.2.1200 at `3869d66d009f52258be35901edbef370e65a399c`

## Checks

- pinned validator: pass
- proof validation: 39 atoms; 21 monetary obligations; zero missing
- companion fixtures: 39/39 pass, including all 30 exact/just-above transitions
- direct compile and engine artifact inventory: pass
- manifest and repository-layout tests: 8 passed
- broader focused repository tests: 18 passed
- reverse index current: 3,942 provisions / 4,668 edges / 4,433 modules
- secure signed exact-base generated-artifact guard: pass
- diff check and worktree: clean

## Review cycle

The rebased one-commit head received an independent exact-head review covering the official New Mexico Legislature schedule, statutory boundary semantics, PolicyEngine target scope, subsection D deferral, proof atoms, fixtures, compiled input/output inventory, generated metadata, and pending-classification diff. The cycle is CLEAN at `b6beb4133986d2bb94470031c746bb9ac64d36f6`; no review edits or actionable findings remain.

Two unrelated repository-level conditions were observed and are not introduced by this branch: 13 stale SNAP pending declarations from registry drift, and those declarations' broader pending-ratchet result. The NM pending-classification diff itself is exact.
