### PR TITLE
Encode Arkansas 2026 individual income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ar/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ar/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-ar/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "296732a523da6b7ac52660d8a8be4362bf34a055b520b42ed1378244f68dcdc2"
+      "sha256": "53305b1547e1a132a78480f6c7703cbde0c2887f52850cd1782606a99595f57a"
     },
     {
       "path": "us-ar/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "df757b9ae94ffdca62beeea520ffcfc85140839157640708aabe2a714802b2d7"
+      "sha256": "e450df6012dadcec268d7aef45679d46dddef062d811000b04783e0b74f4b210"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,12 @@
   "citation": "us-ar:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.864862+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-ar/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "df757b9ae94ffdca62beeea520ffcfc85140839157640708aabe2a714802b2d7",
+  "generated_at": "2026-07-22T11:19:35.162566+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpiugsns4c/sign-applied-files/us-ar/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpiugsns4c",
+  "generated_output_sha256": "e450df6012dadcec268d7aef45679d46dddef062d811000b04783e0b74f4b210",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
+  "manual_exception": "repair",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,22 +34,40 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0b95ebe8da8a06f83f689e3a8151b1530b6787ce5d98d970db78c258033e7623"
+    "value": "6cd5c86cd91b95c0fe7323689f2feed7aa9ba83463315832a861403c9b8206cb"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.890008+00:00",
+    "generated_at": "2026-07-22T10:51:57.526459+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "c03a5367a5fbc5c9629b94507f78cc9538b2f3831e2e5a447f9d6d48bfeaf75d",
-    "prior_signature": "bd033886bb78137d5de29bf4faae09624213e8c7bc8beaa4f613217cc0cc742b",
+    "manifest_sha256": "db6b1bd650c3117bea48e73addfa00d66f3907ea2bb4ca934818ab451879dd16",
+    "prior_signature": "be4b33776a1d6d8231d84a6972fd732609b3d74f3170180de300900b521b84a4",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:46:50.655620+00:00",
+      "generated_at": "2026-07-21T15:45:46.864862+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "9aef3ccf17be12e8142a3bbcc0c0decc7af53f4e992f13b69961317a62503f8c",
-      "prior_signature": "7c0911f387bec3f6dd50cff42222ed6350feed91b0e8c9ac1d9e6438d9429229",
+      "manifest_sha256": "94fa95af768e56cd2f6ceb3234661941d27e70ca9c62e533e0fa874c69ccae44",
+      "prior_signature": "0b95ebe8da8a06f83f689e3a8151b1530b6787ce5d98d970db78c258033e7623",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-21T15:44:47.890008+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "c03a5367a5fbc5c9629b94507f78cc9538b2f3831e2e5a447f9d6d48bfeaf75d",
+        "prior_signature": "bd033886bb78137d5de29bf4faae09624213e8c7bc8beaa4f613217cc0cc742b",
+        "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-16T15:46:50.655620+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "9aef3ccf17be12e8142a3bbcc0c0decc7af53f4e992f13b69961317a62503f8c",
+          "prior_signature": "7c0911f387bec3f6dd50cff42222ed6350feed91b0e8c9ac1d9e6438d9429229",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/us-ar/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ar/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,85 +1,949 @@
-# Expected values are independently hand-computed from section 1 of Arkansas
-# Act 2 of 2026. Supplied taxable-income inputs equal PolicyEngine's completed-
-# return ar_taxable_income_joint values for the standard wage grid. The first,
-# second, and fourth cases use Act 2 schedule (A); the remaining cases use
-# schedule (B). No case occupies the $94,701-$97,600 adjustment interval, so
-# every supplied bracket adjustment is zero. All six liabilities match
-# ar_income_tax_before_non_refundable_credits_unit to float precision.
-- name: single_30000
-  # 609.60 + 3.7% * (27,500 - 26,400) = 650.30.
+# Arkansas Act 2 of 2026 section 1 fixtures. Expected values are
+# independently computed from the enacted schedules. The ordinary schedule is
+# checked at both sides of every bracket boundary. The high-income schedule is
+# checked at $94,701 and at the inclusive upper bound and one dollar above every
+# one of the twenty-nine positive adjustment rows; together those cases exercise
+# each row's lower and upper boundary and the statutory zero-adjustment tail.
+# The completed-return boundary is normalized to nonnegative income.
+- name: negative_completed_return_income_floors_to_zero
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 27500
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 609.6
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 26400
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: -1
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '27500'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '650.3'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '650.3'
-- name: single_60000
-  # 609.60 + 3.7% * (57,500 - 26,400) = 1,760.30.
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '0'
+# Act 2 schedule (A) boundary at $5,599.
+- name: schedule_a_zero_band_upper
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 57500
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 609.6
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 26400
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 5599
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '57500'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '1760.3'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '1760.3'
-- name: single_150000
-  # 94 + 3.7% * (147,500 - 4,700) = 5,377.60.
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '5599'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '0'
+# Act 2 schedule (A) boundary at $5,600.
+- name: schedule_a_two_percent_band_lower
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 147500
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 94
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 4700
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 5600
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '147500'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '5377.6'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '5377.6'
-- name: married_60000
-  # 609.60 + 3.7% * (55,000 - 26,400) = 1,667.80.
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '5600'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '0'
+# Act 2 schedule (A) boundary at $11,199.
+- name: schedule_a_two_percent_band_upper
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 55000
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 609.6
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 26400
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 11199
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '55000'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '1667.8'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '1667.8'
-- name: married_120000
-  # 94 + 3.7% * (115,000 - 4,700) = 4,175.10.
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '11199'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '111.98'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '111.98'
+# Act 2 schedule (A) boundary at $11,200.
+- name: schedule_a_three_percent_band_lower
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 115000
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 94
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 4700
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 11200
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '115000'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '4175.1'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '4175.1'
-- name: married_300000
-  # 94 + 3.7% * (295,000 - 4,700) = 10,835.10.
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '11200'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '112'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '112'
+# Act 2 schedule (A) boundary at $15,999.
+- name: schedule_a_three_percent_band_upper
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_taxable_income: 295000
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_base: 94
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_floor: 4700
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_marginal_rate: 0.037
-    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_supplied_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 15999
   output:
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '295000'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '10835.1'
-    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_liability: '10835.1'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '15999'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '255.97'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '255.97'
+# Act 2 schedule (A) boundary at $16,000.
+- name: schedule_a_three_point_four_percent_band_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 16000
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '16000'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '256'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '256'
+# Act 2 schedule (A) boundary at $26,399.
+- name: schedule_a_three_point_four_percent_band_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 26399
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '26399'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '609.566'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '609.566'
+# Act 2 schedule (A) boundary at $26,400.
+- name: schedule_a_three_point_seven_percent_band_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 26400
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '26400'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '609.6'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '609.6'
+# Act 2 schedule (A) boundary at $94,700.
+- name: schedule_a_final_upper_and_schedule_transition
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94700
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94700'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: not_holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_a_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: '0'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3136.7'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3136.7'
+# First dollar above $94,700; schedule (B) applies and the $290 row begins.
+- name: schedule_b_first_dollar_and_adjustment_row_01_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94701
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94701'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 290
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3134.037'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3134.037'
+# Adjustment row 1 inclusive upper bound; deduct $290.
+- name: adjustment_row_01_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94800
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94800'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 290
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3137.7'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3137.7'
+# One dollar above row 1; adjustment row 2 begins at $94,801.
+- name: adjustment_row_02_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94801
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94801'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 280
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3147.737'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3147.737'
+# Adjustment row 2 inclusive upper bound; deduct $280.
+- name: adjustment_row_02_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94900
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94900'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 280
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3151.4'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3151.4'
+# One dollar above row 2; adjustment row 3 begins at $94,901.
+- name: adjustment_row_03_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94901
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94901'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 270
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3161.437'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3161.437'
+# Adjustment row 3 inclusive upper bound; deduct $270.
+- name: adjustment_row_03_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95000
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95000'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 270
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3165.1'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3165.1'
+# One dollar above row 3; adjustment row 4 begins at $95,001.
+- name: adjustment_row_04_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95001
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95001'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 260
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3175.137'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3175.137'
+# Adjustment row 4 inclusive upper bound; deduct $260.
+- name: adjustment_row_04_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95100
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95100'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 260
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3178.8'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3178.8'
+# One dollar above row 4; adjustment row 5 begins at $95,101.
+- name: adjustment_row_05_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95101
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95101'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 250
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3188.837'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3188.837'
+# Adjustment row 5 inclusive upper bound; deduct $250.
+- name: adjustment_row_05_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95200
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95200'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 250
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3192.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3192.5'
+# One dollar above row 5; adjustment row 6 begins at $95,201.
+- name: adjustment_row_06_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95201
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95201'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 5
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 240
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3202.537'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3202.537'
+# Adjustment row 6 inclusive upper bound; deduct $240.
+- name: adjustment_row_06_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95300
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95300'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 5
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 240
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3206.2'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3206.2'
+# One dollar above row 6; adjustment row 7 begins at $95,301.
+- name: adjustment_row_07_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95301
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95301'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 6
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 230
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3216.237'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3216.237'
+# Adjustment row 7 inclusive upper bound; deduct $230.
+- name: adjustment_row_07_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95400
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95400'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 6
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 230
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3219.9'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3219.9'
+# One dollar above row 7; adjustment row 8 begins at $95,401.
+- name: adjustment_row_08_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95401
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95401'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 7
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 220
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3229.937'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3229.937'
+# Adjustment row 8 inclusive upper bound; deduct $220.
+- name: adjustment_row_08_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95500
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95500'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 7
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 220
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3233.6'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3233.6'
+# One dollar above row 8; adjustment row 9 begins at $95,501.
+- name: adjustment_row_09_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95501
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95501'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 8
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 210
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3243.637'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3243.637'
+# Adjustment row 9 inclusive upper bound; deduct $210.
+- name: adjustment_row_09_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95600
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95600'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 8
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 210
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3247.3'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3247.3'
+# One dollar above row 9; adjustment row 10 begins at $95,601.
+- name: adjustment_row_10_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95601
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95601'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 9
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 200
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3257.337'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3257.337'
+# Adjustment row 10 inclusive upper bound; deduct $200.
+- name: adjustment_row_10_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95700
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95700'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 9
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 200
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3261'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3261'
+# One dollar above row 10; adjustment row 11 begins at $95,701.
+- name: adjustment_row_11_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95701
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95701'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 190
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3271.037'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3271.037'
+# Adjustment row 11 inclusive upper bound; deduct $190.
+- name: adjustment_row_11_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95800
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95800'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 190
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3274.7'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3274.7'
+# One dollar above row 11; adjustment row 12 begins at $95,801.
+- name: adjustment_row_12_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95801
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95801'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 11
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 180
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3284.737'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3284.737'
+# Adjustment row 12 inclusive upper bound; deduct $180.
+- name: adjustment_row_12_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95900
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95900'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 11
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 180
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3288.4'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3288.4'
+# One dollar above row 12; adjustment row 13 begins at $95,901.
+- name: adjustment_row_13_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 95901
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '95901'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 12
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 170
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3298.437'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3298.437'
+# Adjustment row 13 inclusive upper bound; deduct $170.
+- name: adjustment_row_13_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96000
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96000'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 12
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 170
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3302.1'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3302.1'
+# One dollar above row 13; adjustment row 14 begins at $96,001.
+- name: adjustment_row_14_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96001
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96001'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 13
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 160
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3312.137'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3312.137'
+# Adjustment row 14 inclusive upper bound; deduct $160.
+- name: adjustment_row_14_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96100
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96100'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 13
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 160
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3315.8'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3315.8'
+# One dollar above row 14; adjustment row 15 begins at $96,101.
+- name: adjustment_row_15_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96101
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96101'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 14
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 150
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3325.837'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3325.837'
+# Adjustment row 15 inclusive upper bound; deduct $150.
+- name: adjustment_row_15_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96200
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96200'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 14
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 150
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3329.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3329.5'
+# One dollar above row 15; adjustment row 16 begins at $96,201.
+- name: adjustment_row_16_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96201
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96201'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 140
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3339.537'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3339.537'
+# Adjustment row 16 inclusive upper bound; deduct $140.
+- name: adjustment_row_16_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96300
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96300'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 140
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3343.2'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3343.2'
+# One dollar above row 16; adjustment row 17 begins at $96,301.
+- name: adjustment_row_17_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96301
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96301'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 130
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3353.237'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3353.237'
+# Adjustment row 17 inclusive upper bound; deduct $130.
+- name: adjustment_row_17_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96400
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96400'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 130
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3356.9'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3356.9'
+# One dollar above row 17; adjustment row 18 begins at $96,401.
+- name: adjustment_row_18_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96401
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96401'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 120
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3366.937'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3366.937'
+# Adjustment row 18 inclusive upper bound; deduct $120.
+- name: adjustment_row_18_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96500
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96500'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 2
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 120
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3370.6'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3370.6'
+# One dollar above row 18; adjustment row 19 begins at $96,501.
+- name: adjustment_row_19_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96501
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96501'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 110
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3380.637'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3380.637'
+# Adjustment row 19 inclusive upper bound; deduct $110.
+- name: adjustment_row_19_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96600
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96600'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 3
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 110
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3384.3'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3384.3'
+# One dollar above row 19; adjustment row 20 begins at $96,601.
+- name: adjustment_row_20_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96601
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96601'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 100
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3394.337'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3394.337'
+# Adjustment row 20 inclusive upper bound; deduct $100.
+- name: adjustment_row_20_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96700
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96700'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 4
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 100
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3398'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3398'
+# One dollar above row 20; adjustment row 21 begins at $96,701.
+- name: adjustment_row_21_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96701
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96701'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 5
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 90
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3408.037'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3408.037'
+# Adjustment row 21 inclusive upper bound; deduct $90.
+- name: adjustment_row_21_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96800
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96800'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 5
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 90
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3411.7'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3411.7'
+# One dollar above row 21; adjustment row 22 begins at $96,801.
+- name: adjustment_row_22_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96801
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96801'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 6
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 80
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3421.737'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3421.737'
+# Adjustment row 22 inclusive upper bound; deduct $80.
+- name: adjustment_row_22_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96900
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96900'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 6
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 80
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3425.4'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3425.4'
+# One dollar above row 22; adjustment row 23 begins at $96,901.
+- name: adjustment_row_23_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 96901
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '96901'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 7
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 70
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3435.437'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3435.437'
+# Adjustment row 23 inclusive upper bound; deduct $70.
+- name: adjustment_row_23_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97000
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97000'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 7
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 70
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3439.1'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3439.1'
+# One dollar above row 23; adjustment row 24 begins at $97,001.
+- name: adjustment_row_24_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97001
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97001'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 8
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 60
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3449.137'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3449.137'
+# Adjustment row 24 inclusive upper bound; deduct $60.
+- name: adjustment_row_24_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97100
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97100'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 8
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 60
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3452.8'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3452.8'
+# One dollar above row 24; adjustment row 25 begins at $97,101.
+- name: adjustment_row_25_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97101
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97101'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 9
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 50
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3462.837'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3462.837'
+# Adjustment row 25 inclusive upper bound; deduct $50.
+- name: adjustment_row_25_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97200
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97200'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 9
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 50
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3466.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3466.5'
+# One dollar above row 25; adjustment row 26 begins at $97,201.
+- name: adjustment_row_26_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97201
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97201'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 40
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3476.537'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3476.537'
+# Adjustment row 26 inclusive upper bound; deduct $40.
+- name: adjustment_row_26_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97300
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97300'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 40
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3480.2'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3480.2'
+# One dollar above row 26; adjustment row 27 begins at $97,301.
+- name: adjustment_row_27_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97301
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97301'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 11
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 30
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3490.237'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3490.237'
+# Adjustment row 27 inclusive upper bound; deduct $30.
+- name: adjustment_row_27_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97400
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97400'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 11
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 30
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3493.9'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3493.9'
+# One dollar above row 27; adjustment row 28 begins at $97,401.
+- name: adjustment_row_28_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97401
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97401'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 12
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 20
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3503.937'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3503.937'
+# Adjustment row 28 inclusive upper bound; deduct $20.
+- name: adjustment_row_28_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97500
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97500'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 12
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 20
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3507.6'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3507.6'
+# One dollar above row 28; adjustment row 29 begins at $97,501.
+- name: adjustment_row_29_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97501
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97501'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 13
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3517.637'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3517.637'
+# Adjustment row 29 inclusive upper bound; deduct $10.
+- name: adjustment_row_29_upper
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97600
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97600'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 13
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3521.3'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3521.3'
+# One dollar above the final positive row; the statutory zero-adjustment tail begins.
+- name: zero_adjustment_tail_lower
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97601
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97601'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 14
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3531.337'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3531.337'
+# High-income tail keeps schedule (B) and deducts no bracket adjustment.
+- name: high_income_tail_200000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 200000
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '200000'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 14
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '7320.1'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '7320.1'
+# Fractional dollars above the schedule transition remain below section 1(C)'s
+# first explicit "From" amount, so schedule (B) applies without an adjustment.
+- name: fractional_before_adjustment_row_01
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94700.5
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94700.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3424.0185'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3424.0185'
+# A fractional amount after an inclusive upper endpoint does not reach the next
+# statutory row until its integer "From" amount.
+- name: fractional_before_adjustment_row_02
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 94800.5
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '94800.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_lower_half_bracket: 0
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 290
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3137.7185'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3137.7185'
+# The final positive adjustment likewise remains in force until the $97,601
+# zero-adjustment tail begins.
+- name: fractional_before_zero_adjustment_tail
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ar:policies/income_tax/pilot_liability_pipeline#input.ar_pit_pilot_individual_taxable_income: 97600.5
+  output:
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_taxable_income: '97600.5'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_uses_high_income_schedule: holds
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_b_bracket: 1
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_adjustment_upper_half_bracket: 13
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_bracket_adjustment: 10
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_schedule_tax: '3521.3185'
+    us-ar:policies/income_tax/pilot_liability_pipeline#ar_pit_pilot_income_tax_before_non_refundable_credits_indiv: '3521.3185'

--- a/us-ar/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ar/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,42 +5,337 @@ module:
   source_verification:
     corpus_citation_path: us-ar/statute/act-2-2026/section-1
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: checked_higher_authority
       checked_paths:
         - us-ar/statute/act-2-2026
         - us-ar/statute/act-2-2026/section-1
       rationale: |-
-        Section 1 of Arkansas Act 2 of 2026 amends Ark. Code section
-        26-51-201(a)(4) for tax years beginning on or after January 1, 2026. It
-        supplies the full progressive schedule through $94,700, a separate
-        high-income schedule above $94,700, and the complete 29-row bracket-
-        adjustment table for net income from $94,701 through $97,600. This
-        narrow composition accepts completed-return Arkansas net taxable
-        income and the active bracket's cumulative base tax, floor, marginal
-        rate, and applicable adjustment as caller-supplied current-authority
-        inputs. Deductions, exemptions, low-income tables, special income
-        classes, and credits remain outside this rate-section module.
+        Arkansas Act 2 of 2026 section 1 directly amends Ark. Code section
+        26-51-201(a)(4) for tax years beginning on or after January 1, 2026.
+        It supplies all five brackets of the schedule for net income at or
+        below $94,700, both brackets of the schedule for net income above
+        $94,700, and all twenty-nine positive bracket-adjustment rows from
+        $94,701 through $97,600 (plus the statutory zero-adjustment tail).
+        This narrow module accepts completed-return Arkansas individual net
+        taxable income as its sole caller boundary and computes the Act 2
+        schedule component before nonrefundable credits at Person grain. It
+        does not reconstruct Arkansas net income, deductions, exemptions,
+        low-income tables, special income classes, residency, trusts, estates,
+        filing-unit aggregation, or credits. The output therefore corresponds
+        only to PolicyEngine's individual/separate schedule component
+        `ar_income_tax_before_non_refundable_credits_indiv`; it is not a broad
+        TaxUnit liability. The Act 2 amounts are bounded to tax year 2026
+        because section 26-51-201(a)(5) provides for later annual adjustment.
   summary: |-
-    Composed Arkansas individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied completed-
-    return Arkansas net taxable income and applies the supplied active Act 2
-    bracket in cumulative-base-plus-marginal form, less the supplied bracket
-    adjustment, before nonrefundable credits. Its exact PolicyEngine 4.18.9 /
-    PolicyEngine-US 1.752.2 analog is
-    `ar_income_tax_before_non_refundable_credits_unit` on the six-case
-    childless age-40 grid: single at $30,000/$60,000/$150,000 of wages and
-    one-earner joint at $60,000/$120,000/$300,000. PolicyEngine supplies
-    completed taxable income; expected outputs are independently hand-computed
-    from Act 2. None of the standard grid cases falls in the $94,701-$97,600
-    adjustment interval, so its supplied adjustment is zero in all six cases.
+    Arkansas 2026 individual/separate income-tax schedule component before
+    nonrefundable credits. From completed-return Arkansas individual net
+    taxable income, the module selects and applies every Act 2 section 1
+    bracket, switches schedules above $94,700, and deducts the applicable one
+    of the twenty-nine $10-stepped bracket adjustments through $97,600. The
+    result remains at Person grain for later filing-unit aggregation. It does
+    not claim to compute resident TaxUnit liability or any upstream taxable-
+    income or downstream credit surface.
 rules:
-  - name: ar_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
+  - name: ar_pit_pilot_schedule_a_upper
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: Arkansas Act 2 of 2026 section 1, supplied Arkansas net taxable income
+    indexed_by: ar_pit_pilot_schedule_a_bracket
+    source: Arkansas Act 2 of 2026 section 1(A), individual schedule upper bounds through $94,700
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "net income less than or equal to ninety-four thousand seven hundred dollars ($94,700)"
+                row_key: "From"
+                column_key: "Less Than or Equal To"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 5599
+          1: 11199
+          2: 15999
+          3: 26399
+          4: 94700
+
+  - name: ar_pit_pilot_schedule_a_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_schedule_a_bracket
+    source: Arkansas Act 2 of 2026 section 1(A), individual schedule lower bounds through $94,700
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "net income less than or equal to ninety-four thousand seven hundred dollars ($94,700)"
+                row_key: "From"
+                column_key: "Rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 5600
+          2: 11200
+          3: 16000
+          4: 26400
+
+  - name: ar_pit_pilot_schedule_a_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: ar_pit_pilot_schedule_a_bracket
+    source: Arkansas Act 2 of 2026 section 1(A), individual marginal rates through $94,700
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "net income less than or equal to ninety-four thousand seven hundred dollars ($94,700)"
+                row_key: "From"
+                column_key: "Rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 0.02
+          2: 0.03
+          3: 0.034
+          4: 0.037
+
+  - name: ar_pit_pilot_schedule_b_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_schedule_b_bracket
+    source: Arkansas Act 2 of 2026 section 1(B), high-income schedule lower bounds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "net income greater than ninety-four thousand seven hundred dollars ($94,700)"
+                row_key: "From"
+                column_key: "Rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 4700
+
+  - name: ar_pit_pilot_schedule_b_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: ar_pit_pilot_schedule_b_bracket
+    source: Arkansas Act 2 of 2026 section 1(B), high-income marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "net income greater than ninety-four thousand seven hundred dollars ($94,700)"
+                row_key: "From"
+                column_key: "Rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.02
+          1: 0.037
+
+  - name: ar_pit_pilot_adjustment_lower_half_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_adjustment_lower_half_bracket
+    source: Arkansas Act 2 of 2026 section 1(C), bracket-adjustment lower bounds from $94,701 through $96,101
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "Bracket Adjustment Amount"
+                row_key: "From"
+                column_key: "From"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 94701
+          1: 94801
+          2: 94901
+          3: 95001
+          4: 95101
+          5: 95201
+          6: 95301
+          7: 95401
+          8: 95501
+          9: 95601
+          10: 95701
+          11: 95801
+          12: 95901
+          13: 96001
+          14: 96101
+
+  - name: ar_pit_pilot_adjustment_lower_half_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_adjustment_lower_half_bracket
+    source: Arkansas Act 2 of 2026 section 1(C), bracket-adjustment amounts from $290 through $150
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "Bracket Adjustment Amount"
+                row_key: "From"
+                column_key: "Bracket Adjustment Amount"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 290
+          1: 280
+          2: 270
+          3: 260
+          4: 250
+          5: 240
+          6: 230
+          7: 220
+          8: 210
+          9: 200
+          10: 190
+          11: 180
+          12: 170
+          13: 160
+          14: 150
+
+  - name: ar_pit_pilot_adjustment_upper_half_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_adjustment_upper_half_bracket
+    source: Arkansas Act 2 of 2026 section 1(C), bracket-adjustment lower bounds from $96,201 through the $97,601 zero-adjustment tail
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "Bracket Adjustment Amount"
+                row_key: "From"
+                column_key: "From"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 96201
+          1: 96301
+          2: 96401
+          3: 96501
+          4: 96601
+          5: 96701
+          6: 96801
+          7: 96901
+          8: 97001
+          9: 97101
+          10: 97201
+          11: 97301
+          12: 97401
+          13: 97501
+          14: 97601
+
+  - name: ar_pit_pilot_adjustment_upper_half_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: ar_pit_pilot_adjustment_upper_half_bracket
+    source: Arkansas Act 2 of 2026 section 1(C), bracket-adjustment amounts from $140 through $10 and zero tail
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              table:
+                header: "Bracket Adjustment Amount"
+                row_key: "From"
+                column_key: "Bracket Adjustment Amount"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 140
+          1: 130
+          2: 120
+          3: 110
+          4: 100
+          5: 90
+          6: 80
+          7: 70
+          8: 60
+          9: 50
+          10: 40
+          11: 30
+          12: 20
+          13: 10
+          14: 0
+
+  - name: ar_pit_pilot_taxable_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Arkansas Act 2 of 2026 section 1, completed-return individual net taxable income boundary
     metadata:
       proof:
         atoms:
@@ -51,15 +346,182 @@ rules:
               excerpt: "Every resident, individual, trust, or estate having"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, ar_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, ar_pit_pilot_individual_taxable_income)
 
-  - name: ar_pit_pilot_schedule_tax
+  - name: ar_pit_pilot_uses_high_income_schedule
     kind: derived
-    entity: TaxUnit
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Arkansas Act 2 of 2026 section 1(A)-(B), schedule switch above $94,700
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "net income greater than ninety-four thousand seven hundred dollars ($94,700)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ar_pit_pilot_taxable_income > ar_pit_pilot_schedule_a_upper[4]
+
+  - name: ar_pit_pilot_schedule_a_bracket
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: Arkansas Act 2 of 2026 section 1(A), bracket selected from individual net income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "shall determine the amount of income tax due under this subsection"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ar_pit_pilot_taxable_income <= ar_pit_pilot_schedule_a_upper[0]: 0
+          else: if ar_pit_pilot_taxable_income <= ar_pit_pilot_schedule_a_upper[1]: 1
+          else: if ar_pit_pilot_taxable_income <= ar_pit_pilot_schedule_a_upper[2]: 2
+          else: if ar_pit_pilot_taxable_income <= ar_pit_pilot_schedule_a_upper[3]: 3
+          else: 4
+
+  - name: ar_pit_pilot_schedule_b_bracket
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: Arkansas Act 2 of 2026 section 1(B), high-income bracket selected from individual net income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "$4,701 and above"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ar_pit_pilot_taxable_income <= ar_pit_pilot_schedule_b_floor[1]: 0
+          else: 1
+
+  - name: ar_pit_pilot_adjustment_lower_half_bracket
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: Arkansas Act 2 of 2026 section 1(C), lower-half bracket-adjustment row selected from individual net income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "deducting a bracket adjustment amount in accordance with the table set forth below"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[1]: 0
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[2]: 1
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[3]: 2
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[4]: 3
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[5]: 4
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[6]: 5
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[7]: 6
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[8]: 7
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[9]: 8
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[10]: 9
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[11]: 10
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[12]: 11
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[13]: 12
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[14]: 13
+          else: 14
+
+  - name: ar_pit_pilot_adjustment_upper_half_bracket
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Year
+    source: Arkansas Act 2 of 2026 section 1(C), upper-half bracket-adjustment row and zero tail selected from individual net income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "deducting a bracket adjustment amount in accordance with the table set forth below"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[1]: 0
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[2]: 1
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[3]: 2
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[4]: 3
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[5]: 4
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[6]: 5
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[7]: 6
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[8]: 7
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[9]: 8
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[10]: 9
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[11]: 10
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[12]: 11
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[13]: 12
+          else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[14]: 13
+          else: 14
+
+  - name: ar_pit_pilot_bracket_adjustment
+    kind: derived
+    entity: Person
     dtype: Money
     period: Year
     unit: USD
-    source: Arkansas Act 2 of 2026 section 1, dual schedules and bracket adjustment
+    source: Arkansas Act 2 of 2026 section 1(C), adjustment deducted only from the high-income schedule
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ar/statute/act-2-2026/section-1
+              excerpt: "shall reduce the amount of income tax due as determined"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ar_pit_pilot_uses_high_income_schedule:
+            if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_lower_half_floor[0]:
+              0
+            else: if ar_pit_pilot_taxable_income < ar_pit_pilot_adjustment_upper_half_floor[0]:
+              ar_pit_pilot_adjustment_lower_half_amount[ar_pit_pilot_adjustment_lower_half_bracket]
+            else:
+              ar_pit_pilot_adjustment_upper_half_amount[ar_pit_pilot_adjustment_upper_half_bracket]
+          else: 0
+
+  - name: ar_pit_pilot_schedule_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Arkansas Act 2 of 2026 section 1(A)-(C), applicable individual schedule less bracket adjustment
     metadata:
       proof:
         atoms:
@@ -72,28 +534,38 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-ar/statute/act-2-2026/section-1
-              excerpt: "3.7%"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ar/statute/act-2-2026/section-1
               excerpt: "shall reduce the amount of income tax due as determined"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0,
-            ar_pit_pilot_supplied_bracket_base
-            + ar_pit_pilot_supplied_marginal_rate * max(0, ar_pit_pilot_taxable_income - ar_pit_pilot_supplied_bracket_floor)
-            - ar_pit_pilot_supplied_bracket_adjustment
-          )
+          if ar_pit_pilot_uses_high_income_schedule:
+            max(0,
+              ar_pit_pilot_schedule_b_rate[0]
+              * max(0, min(ar_pit_pilot_taxable_income, ar_pit_pilot_schedule_b_floor[1]) - ar_pit_pilot_schedule_b_floor[0])
+              + ar_pit_pilot_schedule_b_rate[1]
+              * max(0, ar_pit_pilot_taxable_income - ar_pit_pilot_schedule_b_floor[1])
+              - ar_pit_pilot_bracket_adjustment
+            )
+          else:
+            ar_pit_pilot_schedule_a_rate[0]
+            * max(0, min(ar_pit_pilot_taxable_income, ar_pit_pilot_schedule_a_floor[1]) - ar_pit_pilot_schedule_a_floor[0])
+            + ar_pit_pilot_schedule_a_rate[1]
+            * max(0, min(ar_pit_pilot_taxable_income, ar_pit_pilot_schedule_a_floor[2]) - ar_pit_pilot_schedule_a_floor[1])
+            + ar_pit_pilot_schedule_a_rate[2]
+            * max(0, min(ar_pit_pilot_taxable_income, ar_pit_pilot_schedule_a_floor[3]) - ar_pit_pilot_schedule_a_floor[2])
+            + ar_pit_pilot_schedule_a_rate[3]
+            * max(0, min(ar_pit_pilot_taxable_income, ar_pit_pilot_schedule_a_floor[4]) - ar_pit_pilot_schedule_a_floor[3])
+            + ar_pit_pilot_schedule_a_rate[4]
+            * max(0, ar_pit_pilot_taxable_income - ar_pit_pilot_schedule_a_floor[4])
 
-  - name: ar_pit_pilot_income_tax_liability
+  - name: ar_pit_pilot_income_tax_before_non_refundable_credits_indiv
     kind: derived
-    entity: TaxUnit
+    entity: Person
     dtype: Money
     period: Year
     unit: USD
-    source: Arkansas Act 2 of 2026 section 1, resident tax before credits
+    source: Arkansas Act 2 of 2026 section 1, individual schedule component before nonrefundable credits
     metadata:
       proof:
         atoms:
@@ -104,4 +576,5 @@ rules:
               excerpt: "shall determine the amount of income tax due under this subsection"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: max(0, ar_pit_pilot_schedule_tax)


### PR DESCRIPTION
## Summary
- encode Arkansas Act 2 of 2026 section 1 individual tax schedules at Person grain
- cover both ordinary and high-income schedules plus all 29 bracket-adjustment rows
- retain completed-return individual taxable income as the sole explicit boundary
- add 73 companion fixtures and signed applied-file provenance

## Scope
This promotes the individual income-tax-before-nonrefundable-credits component. TaxUnit aggregation and broader final liability remain separate work.

## Validation
- RuleSpec validation passed
- 73/73 companion fixtures passed
- proof validation: 19 atoms, 7/7 monetary obligations
- reverse index and signed exact-head guard passed
- independent review found and fixed fractional-dollar adjustment transitions
- final independent re-review: CLEAN at exact head cbaee641cc5cb9c7efba1e01689a06337d9e75b7

No actionable review findings remain.