### PR TITLE
Encode North Dakota 2026 individual income tax schedules

### DIFF
--- a/.axiom/encoding-manifests/us-nd/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nd/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-nd/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "3164afeae9d229e7d94f95f156e6202d78b2b1a6be091460b61ce2151dd74b36"
+      "sha256": "9c305053ff5e775b5a483c252b619d48e68faa14f8ddaf658f5a62ac379bfd2c"
     },
     {
       "path": "us-nd/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "6551ee315cd3031619e24ee3da78c28745c9ba0201e5b40228b1b9bb2ccfb151"
+      "sha256": "5bae98a28d0a5f77b54daac281728c83863d82bce08ab05518210fbb94541168"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-nd:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.877596+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-nd/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "6551ee315cd3031619e24ee3da78c28745c9ba0201e5b40228b1b9bb2ccfb151",
+  "generated_at": "2026-07-22T14:44:00.910582+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcdmd44oq/sign-applied-files/us-nd/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpcdmd44oq",
+  "generated_output_sha256": "5bae98a28d0a5f77b54daac281728c83863d82bce08ab05518210fbb94541168",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +33,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "f07fed6a963a52449cf51dda0fe43aef8c0373130c326c8ca652c44f37a18b9f"
+    "value": "f35e9e1b6c634782a020a68cf8105f3677fa9c118e07bb1b4b1ccf9335351616"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.906662+00:00",
+    "generated_at": "2026-07-21T15:45:46.877596+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "2022c8cf685eae5f7835a27d62ed55821bfc96f70ddb63ccaf73239955e86d9f",
-    "prior_signature": "1cbf8027179dfde2453dd4e47745bcb626aee1c03cd06da146da4f2e75bb4111",
+    "manifest_sha256": "a42cd0295fae632e44c464ed0c857b170a54c890685affff923ba6f4250c12b7",
+    "prior_signature": "f07fed6a963a52449cf51dda0fe43aef8c0373130c326c8ca652c44f37a18b9f",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.201902+00:00",
+      "generated_at": "2026-07-21T15:44:47.906662+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "ead5816675c55e51fbfe2681fc73f6dd04b0603a6a0d744bb413b4826470bd9d",
-      "prior_signature": "3f3156d9439d4949d196228be6cac151e0662de6e7ec93084e2b19bd9e9c2f42",
+      "manifest_sha256": "2022c8cf685eae5f7835a27d62ed55821bfc96f70ddb63ccaf73239955e86d9f",
+      "prior_signature": "1cbf8027179dfde2453dd4e47745bcb626aee1c03cd06da146da4f2e75bb4111",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.268660+00:00",
+        "generated_at": "2026-07-16T15:48:15.201902+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "f62378006f73f6db22f932b8631c2b3c0247980868b4da7052d665edb215e70c",
-        "prior_signature": "081cfc2587f5405c9b32e40d8f4c7080c21c4b9ba103a6ee5a0b37ebca9adc99",
+        "manifest_sha256": "ead5816675c55e51fbfe2681fc73f6dd04b0603a6a0d744bb413b4826470bd9d",
+        "prior_signature": "3f3156d9439d4949d196228be6cac151e0662de6e7ec93084e2b19bd9e9c2f42",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:30.956949+00:00",
+          "generated_at": "2026-07-16T15:22:02.268660+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "ed8aa1c7ddc12f565f372fe28f9bad1cb0a9a284f8a3298f3bab984290a8d34d",
-          "prior_signature": "19b3b8294928c652aaff90b5772f8160d742802b64a118a8629216bb257c34cb",
+          "manifest_sha256": "f62378006f73f6db22f932b8631c2b3c0247980868b4da7052d665edb215e70c",
+          "prior_signature": "081cfc2587f5405c9b32e40d8f4c7080c21c4b9ba103a6ee5a0b37ebca9adc99",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-16T15:09:30.956949+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "ed8aa1c7ddc12f565f372fe28f9bad1cb0a9a284f8a3298f3bab984290a8d34d",
+            "prior_signature": "19b3b8294928c652aaff90b5772f8160d742802b64a118a8629216bb257c34cb",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1672
+ceiling: 1689
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1283,15 +1283,66 @@ entries:
 - legal_id: us-mt:statutes/15-30-2318#state_earned_income_tax_credit_percentage
   source: bulk
   since: '2026-07-08'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_head_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_head_top_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_head_top_threshold
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_head_zero_tax_ceiling
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-16'
-- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_joint_schedule_tax
   source: manual
-  since: '2026-07-16'
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_joint_top_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_joint_top_threshold
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_joint_zero_tax_ceiling
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_middle_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_separate_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_separate_top_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_separate_top_threshold
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_separate_zero_tax_ceiling
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_single_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_single_top_base
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_single_top_threshold
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_single_zero_tax_ceiling
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income
   source: manual
   since: '2026-07-16'
+- legal_id: us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_top_rate
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-nd:statutes/57/57-38-01/28#married_couple_joint_return_credit
   source: bulk
   since: '2026-07-08'

--- a/us-nd/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nd/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,78 +1,258 @@
-# Expected values are independently hand-computed from the Tax Commissioner's
-# official 2026 replacement schedules overlaid on N.D.C.C. section 57-38-30.3.
-# Supplied taxable-income inputs are PolicyEngine's completed-return
-# nd_taxable_income values for the standard 2026 wage grid. The three positive
-# results intentionally expose PolicyEngine-US 1.752.2's carried-forward 2025
-# thresholds; the three zero-liability cases match nd_income_tax_before_credits.
+# Expected values use independent decimal arithmetic from the Tax
+# Commissioner's official 2026 Form ND-1ES schedules. The boundary cases cover
+# every filing-status table and preserve the published cumulative top-bracket
+# base amounts. PolicyEngine-US 1.752.2 is intentionally not the expected-value
+# authority because its 2026 parameters retain the 2025 thresholds.
+
+- name: negative_taxable_income_normalizes_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: -1
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '0'
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_single_schedule_tax: '0'
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_joint_schedule_tax: '0'
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_separate_schedule_tax: '0'
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_head_schedule_tax: '0'
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
+- name: single_at_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 49575
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
+- name: single_one_dollar_above_zero_tax_ceiling
+  # 1.95% * (49,576 - 49,575) = 0.0195.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 49576
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0.0195'
+
+- name: single_at_top_threshold
+  # 1.95% * (250,400 - 49,575) = 3,916.0875.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 250400
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '3916.0875'
+
+- name: single_one_dollar_into_top_bracket
+  # Published base 3,916.09 + 2.50% * 1 = 3,916.115.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 250401
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '3916.115'
+
+- name: joint_at_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 82800
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
+- name: joint_one_dollar_above_zero_tax_ceiling
+  # 1.95% * (82,801 - 82,800) = 0.0195.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 82801
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0.0195'
+
+- name: joint_at_top_threshold
+  # 1.95% * (304,850 - 82,800) = 4,329.975.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 304850
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '4329.975'
+
+- name: joint_one_dollar_into_top_bracket
+  # Published base 4,329.98 + 2.50% * 1 = 4,330.005.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 304851
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '4330.005'
+
+- name: separate_at_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 41400
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
+- name: separate_one_dollar_above_zero_tax_ceiling
+  # 1.95% * (41,401 - 41,400) = 0.0195.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 41401
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0.0195'
+
+- name: separate_at_top_threshold
+  # 1.95% * (152,425 - 41,400) = 2,164.9875.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 152425
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '2164.9875'
+
+- name: separate_one_dollar_into_top_bracket
+  # Published base 2,164.99 + 2.50% * 1 = 2,165.015.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 152426
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '2165.015'
+
+- name: head_at_zero_tax_ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 66400
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
+- name: head_one_dollar_above_zero_tax_ceiling
+  # 1.95% * (66,401 - 66,400) = 0.0195.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 66401
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0.0195'
+
+- name: head_at_top_threshold
+  # 1.95% * (277,600 - 66,400) = 4,118.40.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 277600
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '4118.4'
+
+- name: head_one_dollar_into_top_bracket
+  # Published base 4,118.40 + 2.50% * 1 = 4,118.425.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 277601
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '4118.425'
+
+# Canonical comparison-grid compatibility cases. The taxable-income boundaries
+# are the previously recorded completed-return values, but the expected tax is
+# calculated from the official 2026 schedule rather than the stale oracle.
 - name: single_30000
-  # Taxable income does not exceed the 2026 single zero bracket of $49,575.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 13900
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 13900
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '13900'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '0'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
 - name: single_60000
-  # Taxable income does not exceed the 2026 single zero bracket of $49,575.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 43900
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 43900
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '43900'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '0'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
+
 - name: single_150000
   # 1.95% * (133,900 - 49,575) = 1,644.3375.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 133900
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 49575
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0.0195
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 133900
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '133900'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '1644.3375'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '1644.3375'
-- name: married_60000
-  # Taxable income does not exceed the 2026 joint zero bracket of $82,800.
+
+- name: joint_60000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 27800
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 27800
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '27800'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '0'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '0'
-- name: married_120000
+
+- name: joint_120000
   # 1.95% * (87,800 - 82,800) = 97.50.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 87800
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 82800
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0.0195
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 87800
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '87800'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '97.5'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '97.5'
-- name: married_300000
+
+- name: joint_300000
   # 1.95% * (267,800 - 82,800) = 3,607.50.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_taxable_income: 267800
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_base: 0
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_bracket_floor: 82800
-    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_supplied_marginal_rate: 0.0195
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_state_taxable_income: 267800
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_separate: false
+    us-nd:policies/income_tax/pilot_liability_pipeline#input.nd_pit_pilot_filing_status_head_of_household: false
   output:
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_taxable_income: '267800'
-    us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_schedule_tax: '3607.5'
     us-nd:policies/income_tax/pilot_liability_pipeline#nd_pit_pilot_income_tax_liability: '3607.5'

--- a/us-nd/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nd/policies/income_tax/pilot_liability_pipeline.yaml
@@ -5,36 +5,42 @@ module:
   source_verification:
     corpus_citation_path: us-nd/statute/57/57-38-30.3
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-nd/statute/57/57-38-30.3
       rationale: |-
-        N.D.C.C. section 57-38-30.3(1) imposes tax on North Dakota taxable
-        income under the filing-status schedules in subdivisions a through d,
-        and subdivision g directs the Tax Commissioner to prescribe indexed
-        replacement schedules. The official corpus record overlays the
-        Commissioner's operative 2026 schedule: single filers pay zero through
-        $49,575, 1.95 percent through $250,400, and then $3,916.09 plus 2.50
-        percent; joint filers pay zero through $82,800, 1.95 percent through
-        $304,850, and then $4,329.98 plus 2.50 percent. This narrow composition
-        accepts completed-return North Dakota taxable income and the active
-        bracket's cumulative base tax, floor, and marginal rate as caller-
-        supplied current-authority inputs. Adjustments, credits, part-year
-        allocation, farm-income averaging, and special income classes remain
-        outside this rate-section module.
+        N.D.C.C. section 57-38-30.3(1) imposes individual income tax under
+        filing-status schedules, and subdivision (g) directs the Tax
+        Commissioner to prescribe annually indexed replacement schedules.
+        The official corpus provision composes the current Century Code with
+        the Commissioner's operative 2026 Form ND-1ES schedule. It supplies
+        every threshold, cumulative base amount, and marginal rate for single,
+        joint or qualifying-surviving-spouse, married-separate, and
+        head-of-household returns.
+
+        This module therefore encodes the four 2026 schedules directly. Its
+        only caller boundaries are completed-return North Dakota taxable
+        income and three mutually exclusive filing-status classifications;
+        when all three are false, the single schedule applies. Upstream
+        federal-taxable-income adjustments, residency allocation, farm-income
+        averaging, special income classes, and all credits remain outside this
+        before-credit rate module. Every executable version fails closed
+        outside tax year 2026.
   summary: |-
-    Composed North Dakota individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied completed-
-    return North Dakota taxable income and applies the supplied active N.D.C.C.
-    section 57-38-30.3 bracket in cumulative-base-plus-marginal form before
-    credits. Its closest PolicyEngine 4.18.9 / PolicyEngine-US 1.752.2 analog is
-    `nd_income_tax_before_credits` on the six-case childless age-40 grid:
-    single at $30,000/$60,000/$150,000 of wages and one-earner joint at
-    $60,000/$120,000/$300,000. PolicyEngine supplies completed taxable income;
-    expected outputs are independently hand-computed from the official 2026
-    overlay. Three zero cases match exactly. The other three expose
-    PolicyEngine's stale carry-forward of the 2025 $48,475/$80,975 thresholds
-    instead of the official 2026 $49,575/$82,800 thresholds.
+    North Dakota 2026 individual income-tax schedule before credits under
+    N.D.C.C. section 57-38-30.3(1) and the Tax Commissioner's official Form
+    ND-1ES replacement tables. From completed-return North Dakota taxable
+    income, the module selects and applies the complete single, joint or
+    qualifying-surviving-spouse, married-separate, or head-of-household
+    schedule. It preserves the Commissioner's published cumulative top-bracket
+    base amounts rather than replacing them with mathematically continuous
+    values.
+
+    PolicyEngine-US 1.752.2 is not the numeric authority for this module. Its
+    2026 parameters retain the Commissioner's 2025 thresholds, so parity with
+    `nd_income_tax_before_credits` is neither claimed nor engineered. The
+    official 2026 schedule and focused boundary fixtures are the acceptance
+    standard.
 rules:
   - name: nd_pit_pilot_taxable_income
     kind: derived
@@ -42,8 +48,9 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.D.C.C. section 57-38-30.3(2), supplied North Dakota taxable income
+    source: N.D.C.C. section 57-38-30.3(2), completed-return North Dakota taxable income
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -53,43 +60,348 @@ rules:
               excerpt: 'For purposes of this section, "North Dakota taxable income" means the federal taxable'
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, nd_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, nd_pit_pilot_state_taxable_income)
 
-  - name: nd_pit_pilot_schedule_tax
+  - name: nd_pit_pilot_middle_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: N.D.C.C. section 57-38-30.3(1)(a)-(d), official 2026 middle-bracket rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$49,575 | $250,400 | $0.00 + 1.95% | $49,575"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$82,800 | $304,850 | $0.00 + 1.95% | $82,800"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$41,400 | $152,425 | $0.00 + 1.95% | $41,400"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$66,400 | $277,600 | $0.00 + 1.95% | $66,400"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0195'}
+
+  - name: nd_pit_pilot_top_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: N.D.C.C. section 57-38-30.3(1)(a)-(d), official 2026 top-bracket rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$250,400 |  | $3,916.09 + 2.50% | $250,400"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$304,850 |  | $4,329.98 + 2.50% | $304,850"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$152,425 |  | $2,164.99 + 2.50% | $152,425"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$277,600 |  | $4,118.40 + 2.50% | $277,600"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.025'}
+
+  - name: nd_pit_pilot_single_zero_tax_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES single zero-tax ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$0 | $49,575 | $0.00 + 0.00% | $0"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '49575'}
+
+  - name: nd_pit_pilot_single_top_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES single top-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$49,575 | $250,400 | $0.00 + 1.95% | $49,575"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '250400'}
+
+  - name: nd_pit_pilot_single_top_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES single top-bracket cumulative base
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$250,400 |  | $3,916.09 + 2.50% | $250,400"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '3916.09'}
+
+  - name: nd_pit_pilot_joint_zero_tax_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES joint and qualifying-surviving-spouse zero-tax ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$0 | $82,800 | $0.00 + 0.00% | $0"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '82800'}
+
+  - name: nd_pit_pilot_joint_top_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES joint and qualifying-surviving-spouse top-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$82,800 | $304,850 | $0.00 + 1.95% | $82,800"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '304850'}
+
+  - name: nd_pit_pilot_joint_top_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES joint and qualifying-surviving-spouse top-bracket cumulative base
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$304,850 |  | $4,329.98 + 2.50% | $304,850"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4329.98'}
+
+  - name: nd_pit_pilot_separate_zero_tax_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES married-separate zero-tax ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$0 | $41,400 | $0.00 + 0.00% | $0"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '41400'}
+
+  - name: nd_pit_pilot_separate_top_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES married-separate top-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$41,400 | $152,425 | $0.00 + 1.95% | $41,400"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '152425'}
+
+  - name: nd_pit_pilot_separate_top_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES married-separate top-bracket cumulative base
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$152,425 |  | $2,164.99 + 2.50% | $152,425"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2164.99'}
+
+  - name: nd_pit_pilot_head_zero_tax_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES head-of-household zero-tax ceiling
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$0 | $66,400 | $0.00 + 0.00% | $0"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '66400'}
+
+  - name: nd_pit_pilot_head_top_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES head-of-household top-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$66,400 | $277,600 | $0.00 + 1.95% | $66,400"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '277600'}
+
+  - name: nd_pit_pilot_head_top_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Official 2026 Form ND-1ES head-of-household top-bracket cumulative base
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "$277,600 |  | $4,118.40 + 2.50% | $277,600"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4118.40'}
+
+  - name: nd_pit_pilot_single_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: N.D.C.C. section 57-38-30.3(1)(a)-(b), official 2026 overlay
+    source: N.D.C.C. section 57-38-30.3(1)(a), official 2026 single schedule
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
-            source:
-              corpus_citation_path: us-nd/statute/57/57-38-30.3
-              excerpt: "$0 | $49,575 | $0.00 + 0.00% | $0"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nd/statute/57/57-38-30.3
-              excerpt: "$49,575 | $250,400 | $0.00 + 1.95% | $49,575"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nd/statute/57/57-38-30.3
-              excerpt: "$0 | $82,800 | $0.00 + 0.00% | $0"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nd/statute/57/57-38-30.3
-              excerpt: "$82,800 | $304,850 | $0.00 + 1.95% | $82,800"
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "Single, other than head of household or surviving spouse."}
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          nd_pit_pilot_supplied_bracket_base
-          + nd_pit_pilot_supplied_marginal_rate * max(0, nd_pit_pilot_taxable_income - nd_pit_pilot_supplied_bracket_floor)
+          if nd_pit_pilot_taxable_income <= nd_pit_pilot_single_zero_tax_ceiling: 0
+          else: if nd_pit_pilot_taxable_income <= nd_pit_pilot_single_top_threshold:
+              nd_pit_pilot_middle_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_single_zero_tax_ceiling)
+          else:
+              nd_pit_pilot_single_top_base
+              + nd_pit_pilot_top_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_single_top_threshold)
+
+  - name: nd_pit_pilot_joint_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.D.C.C. section 57-38-30.3(1)(b), official 2026 joint and surviving-spouse schedule
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "Married filing jointly and surviving spouse."}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nd_pit_pilot_taxable_income <= nd_pit_pilot_joint_zero_tax_ceiling: 0
+          else: if nd_pit_pilot_taxable_income <= nd_pit_pilot_joint_top_threshold:
+              nd_pit_pilot_middle_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_joint_zero_tax_ceiling)
+          else:
+              nd_pit_pilot_joint_top_base
+              + nd_pit_pilot_top_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_joint_top_threshold)
+
+  - name: nd_pit_pilot_separate_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.D.C.C. section 57-38-30.3(1)(c), official 2026 married-separate schedule
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "Married filing separately."}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nd_pit_pilot_taxable_income <= nd_pit_pilot_separate_zero_tax_ceiling: 0
+          else: if nd_pit_pilot_taxable_income <= nd_pit_pilot_separate_top_threshold:
+              nd_pit_pilot_middle_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_separate_zero_tax_ceiling)
+          else:
+              nd_pit_pilot_separate_top_base
+              + nd_pit_pilot_top_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_separate_top_threshold)
+
+  - name: nd_pit_pilot_head_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.D.C.C. section 57-38-30.3(1)(d), official 2026 head-of-household schedule
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nd/statute/57/57-38-30.3, excerpt: "Head of household."}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nd_pit_pilot_taxable_income <= nd_pit_pilot_head_zero_tax_ceiling: 0
+          else: if nd_pit_pilot_taxable_income <= nd_pit_pilot_head_top_threshold:
+              nd_pit_pilot_middle_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_head_zero_tax_ceiling)
+          else:
+              nd_pit_pilot_head_top_base
+              + nd_pit_pilot_top_rate * (nd_pit_pilot_taxable_income - nd_pit_pilot_head_top_threshold)
 
   - name: nd_pit_pilot_income_tax_liability
     kind: derived
@@ -97,7 +409,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.D.C.C. section 57-38-30.3(1), individual income tax before credits
+    source: N.D.C.C. section 57-38-30.3(1)(a)-(d), applicable official 2026 individual schedule before credits
     metadata:
       proof:
         atoms:
@@ -108,4 +420,36 @@ rules:
               excerpt: "A tax is hereby imposed for each taxable year upon income earned or received in that"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, nd_pit_pilot_schedule_tax)
+        effective_to: '2026-12-31'
+        formula: |-
+          if nd_pit_pilot_filing_status_joint_or_surviving_spouse:
+              nd_pit_pilot_joint_schedule_tax
+          else: if nd_pit_pilot_filing_status_separate:
+              nd_pit_pilot_separate_schedule_tax
+          else: if nd_pit_pilot_filing_status_head_of_household:
+              nd_pit_pilot_head_schedule_tax
+          else:
+              nd_pit_pilot_single_schedule_tax
+
+inputs:
+  - name: nd_pit_pilot_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return North Dakota taxable income supplied by the caller.
+  - name: nd_pit_pilot_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a joint or qualifying-surviving-spouse return.
+  - name: nd_pit_pilot_filing_status_separate
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a married-separate return.
+  - name: nd_pit_pilot_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a head-of-household return.


### PR DESCRIPTION
## Summary

- replace caller-supplied bracket facts with the complete official TY2026 North Dakota individual income-tax schedules
- cover single, joint or qualifying-surviving-spouse, married-separate, and head-of-household returns
- preserve the Tax Commissioner published cumulative top-bracket bases and bound every executable version to TY2026
- add 23 focused fixtures covering each status boundary and the existing comparison grid
- explicitly record that PolicyEngine-US 1.752.2 retains stale 2025 thresholds, so this PR makes no parity claim

## Official authority

- North Dakota Tax Commissioner, 2026 Form ND-1ES: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2025-iit/28709-form-nd-1es-2026.pdf
- North Dakota Century Code chapter 57-38, section 57-38-30.3: https://ndlegis.gov/cencode/t57c38.pdf
- RuleSpec corpus citation: us-nd/statute/57/57-38-30.3

## Validation

- git diff --check
- axiom-encode proof-validate --require-money-atoms --money-atom-root . us-nd/policies/income_tax/pilot_liability_pipeline.yaml (26 atoms; 0 missing of 12 monetary obligations)
- exact repo-pinned axiom-encode 0.2.1200 plus axiom-rules-engine ffd8213: axiom-encode validate --skip-reviewers us-nd/policies/income_tax/pilot_liability_pipeline.yaml (PASS; 23 fixtures)
- signed applied-file manifest; guard passed

## Review cycle

- Independent review pending; keep this PR in draft until the cycle has no actionable findings.
