### PR TITLE
Promote Mississippi 2026 income tax before credits

### DIFF
--- a/.axiom/encoding-manifests/us-ms/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ms/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-ms/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "f347771e6038b673e8087f187103dd6848a4bd9f8ae0ef4ba31d3221a1233782"
+      "sha256": "c9a098cf732468138ff0f60fd849e2fce728fa6f1c9baad835bab20a9ee6b429"
     },
     {
       "path": "us-ms/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "63fa7e240b154d380d28a8e37652db00e73928f5d60917689e55e159d8e14629"
+      "sha256": "2d8b2e04759751cd6f59f1b8dca975043b7734604ddaefb0638401a2bc97e7b2"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,12 @@
   "citation": "us-ms:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.875494+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-ms/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "63fa7e240b154d380d28a8e37652db00e73928f5d60917689e55e159d8e14629",
+  "generated_at": "2026-07-22T11:45:42.282081+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzpjni26y/sign-applied-files/us-ms/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzpjni26y",
+  "generated_output_sha256": "2d8b2e04759751cd6f59f1b8dca975043b7734604ddaefb0638401a2bc97e7b2",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
+  "manual_exception": "fixtures",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,22 +34,76 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "286146e4e38d7bd2308e8989610e29b010e75b7f7af36e80300c0613428bee4b"
+    "value": "4f9691dc46a6508a752026f9bad97c19edf08fedec329ff4591d3620c808028b"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.904557+00:00",
+    "generated_at": "2026-07-22T11:43:13.135120+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "6798e636ae9172866fb4afff2fa5fd132cd6640fafdf012cee596fe8aa963e96",
-    "prior_signature": "49aeb68f358f1a6d8da5227b1bf9ab655efabb20eb39b5742059c79104278945",
+    "manifest_sha256": "fdf8ffade971b339ab71c7e6c6507e16e9632ba93f43df14eeb462893bad56c2",
+    "prior_signature": "d109a7d0a6ff94f478164fbd3f5f0cb9c222622f4a6ee22049f8764240fc9824",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:46:50.656986+00:00",
+      "generated_at": "2026-07-22T10:57:00.707888+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "ebd31fb9d46a04485d468d32fc869031b1a1acec539b8346083f78af70073e2e",
-      "prior_signature": "3821f66044b3deec817c753cb410382e494a47cc2ed460761cb0f8eaef19220f",
+      "manifest_sha256": "d4517f5fdc147bd5aefb89cfd424aa888d9443bb37a6763a64a3b09b6706db3c",
+      "prior_signature": "502d72fb1fefbd3bceacff1947ef7a97d7311055d0a3751e96eae49284539d2f",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-22T10:56:37.371191+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "5450ab657ea690196a1dc049c6a045aa2d7df1c6b731081453c883343bedd474",
+        "prior_signature": "8eb47663788e5298350d1c84db07c672a5475e62cc08e0a2de032ee8053bca89",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-22T10:45:51.517815+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "9c51cf099cc4419c5ce1167c7440b4bee6091c11f41be1a5ecd8ea2ffd356b63",
+          "prior_signature": "635c437d1839e0072840dcff4c47758178d2921db77ffb541e24846c870dbaf4",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-22T10:44:38.818621+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "336692909ade8cf201215deea08150c7fa488d5859c990f738b9db7792b49fb2",
+            "prior_signature": "e29f2ee4aa1a19c4e49a3b427a154376a3b5282684f5d834063de83f6488961d",
+            "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-21T15:45:46.875494+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "59a52d6660791504bffdf4f48b438a8cc0f1e6ac0d67d180ad9af1947ec95b03",
+              "prior_signature": "286146e4e38d7bd2308e8989610e29b010e75b7f7af36e80300c0613428bee4b",
+              "run_id": null,
+              "supersedes": {
+                "backend": "manual",
+                "generated_at": "2026-07-21T15:44:47.904557+00:00",
+                "generation_prompt_sha256": null,
+                "manifest_sha256": "6798e636ae9172866fb4afff2fa5fd132cd6640fafdf012cee596fe8aa963e96",
+                "prior_signature": "49aeb68f358f1a6d8da5227b1bf9ab655efabb20eb39b5742059c79104278945",
+                "run_id": null,
+                "supersedes": {
+                  "backend": "manual",
+                  "generated_at": "2026-07-16T15:46:50.656986+00:00",
+                  "generation_prompt_sha256": null,
+                  "manifest_sha256": "ebd31fb9d46a04485d468d32fc869031b1a1acec539b8346083f78af70073e2e",
+                  "prior_signature": "3821f66044b3deec817c753cb410382e494a47cc2ed460761cb0f8eaef19220f",
+                  "run_id": null,
+                  "tool": "axiom-encode sign-applied-files"
+                },
+                "tool": "axiom-encode sign-applied-files"
+              },
+              "tool": "axiom-encode sign-applied-files"
+            },
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1664
+ceiling: 1672
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1193,15 +1193,39 @@ entries:
 - legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income
   source: manual
   since: '2026-07-16'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_2026_rate
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-16'
-- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_schedule_tax
   source: manual
-  since: '2026-07-16'
-- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_taxable_income
   source: manual
-  since: '2026-07-16'
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_taxable_income
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_total_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_related_person_has_both_candidates
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_is_strictly_lower
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_zero_tax_ceiling
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-mt:policies/income_tax/pilot_liability_pipeline#mt_pit_pilot_capital_gain_lower_band
   source: manual
   since: '2026-07-21'

--- a/us-ms/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ms/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,77 +1,197 @@
-# Expected values are independently hand-computed from Mississippi Code section
-# 27-7-5's 2026 individual schedule: zero through $10,000 and 4 percent of
-# excess taxable income. Supplied taxable-income inputs equal PolicyEngine's
-# completed-return ms_taxable_income_joint values for the standard wage grid.
-# All six liabilities match ms_income_tax_before_credits_unit exactly.
+# Expected values use independent decimal arithmetic from Mississippi Code
+# section 27-7-5(1): the 2026 tax is 4% of taxable income above $10,000.
+# Person-grain fixtures cover normalization and both taxable-income candidates;
+# TaxUnit fixtures cover relation aggregation and separate, joint, and tie
+# branches. No fixture supplies PolicyEngine's `ms_files_separately` output.
+- name: individual_candidate_negative_income_normalizes_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: -500
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_taxable_income: '0'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_schedule_tax: '0'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_related_person_has_both_candidates: holds
+
+- name: joint_candidate_negative_income_normalizes_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: -500
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_taxable_income: '0'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_schedule_tax: '0'
+
+- name: individual_candidate_one_dollar_below_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 9999
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_taxable_income: '9999'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_schedule_tax: '0'
+
+- name: joint_candidate_at_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 10000
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_taxable_income: '10000'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_schedule_tax: '0'
+
+- name: individual_candidate_one_dollar_above_zero_tax_ceiling
+  # 4% * (10,001 - 10,000) = 0.04.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 10001
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_individual_schedule_tax: '0.04'
+
+- name: joint_candidate_above_zero_tax_ceiling
+  # 4% * (60,000 - 10,000) = 2,000.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 60000
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_schedule_tax: '2000'
+
+- name: relation_aggregates_both_candidate_sets
+  # Individual total: 800 + 400 = 1,200.
+  # Joint total: 1,400 + 600 = 2,000.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 30000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 45000
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 20000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 25000
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_schedule_tax: '1200'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_total_schedule_tax: '2000'
+
+- name: strict_lower_separate_total_selects_separate_branch
+  # Separate total: tax(30,000) + tax(20,000) = 800 + 400 = 1,200.
+  # Joint total: tax(60,000) + tax(0) = 2,000. The strict comparison holds.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 30000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 60000
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 20000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_schedule_tax: '1200'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_total_schedule_tax: '2000'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_is_strictly_lower: holds
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '1200'
+
+- name: lower_joint_total_selects_joint_branch
+  # Separate total: tax(50,000) + tax(40,000) = 1,600 + 1,200 = 2,800.
+  # Joint total: tax(70,000) + tax(0) = 2,400. The strict comparison does not hold.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 50000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 70000
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 40000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_schedule_tax: '2800'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_total_schedule_tax: '2400'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_is_strictly_lower: not_holds
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '2400'
+
+- name: equal_totals_choose_joint_branch
+  # Each total is tax(30,000) + tax(0) = 800. Strict less-than is false,
+  # so this distinguishes the required joint-on-tie behavior.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 30000
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 30000
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
+  output:
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_schedule_tax: '800'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_joint_total_schedule_tax: '800'
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_separate_total_is_strictly_lower: not_holds
+    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '800'
+
+# Canonical oracle-grid compatibility cases. Candidate taxable incomes are the
+# exact Person-grain values returned by PE-US 1.752.2 for the standard 2026
+# wage situations. Expected liabilities use independent section 27-7-5 decimal
+# arithmetic and match PE-US ms_income_tax_before_credits_unit.
 - name: single_30000
-  # 4% * (21,700 - 10,000) = 468.
+  # Separate: 4% * (24,700 - 10,000) = 588.
+  # Joint: 4% * (21,700 - 10,000) = 468; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 21700
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 24700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 21700
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '21700'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '468'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '468'
+
 - name: single_60000
-  # 4% * (51,700 - 10,000) = 1,668.
+  # Separate: 4% * (54,700 - 10,000) = 1,788.
+  # Joint: 4% * (51,700 - 10,000) = 1,668; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 51700
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 54700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 51700
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '51700'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '1668'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '1668'
+
 - name: single_150000
-  # 4% * (141,700 - 10,000) = 5,268.
+  # Separate: 4% * (144,700 - 10,000) = 5,388.
+  # Joint: 4% * (141,700 - 10,000) = 5,268; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 141700
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 144700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 141700
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '141700'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '5268'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '5268'
-- name: married_60000
-  # 4% * (43,400 - 10,000) = 1,336.
+
+- name: joint_60000
+  # Separate: 4% * (51,700 - 10,000) + tax(0) = 1,668.
+  # Joint: 4% * (43,400 - 10,000) + tax(0) = 1,336; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 43400
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 51700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 43400
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '43400'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '1336'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '1336'
-- name: married_120000
-  # 4% * (103,400 - 10,000) = 3,736.
+
+- name: joint_120000
+  # Separate: 4% * (111,700 - 10,000) + tax(0) = 4,068.
+  # Joint: 4% * (103,400 - 10,000) + tax(0) = 3,736; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 103400
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 111700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 103400
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '103400'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '3736'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '3736'
-- name: married_300000
-  # 4% * (283,400 - 10,000) = 10,936.
+
+- name: joint_300000
+  # Separate: 4% * (291,700 - 10,000) + tax(0) = 11,268.
+  # Joint: 4% * (283,400 - 10,000) + tax(0) = 10,936; joint is lower.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income: 283400
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_base: 0
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_bracket_floor: 10000
-    us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_marginal_rate: 0.04
+    us-ms:policies/income_tax/pilot_liability_pipeline#relation.ms_pit_pilot_person_of_tax_unit:
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 291700
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 283400
+      - us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_indiv: 0
+        us-ms:policies/income_tax/pilot_liability_pipeline#input.ms_pit_pilot_supplied_taxable_income_joint: 0
   output:
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_taxable_income: '283400'
-    us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_schedule_tax: '10936'
     us-ms:policies/income_tax/pilot_liability_pipeline#ms_pit_pilot_income_tax_liability: '10936'

--- a/us-ms/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ms/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,37 +5,102 @@ module:
   source_verification:
     corpus_citation_path: us-ms/statute/27-7-5
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-ms/statute/27-7-5
       rationale: |-
-        Mississippi Code section 27-7-5 imposes tax on the net income of every
-        resident individual. For individuals in calendar year 2026, no tax
-        applies through $10,000 of taxable income and the rate on taxable income
-        above $10,000 is 4 percent. This narrow composition accepts completed-
-        return Mississippi taxable income and the active bracket's cumulative
-        base tax, floor, and marginal rate as caller-supplied current-authority
-        inputs. Deductions, exemptions, fiscal-year proration, special income
-        classes, and credits remain outside this rate-section module.
+        Mississippi Code section 27-7-5(1) supplies the complete individual
+        rate schedule operative for calendar year 2026: no tax applies through
+        $10,000 of taxable income and a 4 percent rate applies above $10,000.
+        This narrow module accepts the two completed-return taxable-income
+        candidates used by the pinned comparison target as Person-grain caller
+        boundaries: `ms_taxable_income_indiv` for the separate-return method
+        and `ms_taxable_income_joint` for the joint-return method. It applies
+        only the source-owned section 27-7-5 schedule to each candidate,
+        aggregates each set of Person amounts to the TaxUnit through an
+        explicit relation, and reconstructs the target's non-circular branch
+        comparison from those newly computed amounts. The separate result is
+        selected only when it is strictly less than the joint result; a tie
+        selects the joint result. No `ms_files_separately` value or other tax
+        output is supplied as an input.
+
+        Taxable-income construction, deductions, exemptions, credits,
+        nonresident allocation, S-corporation treatment, and subsection (4)
+        fiscal-year proration remain outside this calendar-year-2026 schedule
+        module. The relation and strict-lower comparison are target-integration
+        mechanics, not a claim that section 27-7-5 creates a filing election.
+        All executable versions fail closed outside tax year 2026.
   summary: |-
-    Composed Mississippi individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied completed-
-    return Mississippi taxable income and applies the supplied active section
-    27-7-5 bracket in cumulative-base-plus-marginal form before credits. Its
-    exact PolicyEngine 4.18.9 / PolicyEngine-US 1.752.2 analog is
-    `ms_income_tax_before_credits_unit` on the six-case childless age-40 grid:
-    single at $30,000/$60,000/$150,000 of wages and one-earner joint at
-    $60,000/$120,000/$300,000. PolicyEngine supplies completed taxable income;
-    expected outputs are independently hand-computed from the statutory 2026
-    schedule.
+    Mississippi calendar-year 2026 individual income-tax schedule before
+    credits under section 27-7-5(1). For each related Person, the module
+    computes 4 percent of the excess over the $10,000 zero-tax amount for both
+    completed-return taxable-income candidates. It aggregates the separate and
+    joint candidate taxes to the TaxUnit, derives the strict lower-tax selector,
+    and returns the separate total only when it is lower, using the joint total
+    on a tie. Upstream taxable-income construction and all credits are outside
+    this narrow target.
 rules:
-  - name: ms_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
+  - name: ms_pit_pilot_person_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: ms_pit_pilot_person_of_tax_unit
+      arity: 2
+      arguments:
+        - Person
+        - TaxUnit
+    source: Runtime relation connecting each compared Person candidate to its Mississippi TaxUnit
+
+  - name: ms_pit_pilot_zero_tax_ceiling
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: Miss. Code section 27-7-5, supplied Mississippi taxable income
+    source: Miss. Code section 27-7-5(1)(a)(ii), (1)(b)(i), 2026 zero-tax amount
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "For calendar year 2022 and all taxable years thereafter, there shall be no tax levied on the first Five Thousand Dollars ($5,000.00) of taxable income"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "there shall be no tax levied under subparagraph (ii) ... in excess of Five Thousand Dollars ($5,000.00) up to and including Ten Thousand Dollars ($10,000.00)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '10000'
+
+  - name: ms_pit_pilot_2026_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Miss. Code section 27-7-5(1)(b)(ii)(3), calendar-year 2026 rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "For calendar year 2026, on such taxable income, the rate shall be four percent (4%)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.04'
+
+  - name: ms_pit_pilot_individual_taxable_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Miss. Code section 27-7-5(1), supplied completed-return `ms_taxable_income_indiv` boundary
     metadata:
       proof:
         atoms:
@@ -46,15 +111,16 @@ rules:
               excerpt: "upon the entire net income of every resident individual"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, ms_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, ms_pit_pilot_supplied_taxable_income_indiv)
 
-  - name: ms_pit_pilot_schedule_tax
+  - name: ms_pit_pilot_joint_taxable_income
     kind: derived
-    entity: TaxUnit
+    entity: Person
     dtype: Money
     period: Year
     unit: USD
-    source: Miss. Code section 27-7-5(1), individual 2026 schedule
+    source: Miss. Code section 27-7-5(1), supplied completed-return `ms_taxable_income_joint` boundary
     metadata:
       proof:
         atoms:
@@ -62,22 +128,130 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-ms/statute/27-7-5
-              excerpt: "For calendar year 2022 and all taxable years thereafter, there shall be no tax levied on the first Five Thousand Dollars ($5,000.00) of taxable income;"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ms/statute/27-7-5
-              excerpt: "For calendar year 2023 and all calendar years thereafter, there shall be no tax levied under subparagraph (ii)"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ms/statute/27-7-5
-              excerpt: "For calendar year 2026, on such taxable income, the rate shall be four percent (4%);"
+              excerpt: "upon the entire net income of every resident individual"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          ms_pit_pilot_supplied_bracket_base
-          + ms_pit_pilot_supplied_marginal_rate * max(0, ms_pit_pilot_taxable_income - ms_pit_pilot_supplied_bracket_floor)
+        effective_to: '2026-12-31'
+        formula: max(0, ms_pit_pilot_supplied_taxable_income_joint)
+
+  - name: ms_pit_pilot_related_person_has_both_candidates
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Relation-member guard for the two completed-return section 27-7-5 schedule candidates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "upon the entire net income of every resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ms_pit_pilot_individual_taxable_income >= 0 and ms_pit_pilot_joint_taxable_income >= 0
+
+  - name: ms_pit_pilot_individual_schedule_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Miss. Code section 27-7-5(1), 2026 schedule on separate-return taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "For calendar year 2026, on such taxable income, the rate shall be four percent (4%)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ms_pit_pilot_2026_rate * max(0, ms_pit_pilot_individual_taxable_income - ms_pit_pilot_zero_tax_ceiling)
+
+  - name: ms_pit_pilot_joint_schedule_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Miss. Code section 27-7-5(1), 2026 schedule on joint-return taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "For calendar year 2026, on such taxable income, the rate shall be four percent (4%)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ms_pit_pilot_2026_rate * max(0, ms_pit_pilot_joint_taxable_income - ms_pit_pilot_zero_tax_ceiling)
+
+  - name: ms_pit_pilot_separate_total_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Miss. Code section 27-7-5(1), aggregate schedule tax on related separate-return candidates
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "upon the entire net income of every resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: sum_where(ms_pit_pilot_person_of_tax_unit, ms_pit_pilot_individual_schedule_tax, ms_pit_pilot_related_person_has_both_candidates)
+
+  - name: ms_pit_pilot_joint_total_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Miss. Code section 27-7-5(1), aggregate schedule tax on related joint-return candidates
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "upon the entire net income of every resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: sum_where(ms_pit_pilot_person_of_tax_unit, ms_pit_pilot_joint_schedule_tax, ms_pit_pilot_related_person_has_both_candidates)
+
+  - name: ms_pit_pilot_separate_total_is_strictly_lower
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Non-circular comparison of the two section 27-7-5 schedule candidates
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ms/statute/27-7-5
+              excerpt: "a tax at the following rates"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ms_pit_pilot_separate_total_schedule_tax < ms_pit_pilot_joint_total_schedule_tax
 
   - name: ms_pit_pilot_income_tax_liability
     kind: derived
@@ -85,7 +259,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: Miss. Code section 27-7-5, resident tax before credits
+    source: Miss. Code section 27-7-5(1), lower compared 2026 schedule amount before credits
     metadata:
       proof:
         atoms:
@@ -96,4 +270,9 @@ rules:
               excerpt: "there is hereby assessed and levied, to be collected and paid"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, ms_pit_pilot_schedule_tax)
+        effective_to: '2026-12-31'
+        formula: |-
+          if ms_pit_pilot_separate_total_is_strictly_lower:
+            ms_pit_pilot_separate_total_schedule_tax
+          else:
+            ms_pit_pilot_joint_total_schedule_tax


### PR DESCRIPTION
## Summary
- promote the source-backed Mississippi schedule-before-credits pipeline
- project Person candidates to TaxUnit with the certified Person, TaxUnit relation order
- add companion fixtures and signed applied-file provenance

## Validation
- RuleSpec validation passed
- 10/10 companion fixtures passed
- proof validation: 12 atoms, 0 missing money atoms
- reverse index and signed generated-file guard passed
- independent review found and fixed the relation-argument order
- final independent re-review: CLEAN at exact head ab36c2b7ad06e95cf9ca65387bb10e34601ed429

No actionable review findings remain.