### PR TITLE
Encode Nebraska 2026 estimated-tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ne/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ne/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "e04ff7e44e7d50a950dd7063eaea3e8103d2637612fd199f9b465a3676780d04"
+      "sha256": "e2d08b438da54743c7c6d1f747336c9b55b6dfe805f7d96540b525a035a880e7"
     },
     {
       "path": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "c49448ecd8f11a5f971ea0c72f69426d41de2250424040cafb8bbc0650c53caa"
+      "sha256": "e464f07aa42356993c7d83c9fd4ecdc4189f571a81aa00ad0f4fdd7e463160e9"
     }
   ],
   "axiom_encode_git": {
-    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1195",
-    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1195",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ne:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T02:00:24.181315+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp59fr2_7y/sign-applied-files/us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp59fr2_7y",
-  "generated_output_sha256": "c49448ecd8f11a5f971ea0c72f69426d41de2250424040cafb8bbc0650c53caa",
+  "generated_at": "2026-07-22T14:53:44.645016+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpth9fye78/sign-applied-files/us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpth9fye78",
+  "generated_output_sha256": "e464f07aa42356993c7d83c9fd4ecdc4189f571a81aa00ad0f4fdd7e463160e9",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "4cf06726f49f8d443a27d5927b7d23820e15836da9ddbaa4461b17e73457d8d2"
+    "value": "50a75005c21a3b8a3962b9a9420f885b642a1da23362ba6dd376909053569fd0"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-09T02:00:24.181315+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "1f84f47dded94b15313a951433ddb8e46a2527515e9a87b61de752bfc6b9aea5",
+    "prior_signature": "4cf06726f49f8d443a27d5927b7d23820e15836da9ddbaa4461b17e73457d8d2",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -25913,12 +25913,20 @@
         ]
       }
     ],
-    "us-ne/statute/77/77-2715.03": [
+    "us-ne/form/individual-income-tax/2026/1040n-es/document-1": [
       {
         "module": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"
+        ]
+      }
+    ],
+    "us-ne/statute/77/77-2715.03": [
+      {
+        "module": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module"
         ]
       },
       {
@@ -25939,13 +25947,6 @@
       }
     ],
     "us-ne/statute/77/77-2716.01": [
-      {
-        "module": "us-ne/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-ne/statutes/77/77-2716/01.yaml",
         "via": [

--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -7471,11 +7471,6 @@
       "module_sha256": "sha256:30643a0f952d24a7a0b7340aadae4ca6ebb51c30ed4fc3d49cdc0d0f15d3b8db",
       "passed": false
     },
-    "us-ne/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:07a5a0149d47fe0c72514b45580287049667b182aa5b088ea0799f9a697288e5",
-      "module_sha256": "sha256:c49448ecd8f11a5f971ea0c72f69426d41de2250424040cafb8bbc0650c53caa",
-      "passed": false
-    },
     "us-ne/statutes/77/77-2715/03.yaml": {
       "fingerprint": "sha256:4c81bb416931fd10d134bb62a50fc8e28e8e56e5f02fa9c3f6e1d618fb0671bd",
       "module_sha256": "sha256:b07174e2752b5a348436c7177dd38c1cf91819413a259ff711fe70ca986440d8",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -14228,12 +14228,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ne/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:07a5a0149d47fe0c72514b45580287049667b182aa5b088ea0799f9a697288e5"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ne/statutes/77/77-2715/03.yaml":
     pending:
       fingerprint: "sha256:4c81bb416931fd10d134bb62a50fc8e28e8e56e5f02fa9c3f6e1d618fb0671bd"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1703
+ceiling: 1728
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1373,12 +1373,87 @@ entries:
 - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax
   source: bulk
   since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_first_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_fourth_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_base_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_base_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_base_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_floor_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_floor_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_floor_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability
   source: bulk
   since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_base_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_base_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_base_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_floor_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_floor_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_floor_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_second_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_base_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_base_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_base_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_floor_2
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_floor_3
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_floor_4
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income
   source: bulk
   since: '2026-07-08'
+- legal_id: us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_third_rate
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-ne:statutes/77/77-2715/03#bracket_adjustment_rounding_increment
   source: bulk
   since: '2026-07-08'

--- a/us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ne/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,160 +1,417 @@
-# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention: the
-# expected values are the author's own shown arithmetic from the supplied
-# schedule, not an oracle read-back). Nebraska liability = Neb. Rev. Stat.
-# 77-2715.03 marginal bracket tax on Nebraska taxable income = supplied Nebraska
-# AGI less the supplied section 77-2716.01 standard deduction. For taxable years
-# beginning in 2026 the four rates are 2.46%, 3.51%, 4.55%, and 4.55% (the top
-# two rates share 4.55% under the L.B. 754 compression) at the inflation-indexed
-# floors PolicyEngine applies for 2026: single 0 / 4,030 / 24,120 / 38,870 and
-# married-filing-jointly 0 / 8,040 / 48,250 / 77,730. The supplied 2026 standard
-# deduction is the section 77-2716.01 amount PolicyEngine applies ($8,750 single
-# / $17,550 married filing jointly). Nebraska's personal exemption is a post-tax
-# credit that this before-credits core excludes, so each liability equals
-# PolicyEngine's ne_income_tax_before_credits exactly.
-- name: single_15k_low
-  # taxable 15000-8750 = 6250. Tax 0.0246*4030 + 0.0351*(6250-4030) = 99.138 + 77.922 = 177.06.
+# Canonical TY2026 boundaries from Nebraska DOR Form 1040N-ES, page 6.
+# Expected values are independent Decimal arithmetic from the printed
+# cumulative-base-plus-marginal formulas. At each threshold the lower row
+# applies because the form says “but not over”; one cent above uses the next
+# row's printed cent-denominated base. The resulting sub-cent discontinuities
+# are therefore source-preserving and intentional.
+#
+# False for both status inputs represents either single or married filing
+# separately, which share a schedule. The joint Boolean represents married
+# filing jointly or surviving spouse. PolicyEngine is not used for expected
+# values because its 2026 Nebraska parameters are stale.
+- name: negative_taxable_income_is_floored
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 15000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: -100
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '6250'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '177.06'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '177.06'
-- name: single_30k
-  # taxable 30000-8750 = 21250. Tax 99.138 + 0.0351*(21250-4030) = 99.138 + 604.422 = 703.56.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '0'
+- name: zero_taxable_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 30000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 0
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '21250'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '703.56'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '703.56'
-- name: single_60k
-  # taxable 51250. Tax 99.138 + 705.159 + 671.125 + 0.0455*(51250-38870) = 99.138 + 705.159 + 671.125 + 563.29 = 2038.712.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '0'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '0'
+- name: single_floor_2_one_cent_below
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 60000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 4129.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '51250'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '2038.712'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '2038.712'
-- name: single_150k
-  # taxable 141250. Tax 99.138 + 705.159 + 671.125 + 0.0455*(141250-38870) = 99.138 + 705.159 + 671.125 + 4658.29 = 6133.712.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '4129.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '101.597754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '101.597754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '101.597754'
+- name: single_floor_2_exact
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 150000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 8750
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 4030
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 24120
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 38870
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 4130
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '141250'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '6133.712'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '6133.712'
-- name: married_60k
-  # taxable 60000-17550 = 42450. Tax 197.784 + 0.0351*(42450-8040) = 197.784 + 1207.791 = 1405.575.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '4130'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '101.598'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '101.598'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '101.598'
+- name: single_floor_2_one_cent_above
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 60000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 4130.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '42450'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1405.575'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1405.575'
-- name: married_120k
-  # taxable 102450. Tax 197.784 + 1411.371 + 1341.34 + 0.0455*(102450-77730) = 197.784 + 1411.371 + 1341.34 + 1124.76 = 4075.255.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '4130.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '101.600351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '101.600351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '101.600351'
+- name: married_separate_floor_3_one_cent_below
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 120000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 24759.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '102450'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '4075.255'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '4075.255'
-- name: married_300k
-  # taxable 282450. Tax 197.784 + 1411.371 + 1341.34 + 0.0455*(282450-77730) = 197.784 + 1411.371 + 1341.34 + 9314.76 = 12265.255.
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '24759.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '825.712649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '825.712649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '825.712649'
+- name: married_separate_floor_3_exact
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_adjusted_gross_income: 300000
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_deductions: 17550
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_1: 0
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_2: 8040
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_3: 48250
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_floor_4: 77730
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_1: 0.0246
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_2: 0.0351
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_3: 0.0455
-    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_bracket_rate_4: 0.0455
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 24760
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
   output:
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '282450'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '12265.255'
-    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '12265.255'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '24760'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '825.713'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '825.713'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '825.713'
+- name: married_separate_floor_3_one_cent_above_uses_printed_base
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 24760.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '24760.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '825.710455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '825.710455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '825.710455'
+- name: single_floor_4_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39899.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39899.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '1514.579545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1514.579545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1514.579545'
+- name: single_floor_4_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39900
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39900'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '1514.58'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1514.58'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1514.58'
+- name: single_floor_4_one_cent_above
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39900.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39900.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_single_separate_schedule_tax: '1514.580455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1514.580455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1514.580455'
+- name: head_of_household_floor_2_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 7699.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '7699.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '189.419754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '189.419754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '189.419754'
+- name: head_of_household_floor_2_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 7700
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '7700'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '189.42'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '189.42'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '189.42'
+- name: head_of_household_floor_2_one_cent_above
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 7700.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '7700.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '189.420351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '189.420351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '189.420351'
+- name: head_of_household_floor_3_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39619.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39619.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '1309.811649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1309.811649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1309.811649'
+- name: head_of_household_floor_3_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39620
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39620'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '1309.812'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1309.812'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1309.812'
+- name: head_of_household_floor_3_one_cent_above_uses_printed_base
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 39620.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '39620.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '1309.810455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1309.810455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1309.810455'
+- name: head_of_household_floor_4_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 59159.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '59159.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '2198.879545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '2198.879545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '2198.879545'
+- name: head_of_household_floor_4_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 59160
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '59160'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '2198.88'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '2198.88'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '2198.88'
+- name: head_of_household_floor_4_one_cent_above
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 59160.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '59160.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_head_schedule_tax: '2198.880455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '2198.880455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '2198.880455'
+- name: married_joint_floor_2_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 8249.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '8249.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '202.949754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '202.949754'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '202.949754'
+- name: married_joint_floor_2_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 8250
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '8250'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '202.95'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '202.95'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '202.95'
+- name: married_joint_floor_2_one_cent_above
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 8250.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '8250.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '202.950351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '202.950351'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '202.950351'
+- name: surviving_spouse_floor_3_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 49529.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '49529.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '1651.877649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1651.877649'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1651.877649'
+- name: surviving_spouse_floor_3_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 49530
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '49530'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '1651.878'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1651.878'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1651.878'
+- name: surviving_spouse_floor_3_one_cent_above_uses_printed_base
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 49530.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '49530.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '1651.880455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '1651.880455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '1651.880455'
+- name: married_joint_floor_4_one_cent_below
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 79799.99
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '79799.99'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '3029.164545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '3029.164545'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '3029.164545'
+- name: married_joint_floor_4_exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 79800
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '79800'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '3029.165'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '3029.165'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '3029.165'
+- name: married_joint_floor_4_one_cent_above_uses_printed_base
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_supplied_taxable_income: 79800.01
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-ne:policies/income_tax/pilot_liability_pipeline#input.ne_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_taxable_income: '79800.01'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_joint_surviving_schedule_tax: '3029.160455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_bracket_tax: '3029.160455'
+    us-ne:policies/income_tax/pilot_liability_pipeline#ne_pit_pilot_income_tax_liability: '3029.160455'

--- a/us-ne/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ne/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,120 +4,627 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
+      - us-ne/form/individual-income-tax/2026/1040n-es/document-1
       - us-ne/statute/77/77-2715.03
-      - us-ne/statute/77/77-2716.01
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
+        - us-ne/form/individual-income-tax/2026/1040n-es/document-1
         - us-ne/statute/77/77-2715.03
-        - us-ne/statute/77/77-2716.01
       rationale: |-
-        This pipeline computes the Neb. Rev. Stat. section 77-2715.03 progressive
-        bracket tax on Nebraska taxable income for the ordinary resident
-        wage-earner slice at the 2026 tax year. Section 77-2715.03 imposes a
-        four-rate schedule; for taxable years beginning in 2026 the first two
-        statutory rates are 2.46 per cent and 3.51 per cent and the third and
-        fourth rates are both 4.55 per cent (the L.B. 754 rate compression phases
-        the top two rates down to a common 4.55 per cent in 2026 and to 3.99 per
-        cent thereafter), applied across dollar brackets that section 77-2715.03
-        indexes for inflation each year. These bracket floors and rates are
-        carried by the encoded us-ne/statute/77/77-2715.03 module. This pipeline
-        supplies the four operative 2026 single or married-filing-jointly bracket
-        floors and rates as declared caller-supplied current-authority inputs so
-        the marginal application runs end to end without importing the encoded
-        bracket rules. Nebraska taxable income is Nebraska adjusted gross income
-        (federal adjusted gross income adjusted by the section 77-2716 additions
-        and subtractions, none of which apply to the wage slice) less the section
-        77-2716.01 standard deduction; the operative 2026 standard deduction
-        ($8,750 single / $17,550 married filing jointly) is supplied as a declared
-        input rather than derived, because that amount sits in the filing-status
-        and inflation mechanics the flat slice does not carry. The Nebraska
-        personal exemption is a post-tax credit under section 77-2716.01 (the
-        section 77-2715.03 tax is imposed before it), so it is excluded from this
-        before-credits core. The pipeline adds no numeric literals of its own; it
-        wires the progressive-tax mechanics only.
+        Neb. Rev. Stat. section 77-2715.03 is the higher authority imposing the
+        individual-income-tax rates and annual bracket indexing. Nebraska
+        Department of Revenue Form 1040N-ES, revision 11-2025, is the current
+        official parameter source for the complete schedule used on line 11 of
+        the 2026 estimated-income-tax worksheet. The form gives the operative
+        indexed thresholds, cumulative base amounts, and marginal rates for
+        single and married-filing-separately taxpayers, heads of household,
+        and married-joint and surviving-spouse taxpayers. This module accepts
+        the worksheet's completed line-10 Nebraska taxable-income amount and
+        only applies that source-owned schedule.
+
+        The form expressly says to use the schedule only for computing 2026
+        estimated income tax and not to use it for any tax returns. Accordingly,
+        this module is bounded to tax year 2026 and does not certify a final-
+        return calculation or PolicyEngine parity. The form's standard-
+        deduction amounts are upstream of the supplied line-10 boundary, and
+        its $176 personal-exemption amount is a line-14 credit after the line-11
+        schedule calculation; neither is independently composed here.
   summary: |-
-    Composed Nebraska individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Nebraska adjusted gross income into the section 77-2715.03 progressive
-    bracket tax, so an end-to-end comparison against PolicyEngine
-    (ne_income_tax_before_credits) and TAXSIM (siitax) does not require the
-    caller to supply the section 77-2715.03 bracket-application stage boundaries.
-    It wires: Nebraska taxable income (adjusted gross income less the supplied
-    section 77-2716.01 standard deduction); the progressive tax as the marginal
-    sum across the four supplied brackets (2.46, 3.51, 4.55, and 4.55 per cent at
-    the supplied 2026 floors); and the liability as that bracket tax. Because the
-    2026 third and fourth statutory rates are both 4.55 per cent, the top two
-    brackets form a single effective 4.55 per cent band, but the pipeline retains
-    the four-bracket shape of the statutory schedule. It deliberately excludes the
-    section 77-2716.01 personal exemption credit (a post-tax nonrefundable credit
-    that PolicyEngine nets into ne_income_tax_before_refundable_credits, which
-    this before-credits core excludes), the section 77-2715.07 credits, the
-    section 77-2715.07 refundable credits (Nebraska EITC, child, stillborn), and
-    itemized deductions. Nebraska adjusted gross income, filing status, the
-    standard deduction, and the bracket floors and rates are supplied inputs; the
-    2026 floors are the section 77-2715.03 inflation-indexed amounts, so this 2026
-    pipeline is compared against PolicyEngine at 2026 and against TAXSIM's latest
-    2024 law year with the bracket and standard-deduction indexation vintage
-    dispositioned.
+    Nebraska 2026 estimated-income-tax schedule from official Form 1040N-ES.
+    The caller supplies completed Nebraska taxable income from worksheet line 10
+    plus mutually exclusive filing-status projections. Joint or surviving-
+    spouse status selects the joint schedule; head-of-household status selects
+    that schedule; false for both selects the common single or married-filing-
+    separately schedule. The module floors supplied taxable income at zero and
+    applies the form's printed cumulative-base-plus-marginal formulas exactly,
+    including its cent-denominated base amounts.
+
+    `ne_pit_pilot_income_tax_liability` is retained as the campaign's historical
+    output name, but it means only the estimated worksheet's line-11 schedule
+    amount. It is not final-return liability. Deductions, personal exemptions,
+    other taxes, credits, withholding, installment calculations, residency and
+    allocation rules, and every final-return step remain outside this module.
+    PolicyEngine-US 1.752.2 carries stale 2025 Nebraska thresholds and is not a
+    source or parity target for these values.
 rules:
+  - name: ne_pit_pilot_first_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 2026 Form 1040N-ES, first marginal rate for every filing-status schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "2.46% of the income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0246'
+
+  - name: ne_pit_pilot_second_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 2026 Form 1040N-ES, second marginal rate for every filing-status schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "+ 3.51% of the excess"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0351'
+
+  - name: ne_pit_pilot_third_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 2026 Form 1040N-ES, third marginal rate for every filing-status schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "+ 4.55% of the excess"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0455'
+
+  - name: ne_pit_pilot_fourth_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 2026 Form 1040N-ES, fourth marginal rate for every filing-status schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "third and fourth brackets are at the same rate of 4.55%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0455'
+
+  - name: ne_pit_pilot_single_separate_floor_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate second-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 0 $ 4,130 2.46% of the income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '4130'
+
+  - name: ne_pit_pilot_single_separate_floor_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate third-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "4,130 24,760 $ 101.60 + 3.51%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '24760'
+
+  - name: ne_pit_pilot_single_separate_floor_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate fourth-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "24,760 39,900 825.71 + 4.55%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '39900'
+
+  - name: ne_pit_pilot_single_separate_base_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate second-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 101.60 + 3.51% of the excess over $ 4,130"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '101.60'
+
+  - name: ne_pit_pilot_single_separate_base_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate third-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "825.71 + 4.55% of the excess over $24,760"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '825.71'
+
+  - name: ne_pit_pilot_single_separate_base_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-separate fourth-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "1,514.58 +4.55% of the excess over $39,900"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1514.58'
+
+  - name: ne_pit_pilot_head_floor_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household second-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 0 $ 7,700 2.46% of the income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '7700'
+
+  - name: ne_pit_pilot_head_floor_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household third-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "7,700 39,620 $ 189.42 + 3.51%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '39620'
+
+  - name: ne_pit_pilot_head_floor_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household fourth-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "39,620 59,160 1,309.81 + 4.55%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '59160'
+
+  - name: ne_pit_pilot_head_base_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household second-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 189.42 + 3.51% of the excess over $ 7,700"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '189.42'
+
+  - name: ne_pit_pilot_head_base_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household third-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "1,309.81 + 4.55% of the excess over $39,620"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1309.81'
+
+  - name: ne_pit_pilot_head_base_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household fourth-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "2,198.88 + 4.55% of the excess over $59,160"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2198.88'
+
+  - name: ne_pit_pilot_joint_surviving_floor_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse second-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 0 $ 8,250 2.46% of the income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '8250'
+
+  - name: ne_pit_pilot_joint_surviving_floor_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse third-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "49,530 79,800 1,651.88 + 4.55%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '49530'
+
+  - name: ne_pit_pilot_joint_surviving_floor_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse fourth-bracket floor
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "49,530 79,800 1,651.88 + 4.55%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '79800'
+
+  - name: ne_pit_pilot_joint_surviving_base_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse second-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "$ 202.95 + 3.51% of the excess over $ 8,250"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '202.95'
+
+  - name: ne_pit_pilot_joint_surviving_base_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse third-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "1,651.88 + 4.55% of the excess over $49,530"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1651.88'
+
+  - name: ne_pit_pilot_joint_surviving_base_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, joint and surviving-spouse fourth-bracket base tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "3,029.16 + 4.55% of the excess over $79,800"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '3029.16'
+
   - name: ne_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Neb. Rev. Stat. 77-2716.01, Nebraska taxable income after the supplied standard deduction
+    source: 2026 Form 1040N-ES worksheet line 10, supplied completed Nebraska taxable income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ne/statute/77/77-2716.01
-              excerpt: "the Nebraska standard deduction"
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "Estimated Nebraska taxable income (line 7 plus line 8, minus line 9)"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, ne_pit_pilot_supplied_taxable_income)
+
+  - name: ne_pit_pilot_single_separate_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, single and married-filing-separately estimated-tax schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "Single Taxpayer Head of Household Married, Filing Separately"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, ne_pit_pilot_adjusted_gross_income - ne_pit_pilot_supplied_deductions)
+          if ne_pit_pilot_taxable_income <= ne_pit_pilot_single_separate_floor_2:
+            ne_pit_pilot_first_rate * ne_pit_pilot_taxable_income
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_single_separate_floor_3:
+            ne_pit_pilot_single_separate_base_2 + ne_pit_pilot_second_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_single_separate_floor_2)
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_single_separate_floor_4:
+            ne_pit_pilot_single_separate_base_3 + ne_pit_pilot_third_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_single_separate_floor_3)
+          else:
+            ne_pit_pilot_single_separate_base_4 + ne_pit_pilot_fourth_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_single_separate_floor_4)
+
+  - name: ne_pit_pilot_head_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, head-of-household estimated-tax schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "Head of Household"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ne_pit_pilot_taxable_income <= ne_pit_pilot_head_floor_2:
+            ne_pit_pilot_first_rate * ne_pit_pilot_taxable_income
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_head_floor_3:
+            ne_pit_pilot_head_base_2 + ne_pit_pilot_second_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_head_floor_2)
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_head_floor_4:
+            ne_pit_pilot_head_base_3 + ne_pit_pilot_third_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_head_floor_3)
+          else:
+            ne_pit_pilot_head_base_4 + ne_pit_pilot_fourth_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_head_floor_4)
+
+  - name: ne_pit_pilot_joint_surviving_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1040N-ES, married-joint and surviving-spouse estimated-tax schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "Married, Filing Jointly and Surviving Spouses"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ne_pit_pilot_taxable_income <= ne_pit_pilot_joint_surviving_floor_2:
+            ne_pit_pilot_first_rate * ne_pit_pilot_taxable_income
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_joint_surviving_floor_3:
+            ne_pit_pilot_joint_surviving_base_2 + ne_pit_pilot_second_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_joint_surviving_floor_2)
+          else: if ne_pit_pilot_taxable_income <= ne_pit_pilot_joint_surviving_floor_4:
+            ne_pit_pilot_joint_surviving_base_3 + ne_pit_pilot_third_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_joint_surviving_floor_3)
+          else:
+            ne_pit_pilot_joint_surviving_base_4 + ne_pit_pilot_fourth_rate * (ne_pit_pilot_taxable_income - ne_pit_pilot_joint_surviving_floor_4)
+
   - name: ne_pit_pilot_bracket_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Neb. Rev. Stat. 77-2715.03, progressive tax as the marginal sum across the supplied bracket floors and rates
+    source: 2026 Form 1040N-ES, filing-status-selected estimated-income-tax schedule
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ne/statute/77/77-2715.03
-              excerpt: "There is hereby imposed a tax on the Nebraska taxable income of every resident individual"
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "2026 Nebraska Estimated Income Tax Rate Schedule"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_2) - ne_pit_pilot_supplied_bracket_floor_1) * ne_pit_pilot_supplied_bracket_rate_1
-          + max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_3) - ne_pit_pilot_supplied_bracket_floor_2) * ne_pit_pilot_supplied_bracket_rate_2
-          + max(0, min(ne_pit_pilot_taxable_income, ne_pit_pilot_supplied_bracket_floor_4) - ne_pit_pilot_supplied_bracket_floor_3) * ne_pit_pilot_supplied_bracket_rate_3
-          + max(0, ne_pit_pilot_taxable_income - ne_pit_pilot_supplied_bracket_floor_4) * ne_pit_pilot_supplied_bracket_rate_4
+          if ne_pit_pilot_filing_status_joint_or_surviving_spouse:
+            ne_pit_pilot_joint_surviving_schedule_tax
+          else: if ne_pit_pilot_filing_status_head_of_household:
+            ne_pit_pilot_head_schedule_tax
+          else:
+            ne_pit_pilot_single_separate_schedule_tax
+
   - name: ne_pit_pilot_income_tax_liability
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Neb. Rev. Stat. 77-2715.03 bracket tax, before the section 77-2716.01 personal exemption credit and the section 77-2715.07 credits, for the wage-earner slice
+    source: 2026 Form 1040N-ES worksheet line 11 estimated schedule amount, not final-return liability
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ne/statute/77/77-2715.03
-              excerpt: "There is hereby imposed a tax on the Nebraska taxable income"
+              corpus_citation_path: us-ne/form/individual-income-tax/2026/1040n-es/document-1
+              excerpt: "Enter the tax calculated from this schedule on line 11"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          ne_pit_pilot_bracket_tax
+        effective_to: '2026-12-31'
+        formula: ne_pit_pilot_bracket_tax
+inputs:
+  - name: ne_pit_pilot_supplied_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed 2026 Nebraska estimated-tax worksheet line-10 taxable income supplied by the caller; this is not asserted to be a final-return amount.
+  - name: ne_pit_pilot_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True for married filing jointly or surviving-spouse status; mutually exclusive with head-of-household.
+  - name: ne_pit_pilot_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: True for head-of-household status; mutually exclusive with joint or surviving-spouse. False for both status inputs selects the common single or married-filing-separately schedule.


### PR DESCRIPTION
## Summary

- replace caller-supplied stale Nebraska brackets with the official TY2026 Form 1040N-ES thresholds, rates, and printed cumulative bases
- accept completed estimated-tax worksheet line-10 Nebraska taxable income and route all individual filing statuses across the three official schedules
- add 29 hand-computed fixtures covering one cent below, exactly at, and one cent above every schedule transition
- consume the axiom-corpus 47cdff0d33ffe943cbb4c19f37af9e02d0f2f2b6 pin now inherited from main after Oregon PR #992; this PR no longer changes the global toolchain pin
- update the reverse index for the new Nebraska form citation and remove only the now-fixed Nebraska validation-waiver entries

## Scope limitation

Form 1040N-ES expressly says this schedule is only for computing 2026 estimated income tax and must not be used for tax returns. This PR therefore does not certify final-return liability or PolicyEngine parity. PolicyEngine-US 1.752.2 carries stale 2025 Nebraska thresholds.

The standard deduction remains upstream of the supplied line-10 taxable-income boundary. The 176-dollar personal-exemption amount is a line-14 credit after the line-11 schedule calculation. Neither is independently composed here.

## Focused validation after rebase

- compile: 28 rules passed with axiom-rules-engine ffd8213271947b0189a9dd61a055c1e0e78908a0
- companion tests: 29 of 29 passed
- proof validation: 28 atoms passed; 0 of 18 monetary obligations missing
- validate with merged local corpus source and reviewers skipped: passed with no errors
- reverse-index regeneration: idempotent after expected Nebraska mapping update
- pending ledgers: counts changed only by one Nebraska waiver removal in each validation ledger; relative order and uniqueness preserved; oracle pending remains sorted and unique
- signed guard-generated against rebased origin/main: passed with no issues
- git diff --check: passed

## Review cycle

The first review found the missing reverse-index update and the temporary overlapping corpus-pin diff. Both are resolved: the reverse index is regenerated and the Oregon merge moved the same corpus pin into main before this rebase. This rewritten exact head now requires a second independent review. Keep the PR in draft and do not merge until that review is clean and all CI checks are green.