### PR TITLE
Encode Hawaii 2026 income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-hi/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-hi/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-hi/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "dd49a2b1f0fa88362cd4502683a9c8ad485cf68e8345af45a040ae54d2b72282"
+      "sha256": "158fe525efc4d1366b15d0d319d2b23ee64582dbe1fea54883ecb24334691721"
     },
     {
       "path": "us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "c4c33cd1da4ee49df9913c3c2d0fd52bdc4494706d1907f7acde21671b568e47"
+      "sha256": "e26f8a865ba9db59540d194910acce123798e21ff32a852da6aacb2640f29081"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-hi:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.868390+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "c4c33cd1da4ee49df9913c3c2d0fd52bdc4494706d1907f7acde21671b568e47",
+  "generated_at": "2026-07-22T09:44:23.121491+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcihi4il1/sign-applied-files/us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcihi4il1",
+  "generated_output_sha256": "e26f8a865ba9db59540d194910acce123798e21ff32a852da6aacb2640f29081",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,71 +33,98 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "61e96573930d80fa96d63144f11854b0b0e3928c4f2a9e33b1b43781b919250a"
+    "value": "fdb774d99d7a20ba3296b622f7a06c1a67b1f9118eae38f678af3d50325a2365"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.898329+00:00",
+    "generated_at": "2026-07-22T09:30:40.890353+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "bc4240e578ea5a6298bcaf10a4da65e86f2f4f9e7452fb3261a2185241c4d3c3",
-    "prior_signature": "de5e9512028c686af7c56014d9498e5ea111c82e977a2491119c8caac74c6a2a",
+    "manifest_sha256": "650801e4d3e0f12ba02edea2c5bd0f7d43fc8f72572cd1998cf02eeaaee19849",
+    "prior_signature": "f852bbf2069a78ac7e0a346911e6d54c8320646cef846bffb79d0c0659e39b52",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.197035+00:00",
+      "generated_at": "2026-07-22T08:35:59.868096+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "ef48118549213d133d7a506beea3530af84be558892ca3ec4c434c95e0f66595",
-      "prior_signature": "916e68eda28fd3ab2890e97f62807b864da608c5916d57c1a580273cd66f61f4",
+      "manifest_sha256": "c7603e45f2c40c1e4fdb9d5b3cafdc400c034a5310f68bc0f6f21f09984c162b",
+      "prior_signature": "a477652c3b1ec74d2416c3a6d510d205f365a477ef528e554e9077eff9c0f2e9",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.265181+00:00",
+        "generated_at": "2026-07-21T15:45:46.868390+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "06cf8320baadfddc9ff83975c9e0c26b5ca97ba770a4b7f7d54c7bdd3cb045a6",
-        "prior_signature": "d3ee05610c2dd0b77adb393033dfa0ba226838ca8be982891fe6733a5471945e",
+        "manifest_sha256": "c04b36b499ed16d637ab06205bf9c3b2bacbc076ce01c1f67a6dbbc73e8dec49",
+        "prior_signature": "61e96573930d80fa96d63144f11854b0b0e3928c4f2a9e33b1b43781b919250a",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:31.548437+00:00",
+          "generated_at": "2026-07-21T15:44:47.898329+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "93f02b0aafdb6d839a06f024dfb4d4869b1591a50025ded2f2b487a53d9ee7ed",
-          "prior_signature": "3c01c211cdf4992a0d79ee232a73919443c6c990b178d0398bdbfbc85efdb12e",
+          "manifest_sha256": "bc4240e578ea5a6298bcaf10a4da65e86f2f4f9e7452fb3261a2185241c4d3c3",
+          "prior_signature": "de5e9512028c686af7c56014d9498e5ea111c82e977a2491119c8caac74c6a2a",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T14:52:20.235989+00:00",
+            "generated_at": "2026-07-16T15:48:15.197035+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "a3347e29240439c91a96e320bad99ee3b77788cdfbe11765b0d8ac947d6a904a",
-            "prior_signature": "ec1658b6032a826849b1cde9f8c4e61d5e553b9d97f997e91b06614be9581dac",
+            "manifest_sha256": "ef48118549213d133d7a506beea3530af84be558892ca3ec4c434c95e0f66595",
+            "prior_signature": "916e68eda28fd3ab2890e97f62807b864da608c5916d57c1a580273cd66f61f4",
             "run_id": null,
             "supersedes": {
               "backend": "manual",
-              "generated_at": "2026-07-16T14:39:34.872961+00:00",
+              "generated_at": "2026-07-16T15:22:02.265181+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "1711459bfa71ef72caea8d97d9d3ddb5790224c16865ca174c3287e0138049fc",
-              "prior_signature": "bf61c5d7821d307373c5836ebe1c19d0bcf5fd3777e76a5716db4c74002a0939",
+              "manifest_sha256": "06cf8320baadfddc9ff83975c9e0c26b5ca97ba770a4b7f7d54c7bdd3cb045a6",
+              "prior_signature": "d3ee05610c2dd0b77adb393033dfa0ba226838ca8be982891fe6733a5471945e",
               "run_id": null,
               "supersedes": {
                 "backend": "manual",
-                "generated_at": "2026-07-16T14:29:10.617966+00:00",
+                "generated_at": "2026-07-16T15:09:31.548437+00:00",
                 "generation_prompt_sha256": null,
-                "manifest_sha256": "2bb1f598e8e29ed84ec779cb3afab3acfcc3a345fccdef2338d590e8ad2154d1",
-                "prior_signature": "57502ce24958fe4e61aa594962d000d7a25b91c5ab4498b6e547a6f637675f8a",
+                "manifest_sha256": "93f02b0aafdb6d839a06f024dfb4d4869b1591a50025ded2f2b487a53d9ee7ed",
+                "prior_signature": "3c01c211cdf4992a0d79ee232a73919443c6c990b178d0398bdbfbc85efdb12e",
                 "run_id": null,
                 "supersedes": {
                   "backend": "manual",
-                  "generated_at": "2026-07-15T14:31:12.051494+00:00",
+                  "generated_at": "2026-07-16T14:52:20.235989+00:00",
                   "generation_prompt_sha256": null,
-                  "manifest_sha256": "1cbb190ae8203180cbe599cc441b8542eb4a0fba845e007bc6af7c09d99084d5",
-                  "prior_signature": "d18abb91e0e259de926a0d1b53c24fb50a77069ed8fedb706653965c5777d12d",
+                  "manifest_sha256": "a3347e29240439c91a96e320bad99ee3b77788cdfbe11765b0d8ac947d6a904a",
+                  "prior_signature": "ec1658b6032a826849b1cde9f8c4e61d5e553b9d97f997e91b06614be9581dac",
                   "run_id": null,
                   "supersedes": {
                     "backend": "manual",
-                    "generated_at": "2026-07-15T14:18:32.182527+00:00",
+                    "generated_at": "2026-07-16T14:39:34.872961+00:00",
                     "generation_prompt_sha256": null,
-                    "manifest_sha256": "988a87cee4784d4c47bf1ce095685115d9ba5663f9a23fee96edd69eec7c9b45",
-                    "prior_signature": "1ea030d0409cf1f4b76353f6039e1b85f93fb329bd53805afee1922b0bbefe58",
+                    "manifest_sha256": "1711459bfa71ef72caea8d97d9d3ddb5790224c16865ca174c3287e0138049fc",
+                    "prior_signature": "bf61c5d7821d307373c5836ebe1c19d0bcf5fd3777e76a5716db4c74002a0939",
                     "run_id": null,
+                    "supersedes": {
+                      "backend": "manual",
+                      "generated_at": "2026-07-16T14:29:10.617966+00:00",
+                      "generation_prompt_sha256": null,
+                      "manifest_sha256": "2bb1f598e8e29ed84ec779cb3afab3acfcc3a345fccdef2338d590e8ad2154d1",
+                      "prior_signature": "57502ce24958fe4e61aa594962d000d7a25b91c5ab4498b6e547a6f637675f8a",
+                      "run_id": null,
+                      "supersedes": {
+                        "backend": "manual",
+                        "generated_at": "2026-07-15T14:31:12.051494+00:00",
+                        "generation_prompt_sha256": null,
+                        "manifest_sha256": "1cbb190ae8203180cbe599cc441b8542eb4a0fba845e007bc6af7c09d99084d5",
+                        "prior_signature": "d18abb91e0e259de926a0d1b53c24fb50a77069ed8fedb706653965c5777d12d",
+                        "run_id": null,
+                        "supersedes": {
+                          "backend": "manual",
+                          "generated_at": "2026-07-15T14:18:32.182527+00:00",
+                          "generation_prompt_sha256": null,
+                          "manifest_sha256": "988a87cee4784d4c47bf1ce095685115d9ba5663f9a23fee96edd69eec7c9b45",
+                          "prior_signature": "1ea030d0409cf1f4b76353f6039e1b85f93fb329bd53805afee1922b0bbefe58",
+                          "run_id": null,
+                          "tool": "axiom-encode sign-applied-files"
+                        },
+                        "tool": "axiom-encode sign-applied-files"
+                      },
+                      "tool": "axiom-encode sign-applied-files"
+                    },
                     "tool": "axiom-encode sign-applied-files"
                   },
                   "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17945,6 +17945,15 @@
         ]
       }
     ],
+    "us-hi/form/individual-income-tax/2025/n-11-instructions/capital-gains-tax-worksheet": [
+      {
+        "module": "us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-hi/regulation/har/17/680/page-11": [
       {
         "module": "us-hi/regulations/har/17/680/17-680-12.yaml",
@@ -17963,15 +17972,6 @@
         ]
       }
     ],
-    "us-hi/statute/235-2.4": [
-      {
-        "module": "us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      }
-    ],
     "us-hi/statute/235-51": [
       {
         "module": "us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
@@ -17982,13 +17982,6 @@
       }
     ],
     "us-hi/statute/235-54": [
-      {
-        "module": "us-hi/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-hi/statutes/235-54.yaml",
         "via": [

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "588580d508856960453bee044d4dab8c5c5216db"
+axiom_corpus_ref = "58d890cea6ff52604f722c6a0978d191ae18419f"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1638
+ceiling: 1664
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -23,15 +23,93 @@ entries:
 - legal_id: us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person
   source: bulk
   since: '2026-07-08'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_a_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_a_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_b_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_b_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_rate
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-15'
-- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate
   source: manual
-  since: '2026-07-15'
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_floor
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_floor
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_floor
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_smaller_net_capital_gain
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income
   source: manual
   since: '2026-07-15'
+- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-hi:statutes/235-54#blind_deaf_or_totally_disabled_person_exemption_amount
   source: bulk
   since: '2026-07-08'

--- a/us-hi/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-hi/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,100 +1,1239 @@
-# Hand-computed 2026 fixtures from the supplied schedule. PolicyEngine supplied
-# the case taxable-income subtraction and active bracket inputs; the expected
-# values below are the shown decimal arithmetic, independently executed by the
-# Axiom rules engine rather than read back from the oracle.
-- name: single_30000
-  # taxable 30000 - 9144 = 20856; schedule 552 + 0.064 * max(0, 20856 - 19200) = 657.984.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# HRS 235-51 fixtures. Every one of the eleven transitions in each 2026
+# individual filing-class schedule is checked at the exact upper bound and one
+# dollar above it. Additional cases cover all filing classifications and every
+# min/max branch in subsection (f).
+# Exact statutory upper bound 19200.
+- name: schedule_a_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 30000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 9144
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 19200
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 552
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.064
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 19200
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '20856'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '657.984'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '657.984'
-- name: single_60000
-  # taxable 60000 - 9144 = 50856; schedule 2539.2 + 0.076 * max(0, 50856 - 48000) = 2756.256.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '19200'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '268.8'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '268.8'
+# One dollar above the statutory upper bound 19200.
+- name: schedule_a_transition_1_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 60000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 9144
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 48000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 2539.2
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.076
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 19201
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '50856'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '2756.256'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2756.256'
-- name: single_150000
-  # taxable 150000 - 10878.2 = 139121.8; schedule 8391.2 + 0.079 * max(0, 139121.8 - 125000) = 9506.8222.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '19201'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '269.032'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '269.032'
+# Exact statutory upper bound 28800.
+- name: schedule_a_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 150000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 10878.2
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 125000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 8391.2
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.079
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 28800
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '139121.8'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '9506.8222'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '9506.8222'
-- name: married_60000
-  # taxable 60000 - 18288 = 41712; schedule 1104 + 0.064 * max(0, 41712 - 38400) = 1315.968.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '28800'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '576.2'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '576.2'
+# One dollar above the statutory upper bound 28800.
+- name: schedule_a_transition_2_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 60000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 18288
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 38400
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 1104
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.064
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 28801
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '41712'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '1315.968'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1315.968'
-- name: married_120000
-  # taxable 120000 - 18288 = 101712; schedule 5078.4 + 0.076 * max(0, 101712 - 96000) = 5512.512.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '28801'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '576.055'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '576.055'
+# Exact statutory upper bound 38400.
+- name: schedule_a_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 120000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 18288
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 96000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 5078.4
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.076
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 38400
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '101712'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '5512.512'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '5512.512'
-- name: married_300000
-  # taxable 300000 - 20958.2 = 279041.8; schedule 16782.4 + 0.079 * max(0, 279041.8 - 250000) = 19076.7022.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '38400'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1104'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1104'
+# One dollar above the statutory upper bound 38400.
+- name: schedule_a_transition_3_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_adjusted_gross_income: 300000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_taxable_income_subtraction: 20958.2
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_floor: 250000
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_bracket_base: 16782.4
-    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_supplied_marginal_rate: 0.079
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 38401
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
   output:
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '279041.8'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_tax: '19076.7022'
-    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '19076.7022'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '38401'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1104.064'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1104.064'
+# Exact statutory upper bound 48000.
+- name: schedule_a_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 48000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1718.4'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1718.4'
+# One dollar above the statutory upper bound 48000.
+- name: schedule_a_transition_4_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 48001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '48001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1718.068'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1718.068'
+# Exact statutory upper bound 72000.
+- name: schedule_a_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 72000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '72000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '3350'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '3350'
+# One dollar above the statutory upper bound 72000.
+- name: schedule_a_transition_5_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 72001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '72001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '3350.072'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '3350.072'
+# Exact statutory upper bound 96000.
+- name: schedule_a_transition_6_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 96000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '96000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '5078'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '5078'
+# One dollar above the statutory upper bound 96000.
+- name: schedule_a_transition_6_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 96001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '96001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '5078.076'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '5078.076'
+# Exact statutory upper bound 250000.
+- name: schedule_a_transition_7_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 250000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '250000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '16782'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '16782'
+# One dollar above the statutory upper bound 250000.
+- name: schedule_a_transition_7_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 250001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '250001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '16782.079'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '16782.079'
+# Exact statutory upper bound 350000.
+- name: schedule_a_transition_8_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 350000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '350000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '24682'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '24682'
+# One dollar above the statutory upper bound 350000.
+- name: schedule_a_transition_8_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 350001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '350001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '24682.0825'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '24682.0825'
+# Exact statutory upper bound 450000.
+- name: schedule_a_transition_9_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 450000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '450000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '32932'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '32932'
+# One dollar above the statutory upper bound 450000.
+- name: schedule_a_transition_9_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 450001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '450001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '32932.09'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '32932.09'
+# Exact statutory upper bound 550000.
+- name: schedule_a_transition_10_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 550000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '550000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '41932'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '41932'
+# One dollar above the statutory upper bound 550000.
+- name: schedule_a_transition_10_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 550001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '550001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '41932.1'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '41932.1'
+# Exact statutory upper bound 650000.
+- name: schedule_a_transition_11_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 650000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '650000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '51932'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '51932'
+# One dollar above the statutory upper bound 650000.
+- name: schedule_a_transition_11_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 650001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '650001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 11
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '51932.11'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '51932.11'
+# Exact statutory upper bound 14400.
+- name: schedule_b_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 14400
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '14400'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '201.6'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '201.6'
+# One dollar above the statutory upper bound 14400.
+- name: schedule_b_transition_1_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 14401
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '14401'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '202.032'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '202.032'
+# Exact statutory upper bound 21600.
+- name: schedule_b_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 21600
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '21600'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '432.4'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '432.4'
+# One dollar above the statutory upper bound 21600.
+- name: schedule_b_transition_2_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 21601
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '21601'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '432.055'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '432.055'
+# Exact statutory upper bound 28800.
+- name: schedule_b_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 28800
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '28800'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '828'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '828'
+# One dollar above the statutory upper bound 28800.
+- name: schedule_b_transition_3_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 28801
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '28801'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '828.064'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '828.064'
+# Exact statutory upper bound 36000.
+- name: schedule_b_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 36000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '36000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1288.8'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1288.8'
+# One dollar above the statutory upper bound 36000.
+- name: schedule_b_transition_4_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 36001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '36001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1289.068'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1289.068'
+# Exact statutory upper bound 54000.
+- name: schedule_b_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 54000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '54000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '2513'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2513'
+# One dollar above the statutory upper bound 54000.
+- name: schedule_b_transition_5_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 54001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '54001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '2513.072'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2513.072'
+# Exact statutory upper bound 72000.
+- name: schedule_b_transition_6_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 72000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '72000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '3809'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '3809'
+# One dollar above the statutory upper bound 72000.
+- name: schedule_b_transition_6_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 72001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '72001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '3809.076'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '3809.076'
+# Exact statutory upper bound 187500.
+- name: schedule_b_transition_7_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 187500
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '187500'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '12587'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '12587'
+# One dollar above the statutory upper bound 187500.
+- name: schedule_b_transition_7_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 187501
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '187501'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '12587.079'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '12587.079'
+# Exact statutory upper bound 262500.
+- name: schedule_b_transition_8_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 262500
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '262500'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '18512'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '18512'
+# One dollar above the statutory upper bound 262500.
+- name: schedule_b_transition_8_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 262501
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '262501'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '18512.0825'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '18512.0825'
+# Exact statutory upper bound 337500.
+- name: schedule_b_transition_9_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 337500
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '337500'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '24699.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '24699.5'
+# One dollar above the statutory upper bound 337500.
+- name: schedule_b_transition_9_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 337501
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '337501'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '24699.09'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '24699.09'
+# Exact statutory upper bound 412500.
+- name: schedule_b_transition_10_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 412500
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '412500'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '31449'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '31449'
+# One dollar above the statutory upper bound 412500.
+- name: schedule_b_transition_10_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 412501
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '412501'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '31449.1'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '31449.1'
+# Exact statutory upper bound 487500.
+- name: schedule_b_transition_11_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 487500
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '487500'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '38949'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '38949'
+# One dollar above the statutory upper bound 487500.
+- name: schedule_b_transition_11_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 487501
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '487501'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 11
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '38949.11'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '38949.11'
+# Exact statutory upper bound 9600.
+- name: schedule_c_transition_1_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 9600
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '9600'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '134.4'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '134.4'
+# One dollar above the statutory upper bound 9600.
+- name: schedule_c_transition_1_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 9601
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '9601'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '134.032'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '134.032'
+# Exact statutory upper bound 14400.
+- name: schedule_c_transition_2_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 14400
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '14400'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '287.6'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '287.6'
+# One dollar above the statutory upper bound 14400.
+- name: schedule_c_transition_2_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 14401
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '14401'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '288.055'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '288.055'
+# Exact statutory upper bound 19200.
+- name: schedule_c_transition_3_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 19200
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '19200'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '552'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '552'
+# One dollar above the statutory upper bound 19200.
+- name: schedule_c_transition_3_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 19201
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '19201'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '552.064'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '552.064'
+# Exact statutory upper bound 24000.
+- name: schedule_c_transition_4_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 24000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '24000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '859.2'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '859.2'
+# One dollar above the statutory upper bound 24000.
+- name: schedule_c_transition_4_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 24001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '24001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '859.068'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '859.068'
+# Exact statutory upper bound 36000.
+- name: schedule_c_transition_5_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 36000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '36000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 4
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1675'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1675'
+# One dollar above the statutory upper bound 36000.
+- name: schedule_c_transition_5_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 36001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '36001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '1675.072'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '1675.072'
+# Exact statutory upper bound 48000.
+- name: schedule_c_transition_6_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 48000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2539'
+# One dollar above the statutory upper bound 48000.
+- name: schedule_c_transition_6_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 48001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '48001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '2539.076'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2539.076'
+# Exact statutory upper bound 125000.
+- name: schedule_c_transition_7_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 125000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '125000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '8391'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '8391'
+# One dollar above the statutory upper bound 125000.
+- name: schedule_c_transition_7_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 125001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '125001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '8391.079'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '8391.079'
+# Exact statutory upper bound 175000.
+- name: schedule_c_transition_8_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 175000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '175000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 7
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '12341'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '12341'
+# One dollar above the statutory upper bound 175000.
+- name: schedule_c_transition_8_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 175001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '175001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '12341.0825'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '12341.0825'
+# Exact statutory upper bound 225000.
+- name: schedule_c_transition_9_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 225000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '225000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '16466'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '16466'
+# One dollar above the statutory upper bound 225000.
+- name: schedule_c_transition_9_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 225001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '225001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '16466.09'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '16466.09'
+# Exact statutory upper bound 275000.
+- name: schedule_c_transition_10_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 275000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '275000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 9
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '20966'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '20966'
+# One dollar above the statutory upper bound 275000.
+- name: schedule_c_transition_10_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 275001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '275001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '20966.1'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '20966.1'
+# Exact statutory upper bound 325000.
+- name: schedule_c_transition_11_exact
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 325000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '325000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 10
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '25966'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '25966'
+# One dollar above the statutory upper bound 325000.
+- name: schedule_c_transition_11_above
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 325001
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '325001'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 11
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '25966.11'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '25966.11'
+# The fixture name records the canonical filing status projected to the two reviewed Boolean inputs.
+- name: joint_routes_schedule_a
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 20000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '294.6'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '294.6'
+# The fixture name records the canonical filing status projected to the two reviewed Boolean inputs.
+- name: surviving_spouse_routes_schedule_a
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 30000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '642'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '642'
+# The fixture name records the canonical filing status projected to the two reviewed Boolean inputs.
+- name: head_of_household_routes_schedule_b
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 30000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 3
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '904.8'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '904.8'
+# The fixture name records the canonical filing status projected to the two reviewed Boolean inputs.
+- name: single_routes_schedule_c
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 10000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 1
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '146.8'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '146.8'
+# The fixture name records the canonical filing status projected to the two reviewed Boolean inputs.
+- name: married_separate_routes_schedule_c
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 15000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 2
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '321'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '321'
+# min(net, long-term) selects net gain; reduced income controls the greater-of; alternative tax wins.
+- name: alternative_net_gain_min_reduced_max_and_alternative_win
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 200000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 20000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '200000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '14403.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '180000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '180000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '12753.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '14203.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '14203.5'
+# min(net, long-term) selects long-term gain; reduced income controls the greater-of.
+- name: alternative_long_term_min_reduced_max_and_alternative_win
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 200000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 20000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '200000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '14403.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '180000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '180000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '12753.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '14203.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '14203.5'
+# The amount taxed below 7.25 percent controls the greater-of branch.
+- name: alternative_cap_max_controls
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 200000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 180000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '200000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 8
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '14403.5'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '20000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '13559'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '13559'
+# Both capital-gain inputs tie and reduced income equals the schedule C cap.
+- name: alternative_min_and_max_tie_at_schedule_c_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 100000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 52000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '6309'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '6309'
+# A nonpositive completed worksheet line 10 fails closed to the regular tax.
+- name: nonpositive_worksheet_line_10_uses_regular_tax
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 100000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '6491'
+# A zero completed worksheet line 10 is ineligible and returns regular tax.
+- name: zero_worksheet_line_10_uses_regular_tax
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 100000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: not_holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '100000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '6491'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '6491'
+# Reduced income equals the joint/surviving-spouse 96,000 cap.
+- name: schedule_a_exact_below_7_25_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 146000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 50000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '146000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_a_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '8878'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '96000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '96000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '96000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_a_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '5078'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '8703'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '8703'
+# Reduced income equals the head-of-household 72,000 cap.
+- name: schedule_b_exact_below_7_25_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 122000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 50000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '122000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_b_bracket: 6
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '7609'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '72000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '72000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '72000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_b_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '3809'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '7434'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '7434'
+# At the 48,000 schedule C cap, paragraph (1)(B) preserves all taxable income.
+- name: eligible_at_schedule_c_cap_preserves_regular_tax
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 48000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 1000
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_capital_gain_alternative_eligible: holds
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income_reduced_by_capital_gain: '47000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_taxed_below_capital_gain_rate: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '48000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 5
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '2539'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '2539'
+# Zero taxable income remains zero.
+- name: zero_taxable_income
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '0'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '0'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '0'
+# The completed-return boundary fails safely for a negative supplied amount.
+- name: negative_taxable_income_floors_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: -100
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 0
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income: '0'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_regular_schedule_tax: '0'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '0'
+
+# Eligible alternative computation remains in schedule A's first bracket.
+- name: alternative_schedule_a_zero_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 10000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 100
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '10000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_a_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '140'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '140'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '140'
+
+# Eligible alternative computation remains in schedule B's first bracket.
+- name: alternative_schedule_b_zero_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 10000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: true
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 100
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '10000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_b_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '140'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '140'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '140'
+
+# Eligible alternative computation remains in schedule C's first bracket.
+- name: alternative_schedule_c_zero_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_state_taxable_income: 5000
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_filing_status_head_of_household: false
+    us-hi:policies/income_tax/pilot_liability_pipeline#input.hi_pit_pilot_capital_gains_worksheet_line_10: 100
+  output:
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_taxable_income: '5000'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_schedule_c_bracket: 0
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax: '70'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_tax_on_capital_gains: '70'
+    us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_income_tax_liability: '70'

--- a/us-hi/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-hi/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,70 +3,501 @@ module:
   proof_validation:
     required: true
   source_verification:
+    corpus_citation_path: us-hi/statute/235-51
     corpus_citation_paths:
       - us-hi/statute/235-51
-      - us-hi/statute/235-2.4
-      - us-hi/statute/235-54
+      - us-hi/form/individual-income-tax/2025/n-11-instructions/capital-gains-tax-worksheet
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: checked_higher_authority
       checked_paths:
         - us-hi/statute/235-51
-        - us-hi/statute/235-2.4
-        - us-hi/statute/235-54
+        - us-hi/form/individual-income-tax/2025/n-11-instructions/capital-gains-tax-worksheet
       rationale: |-
-        This pipeline computes the Hawaii individual income-tax liability
-        for the ordinary resident wage-earner slice at tax year 2026. The
-        supplied-current primary authority establishes the graduated tax
-        on taxable income and the relevant deductions and personal exemptions. Values
-        that vary by filing status, bracket, annual indexing, or the choice
-        between standard and itemized deductions remain declared caller inputs:
-        adjusted gross income, the AGI-to-taxable-income subtraction, the active
-        bracket floor, cumulative tax at that floor, and marginal rate. The
-        module adds no numeric tax-law literals; it wires those supplied values
-        into the statutory taxable-income and schedule mechanics. The six
-        companion cases use the current values PolicyEngine applies at 2026 and
-        compare to hi_income_tax_before_non_refundable_credits.
+        Hawaii Revised Statutes section 235-51(a), (b), and (c) supplies the
+        complete individual rate schedules for taxable years beginning after
+        December 31, 2024, including the joint-or-surviving-spouse, head-of-
+        household, and single-or-married-separate tables operative in 2026.
+        Subsection (f) limits the resulting tax for a taxpayer with net capital
+        gain to the regular tax on the greater of taxable income reduced by net
+        capital gain or the amount taxed below 7.25 percent, plus 7.25 percent
+        of the remaining taxable income. The official 2025 Form N-11
+        instructions supply the stable worksheet mechanics that combine the
+        Hawaii-adjusted long-term and net capital-gain amounts, subtract any
+        Form N-158 amount, and produce line 10. This module accepts completed-
+        return Hawaii taxable income, that completed worksheet line-10 amount,
+        and two mutually exclusive filing-status classifications as upstream
+        caller boundaries. It does not reconstruct federal or Hawaii taxable
+        income, deductions, exemptions, capital-gain classifications, Hawaii
+        adjustments, or Form N-158. The form's 2025 filing-status amounts are
+        not imported: the module derives the operative 2026 amounts taxed below
+        7.25 percent from the current HRS schedules.
+        It fails closed outside 2026. Estates and trusts under subsection (d)
+        and the multi-state business gross-sales election under subsection (e)
+        are outside this individual-TaxUnit target and certified population.
   summary: |-
-    Composed Hawaii individual income-tax liability pipeline for the 2026
-    ordinary resident childless wage-earner oracle slice. It computes taxable
-    income from supplied adjusted gross income and supplied deductions or
-    exemptions, then applies the active graduated bracket as supplied
-    cumulative base tax plus the supplied marginal rate on income above the
-    supplied floor. Credits and special income classes are outside this
-    before-credit core. All tax-law amounts are inputs so the composition is
-    source-grounded without embedding an unencoded annual schedule.
+    Hawaii 2026 individual income tax before nonrefundable credits. The module
+    encodes every bracket of the three individual schedules in HRS 235-51(a)-
+    (c), routes joint and surviving-spouse filers to schedule A, heads of
+    household to schedule B, and single and married-separate filers to schedule
+    C, and applies the subsection (f) capital-gain alternative and final tax
+    limitation from a completed Form N-11 capital-gains worksheet line-10 caller
+    boundary. Upstream completed-return taxable income and worksheet gain
+    classification and adjustment mechanics remain caller boundaries. Credits,
+    estates and trusts, and the subsection (e) business election are outside
+    this narrow target.
 rules:
+  - name: hi_pit_pilot_schedule_a_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_a_bracket
+    source: HRS 235-51(a), 2025-and-later joint and surviving-spouse schedule floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "joint return and surviving spouse, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "excess-over floor"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 19200
+          2: 28800
+          3: 38400
+          4: 48000
+          5: 72000
+          6: 96000
+          7: 250000
+          8: 350000
+          9: 450000
+          10: 550000
+          11: 650000
+
+  - name: hi_pit_pilot_schedule_a_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_a_bracket
+    source: HRS 235-51(a), 2025-and-later joint and surviving-spouse cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "joint return and surviving spouse, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 269
+          2: 576
+          3: 1104
+          4: 1718
+          5: 3350
+          6: 5078
+          7: 16782
+          8: 24682
+          9: 32932
+          10: 41932
+          11: 51932
+
+  - name: hi_pit_pilot_schedule_b_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_b_bracket
+    source: HRS 235-51(b), 2025-and-later head-of-household schedule floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "head of household, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "excess-over floor"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 14400
+          2: 21600
+          3: 28800
+          4: 36000
+          5: 54000
+          6: 72000
+          7: 187500
+          8: 262500
+          9: 337500
+          10: 412500
+          11: 487500
+
+  - name: hi_pit_pilot_schedule_b_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_b_bracket
+    source: HRS 235-51(b), 2025-and-later head-of-household cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "head of household, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 202
+          2: 432
+          3: 828
+          4: 1289
+          5: 2513
+          6: 3809
+          7: 12587
+          8: 18512
+          9: 24699
+          10: 31449
+          11: 38949
+
+  - name: hi_pit_pilot_schedule_c_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_c_bracket
+    source: HRS 235-51(c), 2025-and-later single and married-separate schedule floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "single and married separate, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "excess-over floor"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 9600
+          2: 14400
+          3: 19200
+          4: 24000
+          5: 36000
+          6: 48000
+          7: 125000
+          8: 175000
+          9: 225000
+          10: 275000
+          11: 325000
+
+  - name: hi_pit_pilot_schedule_c_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: hi_pit_pilot_schedule_c_bracket
+    source: HRS 235-51(c), 2025-and-later single and married-separate cumulative base tax
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "single and married separate, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 134
+          2: 288
+          3: 552
+          4: 859
+          5: 1675
+          6: 2539
+          7: 8391
+          8: 12341
+          9: 16466
+          10: 20966
+          11: 25966
+
+  - name: hi_pit_pilot_schedule_a_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_schedule_a_bracket
+    source: HRS 235-51(a)-(c), shared 2025-and-later individual marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "individual schedules, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_schedule_b_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_schedule_b_bracket
+    source: HRS 235-51(b), 2025-and-later head-of-household marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "head of household, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_schedule_c_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_schedule_c_bracket
+    source: HRS 235-51(c), 2025-and-later single and married-separate marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "single and married separate, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_alternative_schedule_a_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_alternative_schedule_a_bracket
+    source: HRS 235-51(a) and (f)(1), marginal rates for the alternative schedule A computation
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "joint return and surviving spouse, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_alternative_schedule_b_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_alternative_schedule_b_bracket
+    source: HRS 235-51(b) and (f)(1), marginal rates for the alternative schedule B computation
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "head of household, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_alternative_schedule_c_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: hi_pit_pilot_alternative_schedule_c_bracket
+    source: HRS 235-51(c) and (f)(1), marginal rates for the alternative schedule C computation
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              table:
+                header: "single and married separate, taxable years beginning after December 31, 2024"
+                row_key: "taxable income bracket"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.014
+          1: 0.032
+          2: 0.055
+          3: 0.064
+          4: 0.068
+          5: 0.072
+          6: 0.076
+          7: 0.079
+          8: 0.0825
+          9: 0.09
+          10: 0.10
+          11: 0.11
+
+  - name: hi_pit_pilot_capital_gain_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: HRS 235-51(f)(2), alternative tax rate on taxable income above the paragraph (1) amount
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "A tax of 7.25 per cent of the amount of taxable income in excess of the amount determined under paragraph (1)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0725'
+
   - name: hi_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: HRS sections 235-2.4 and 235-54, taxable income after the supplied subtraction
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-hi/statute/235-2.4
-              excerpt: "the standard deduction amounts provided therein shall instead mean"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-hi/statute/235-54
-              excerpt: "multiply that number by $1,144"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, hi_pit_pilot_adjusted_gross_income - hi_pit_pilot_supplied_taxable_income_subtraction)
-  - name: hi_pit_pilot_schedule_tax
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: HRS section 235-51, graduated tax using the supplied active bracket
+    source: HRS 235-51(a)-(c), supplied completed-return Hawaii taxable income
     metadata:
       proof:
         atoms:
@@ -74,19 +505,388 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-hi/statute/235-51
-              excerpt: "There is hereby imposed on the taxable income of every"
+              excerpt: "There is hereby imposed on the taxable income"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, hi_pit_pilot_state_taxable_income)
+
+  - name: hi_pit_pilot_schedule_a_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(a), joint and surviving-spouse bracket selected from taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "In the case of any taxable year beginning after December 31, 2024: If the taxable income is: The tax shall be:"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          hi_pit_pilot_supplied_bracket_base
-          + hi_pit_pilot_supplied_marginal_rate * max(0, hi_pit_pilot_taxable_income - hi_pit_pilot_supplied_bracket_floor)
+          if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[1]: 0
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[2]: 1
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[3]: 2
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[4]: 3
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[5]: 4
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[6]: 5
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[7]: 6
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[8]: 7
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[9]: 8
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[10]: 9
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_a_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_schedule_b_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(b), head-of-household bracket selected from taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "There is hereby imposed on the taxable income of every head of a household a tax determined in accordance with the following table"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[1]: 0
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[2]: 1
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[3]: 2
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[4]: 3
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[5]: 4
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[6]: 5
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[7]: 6
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[8]: 7
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[9]: 8
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[10]: 9
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_b_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_schedule_c_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(c), single and married-separate bracket selected from taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "on the taxable income of every married individual who does not make a single return jointly"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[1]: 0
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[2]: 1
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[3]: 2
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[4]: 3
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[5]: 4
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[6]: 5
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[7]: 6
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[8]: 7
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[9]: 8
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[10]: 9
+          else: if hi_pit_pilot_taxable_income <= hi_pit_pilot_schedule_c_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_regular_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(a)-(c), regular tax under the applicable 2026 filing-status schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "tax determined in accordance with the following table"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_filing_status_joint_or_surviving_spouse:
+            hi_pit_pilot_schedule_a_base[hi_pit_pilot_schedule_a_bracket]
+            + hi_pit_pilot_schedule_a_rate[hi_pit_pilot_schedule_a_bracket]
+            * max(0, hi_pit_pilot_taxable_income - hi_pit_pilot_schedule_a_floor[hi_pit_pilot_schedule_a_bracket])
+          else: if hi_pit_pilot_filing_status_head_of_household:
+            hi_pit_pilot_schedule_b_base[hi_pit_pilot_schedule_b_bracket]
+            + hi_pit_pilot_schedule_b_rate[hi_pit_pilot_schedule_b_bracket]
+            * max(0, hi_pit_pilot_taxable_income - hi_pit_pilot_schedule_b_floor[hi_pit_pilot_schedule_b_bracket])
+          else:
+            hi_pit_pilot_schedule_c_base[hi_pit_pilot_schedule_c_bracket]
+            + hi_pit_pilot_schedule_c_rate[hi_pit_pilot_schedule_c_bracket]
+            * max(0, hi_pit_pilot_taxable_income - hi_pit_pilot_schedule_c_floor[hi_pit_pilot_schedule_c_bracket])
+
+  - name: hi_pit_pilot_capital_gain_alternative_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Form N-11 capital-gains worksheet line 10, positive completed worksheet amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-hi/form/individual-income-tax/2025/n-11-instructions/capital-gains-tax-worksheet
+              excerpt: "Line 8 minus line 9 (If this amount is zero or less, stop here; you cannot use this worksheet to figure your tax.)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: hi_pit_pilot_capital_gains_worksheet_line_10 > 0
+
+  - name: hi_pit_pilot_taxable_income_reduced_by_capital_gain
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(f)(1)(A) and Form N-11 worksheet line 11, taxable income reduced by completed line 10
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/form/individual-income-tax/2025/n-11-instructions/capital-gains-tax-worksheet
+              excerpt: "Line 1 minus line 10"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: hi_pit_pilot_taxable_income - hi_pit_pilot_capital_gains_worksheet_line_10
+
+  - name: hi_pit_pilot_income_taxed_below_capital_gain_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(f)(1)(B), taxable income taxed below 7.25 percent under the applicable schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "The amount of taxable income taxed at a rate below 7.25 per cent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_filing_status_joint_or_surviving_spouse:
+            min(hi_pit_pilot_taxable_income, hi_pit_pilot_schedule_a_floor[6])
+          else: if hi_pit_pilot_filing_status_head_of_household:
+            min(hi_pit_pilot_taxable_income, hi_pit_pilot_schedule_b_floor[6])
+          else:
+            min(hi_pit_pilot_taxable_income, hi_pit_pilot_schedule_c_floor[6])
+
+  - name: hi_pit_pilot_alternative_schedule_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(f)(1), greater of the paragraph (A) and (B) amounts
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "on the greater of"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, max(hi_pit_pilot_taxable_income_reduced_by_capital_gain, hi_pit_pilot_income_taxed_below_capital_gain_rate))
+
+  - name: hi_pit_pilot_alternative_schedule_a_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(a) and (f)(1), schedule A bracket for the alternative-tax paragraph (1) amount
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "The tax computed at the rates and in the same manner as if this subsection had not been enacted"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[1]: 0
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[2]: 1
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[3]: 2
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[4]: 3
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[5]: 4
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[6]: 5
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[7]: 6
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[8]: 7
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[9]: 8
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[10]: 9
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_a_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_alternative_schedule_b_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(b) and (f)(1), schedule B bracket for the alternative-tax paragraph (1) amount
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "The tax computed at the rates and in the same manner as if this subsection had not been enacted"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[1]: 0
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[2]: 1
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[3]: 2
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[4]: 3
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[5]: 4
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[6]: 5
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[7]: 6
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[8]: 7
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[9]: 8
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[10]: 9
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_b_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_alternative_schedule_c_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: HRS 235-51(c) and (f)(1), schedule C bracket for the alternative-tax paragraph (1) amount
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "The tax computed at the rates and in the same manner as if this subsection had not been enacted"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[1]: 0
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[2]: 1
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[3]: 2
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[4]: 3
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[5]: 4
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[6]: 5
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[7]: 6
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[8]: 7
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[9]: 8
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[10]: 9
+          else: if hi_pit_pilot_alternative_schedule_taxable_income <= hi_pit_pilot_schedule_c_floor[11]: 10
+          else: 11
+
+  - name: hi_pit_pilot_alternative_regular_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(f)(1), regular schedule tax on the paragraph (1) amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "The tax computed at the rates and in the same manner as if this subsection had not been enacted"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if hi_pit_pilot_filing_status_joint_or_surviving_spouse:
+            hi_pit_pilot_schedule_a_base[hi_pit_pilot_alternative_schedule_a_bracket]
+            + hi_pit_pilot_alternative_schedule_a_rate[hi_pit_pilot_alternative_schedule_a_bracket]
+            * max(0, hi_pit_pilot_alternative_schedule_taxable_income - hi_pit_pilot_schedule_a_floor[hi_pit_pilot_alternative_schedule_a_bracket])
+          else: if hi_pit_pilot_filing_status_head_of_household:
+            hi_pit_pilot_schedule_b_base[hi_pit_pilot_alternative_schedule_b_bracket]
+            + hi_pit_pilot_alternative_schedule_b_rate[hi_pit_pilot_alternative_schedule_b_bracket]
+            * max(0, hi_pit_pilot_alternative_schedule_taxable_income - hi_pit_pilot_schedule_b_floor[hi_pit_pilot_alternative_schedule_b_bracket])
+          else:
+            hi_pit_pilot_schedule_c_base[hi_pit_pilot_alternative_schedule_c_bracket]
+            + hi_pit_pilot_alternative_schedule_c_rate[hi_pit_pilot_alternative_schedule_c_bracket]
+            * max(0, hi_pit_pilot_alternative_schedule_taxable_income - hi_pit_pilot_schedule_c_floor[hi_pit_pilot_alternative_schedule_c_bracket])
+
+  - name: hi_pit_pilot_alternative_tax_on_capital_gains
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: HRS 235-51(f), regular tax on paragraph (1) amount plus 7.25 percent of the excess
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "then the tax imposed by this section shall not exceed the sum of"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-hi/statute/235-51
+              excerpt: "A tax of 7.25 per cent of the amount of taxable income in excess of the amount determined under paragraph (1)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          hi_pit_pilot_alternative_regular_tax
+          + hi_pit_pilot_capital_gain_rate
+          * max(0, hi_pit_pilot_taxable_income - hi_pit_pilot_alternative_schedule_taxable_income)
+
   - name: hi_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: HRS section 235-51, tax imposed on taxable income
+    source: HRS 235-51, regular individual tax limited by subsection (f) when applicable
     metadata:
       proof:
         atoms:
@@ -94,8 +894,35 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-hi/statute/235-51
-              excerpt: "There is hereby imposed on the taxable income of every"
+              excerpt: "the tax imposed by this section shall not exceed the sum of"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, hi_pit_pilot_schedule_tax)
+          if hi_pit_pilot_capital_gain_alternative_eligible:
+            min(hi_pit_pilot_regular_schedule_tax, hi_pit_pilot_alternative_tax_on_capital_gains)
+          else:
+            hi_pit_pilot_regular_schedule_tax
+inputs:
+  - name: hi_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return Hawaii taxable income supplied by the caller as an upstream oracle boundary.
+  - name: hi_pit_pilot_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: True for a joint return or surviving-spouse filing status.
+  - name: hi_pit_pilot_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: True for head-of-household filing status; mutually exclusive with joint or surviving spouse.
+  - name: hi_pit_pilot_capital_gains_worksheet_line_10
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return Form N-11 capital-gains worksheet line 10 supplied by the caller after Hawaii gain adjustments and any Form N-158 subtraction; nonpositive worksheet results are supplied as zero.


### PR DESCRIPTION
## Summary
- encode all three 2026 HRS 235-51(a)-(c) individual schedules and filing-status routing
- encode the subsection (f) greater-of, 7.25%, and final-min computation from completed Form N-11 capital-gains worksheet line 10
- use the official worksheet source merged in axiom-corpus#469 strictly for structural lines 1–19; 2026 schedule amounts remain grounded in current HRS authority
- pin axiom-corpus to merged Hawaii source commit `58d890cea6ff52604f722c6a0978d191ae18419f`

## Validation
- independent review/fix/re-review cycle: CLEAN at exact signed head `2a5a97bae8408d658af2798164eeb9261ff72f94`
- proof validation: 29 atoms, 0 issues
- companion fixtures: 85/85 passed
- focused repository checks: passed
- exact signed generated-file guard: passed, 0 issues
- full certified Populace run: 1,519/1,519, zero mismatches/errors, max absolute difference $0.7903125007 at $1 tolerance
- final artifact SHA-256: `4d1e22f4ecce5c4838be01d5efcd6f554a567d499482b75cc6e97b86bc31a99a`
- artifact provenance: RuleSpec `2a5a97bae8408d658af2798164eeb9261ff72f94` clean; engine `ffd8213271947b0189a9dd61a055c1e0e78908a0` clean; PolicyEngine-US 1.752.2

## Caller boundaries
The module accepts completed Hawaii taxable income, two filing-status classifications, and completed N-11 worksheet line 10. It does not reconstruct Hawaii gain adjustments or Form N-158, and it does not import the form’s obsolete printed 2025 line-12 amounts.