### PR TITLE
Promote New Jersey 2026 income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-nj/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nj/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-nj/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "606b7155b3a893967a70cf67a27f1d0526f0e0e15f5121369401f1750034a4fc"
+      "sha256": "ab0eb231f4aacc3ab4347f16d4cf1c2e9912d880bf0011d80cb0511a40b36c44"
     },
     {
       "path": "us-nj/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "6f7d2192ab19d3961f705b55e97de203fd51597aefb8653ced857802e42907d3"
+      "sha256": "d0b439416b3c308d820891e6f5537096024b701363af92d92cc70705887d94ff"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-nj:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.879993+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-nj/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "6f7d2192ab19d3961f705b55e97de203fd51597aefb8653ced857802e42907d3",
+  "generated_at": "2026-07-22T05:54:14.806625+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbw79ctri/sign-applied-files/us-nj/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbw79ctri",
+  "generated_output_sha256": "d0b439416b3c308d820891e6f5537096024b701363af92d92cc70705887d94ff",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,43 +33,52 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "db50dd852e3ced7c4f054fc967128817dea670bf3ff11e6282d064a9477f2209"
+    "value": "ed17fb3cb85ea8b906c01ac26c1f4faeb47868d62bb7562b77d47b21a41e1b41"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.908979+00:00",
+    "generated_at": "2026-07-21T15:45:46.879993+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "7e4c12f58750f6efb3547678c381babe199673aeb71a6f815a865ae70165edb6",
-    "prior_signature": "678043f02f93cefc2a908dc2bb6495542d2b3b7eb79ee8e9662f5387bcef8f93",
+    "manifest_sha256": "5b84dc4d2f47843391010500f21c3e1b5c2720387f20b510b0609144882edc64",
+    "prior_signature": "db50dd852e3ced7c4f054fc967128817dea670bf3ff11e6282d064a9477f2209",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.202472+00:00",
+      "generated_at": "2026-07-21T15:44:47.908979+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "2157b4e77e753b6780cbf120c15418fc2c031dfb8d2e0c832e928029c6b9bf8b",
-      "prior_signature": "666068d3c1826b2c07e827b164f2de583d42c3f50b5fa9615455ef0d818078b2",
+      "manifest_sha256": "7e4c12f58750f6efb3547678c381babe199673aeb71a6f815a865ae70165edb6",
+      "prior_signature": "678043f02f93cefc2a908dc2bb6495542d2b3b7eb79ee8e9662f5387bcef8f93",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.269133+00:00",
+        "generated_at": "2026-07-16T15:48:15.202472+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "2bbd7822a3e015d6ed9c54429fea0fb2312f8bc5b7b071ad59c1b82d56cc614c",
-        "prior_signature": "099a25f8acf2872cd35a73e116509aa7820b49e0b96ab719acbd7e8bf35af9f0",
+        "manifest_sha256": "2157b4e77e753b6780cbf120c15418fc2c031dfb8d2e0c832e928029c6b9bf8b",
+        "prior_signature": "666068d3c1826b2c07e827b164f2de583d42c3f50b5fa9615455ef0d818078b2",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:31.551850+00:00",
+          "generated_at": "2026-07-16T15:22:02.269133+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "e534ff77fd02da7a6b473f405335bcc821bb3202a73fca8500b8b026a1fbac20",
-          "prior_signature": "c0fa97c021c991d141aa86848dd7d31865aabfccac8aaab28251b2e7475c0317",
+          "manifest_sha256": "2bbd7822a3e015d6ed9c54429fea0fb2312f8bc5b7b071ad59c1b82d56cc614c",
+          "prior_signature": "099a25f8acf2872cd35a73e116509aa7820b49e0b96ab719acbd7e8bf35af9f0",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T14:52:11.715987+00:00",
+            "generated_at": "2026-07-16T15:09:31.551850+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "c4969ba33f6b324a95aea63e214459538f4cfaa0eaf956e0642210120c4adaa9",
-            "prior_signature": "df3401c857122629417708a483c7489252609787eb03b8136a82bd256ba7160c",
+            "manifest_sha256": "e534ff77fd02da7a6b473f405335bcc821bb3202a73fca8500b8b026a1fbac20",
+            "prior_signature": "c0fa97c021c991d141aa86848dd7d31865aabfccac8aaab28251b2e7475c0317",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-16T14:52:11.715987+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "c4969ba33f6b324a95aea63e214459538f4cfaa0eaf956e0642210120c4adaa9",
+              "prior_signature": "df3401c857122629417708a483c7489252609787eb03b8136a82bd256ba7160c",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/us-nj/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nj/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,75 +1,399 @@
-# Expected values are independently hand-computed from the supplied active
-# post-2020 section 54A:2-1 bracket. The supplied taxable-income grid and final
-# liabilities match PolicyEngine nj_main_income_tax for tax year 2026.
-- name: single_30000
-  # 280 + .0175 * (29,000 - 20,000) = 437.50.
+# Hand-computed fixtures for the tax-year-2026 schedules in N.J. Stat.
+# section 54A:2-1(a)(7) and (b)(7). Each bracket is exercised directly from
+# the official cumulative base, excess floor, and marginal rate. The wide
+# fixtures around $70,000 and $80,000 preserve the statute's literal $0.50
+# discontinuities rather than substituting a continuous marginal scale.
+- name: negative_narrow_boundary_is_floored
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 29000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 280
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 20000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.0175
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: -100
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '29000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '437.5'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '437.5'
-- name: single_60000
-  # 717.50 + .05525 * (59,000 - 40,000) = 1,767.25.
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '0'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 0
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '0'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '0'
+
+- name: narrow_first_bracket_upper_bound
+  # 1.4% * 20,000 = 280.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 59000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 717.50
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 40000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.05525
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 20000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '59000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1767.25'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1767.25'
-- name: single_150000
-  # 2,651.25 + .0637 * (149,000 - 75,000) = 7,365.05.
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '20000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 0
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '280'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '280'
+
+- name: narrow_second_bracket
+  # 280 + 1.75% * (25,000 - 20,000) = 367.50.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 149000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 2651.25
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 75000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.0637
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 25000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '149000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '7365.05'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '7365.05'
-- name: married_60000
-  # 805 + .0245 * (58,000 - 50,000) = 1,001.
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '25000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '367.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '367.5'
+
+- name: narrow_third_bracket
+  # 542.50 + 3.5% * (37,000 - 35,000) = 612.50.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 58000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 805
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 50000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.0245
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 37000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '58000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1001'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1001'
-- name: married_120000
-  # 1,645 + .05525 * (118,000 - 80,000) = 3,744.50.
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '37000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '612.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '612.5'
+
+- name: narrow_fourth_bracket
+  # 717.50 + 5.525% * (60,000 - 40,000) = 1,822.50.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 118000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 1645
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 80000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.05525
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 60000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '118000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '3744.5'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '3744.5'
-- name: married_300000
-  # 5,512.50 + .0637 * (298,000 - 150,000) = 14,940.10.
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '60000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 3
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1822.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1822.5'
+
+- name: narrow_fifth_bracket
+  # 2,651.25 + 6.37% * (100,000 - 75,000) = 4,243.75.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_taxable_income: 298000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_base: 5512.50
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_bracket_floor: 150000
-    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_supplied_marginal_rate: 0.0637
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 100000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
   output:
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '298000'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '14940.1'
-    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '14940.1'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '100000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 4
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '4243.75'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '4243.75'
+
+- name: narrow_sixth_bracket
+  # 29,723.75 + 8.97% * (600,000 - 500,000) = 38,693.75.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 600000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '600000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '38693.75'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '38693.75'
+
+- name: narrow_top_bracket
+  # 74,573.75 + 10.75% * (1,200,000 - 1,000,000) = 96,073.75.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1200000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '1200000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 6
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '96073.75'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '96073.75'
+
+- name: wide_first_bracket_upper_bound
+  # 1.4% * 20,000 = 280.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 20000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '20000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 0
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '280'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '280'
+
+- name: wide_second_bracket
+  # 280 + 1.75% * (35,000 - 20,000) = 542.50.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 35000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '35000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '542.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '542.5'
+
+- name: wide_third_bracket
+  # 805 + 2.45% * (60,000 - 50,000) = 1,050.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 60000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '60000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1050'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1050'
+
+- name: wide_statutory_half_dollar_band_starts
+  # 1,295.50 + 3.5% * (70,001 - 70,000) = 1,295.535.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 70001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '70001'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 3
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1295.535'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1295.535'
+
+- name: wide_statutory_half_dollar_band_upper_bound
+  # 1,295.50 + 3.5% * (80,000 - 70,000) = 1,645.50.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 80000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '80000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 3
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1645.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1645.5'
+
+- name: wide_fifth_bracket_preserves_literal_base
+  # 1,645 + 5.525% * (80,001 - 80,000) = 1,645.05525.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 80001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '80001'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 4
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1645.05525'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '1645.05525'
+
+- name: wide_sixth_bracket
+  # 5,512.50 + 6.37% * (200,000 - 150,000) = 8,697.50.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 200000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '200000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '8697.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '8697.5'
+
+- name: wide_seventh_bracket
+  # 27,807.50 + 8.97% * (600,000 - 500,000) = 36,777.50.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 600000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '600000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 6
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '36777.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '36777.5'
+
+- name: wide_top_bracket
+  # 72,657.50 + 10.75% * (1,200,000 - 1,000,000) = 94,157.50.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1200000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_taxable_income: '1200000'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 7
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '94157.5'
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_income_tax_liability: '94157.5'
+
+# Exact selector-transition pairs. These supplement the interior bracket cases
+# above and prove both the inclusive statutory upper bounds and the first dollar
+# assigned to each following bracket.
+- name: narrow_20001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 20001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '280.0175'
+
+- name: wide_20001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 20001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '280.0175'
+
+- name: narrow_35000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 35000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '542.5'
+
+- name: narrow_35001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 35001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '542.535'
+
+- name: narrow_40000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 40000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '717.5'
+
+- name: narrow_40001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 40001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 3
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '717.55525'
+
+- name: narrow_75000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 75000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 3
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '2651.25'
+
+- name: narrow_75001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 75001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 4
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '2651.3137'
+
+- name: narrow_500000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 500000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 4
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '29723.75'
+
+- name: narrow_500001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 500001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '29723.8397'
+
+- name: narrow_1000000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1000000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '74573.75'
+
+- name: narrow_1000001_top_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1000001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: false
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_selector: 6
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '74573.8575'
+
+- name: wide_50000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 50000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 1
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '805'
+
+- name: wide_50001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 50001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '805.0245'
+
+- name: wide_70000_upper_bound_before_discontinuity
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 70000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 2
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '1295'
+
+- name: wide_150000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 150000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 4
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '5512.5'
+
+- name: wide_150001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 150001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '5512.5637'
+
+- name: wide_500000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 500000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 5
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '27807.5'
+
+- name: wide_500001_next_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 500001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 6
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '27807.5897'
+
+- name: wide_1000000_upper_bound
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1000000
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 6
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '72657.5'
+
+- name: wide_1000001_top_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_state_taxable_income: 1000001
+    us-nj:policies/income_tax/pilot_liability_pipeline#input.nj_pit_pilot_filing_status_joint_head_or_surviving: true
+  output:
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_selector: 7
+    us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_schedule_tax: '72657.6075'

--- a/us-nj/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nj/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,29 +5,44 @@ module:
   source_verification:
     corpus_citation_path: us-nj/statute/54a:2-1
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-nj/statute/54a:2-1
       rationale: |-
-        N.J. Stat. section 54A:2-1 imposes tax on New Jersey taxable income
-        under separate post-2020 schedules for joint and single filers. This
-        narrow 2026 composition accepts completed-return New Jersey taxable
-        income and the applicable bracket's cumulative base tax, floor, and
-        marginal rate as caller-supplied current-authority inputs. It therefore
-        owns only the statutory active-bracket mechanics and does not claim that
-        the rate section proves upstream gross-income modifications, deductions,
-        exemptions, or credits. The six companion cases use the schedule inputs
-        selected by PolicyEngine for the standard resident wage grid.
+        N.J. Stat. section 54A:2-1(a)(7) and (b)(7) provide the complete
+        individual-income-tax schedules for taxable years beginning on or
+        after January 1, 2020. Subsection (a)(7) applies the wide schedule to
+        joint, head-of-household, and surviving-spouse filers. Subsection
+        (b)(7) applies the narrow schedule to single and married-separate
+        filers. Subsection (c) also directs an individual who would qualify as
+        head of household but for nonresident-alien status to the subsection
+        (a) wide schedule. The statute fixes every threshold, cumulative base
+        amount, and marginal rate, so the 2026 schedule contains no indexed or
+        projected parameters.
+
+        This module accepts completed-return New Jersey taxable income and a
+        filing-status classification as its only caller boundaries. Upstream
+        gross-income modifications, deductions, exemptions, residency and
+        allocation decisions remain outside this rate-schedule module. The
+        statutory wide schedule deliberately uses a $1,295.50 base above
+        $70,000 and a $1,645.00 base above $80,000. That literal half-dollar
+        discontinuity is preserved rather than normalized into a continuous
+        marginal scale. All rules fail closed outside tax year 2026.
   summary: |-
-    Composed New Jersey individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied New Jersey
-    taxable income, applies the supplied active section 54A:2-1 bracket in
-    cumulative-base-plus-marginal form, and exposes the resulting main income
-    tax. Its exact PolicyEngine 4.18.9 analog is `nj_main_income_tax` on the
-    six-case childless age-40 grid: single at $30,000/$60,000/$150,000 of wages
-    and one-earner joint at $60,000/$120,000/$300,000. PolicyEngine supplies the
-    completed taxable income and active schedule inputs; expected outputs are
-    independently hand-computed from those inputs and the official statute.
+    New Jersey 2026 main individual-income-tax schedule before credits. The
+    caller supplies completed-return New Jersey taxable income and whether the
+    return uses the section 54A:2-1(a)(7) wide schedule. The module selects and
+    applies every statutory bracket in either the wide joint/head/surviving
+    schedule (including the subsection-(c) nonresident-alien exception) or the
+    narrow single/separate schedule, including the exact statutory cumulative
+    base amounts through the 10.75-percent top bracket.
+
+    PolicyEngine-US 1.752.2 feeds `nj_taxable_income` and `filing_status`
+    directly into the distinct `nj_main_income_tax` target. PolicyEngine models
+    the schedules as continuous marginal scales, while the official wide table
+    is $0.50 higher for taxable income over $70,000 through $80,000. The
+    population comparison therefore uses the existing $1 absolute tolerance
+    and does not erase that source-literal difference.
 rules:
   - name: nj_pit_pilot_taxable_income
     kind: derived
@@ -35,7 +50,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.J. Stat. section 54A:2-1, supplied completed-return taxable income
+    source: N.J. Stat. § 54A:2-1, completed-return New Jersey taxable income
     metadata:
       proof:
         atoms:
@@ -46,7 +61,8 @@ rules:
               excerpt: "subject to the deductions, limitations and modifications hereinafter provided, determined in accordance with the following tables with respect to taxpayers' taxable income"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, nj_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, nj_pit_pilot_state_taxable_income)
 
   - name: nj_pit_pilot_schedule_tax
     kind: derived
@@ -54,7 +70,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.J. Stat. section 54A:2-1(a)(7) and (b)(7), supplied active bracket
+    source: N.J. Stat. § 54A:2-1(a)(7) and (b)(7), post-2020 schedules
     metadata:
       proof:
         atoms:
@@ -63,11 +79,437 @@ rules:
             source:
               corpus_citation_path: us-nj/statute/54a:2-1
               excerpt: "for taxable years beginning on or after January 1, 2020: If the taxable income is: The tax is:"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_base
+              output: nj_pit_pilot_wide_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_floor
+              output: nj_pit_pilot_wide_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_wide_bracket_rate
+              output: nj_pit_pilot_wide_bracket_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_base
+              output: nj_pit_pilot_narrow_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_floor
+              output: nj_pit_pilot_narrow_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nj:policies/income_tax/pilot_liability_pipeline#nj_pit_pilot_narrow_bracket_rate
+              output: nj_pit_pilot_narrow_bracket_rate
+              hash: sha256:local
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          nj_pit_pilot_supplied_bracket_base
-          + nj_pit_pilot_supplied_marginal_rate * max(0, nj_pit_pilot_taxable_income - nj_pit_pilot_supplied_bracket_floor)
+          if nj_pit_pilot_filing_status_joint_head_or_surviving:
+              nj_pit_pilot_wide_bracket_base[nj_pit_pilot_wide_bracket_selector]
+              + nj_pit_pilot_wide_bracket_rate[nj_pit_pilot_wide_bracket_selector]
+              * max(0, nj_pit_pilot_taxable_income - nj_pit_pilot_wide_bracket_floor[nj_pit_pilot_wide_bracket_selector])
+          else:
+              nj_pit_pilot_narrow_bracket_base[nj_pit_pilot_narrow_bracket_selector]
+              + nj_pit_pilot_narrow_bracket_rate[nj_pit_pilot_narrow_bracket_selector]
+              * max(0, nj_pit_pilot_taxable_income - nj_pit_pilot_narrow_bracket_floor[nj_pit_pilot_narrow_bracket_selector])
+
+  - name: nj_pit_pilot_wide_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: N.J. Stat. § 54A:2-1(a)(7), wide-schedule bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              excerpt: "For married individuals filing a joint return"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              excerpt: "individuals filing as head of household or as surviving spouse"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              excerpt: "such taxpayer is a nonresident alien, shall determine tax pursuant to subsection a. of this section"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_first_upper_bound: 0
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_second_upper_bound: 1
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_third_upper_bound: 2
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_fourth_upper_bound: 3
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_fifth_upper_bound: 4
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_sixth_upper_bound: 5
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_wide_seventh_upper_bound: 6
+          else: 7
+
+  - name: nj_pit_pilot_wide_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Not over $20,000.00........ 1.400% of taxable income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '20000'}
+
+  - name: nj_pit_pilot_wide_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $20,000.00 but not over $50,000.00.... $280.00 plus 1.750% of the excess over $20,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '50000'}
+
+  - name: nj_pit_pilot_wide_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $50,000.00 but not over $70,000.00.... $805.00 plus 2.450% of the excess over $50,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '70000'}
+
+  - name: nj_pit_pilot_wide_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $70,000.00 but not over $80,000.00... $1,295.50 plus 3.500% of the excess over $70,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '80000'}
+
+  - name: nj_pit_pilot_wide_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $80,000.00 but not over $150,000.00.. $1,645.00 plus 5.525% of the excess over $80,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '150000'}
+
+  - name: nj_pit_pilot_wide_sixth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide sixth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $150,000.00 but not over $500,000.00.. $5,512.50 plus 6.370% of the excess over $150,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '500000'}
+
+  - name: nj_pit_pilot_wide_seventh_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(a)(7), wide seventh upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $500,000.00 but not over $1,000,000.00.. $27,807.50 plus 8.970% of the excess over $500,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '1000000'}
+
+  - name: nj_pit_pilot_wide_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nj_pit_pilot_wide_bracket_selector
+    source: N.J. Stat. § 54A:2-1(a)(7), wide excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection a.(7) rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 20000, 2: 50000, 3: 70000, 4: 80000, 5: 150000, 6: 500000, 7: 1000000}
+
+  - name: nj_pit_pilot_wide_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nj_pit_pilot_wide_bracket_selector
+    source: N.J. Stat. § 54A:2-1(a)(7), wide cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection a.(7) rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 280, 2: 805, 3: 1295.50, 4: 1645, 5: 5512.50, 6: 27807.50, 7: 72657.50}
+
+  - name: nj_pit_pilot_wide_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: nj_pit_pilot_wide_bracket_selector
+    source: N.J. Stat. § 54A:2-1(a)(7), wide marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection a.(7) rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.014, 1: 0.0175, 2: 0.0245, 3: 0.035, 4: 0.05525, 5: 0.0637, 6: 0.0897, 7: 0.1075}
+
+  - name: nj_pit_pilot_narrow_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow-schedule bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              excerpt: "For married individuals filing separately"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              excerpt: "unmarried individuals other than individuals filing as head of household or as a surviving spouse"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_first_upper_bound: 0
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_second_upper_bound: 1
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_third_upper_bound: 2
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_fourth_upper_bound: 3
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_fifth_upper_bound: 4
+          else: if nj_pit_pilot_taxable_income <= nj_pit_pilot_narrow_sixth_upper_bound: 5
+          else: 6
+
+  - name: nj_pit_pilot_narrow_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Not over $20,000.00...... 1.400% of taxable income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '20000'}
+
+  - name: nj_pit_pilot_narrow_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $20,000.00 but not over $35,000.00....... $280.00 plus 1.750% of the excess over $20,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '35000'}
+
+  - name: nj_pit_pilot_narrow_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $35,000.00 but not over $40,000.00...... $542.50 plus 3.500% of the excess over $35,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '40000'}
+
+  - name: nj_pit_pilot_narrow_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $40,000.00 but not over $75,000.00...... $717.50 plus 5.525% of the excess over $40,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '75000'}
+
+  - name: nj_pit_pilot_narrow_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $75,000.00 but not over $500,000.00... $2,651.25 plus 6.370% of the excess over $75,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '500000'}
+
+  - name: nj_pit_pilot_narrow_sixth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow sixth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nj/statute/54a:2-1, excerpt: "Over $500,000.00 but not over $1,000,000.00.. $29,723.75 plus 8.970% of the excess over $500,000.00"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '1000000'}
+
+  - name: nj_pit_pilot_narrow_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nj_pit_pilot_narrow_bracket_selector
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection b.(7) rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 20000, 2: 35000, 3: 40000, 4: 75000, 5: 500000, 6: 1000000}
+
+  - name: nj_pit_pilot_narrow_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: nj_pit_pilot_narrow_bracket_selector
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection b.(7) rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 280, 2: 542.50, 3: 717.50, 4: 2651.25, 5: 29723.75, 6: 74573.75}
+
+  - name: nj_pit_pilot_narrow_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: nj_pit_pilot_narrow_bracket_selector
+    source: N.J. Stat. § 54A:2-1(b)(7), narrow marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nj/statute/54a:2-1
+              table: {header: "Subsection b.(7) rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.014, 1: 0.0175, 2: 0.035, 3: 0.05525, 4: 0.0637, 5: 0.0897, 6: 0.1075}
 
   - name: nj_pit_pilot_income_tax_liability
     kind: derived
@@ -75,7 +517,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.J. Stat. section 54A:2-1 main income tax before downstream credits
+    source: N.J. Stat. § 54A:2-1 main income tax before credits
     metadata:
       proof:
         atoms:
@@ -86,4 +528,17 @@ rules:
               excerpt: "There is hereby imposed a tax for each taxable year"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: max(0, nj_pit_pilot_schedule_tax)
+inputs:
+  - name: nj_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return New Jersey taxable income supplied by the caller as an upstream oracle boundary.
+  - name: nj_pit_pilot_filing_status_joint_head_or_surviving
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True when the subsection-(a) wide schedule applies—joint, head-of-household, surviving-spouse, or the subsection-(c) nonresident-alien exception; false for ordinary single or married-separate filers.


### PR DESCRIPTION
## Summary

Promote the complete New Jersey 2026 individual-income-tax schedules under N.J. Stat. §54A:2-1 for the ordinary `nj_main_income_tax` target. The RuleSpec accepts completed-return New Jersey taxable income plus an explicit filing-status classification, applies the post-2020 wide schedule to joint/head-of-household/surviving-spouse filers, and applies the narrow schedule to single/married-separate filers.

The statutory subsection (c) nonresident-alien would-be-head-of-household exception remains explicit at the caller boundary. Certified-population validation proves it is absent from the pinned comparison population rather than silently treating it as zero.

## Legal and branch coverage

- All subsection (a)(7) wide thresholds, bases, and rates are exact
- All subsection (b)(7) narrow thresholds, bases, and rates are exact
- Inclusive upper bounds and first-dollar transitions are preserved
- The literal wide-schedule `$1,295.50` to `$1,645.00` discontinuity is intentionally source-faithful
- Joint, head-of-household, and surviving-spouse use the wide schedule
- Single and married-separate use the narrow schedule
- The module fails closed outside tax year 2026

## Certified Populace evidence

- 1,693 positive-weight New Jersey TaxUnits
- 3,056 selected persons, all exactly `CITIZEN`
- Weighted TaxUnits: 5,155,329.329459501
- PolicyEngine target: `nj_main_income_tax`
- Zero mismatches under `$1 absolute OR 1e-7 relative`
- Maximum absolute difference: `$1.939999997616`
- Maximum reported relative difference: `0.0003828805332` (the corresponding units pass the absolute leg)
- Citizenship guard fails closed on missing, noncitizen, or memberless selected data

## Exact base and provenance

- Exact base: `034e299693d8e1b28001d6b2dc96476e31ac9f48`
- Exact reviewed head: `033968c9603a7b2900d51e91375faf2a29b6bbb2`
- Branch shape: one clean commit above the New Mexico merge
- Rebase stable patch ID: `0e9b0eb8706a8acf9d6a0f44af0125edb0f53f7c`
- Module SHA-256: `d0b439416b3c308d820891e6f5537096024b701363af92d92cc70705887d94ff`
- Test SHA-256: `ab0eb231f4aacc3ab4347f16d4cf1c2e9912d880bf0011d80cb0511a40b36c44`
- Signed manifest pins clean axiom-encode `3869d66d009f52258be35901edbef370e65a399c`

## Checks

- Companion fixtures: 38/38 passed
- Every 7 wide and 6 narrow boundary has inclusive-upper and next-dollar coverage
- Every bracket, negative floor, half-dollar discontinuity, and top branch is covered
- Independent Decimal recomputation: zero arithmetic/selector errors
- Validate: pass
- Proof validation: 33 atoms
- Secure exact-base generated-artifact guard: pass, zero issues
- Reverse index current: 3,942 provisions / 4,668 edges / 4,433 modules
- Focused repository tests: 18 passed
- Diff and worktree hygiene: clean

## Review cycle

The original exact content was independently reviewed, then rebased conflict-free onto the New Mexico merge with an identical stable patch ID and range-diff. A second independent exact-head review rechecked the certified statute, both schedules, boundary semantics, filing selectors, NRA scope, PolicyEngine target graph, all 38 fixtures, proofs, signed manifest, reverse index, and pending metadata. The cycle is CLEAN at `033968c9603a7b2900d51e91375faf2a29b6bbb2`; no actionable findings remain.
