### PR TITLE
Encode New York 2026 main income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "8f9274c5afe2ab83ebc6e93d7f6634bd183a6b8248954752e53870c029ed552f"
+      "sha256": "66e047b6c5a70c59f9b797575477753dfae441a62efbafd99c4ee36fb8242515"
     },
     {
       "path": "us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "f75eb466553defcbebb8ddbce932b2b49bbcf32004f6ad446dcfc03e09eca3e0"
+      "sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d6cf9cb0f65c9af094d23b591268fe7be7bc9f80",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/statetax-liability-20260706/axiom-encode-pin",
-    "version": "0.2.1160",
-    "version_commit": "d6cf9cb0f65c9af094d23b591268fe7be7bc9f80"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1160",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ny:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-06T17:33:07.803431+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpwwk_rukg/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpwwk_rukg",
-  "generated_output_sha256": "f75eb466553defcbebb8ddbce932b2b49bbcf32004f6ad446dcfc03e09eca3e0",
+  "generated_at": "2026-07-22T09:21:07.368809+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpftfzah41/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpftfzah41",
+  "generated_output_sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,7 +33,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5"
+    "value": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-06T17:33:07.803431+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
+    "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -26359,13 +26359,6 @@
     ],
     "us-ny/statute/TAX/614": [
       {
-        "module": "us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-ny/statutes/TAX/614.yaml",
         "via": [
           "module",

--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -7596,11 +7596,6 @@
       "module_sha256": "sha256:65989d40579576e19b0fe70652d87f56ab5325a43bfd158cf5dacb021d423ec3",
       "passed": false
     },
-    "us-ny/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:745acdeb088e452a586aeee02343162d3c9a08a0849b4b637d5c932ad6efcac7",
-      "module_sha256": "sha256:f75eb466553defcbebb8ddbce932b2b49bbcf32004f6ad446dcfc03e09eca3e0",
-      "passed": false
-    },
     "us-ny/policies/otda/tanf-state-plan-2024-2026/shelter-allowance-with-children.yaml": {
       "fingerprint": "sha256:7ed552924effa7091993a4abb72191ce770cc5913e102669443845ae9026e180",
       "module_sha256": "sha256:a75bd1e8eea868ed9a2531337ee3542eb6b3a918cf9e210cbe830fc69774df29",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -14378,12 +14378,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ny/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:745acdeb088e452a586aeee02343162d3c9a08a0849b4b637d5c932ad6efcac7"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ny/policies/otda/tanf-state-plan-2024-2026/shelter-allowance-with-children.yaml":
     pending:
       fingerprint: "sha256:7ed552924effa7091993a4abb72191ce770cc5913e102669443845ae9026e180"

--- a/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,178 +1,631 @@
-# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
-# expected values are the author's own shown arithmetic from the supplied
-# schedule, not an oracle read-back). New York liability = Tax Law s.601 main
-# bracket tax on (NY AGI - standard deduction) plus the s.601(d) supplemental
-# recapture. The supplied 2026 schedule reflects the Chapter 59 of the Laws of
-# 2025 rate reductions (NYS-50-T-NYS, 2026 withholding methods); the DTF had not
-# published the tax-year-2026 IT-201 return schedule at authoring. Bracket floors
-# (single): 0, 8500, 11700, 13900, 80650, 215400; (joint): 0, 17150, 23600,
-# 27900, 161550, 323200. Rates: 3.9, 4.4, 5.15, 5.4, 5.9, 6.85 per cent.
-# Standard deduction: single 8,000; joint 16,050. The s.601(d) supplemental
-# recapture is a supplied completed-return amount (zero below the recapture
-# phase-in, positive above New York AGI 107,650).
-- name: single_30k
-  # taxable 30000-8000 = 22000. Main: 0.039*8500 + 0.044*(11700-8500) +
-  # 0.0515*(13900-11700) + 0.054*(22000-13900) = 331.5 + 140.8 + 113.3 + 437.4
-  # = 1023.00. Supplemental 0. Liability 1023.00.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Hand-computed fixtures for Tax Law section 601(a)(1)(B)(vii),
+# (b)(1)(B)(vii), and (c)(1)(B)(vii). Every inclusive upper bound and
+# the first dollar in every following bracket is covered for all three status
+# groups, plus each top bracket and the defensive zero floor. Expected values
+# use the statute's published cumulative base, excess floor, and rate; they are
+# not PolicyEngine read-backs. The joint Boolean also represents surviving
+# spouses, and the all-false branch represents both single and separate filers.
+
+- name: negative_taxable_income_is_floored
+  # max(0, -100) = 0; 3.9% of zero = zero.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 30000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 8000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 8500
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 11700
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 13900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 80650
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 215400
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: -100
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '22000'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '1023'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '1023'
-- name: single_60k
-  # taxable 52000. Main: 331.5 + 140.8 + 113.3 + 0.054*(80650-13900 capped at
-  # 52000 -> 52000-13900=38100)*... = fills to 5.4% band: 0.054*(52000-13900) =
-  # 2057.4; total 331.5+140.8+113.3+2057.4 = 2643.00. Liability 2643.00.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '0'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 0
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '0'
+
+- name: joint_or_surviving_17150_upper_bound
+  # 0 + 0.039 * (17150 - 0) = 668.85.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 60000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 8000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 8500
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 11700
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 13900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 80650
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 215400
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 17150
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '52000'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '2643'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '2643'
-- name: single_150k_with_supplemental_recapture
-  # taxable 142000. Main bracket tax 7809.75. Supplemental s.601(d) recapture
-  # 480.2489929199219 (supplied). Liability 7809.75 + 480.2489929199219 =
-  # 8289.9989929199219.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '17150'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 0
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '668.85'
+
+- name: joint_or_surviving_17151_next_bracket
+  # 669 + 0.044 * (17151 - 17150) = 669.044.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 150000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 8000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 480.2489929199219
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 8500
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 11700
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 13900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 80650
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 215400
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 17151
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '142000'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '7809.75'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '8289.9989929199219'
-- name: joint_60k
-  # taxable 60000-16050 = 43950. Main: 0.039*17150 + 0.044*(23600-17150) +
-  # 0.0515*(27900-23600) + 0.054*(43950-27900) = 668.85 + 283.8 + 221.45 +
-  # 866.7 = 2040.80. Liability 2040.80.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '17151'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '669.044'
+
+- name: joint_or_surviving_23600_upper_bound
+  # 669 + 0.044 * (23600 - 17150) = 952.8.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 60000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 16050
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 17150
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 23600
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 27900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 161550
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 323200
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 23600
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '43950'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '2040.8'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '2040.8'
-- name: joint_120k_with_supplemental_recapture
-  # taxable 103950. Main bracket tax 5280.80. Supplemental 82.2509994506836.
-  # Liability 5280.80 + 82.2509994506836 = 5363.0509994506836.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '23600'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '952.8'
+
+- name: joint_or_surviving_23601_next_bracket
+  # 953 + 0.0515 * (23601 - 23600) = 953.0515.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 120000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 16050
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 82.2509994506836
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 17150
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 23600
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 27900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 161550
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 323200
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 23601
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '103950'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '5280.8'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '5363.0509994506836'
-- name: joint_300k_with_supplemental_recapture
-  # taxable 283950. Main bracket tax 15612.80. Supplemental 1140.00.
-  # Liability 15612.80 + 1140.00 = 16752.80.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '23601'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '953.0515'
+
+- name: joint_or_surviving_27900_upper_bound
+  # 953 + 0.0515 * (27900 - 23600) = 1174.45.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_adjusted_gross_income: 300000
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_standard_deduction: 16050
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_supplemental_recapture: 1140.00
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_1: 0
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_2: 17150
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_3: 23600
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_4: 27900
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_5: 161550
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_floor_6: 323200
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_1: 0.039
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_2: 0.044
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_3: 0.0515
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_4: 0.054
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_5: 0.059
-    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_supplied_bracket_rate_6: 0.0685
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 27900
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '283950'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_tax: '15612.8'
-    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_liability: '16752.8'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '27900'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '1174.45'
+
+- name: joint_or_surviving_27901_next_bracket
+  # 1174 + 0.054 * (27901 - 27900) = 1174.054.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 27901
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '27901'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '1174.054'
+
+- name: joint_or_surviving_161550_upper_bound
+  # 1174 + 0.054 * (161550 - 27900) = 8391.1.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 161550
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '161550'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '8391.1'
+
+- name: joint_or_surviving_161551_next_bracket
+  # 8391 + 0.059 * (161551 - 161550) = 8391.059.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 161551
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '161551'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '8391.059'
+
+- name: joint_or_surviving_323200_upper_bound
+  # 8391 + 0.059 * (323200 - 161550) = 17928.35.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 323200
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '323200'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '17928.35'
+
+- name: joint_or_surviving_323201_next_bracket
+  # 17928 + 0.0685 * (323201 - 323200) = 17928.0685.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 323201
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '323201'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '17928.0685'
+
+- name: joint_or_surviving_2155350_upper_bound
+  # 17928 + 0.0685 * (2155350 - 323200) = 143430.275.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 2155350
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '2155350'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '143430.275'
+
+- name: joint_or_surviving_2155351_next_bracket
+  # 143430 + 0.0965 * (2155351 - 2155350) = 143430.0965.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 2155351
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '2155351'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '143430.0965'
+
+- name: joint_or_surviving_5000000_upper_bound
+  # 143430 + 0.0965 * (5000000 - 2155350) = 417938.725.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '417938.725'
+
+- name: joint_or_surviving_5000001_next_bracket
+  # 417939 + 0.103 * (5000001 - 5000000) = 417939.103.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '417939.103'
+
+- name: joint_or_surviving_25000000_upper_bound
+  # 417939 + 0.103 * (25000000 - 5000000) = 2477939.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2477939'
+
+- name: joint_or_surviving_25000001_next_bracket
+  # 2477939 + 0.109 * (25000001 - 25000000) = 2477939.109.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2477939.109'
+
+- name: joint_or_surviving_top_bracket_30m
+  # 2477939 + 0.109 * (30000000 - 25000000) = 3022939.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 30000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '30000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '3022939'
+
+- name: head_of_household_12800_upper_bound
+  # 0 + 0.039 * (12800 - 0) = 499.2.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 12800
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '12800'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 0
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '499.2'
+
+- name: head_of_household_12801_next_bracket
+  # 499 + 0.044 * (12801 - 12800) = 499.044.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 12801
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '12801'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '499.044'
+
+- name: head_of_household_17650_upper_bound
+  # 499 + 0.044 * (17650 - 12800) = 712.4.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 17650
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '17650'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '712.4'
+
+- name: head_of_household_17651_next_bracket
+  # 712 + 0.0515 * (17651 - 17650) = 712.0515.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 17651
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '17651'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '712.0515'
+
+- name: head_of_household_20900_upper_bound
+  # 712 + 0.0515 * (20900 - 17650) = 879.375.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 20900
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '20900'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '879.375'
+
+- name: head_of_household_20901_next_bracket
+  # 879 + 0.054 * (20901 - 20900) = 879.054.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 20901
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '20901'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '879.054'
+
+- name: head_of_household_107650_upper_bound
+  # 879 + 0.054 * (107650 - 20900) = 5563.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 107650
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '107650'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '5563.5'
+
+- name: head_of_household_107651_next_bracket
+  # 5564 + 0.059 * (107651 - 107650) = 5564.059.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 107651
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '107651'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '5564.059'
+
+- name: head_of_household_269300_upper_bound
+  # 5564 + 0.059 * (269300 - 107650) = 15101.35.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 269300
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '269300'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '15101.35'
+
+- name: head_of_household_269301_next_bracket
+  # 15101 + 0.0685 * (269301 - 269300) = 15101.0685.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 269301
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '269301'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '15101.0685'
+
+- name: head_of_household_1616450_upper_bound
+  # 15101 + 0.0685 * (1616450 - 269300) = 107380.775.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 1616450
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '1616450'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '107380.775'
+
+- name: head_of_household_1616451_next_bracket
+  # 107381 + 0.0965 * (1616451 - 1616450) = 107381.0965.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 1616451
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '1616451'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '107381.0965'
+
+- name: head_of_household_5000000_upper_bound
+  # 107381 + 0.0965 * (5000000 - 1616450) = 433893.575.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '433893.575'
+
+- name: head_of_household_5000001_next_bracket
+  # 433894 + 0.103 * (5000001 - 5000000) = 433894.103.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '433894.103'
+
+- name: head_of_household_25000000_upper_bound
+  # 433894 + 0.103 * (25000000 - 5000000) = 2493894.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2493894'
+
+- name: head_of_household_25000001_next_bracket
+  # 2493894 + 0.109 * (25000001 - 25000000) = 2493894.109.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2493894.109'
+
+- name: head_of_household_top_bracket_30m
+  # 2493894 + 0.109 * (30000000 - 25000000) = 3038894.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 30000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '30000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '3038894'
+
+- name: single_or_separate_8500_upper_bound
+  # 0 + 0.039 * (8500 - 0) = 331.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 8500
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '8500'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 0
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '331.5'
+
+- name: single_or_separate_8501_next_bracket
+  # 332 + 0.044 * (8501 - 8500) = 332.044.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 8501
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '8501'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '332.044'
+
+- name: single_or_separate_11700_upper_bound
+  # 332 + 0.044 * (11700 - 8500) = 472.8.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 11700
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '11700'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 1
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '472.8'
+
+- name: single_or_separate_11701_next_bracket
+  # 473 + 0.0515 * (11701 - 11700) = 473.0515.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 11701
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '11701'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '473.0515'
+
+- name: single_or_separate_13900_upper_bound
+  # 473 + 0.0515 * (13900 - 11700) = 586.3.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 13900
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '13900'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 2
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '586.3'
+
+- name: single_or_separate_13901_next_bracket
+  # 586 + 0.054 * (13901 - 13900) = 586.054.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 13901
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '13901'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '586.054'
+
+- name: single_or_separate_80650_upper_bound
+  # 586 + 0.054 * (80650 - 13900) = 4190.5.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 80650
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '80650'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '4190.5'
+
+- name: single_or_separate_80651_next_bracket
+  # 4191 + 0.059 * (80651 - 80650) = 4191.059.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 80651
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '80651'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '4191.059'
+
+- name: single_or_separate_215400_upper_bound
+  # 4191 + 0.059 * (215400 - 80650) = 12141.25.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 215400
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '215400'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '12141.25'
+
+- name: single_or_separate_215401_next_bracket
+  # 12141 + 0.0685 * (215401 - 215400) = 12141.0685.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 215401
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '215401'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '12141.0685'
+
+- name: single_or_separate_1077550_upper_bound
+  # 12141 + 0.0685 * (1077550 - 215400) = 71198.275.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 1077550
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '1077550'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 5
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '71198.275'
+
+- name: single_or_separate_1077551_next_bracket
+  # 71198 + 0.0965 * (1077551 - 1077550) = 71198.0965.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 1077551
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '1077551'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '71198.0965'
+
+- name: single_or_separate_5000000_upper_bound
+  # 71198 + 0.0965 * (5000000 - 1077550) = 449714.425.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 6
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '449714.425'
+
+- name: single_or_separate_5000001_next_bracket
+  # 449714 + 0.103 * (5000001 - 5000000) = 449714.103.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 5000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '5000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '449714.103'
+
+- name: single_or_separate_25000000_upper_bound
+  # 449714 + 0.103 * (25000000 - 5000000) = 2509714.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 7
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2509714'
+
+- name: single_or_separate_25000001_next_bracket
+  # 2509714 + 0.109 * (25000001 - 25000000) = 2509714.109.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 25000001
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '25000001'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2509714.109'
+
+- name: single_or_separate_top_bracket_30m
+  # 2509714 + 0.109 * (30000000 - 25000000) = 3054714.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 30000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '30000000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 8
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '3054714'

--- a/us-ny/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ny/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,59 +3,58 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-ny/statute/TAX/601
-      - us-ny/statute/TAX/614
+    corpus_citation_path: us-ny/statute/TAX/601
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-ny/statute/TAX/601
-        - us-ny/statute/TAX/614
       rationale: |-
-        This pipeline computes the Tax Law section 601 resident tax on New York
-        taxable income and adds the section 601(d) supplemental tax (the tax-
-        table benefit recapture) to reach the New York income-tax liability for
-        the ordinary resident wage-earner slice. The encoded Tax Law section 601
-        and section 614 modules are both deferred with empty rule sets: section
-        601 computes tax from tables that section 601(a) sets and section 601-a
-        indexes by the cost-of-living adjustment, and section 614 states the
-        standard deduction amounts that section 601-a likewise indexes, neither
-        of which the encoding could ground without the section 601-a adjustment
-        and the filing-status classifications the RuleSpec guidance declines to
-        model as local status inputs. Because the Department of Taxation and
-        Finance had not published the tax-year-2026 Form IT-201 rate schedule and
-        standard-deduction table at authoring (the 2026 rate reductions enacted
-        under Chapter 59 of the Laws of 2025 are reflected in the 2026 withholding
-        methods NYS-50-T-NYS, but the IT-201 return schedule issues near the end
-        of the tax year), every indexed amount this pipeline needs is a declared
-        caller-supplied input: the bracket floors and their rates, the standard
-        deduction, and the section 601(d) supplemental recapture. The pipeline
-        adds no numeric literals of its own; it wires the progressive-tax
-        mechanics only, and the oracle disposition records the indexation vintage
-        against TAXSIM's 2024 law year.
+        Tax Law section 601(a)(1)(B)(vii), (b)(1)(B)(vii), and
+        (c)(1)(B)(vii) provide the complete individual-income-tax rate tables
+        for taxable years beginning after 2025 and before 2027. The three
+        tables apply respectively to joint and surviving-spouse returns,
+        head-of-household returns, and single or married-separate returns.
+        They fix every threshold, cumulative base amount, and marginal rate,
+        including the 9.65, 10.3, and 10.9 percent high-income bands.
+
+        This module accepts completed-return New York taxable income plus two
+        mutually exclusive filing-status classifications as its only caller
+        boundaries. Upstream adjusted-gross-income modifications, deductions,
+        exemptions, residency, and allocation decisions remain outside this
+        rate-schedule module. It preserves the statute's published cumulative
+        base amounts rather than normalizing them into a continuous marginal
+        scale, and fails closed outside tax year 2026.
   summary: |-
-    Composed New York personal income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    New York adjusted gross income into the Tax Law section 601 resident tax plus
-    the section 601(d) supplemental tax, so an end-to-end comparison against
-    PolicyEngine (ny_income_tax) and TAXSIM (siitax) does not require the caller
-    to supply the section 601 bracket-application or section 614 standard-
-    deduction stage boundaries. It wires: New York taxable income (AGI less the
-    supplied standard deduction); the resident tax as the marginal sum across the
-    first six brackets (3.9, 4.4, 5.15, 5.4, 5.9, and 6.85 per cent), which cover
-    the entire ordinary-wage grid up to the 1,077,550-dollar single / 2,155,350-
-    dollar joint 9.65 per cent bracket floor; and the section 601 tax plus the
-    supplied section 601(d) supplemental recapture. It deliberately excludes the
-    nonresident and part-year-resident source-fraction proration, the section 606
-    credits, the New York City and Yonkers local taxes, the itemized deduction,
-    and the dependent-exemption and household-credit surfaces, all of which are
-    supplied as zero or omitted for this resident wage-earner slice. New York
-    AGI, filing status, the bracket floors and rates, the standard deduction, and
-    the section 601(d) supplemental recapture are supplied inputs; the Department
-    of Taxation and Finance indexes the brackets and standard deduction each
-    year, so this 2026 pipeline is compared against PolicyEngine at 2026 and
-    against TAXSIM's latest 2024 law year with the indexation vintage
-    dispositioned.
+    New York 2026 main resident individual-income-tax schedule before the
+    section 601(d-5) supplemental tax and all credits. The caller supplies
+    completed-return New York taxable income and Boolean classifications for
+    joint-or-surviving-spouse and head-of-household returns. When both are
+    false, the single/married-separate schedule applies. The module selects
+    and applies every statutory bracket through the 10.9-percent top band.
+
+    PolicyEngine-US 1.752.2 feeds `ny_taxable_income` and `filing_status`
+    directly into the distinct `ny_main_income_tax` target. PolicyEngine
+    models section 601's tables as continuous marginal scales, while the
+    statute publishes rounded cumulative base amounts. Across all 3,741
+    positive-weight New York TaxUnits in the certified Populace, the direct
+    statutory tables differ from that target by at most $2.12.
+  deferred_outputs:
+    - output: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_supplemental_tax
+      reason: |-
+        Tax Law section 601(d-5) is intentionally deferred. Its special
+        low-taxable-income provisos are operative for seven certified-Populace
+        TaxUnits, and PolicyEngine-US 1.752.2 substitutes fixed scale amounts
+        for the statute's flat-rate-minus-main-tax calculation. The resulting
+        discrepancy reaches $117.86, so encoding PolicyEngine's behavior as
+        law would not be source-faithful.
+    - output: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax_before_credits
+      reason: |-
+        Main tax plus section 601(d-5) supplemental tax remains deferred until
+        the operative PolicyEngine supplemental-tax divergence is resolved.
+    - output: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_income_tax
+      reason: |-
+        Section 606 credits and final New York income tax are outside the
+        narrow non-circular `ny_main_income_tax` comparison target.
 rules:
   - name: ny_pit_pilot_taxable_income
     kind: derived
@@ -63,27 +62,9 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: Tax Law s.614 and s.601, New York taxable income after the supplied standard deduction
+    source: Tax Law § 601, completed-return New York taxable income
     metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ny/statute/TAX/614
-              excerpt: "standard deduction"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ny_pit_pilot_adjusted_gross_income - ny_pit_pilot_supplied_standard_deduction)
-  - name: ny_pit_pilot_main_tax
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Tax Law s.601, progressive resident tax as the marginal sum across the supplied bracket floors and rates
-    metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -93,20 +74,16 @@ rules:
               excerpt: "There is hereby imposed for each taxable year on the New York taxable income"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, min(ny_pit_pilot_taxable_income, ny_pit_pilot_supplied_bracket_floor_2) - ny_pit_pilot_supplied_bracket_floor_1) * ny_pit_pilot_supplied_bracket_rate_1
-          + max(0, min(ny_pit_pilot_taxable_income, ny_pit_pilot_supplied_bracket_floor_3) - ny_pit_pilot_supplied_bracket_floor_2) * ny_pit_pilot_supplied_bracket_rate_2
-          + max(0, min(ny_pit_pilot_taxable_income, ny_pit_pilot_supplied_bracket_floor_4) - ny_pit_pilot_supplied_bracket_floor_3) * ny_pit_pilot_supplied_bracket_rate_3
-          + max(0, min(ny_pit_pilot_taxable_income, ny_pit_pilot_supplied_bracket_floor_5) - ny_pit_pilot_supplied_bracket_floor_4) * ny_pit_pilot_supplied_bracket_rate_4
-          + max(0, min(ny_pit_pilot_taxable_income, ny_pit_pilot_supplied_bracket_floor_6) - ny_pit_pilot_supplied_bracket_floor_5) * ny_pit_pilot_supplied_bracket_rate_5
-          + max(0, ny_pit_pilot_taxable_income - ny_pit_pilot_supplied_bracket_floor_6) * ny_pit_pilot_supplied_bracket_rate_6
-  - name: ny_pit_pilot_income_tax_liability
+        effective_to: '2026-12-31'
+        formula: max(0, ny_pit_pilot_state_taxable_income)
+
+  - name: ny_pit_pilot_main_income_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Tax Law s.601 resident tax plus the s.601(d) supplemental tax (tax-table benefit recapture), before section 606 credits
+    source: Tax Law § 601(a)(1)(B)(vii), (b)(1)(B)(vii), and (c)(1)(B)(vii), complete 2026 main tax
     metadata:
       proof:
         atoms:
@@ -114,8 +91,820 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-ny/statute/TAX/601
-              excerpt: "supplemental tax"
+              excerpt: "For taxable years beginning after two thousand twenty-five and before two thousand twenty-seven the following rates shall apply"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_base
+              output: ny_pit_pilot_joint_or_surviving_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_floor
+              output: ny_pit_pilot_joint_or_surviving_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_rate
+              output: ny_pit_pilot_joint_or_surviving_bracket_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_base
+              output: ny_pit_pilot_head_of_household_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_floor
+              output: ny_pit_pilot_head_of_household_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_rate
+              output: ny_pit_pilot_head_of_household_bracket_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_base
+              output: ny_pit_pilot_single_or_separate_bracket_base
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_floor
+              output: ny_pit_pilot_single_or_separate_bracket_floor
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_rate
+              output: ny_pit_pilot_single_or_separate_bracket_rate
+              hash: sha256:local
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, ny_pit_pilot_main_tax + ny_pit_pilot_supplied_supplemental_recapture)
+          if ny_pit_pilot_filing_status_joint_or_surviving_spouse:
+              ny_pit_pilot_joint_or_surviving_bracket_base[ny_pit_pilot_joint_or_surviving_bracket_selector]
+              + ny_pit_pilot_joint_or_surviving_bracket_rate[ny_pit_pilot_joint_or_surviving_bracket_selector]
+              * max(0, ny_pit_pilot_taxable_income - ny_pit_pilot_joint_or_surviving_bracket_floor[ny_pit_pilot_joint_or_surviving_bracket_selector])
+          else:
+              if ny_pit_pilot_filing_status_head_of_household:
+                  ny_pit_pilot_head_of_household_bracket_base[ny_pit_pilot_head_of_household_bracket_selector]
+                  + ny_pit_pilot_head_of_household_bracket_rate[ny_pit_pilot_head_of_household_bracket_selector]
+                  * max(0, ny_pit_pilot_taxable_income - ny_pit_pilot_head_of_household_bracket_floor[ny_pit_pilot_head_of_household_bracket_selector])
+              else:
+                  ny_pit_pilot_single_or_separate_bracket_base[ny_pit_pilot_single_or_separate_bracket_selector]
+                  + ny_pit_pilot_single_or_separate_bracket_rate[ny_pit_pilot_single_or_separate_bracket_selector]
+                  * max(0, ny_pit_pilot_taxable_income - ny_pit_pilot_single_or_separate_bracket_floor[ny_pit_pilot_single_or_separate_bracket_selector])
+
+  - name: ny_pit_pilot_joint_or_surviving_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "For taxable years beginning after two thousand twenty-five and before two thousand twenty-seven the following rates shall apply"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_first_upper_bound: 0
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_second_upper_bound: 1
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_third_upper_bound: 2
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_fourth_upper_bound: 3
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_fifth_upper_bound: 4
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_sixth_upper_bound: 5
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_seventh_upper_bound: 6
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_joint_or_surviving_eighth_upper_bound: 7
+          else: 8
+
+  - name: ny_pit_pilot_head_of_household_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "For taxable years beginning after two thousand twenty-five and before two thousand twenty-seven the following rates shall apply"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_first_upper_bound: 0
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_second_upper_bound: 1
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_third_upper_bound: 2
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_fourth_upper_bound: 3
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_fifth_upper_bound: 4
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_sixth_upper_bound: 5
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_seventh_upper_bound: 6
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_head_of_household_eighth_upper_bound: 7
+          else: 8
+
+  - name: ny_pit_pilot_single_or_separate_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate bracket selection
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "For taxable years beginning after two thousand twenty-five and before two thousand twenty-seven the following rates shall apply"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_first_upper_bound: 0
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_second_upper_bound: 1
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_third_upper_bound: 2
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_fourth_upper_bound: 3
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_fifth_upper_bound: 4
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_sixth_upper_bound: 5
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_seventh_upper_bound: 6
+          else: if ny_pit_pilot_taxable_income <= ny_pit_pilot_single_or_separate_eighth_upper_bound: 7
+          else: 8
+
+  - name: ny_pit_pilot_joint_or_surviving_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Not over $17,150                      3.90% of the New York taxable"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '17150'
+
+  - name: ny_pit_pilot_joint_or_surviving_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $17,150 but not over $23,600     $669 plus 4.40% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '23600'
+
+  - name: ny_pit_pilot_joint_or_surviving_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $23,600 but not over $27,900     $953 plus 5.15% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '27900'
+
+  - name: ny_pit_pilot_joint_or_surviving_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $27,900 but not over $161,550    $1,174 plus 5.40% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '161550'
+
+  - name: ny_pit_pilot_joint_or_surviving_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $161,550 but not over $323,200   $8,391 plus 5.90% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '323200'
+
+  - name: ny_pit_pilot_joint_or_surviving_sixth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse sixth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $323,200 but not over            $17,928 plus 6.85% of excess
+                $2,155,350                            over $323,200
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2155350'
+
+  - name: ny_pit_pilot_joint_or_surviving_seventh_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse seventh upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $2,155,350 but not over          $143,430 plus 9.65% of excess
+                $5,000,000                            over $2,155,350
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '5000000'
+
+  - name: ny_pit_pilot_joint_or_surviving_eighth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse eighth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $5,000,000 but not over          $417,939 plus 10.30% of excess
+                $25,000,000                           over $5,000,000
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000000'
+
+  - name: ny_pit_pilot_head_of_household_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Not over $12,800                      3.90% of the New York taxable"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '12800'
+
+  - name: ny_pit_pilot_head_of_household_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $12,800 but not over             $499 plus 4.40% of excess over
+                $17,650                               $12,800
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '17650'
+
+  - name: ny_pit_pilot_head_of_household_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $17,650 but not over             $712 plus 5.15% of excess over
+                $20,900                               $17,650
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '20900'
+
+  - name: ny_pit_pilot_head_of_household_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $20,900 but not over             $879 plus 5.40% of excess over
+                $107,650                              $20,900
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '107650'
+
+  - name: ny_pit_pilot_head_of_household_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $107,650 but not over            $5,564 plus 5.90% of excess
+                $269,300                              over $107,650
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '269300'
+
+  - name: ny_pit_pilot_head_of_household_sixth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household sixth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $269,300 but not over            $15,101 plus 6.85% of excess
+                $1,616,450                            over $269,300
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1616450'
+
+  - name: ny_pit_pilot_head_of_household_seventh_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household seventh upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $1,616,450 but not over          $107,381 plus 9.65% of excess
+                $5,000,000                            over $1,616,450
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '5000000'
+
+  - name: ny_pit_pilot_head_of_household_eighth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household eighth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $5,000,000 but not over          $433,894 plus 10.30% of excess
+                $25,000,000                           over $5,000,000
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000000'
+
+  - name: ny_pit_pilot_single_or_separate_first_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate first upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Not over $8,500                       3.90% of the New York taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '8500'
+
+  - name: ny_pit_pilot_single_or_separate_second_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate second upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $8,500 but not over $11,700      $332 plus 4.40% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '11700'
+
+  - name: ny_pit_pilot_single_or_separate_third_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate third upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $11,700 but not over $13,900     $473 plus 5.15% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '13900'
+
+  - name: ny_pit_pilot_single_or_separate_fourth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate fourth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $13,900 but not over $80,650     $586 plus 5.40% of excess over"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '80650'
+
+  - name: ny_pit_pilot_single_or_separate_fifth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate fifth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: "Over $80,650 but not over $215,400    $4,191 plus 5.90% of excess"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '215400'
+
+  - name: ny_pit_pilot_single_or_separate_sixth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate sixth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $215,400 but not over            $12,141 plus 6.85% of excess
+                $1,077,550                            over $215,400
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1077550'
+
+  - name: ny_pit_pilot_single_or_separate_seventh_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate seventh upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $1,077,550 but not over          $71,198 plus 9.65% of excess
+                $5,000,000                            over $1,077,550
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '5000000'
+
+  - name: ny_pit_pilot_single_or_separate_eighth_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate eighth upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              excerpt: |-
+                Over $5,000,000 but not over          $449,714 plus 10.30% of excess
+                $25,000,000                           over $5,000,000
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000000'
+
+  - name: ny_pit_pilot_joint_or_surviving_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_joint_or_surviving_bracket_selector
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "joint and surviving-spouse 2026 rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 17150, 2: 23600, 3: 27900, 4: 161550, 5: 323200, 6: 2155350, 7: 5000000, 8: 25000000}
+
+  - name: ny_pit_pilot_joint_or_surviving_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_joint_or_surviving_bracket_selector
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "joint and surviving-spouse 2026 rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 669, 2: 953, 3: 1174, 4: 8391, 5: 17928, 6: 143430, 7: 417939, 8: 2477939}
+
+  - name: ny_pit_pilot_joint_or_surviving_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: ny_pit_pilot_joint_or_surviving_bracket_selector
+    source: Tax Law § 601(a)(1)(B)(vii), joint and surviving-spouse marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "joint and surviving-spouse 2026 rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.039, 1: 0.044, 2: 0.0515, 3: 0.054, 4: 0.059, 5: 0.0685, 6: 0.0965, 7: 0.103, 8: 0.109}
+  - name: ny_pit_pilot_head_of_household_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_head_of_household_bracket_selector
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "head-of-household 2026 rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 12800, 2: 17650, 3: 20900, 4: 107650, 5: 269300, 6: 1616450, 7: 5000000, 8: 25000000}
+
+  - name: ny_pit_pilot_head_of_household_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_head_of_household_bracket_selector
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "head-of-household 2026 rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 499, 2: 712, 3: 879, 4: 5564, 5: 15101, 6: 107381, 7: 433894, 8: 2493894}
+
+  - name: ny_pit_pilot_head_of_household_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: ny_pit_pilot_head_of_household_bracket_selector
+    source: Tax Law § 601(b)(1)(B)(vii), head-of-household marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "head-of-household 2026 rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.039, 1: 0.044, 2: 0.0515, 3: 0.054, 4: 0.059, 5: 0.0685, 6: 0.0965, 7: 0.103, 8: 0.109}
+
+  - name: ny_pit_pilot_single_or_separate_bracket_floor
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_single_or_separate_bracket_selector
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate excess floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "single and married-separate 2026 rate schedule", row_key: bracket, column_key: excess_floor}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 8500, 2: 11700, 3: 13900, 4: 80650, 5: 215400, 6: 1077550, 7: 5000000, 8: 25000000}
+
+  - name: ny_pit_pilot_single_or_separate_bracket_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: ny_pit_pilot_single_or_separate_bracket_selector
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "single and married-separate 2026 rate schedule", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 332, 2: 473, 3: 586, 4: 4191, 5: 12141, 6: 71198, 7: 449714, 8: 2509714}
+
+  - name: ny_pit_pilot_single_or_separate_bracket_rate
+    kind: parameter
+    dtype: Rate
+    indexed_by: ny_pit_pilot_single_or_separate_bracket_selector
+    source: Tax Law § 601(c)(1)(B)(vii), single and married-separate marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ny/statute/TAX/601
+              table: {header: "single and married-separate 2026 rate schedule", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.039, 1: 0.044, 2: 0.0515, 3: 0.054, 4: 0.059, 5: 0.0685, 6: 0.0965, 7: 0.103, 8: 0.109}


### PR DESCRIPTION
## Summary
- replace the bounded New York pilot with all three 2026 TAX §601 main-income-tax schedules and all nine bands
- route joint/surviving-spouse, head-of-household, and single/married-separate filing statuses from explicit upstream classifications
- remove the obsolete failed-validation fingerprint and matching pending waiver for the replaced module
- keep §601(d-5) supplemental tax and credits explicitly outside this narrow target because PolicyEngine-US 1.752.2 conflicts with the statute on the supplemental computation

## Validation
- independent review/fix/rebase/re-review cycle: CLEAN at exact final head `fb41b32fc55a55d7d114b90e60275e8c818f62ef` atop merged Hawaii main `60209666fbd5d4fef2823fbd2c873bd0d9094989`
- proof validation: 47 atoms; 0/30 missing money atoms
- deterministic validation/compile: passed; 38 rules
- companion fixtures: 52/52 passed
- repository layout and reverse-index checks: passed
- exact signed generated-file guard: passed, 0 issues
- independent BigDecimal recomputation: 52/52 exact
- final waiver-debt review confirmed exactly the stale module fingerprint and waiver were removed

## Scope
This PR encodes only `ny_main_income_tax`. It deliberately does not claim parity for `ny_income_tax` or `ny_income_tax_before_credits`; the §601(d-5) oracle/statute discrepancy remains documented and deferred.