### PR TITLE
Add New York main-tax comparison grid fixtures

### DIFF
--- a/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
@@ -2,11 +2,7 @@
   "applied_files": [
     {
       "path": "us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "66e047b6c5a70c59f9b797575477753dfae441a62efbafd99c4ee36fb8242515"
-    },
-    {
-      "path": "us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c"
+      "sha256": "4b5bf3902cf6c14912d2f843049c2409c4d153f0f21878e47c7332697911fa5f"
     }
   ],
   "axiom_encode_git": {
@@ -21,11 +17,12 @@
   "citation": "us-ny:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T09:21:07.368809+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpftfzah41/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpftfzah41",
+  "generated_at": "2026-07-22T10:58:56.863637+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa9ls3ejf/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa9ls3ejf",
   "generated_output_sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c",
   "generation_prompt_sha256": null,
+  "manual_exception": "fixtures",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -33,15 +30,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a"
+    "value": "2bec9ce33d3223ea90c330321d2c3d85f8d66b39a3fc4143498d1e7298804e6c"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-06T17:33:07.803431+00:00",
+    "generated_at": "2026-07-22T09:21:07.368809+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
-    "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+    "manifest_sha256": "8343167e4b6a1e2718298a3bed909d94b3e2059da68a3ac8a4569e3081978640",
+    "prior_signature": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-06T17:33:07.803431+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
+      "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -629,3 +629,82 @@
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '30000000'
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 8
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '3054714'
+
+# PolicyEngine-US 1.752.2 2026 wage-grid bridge fixtures. The case names retain
+# the employment-income grid amount used by axiom-oracles, while each input is
+# the independently captured upstream `ny_taxable_income` value supplied to the
+# narrow section 601 schedule. Expected tax remains statutory arithmetic, not a
+# PolicyEngine target read-back; the small differences preserve the statute's
+# published rounded cumulative bases.
+
+- name: single_30000
+  # PolicyEngine filing_status SINGLE; 586 + 0.054 * (22000 - 13900) = 1023.4.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 22000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '22000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '1023.4'
+
+- name: single_60000
+  # PolicyEngine filing_status SINGLE; 586 + 0.054 * (52000 - 13900) = 2643.4.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 52000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '52000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2643.4'
+
+- name: single_150000
+  # PolicyEngine filing_status SINGLE; 4191 + 0.059 * (142000 - 80650) = 7810.65.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 142000
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '142000'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '7810.65'
+
+- name: joint_60000
+  # PolicyEngine filing_status JOINT; 1174 + 0.054 * (43950 - 27900) = 2040.7.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 43950
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '43950'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '2040.7'
+
+- name: joint_120000
+  # PolicyEngine filing_status JOINT; 1174 + 0.054 * (103950 - 27900) = 5280.7.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 103950
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '103950'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 3
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '5280.7'
+
+- name: joint_300000
+  # PolicyEngine filing_status JOINT; 8391 + 0.059 * (283950 - 161550) = 15612.6.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_state_taxable_income: 283950
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '283950'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 4
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '15612.6'


### PR DESCRIPTION
## Summary
- add the six canonical single/joint comparison-grid fixtures to the promoted New York section 601 main-tax module
- preserve all 52 existing boundary fixtures unchanged
- refresh fixture-only signed provenance

## Validation
- 58/58 companion fixtures passed
- RuleSpec validation passed
- proof validation: 47 atoms and 30/30 monetary obligations
- PolicyEngine-US 1.752.2 independently reproduced all six taxable-income inputs and filing classifications
- reverse index, diff checks, Oracle generator mapping, and signed exact-head guard passed
- independent review: CLEAN at exact head b1532b560b96ff87f606e4216a35953e5e8c1296

No actionable review findings remain.