### PR TITLE
Promote Colorado 2026 PIT base tax

### DIFF
--- a/.axiom/encoding-manifests/us-co/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-co/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-co/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "8c9dd37468f36c3ab1529de0b493d19ab740f49d844e95df6145b5ad8c01cc27"
+      "sha256": "18c4e509cafa243648eb18fd2173e999d1d120151b98c0177ecd00c84692ffa5"
     },
     {
       "path": "us-co/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "3d1af043b44c6d6dfba556ced4a2c889d07e18b960248b6ca87a21669781a869"
+      "sha256": "e1006c84cb535bf92cd4ec1e8bbd0273bfecdde2de1d2d453b05da7707e3a28d"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/co-af-20260712/axiom-encode",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-co:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-18T13:12:07.616764+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj9tytoc7/sign-applied-files/us-co/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpj9tytoc7",
-  "generated_output_sha256": "3d1af043b44c6d6dfba556ced4a2c889d07e18b960248b6ca87a21669781a869",
+  "generated_at": "2026-07-22T11:59:50.761263+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcolundq1/sign-applied-files/us-co/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcolundq1",
+  "generated_output_sha256": "e1006c84cb535bf92cd4ec1e8bbd0273bfecdde2de1d2d453b05da7707e3a28d",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,22 +34,49 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "48da31200a426721b1c7f932cb79b19ef998fad34a68f18fed82508617317b60"
+    "value": "39b46ec067368ed38097f475a0a92644a245b9c826a7188f9aa2bcf705047ee6"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-18T13:10:56.290881+00:00",
+    "generated_at": "2026-07-22T11:56:44.068236+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "99638800f8f36eb0e694ad6cf28adc964c8e1b6572475b5e2e0b1acd59433dc0",
-    "prior_signature": "f9d315246117333cc715bf514357bbceda4ce55c6aacd3cef9b8f578d196a573",
+    "manifest_sha256": "2ebdeb3c881817706adeb8ae175aa9ba70cccb7293a0c307d2e02235817c91e8",
+    "prior_signature": "40182f4b96d2c304af68c0926648077f50dcedc4140ea850ff11e3f7bc2dba74",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-18T13:10:48.217128+00:00",
+      "generated_at": "2026-07-22T10:42:34.979502+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "3a5f58336880b3f652d99ef55e74f843bf30a354989ee78c3e23356142b4081c",
-      "prior_signature": "1cffdc43f5f838e777065472a5a474d4eb8767c9826fa8775496e267198f8a4c",
+      "manifest_sha256": "e5c6d663fc5fe824dddb8b3dbf937856ac390970015bb01f64da66941fa6ec0c",
+      "prior_signature": "d677e76fe9ac89a761ff6ef8d3d4ef0018e1411362724a1afcd3136dec8b435b",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-18T13:12:07.616764+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "57d01bfcd6a232089f6064fb95659cd06228b61b5027bd90b0d53bad163ab41e",
+        "prior_signature": "48da31200a426721b1c7f932cb79b19ef998fad34a68f18fed82508617317b60",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-18T13:10:56.290881+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "99638800f8f36eb0e694ad6cf28adc964c8e1b6572475b5e2e0b1acd59433dc0",
+          "prior_signature": "f9d315246117333cc715bf514357bbceda4ce55c6aacd3cef9b8f578d196a573",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-18T13:10:48.217128+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "3a5f58336880b3f652d99ef55e74f843bf30a354989ee78c3e23356142b4081c",
+            "prior_signature": "1cffdc43f5f838e777065472a5a474d4eb8767c9826fa8775496e267198f8a4c",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -2921,11 +2921,6 @@
       "module_sha256": "sha256:9b011817bcab7a7c84542edbd5648f03fce5c2c5f019a3720736b83788e6de8f",
       "passed": false
     },
-    "us-co/statutes/39/39-22-627.yaml": {
-      "fingerprint": "sha256:71f243ea1d6040b013ffdb2510a02d1d152e0ac4b266123891a25f2493f353ad",
-      "module_sha256": "sha256:8097733ee3df4fee3c08bfbf732e03083864b97a089605906dffc3a64e9a2dc0",
-      "passed": false
-    },
     "us-co/statutes/39/39-26-102.5.yaml": {
       "fingerprint": "sha256:9bb252d466f12075d658590f0f66516a93a159dc37bf1431f245ae77449768c6",
       "module_sha256": "sha256:3cd4c6621b32ae4d48ac4be28acfa078c7b00056af24f9de7d0d51aecfa160d9",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -8834,12 +8834,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-co/statutes/39/39-22-627.yaml":
-    pending:
-      fingerprint: "sha256:71f243ea1d6040b013ffdb2510a02d1d152e0ac4b266123891a25f2493f353ad"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-co/statutes/39/39-26-102.5.yaml":
     pending:
       fingerprint: "sha256:9bb252d466f12075d658590f0f66516a93a159dc37bf1431f245ae77449768c6"

--- a/us-co/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-co/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,99 +1,201 @@
-# Fixtures are hand-computed at the 2026 tax year (shown arithmetic proved
-# equal to engine output by axiom-encode test, not an oracle read-back).
-# Colorado liability = the imported 39-22-104(1.7)(c) flat rate (0.044 for
-# taxable years commencing on or after January 1, 2022) times Colorado taxable
-# income: section 63 federal taxable income (the supplied AGI less the supplied
-# federal deductions, calibrated to the PolicyEngine 2026 standard deduction —
-# 16,100 single / 32,200 joint) plus the supplied subsection (3) additions less
-# the supplied subsection (4) subtractions, floored at zero. The supplied
-# aggregates stand in for the encoded-but-uncomposed subsection (3)/(4) chains
-# and are zero on this ordinary wage-earner grid; the subsection (3)
-# deduction-limitation addback that binds at the 300,000-dollar joint case is
-# out of this pilot slice and recorded in the oracle suite's dispositions.
+# Hand-computed fixtures for the narrow C.R.S. § 39-22-104(1.7)(c) base
+# tax. Each expected liability is completed Colorado taxable income × 0.044.
+# The output intentionally precedes § 39-22-627 temporary rate adjustments
+# and all credits. Negative input is included only to prove the defensive zero
+# floor on the caller's declared nonnegative completed-return boundary.
+#
+# The six canonical single/joint cases retain the state-oracle grid names. The
+# numeric suffix is employment income in the PE-US 1.752.2 source case; each
+# supplied input below is that case's independently calculated completed-return
+# co_taxable_income. Axiom's expected output remains statutory arithmetic on
+# that completed-return boundary, not a read-back from the comparison target.
 - name: single_30000
-  # taxable max(0, 30000 - 16100) = 13900. Liability 0.044 * 13900 = 611.6.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 30000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 13900
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '13900'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '611.6'
 - name: single_60000
-  # taxable max(0, 60000 - 16100) = 43900. Liability 0.044 * 43900 = 1931.6.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 60000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 43900
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '43900'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1931.6'
 - name: single_150000
-  # taxable max(0, 150000 - 16100) = 133900. Liability 0.044 * 133900 = 5891.6.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 150000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 16100
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 133900
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '133900'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '5891.6'
 - name: joint_60000
-  # taxable max(0, 60000 - 32200) = 27800. Liability 0.044 * 27800 = 1223.2.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 60000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 27800
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '27800'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1223.2'
 - name: joint_120000
-  # taxable max(0, 120000 - 32200) = 87800. Liability 0.044 * 87800 = 3863.2.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 120000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 87800
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '87800'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '3863.2'
 - name: joint_300000
-  # taxable max(0, 300000 - 32200) = 267800. Liability 0.044 * 267800 = 11783.2.
-  # PolicyEngine additionally applies the 39-22-104(3) deduction-limitation
-  # addback at this AGI; that definitional gap lives in the oracle suite's
-  # dispositions, not in this pilot's supplied aggregates.
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_adjusted_gross_income: 300000
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_federal_deductions: 32200
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_additions: 0
-    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_supplied_subtractions: 0
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 267800
   output:
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '267800'
     us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '11783.2'
+- name: negative_boundary_is_defensively_floored
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: -100
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '0'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '0'
+- name: zero_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 0
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '0'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '0'
+- name: one_cent_preserves_decimal_precision
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 0.01
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '0.01'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '0.00044'
+- name: one_dollar
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 1
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '1'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '0.044'
+- name: one_hundred_dollars
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 100
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '100'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '4.4'
+- name: ordinary_single_like_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 13900
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '13900'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '611.6'
+- name: ordinary_joint_like_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 27800
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '27800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1223.2'
+- name: midrange_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 87800
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '87800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '3863.2'
+- name: high_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 267800
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '267800'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '11783.2'
+- name: exact_three_hundred_thousand
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 300000
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '300000'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '13200'
+- name: million_dollar_taxable_income
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 1000000
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '1000000'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '44000'
+- name: statutory_effective_boundary_2022
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 25000
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '25000'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '1100'
+- name: open_ended_statutory_period_after_2026
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-co:policies/income_tax/pilot_liability_pipeline#input.co_pit_pilot_state_taxable_income: 123456.78
+  output:
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_taxable_income: '123456.78'
+    us-co:policies/income_tax/pilot_liability_pipeline#co_pit_pilot_income_tax_liability: '5432.09832'

--- a/us-co/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-co/policies/income_tax/pilot_liability_pipeline.yaml
@@ -12,27 +12,29 @@ module:
         - us-co/statute/39/39-22-104
         - us-co/statute/39/39-22-627
       rationale: |-
-        This pipeline computes the Colorado section 39-22-104 individual
-        income-tax liability before credits for the ordinary resident slice:
-        the flat tax prescribed by subsection (1.7)(c) — four and forty
-        one-hundredths percent for taxable years commencing on or after
-        January 1, 2022 — applied to Colorado taxable income, which
-        subsection (2) defines as federal taxable income modified by the
-        subsection (3) additions and subsection (4) subtractions. The rate is
-        imported from the encoded 39-22-104(1.7)(c) module rather than
-        restated, so this pipeline adds no numeric literals of its own.
-        The caller supplies adjusted gross income and the federal
-        deductions that take it to section 63 federal taxable income (the
-        subsection (1.7)(c) base is federal taxable income "as determined
-        pursuant to section 63 of the internal revenue code"), plus single
-        aggregate subsection (3) addition and subsection (4) subtraction
-        amounts, pending executable composition of those chains: their child
-        modules are individually encoded, but the 39-22-104 aggregate parent
-        defers composition across their distinct legal entities and adjusted
-        federal taxable-income bases (see its deferred_outputs), mirroring
-        the Alabama and California pilots' supplied-deduction pattern. The
-        section 39-22-627 temporary rate reduction is a distinct
-        revenue-triggered mechanism and is out of scope for this pilot slice.
+        Both cited provisions are current official Colorado Revised Statutes
+        from the consolidated OLLS Title 39 corpus. Section 39-22-104(1.7)(c)
+        supplies the base and imported rate. Section 39-22-627 was checked
+        because subsection (1.7)(c) expressly makes its rate subject to that
+        separate temporary-adjustment mechanism. This narrow component stops
+        before the section 39-22-627 adjustment and therefore does not encode
+        its fiscal-year revenue determinations as taxpayer inputs.
+  summary: |-
+    Narrow Colorado individual-income-tax base calculation under C.R.S.
+    § 39-22-104(1.7)(c). It accepts one TaxUnit-level completed-return
+    Colorado taxable-income boundary, floors that value at zero, and applies
+    the 4.4-per-cent rate imported from the existing subsection (1.7)(c)
+    encoding. The caller boundary already reflects federal taxable income and
+    every applicable subsection (2), (3), and (4) Colorado modification, so
+    this module makes no independent claim about that upstream chain.
+
+    The output is expressly the subsection (1.7)(c) base tax before any
+    temporary rate adjustment under § 39-22-627 and before all credits. That
+    narrow output aligns with PolicyEngine's
+    co_income_tax_before_non_refundable_credits only where the oracle contract
+    separately confirms that § 39-22-627 does not alter the comparison. The
+    imported rate and this calculation take effect for taxable years beginning
+    on or after January 1, 2022, as stated in subsection (1.7)(c).
 imports:
   - us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate
 rules:
@@ -42,7 +44,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: 39-22-104 subsection 2, section 63 federal taxable income from the supplied adjusted gross income and federal deductions, modified by the supplied additions and subtractions, floored at zero
+    source: C.R.S. § 39-22-104(2), supplied completed-return Colorado taxable income after all subsection (3) additions and subsection (4) subtractions, defensively floored at zero
     metadata:
       proof:
         atoms:
@@ -50,18 +52,23 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-co/statute/39/39-22-104
-              excerpt: "the federal taxable income shall be modified as provided in"
+              excerpt: "Prior to the application of the rate of tax prescribed in subsection (1), (1.5), or (1.7) of this section, the federal taxable income shall be modified as provided in subsections (3) and (4) of this section."
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "with respect to taxable years commencing on or after January 1, 2022"
     versions:
       - effective_from: '2022-01-01'
         formula: |-
-          max(0, co_pit_pilot_adjusted_gross_income - co_pit_pilot_supplied_federal_deductions + co_pit_pilot_supplied_additions - co_pit_pilot_supplied_subtractions)
+          max(0, co_pit_pilot_state_taxable_income)
   - name: co_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 39-22-104 subsection 1.7 paragraph c, the four and forty one-hundredths percent tax imposed on modified federal taxable income for taxable years commencing on or after January 1, 2022, via the imported encoded rate
+    source: C.R.S. § 39-22-104(1.7)(c) base tax on completed Colorado taxable income before § 39-22-627 temporary adjustment and all credits
     metadata:
       proof:
         atoms:
@@ -75,8 +82,20 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-co/statute/39/39-22-104
-              excerpt: "a tax of four and forty one-hundredths percent is imposed"
+              excerpt: "a tax of four and forty one-hundredths percent is imposed on the federal taxable income"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "with respect to taxable years commencing on or after January 1, 2022"
     versions:
       - effective_from: '2022-01-01'
         formula: |-
-          individual_estate_trust_income_tax_rate * co_pit_pilot_taxable_income
+          co_pit_pilot_taxable_income * individual_estate_trust_income_tax_rate
+inputs:
+  - name: co_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Nonnegative completed-return Colorado taxable income supplied by the caller as the sole upstream oracle boundary.


### PR DESCRIPTION
## Summary
- promote the source-backed Colorado 39-22-104 base tax before section 39-22-627 and credits
- retain one explicit completed-return Colorado taxable-income boundary
- add 13 boundary fixtures and signed applied-file provenance
- remove the paired stale validation waiver

## Scope
This is deliberately the section 104 base-tax surface. Section 627 and credits remain outside the promoted output.

## Validation
- RuleSpec validation passed
- 13/13 companion fixtures passed
- proof validation: 5 atoms, 0 missing money atoms
- reverse index and signed generated-file guard passed
- independent review/fix cycle: CLEAN at exact head 2ebad2723f0f87d6b2a128e54d1f01956a965f8b

No actionable review findings remain.