### PR TITLE
Encode Missouri 2026 individual tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-mo/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-mo/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-mo/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "18f09952a33e07081888a0c1243d6f032c4f81ece47ecfe1c3f18566098cc740"
+      "sha256": "aa2b62812c243a8b218515586630e298962f2ae5a8097d6ab42a12135115b294"
     },
     {
       "path": "us-mo/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "d84f3cd1d9d013bc4e404a9a2b7d98c99e2d49b52635f6c142d33a0712b1d051"
+      "sha256": "926c3bb534f25b175c5e33873dab674d01eba6709b401febad9ceeb74418694b"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-mo:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.874657+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-mo/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "d84f3cd1d9d013bc4e404a9a2b7d98c99e2d49b52635f6c142d33a0712b1d051",
+  "generated_at": "2026-07-22T15:27:14.775660+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjncdiufh/sign-applied-files/us-mo/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjncdiufh",
+  "generated_output_sha256": "926c3bb534f25b175c5e33873dab674d01eba6709b401febad9ceeb74418694b",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,29 +34,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "493cb93eab74c2933a57e5209a0d3e89fe2573462152a8e7e85be69981eb32bb"
+    "value": "fe706c5b09a81e6d167a7ead6b29ed02e0456e53ded840c8454d2d45ee7be7ce"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.903703+00:00",
+    "generated_at": "2026-07-21T15:45:46.874657+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "f32b985657278d47ca1de0f8b00d8926791661a50544bd5422e6b896ef650bf3",
-    "prior_signature": "ccc893de71b98c4fc39fc6fe8edab03817c005ef030073da39a73e3d26909f37",
+    "manifest_sha256": "7fae658695486c2426aecf5134c3ceb9aa30427a841f12a227934f20987ffd86",
+    "prior_signature": "493cb93eab74c2933a57e5209a0d3e89fe2573462152a8e7e85be69981eb32bb",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.200826+00:00",
+      "generated_at": "2026-07-21T15:44:47.903703+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "3efd9027808db86e988935b8f7e79704eac0c8cde7c77d98fbc21e6ddc28f5c2",
-      "prior_signature": "e2e3d4da887d339ce93f4063a7ab7fd28b333fe19681961b019de7e88e147a81",
+      "manifest_sha256": "f32b985657278d47ca1de0f8b00d8926791661a50544bd5422e6b896ef650bf3",
+      "prior_signature": "ccc893de71b98c4fc39fc6fe8edab03817c005ef030073da39a73e3d26909f37",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:01.698150+00:00",
+        "generated_at": "2026-07-16T15:48:15.200826+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "f0ef3a18b922571273e6de3fe5d24342a1a2f94d27bea0098aa1cb3de0419291",
-        "prior_signature": "927bafe5273b9466ff8af80aa53f615e45c3f881e369049442dbbc91373019b0",
+        "manifest_sha256": "3efd9027808db86e988935b8f7e79704eac0c8cde7c77d98fbc21e6ddc28f5c2",
+        "prior_signature": "e2e3d4da887d339ce93f4063a7ab7fd28b333fe19681961b019de7e88e147a81",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-16T15:22:01.698150+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "f0ef3a18b922571273e6de3fe5d24342a1a2f94d27bea0098aa1cb3de0419291",
+          "prior_signature": "927bafe5273b9466ff8af80aa53f615e45c3f881e369049442dbbc91373019b0",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1699
+ceiling: 1703
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
   source: manual
@@ -1184,12 +1184,24 @@ entries:
 - legal_id: us-mo:policies/dss/snap/1105-000-00/1105-015-00/block-1#persons_grouped_together_as_one_snap_household
   source: bulk
   since: '2026-07-13'
-- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket
   source: manual
-  since: '2026-07-16'
-- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax
+  since: '2026-07-22'
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket_base
   source: manual
-  since: '2026-07-16'
+  since: '2026-07-22'
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket_floor
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket_upper
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income
   source: manual
   since: '2026-07-16'

--- a/us-mo/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-mo/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,79 +1,158 @@
-# Expected values are independently hand-computed from the Department of
-# Revenue's official 2026 schedule overlaid on Mo. Rev. Stat. section 143.011.
-# Supplied taxable-income inputs are PolicyEngine's completed-return
-# mo_taxable_income values for the standard 2026 wage grid. All cases occupy
-# the published top bracket: $263 plus 4.7% of excess over $9,436. The fixtures
-# intentionally retain PolicyEngine-US 1.752.2's roughly $0.563 modeled-uprating
-# residual as a separately dispositioned oracle gap.
-- name: single_30000
-  # 263 + 4.7% * (13,545 - 9,436) = 456.123.
+# Expected values use independent decimal arithmetic from the Department of
+# Revenue's official 2026 schedule composed into Mo. Rev. Stat. section
+# 143.011. Each transition is tested at the published upper bound and one
+# dollar into the next bracket. Published cumulative bases are preserved even
+# where they do not equal the exact unrounded tax at the preceding boundary.
+
+- name: negative_individual_taxable_income_normalizes_to_zero
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 13545
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: -1
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '13545'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '456.123'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '456.123'
-- name: single_60000
-  # 263 + 4.7% * (43,147 - 9,436) = 1,847.417.
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '0'
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 0
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '0'
+
+- name: zero_tax_band_upper_1348
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 43147
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 1348
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '43147'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '1847.417'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '1847.417'
-- name: single_150000
-  # 263 + 4.7% * (133,900 - 9,436) = 6,112.808.
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 0
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '0'
+
+- name: two_percent_band_lower_1349
+  # 2% * (1,349 - 1,348) = 0.02.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 133900
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 1349
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '133900'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '6112.808'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '6112.808'
-- name: married_60000
-  # 263 + 4.7% * (27,374 - 9,436) = 1,106.086.
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 1
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '0.02'
+
+- name: two_percent_band_upper_2696
+  # 2% * (2,696 - 1,348) = 26.96.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 27374
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 2696
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '27374'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '1106.086'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '1106.086'
-- name: married_120000
-  # 263 + 4.7% * (87,298 - 9,436) = 3,922.514.
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 1
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '26.96'
+
+- name: two_and_half_percent_band_lower_2697
+  # Published base 27 + 2.5% * 1 = 27.025.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 87298
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 2697
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '87298'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '3922.514'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '3922.514'
-- name: married_300000
-  # 263 + 4.7% * (267,800 - 9,436) = 12,406.108.
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 2
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '27.025'
+
+- name: two_and_half_percent_band_upper_4044
+  # 27 + 2.5% * 1,348 = 60.70.
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_taxable_income: 267800
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_base: 263
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_bracket_floor: 9436
-    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_supplied_marginal_rate: 0.047
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 4044
   output:
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_taxable_income: '267800'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_schedule_tax: '12406.108'
-    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_liability: '12406.108'
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 2
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '60.7'
+
+- name: three_percent_band_lower_4045
+  # Published base 61 + 3% * 1 = 61.03.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 4045
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 3
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '61.03'
+
+- name: three_percent_band_upper_5392
+  # 61 + 3% * 1,348 = 101.44.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 5392
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 3
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '101.44'
+
+- name: three_and_half_percent_band_lower_5393
+  # Published base 101 + 3.5% * 1 = 101.035.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 5393
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 4
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '101.035'
+
+- name: three_and_half_percent_band_upper_6740
+  # 101 + 3.5% * 1,348 = 148.18.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 6740
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 4
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '148.18'
+
+- name: four_percent_band_lower_6741
+  # Published base 148 + 4% * 1 = 148.04.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 6741
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 5
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '148.04'
+
+- name: four_percent_band_upper_8088
+  # 148 + 4% * 1,348 = 201.92.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 8088
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 5
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '201.92'
+
+- name: four_and_half_percent_band_lower_8089
+  # Published base 202 + 4.5% * 1 = 202.045.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 8089
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 6
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '202.045'
+
+- name: four_and_half_percent_band_upper_9436
+  # 202 + 4.5% * 1,348 = 262.66.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 9436
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 6
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '262.66'
+
+- name: four_and_seven_tenths_percent_band_lower_9437
+  # Published base 263 + 4.7% * 1 = 263.047.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 9437
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_bracket: 7
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '263.047'
+
+# Companion Person-grain cases model the two individual completed-return
+# inputs from a dual-earner situation independently. This schedule module does
+# not allocate between spouses or aggregate either amount to a TaxUnit.
+- name: dual_person_y_companion_9100
+  # 202 + 4.5% * (9,100 - 8,088) = 247.54.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 9100
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '247.54'
+
+- name: dual_person_s_companion_3900
+  # 27 + 2.5% * (3,900 - 2,696) = 57.10.
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mo:policies/income_tax/pilot_liability_pipeline#input.mo_pit_pilot_individual_taxable_income: 3900
+  output:
+    us-mo:policies/income_tax/pilot_liability_pipeline#mo_pit_pilot_income_tax_before_credits_indiv: '57.1'

--- a/us-mo/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-mo/policies/income_tax/pilot_liability_pipeline.yaml
@@ -7,44 +7,175 @@ module:
       - us-mo/statute/143.011
       - us-mo/statute/143.021
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
         - us-mo/statute/143.011
         - us-mo/statute/143.021
       rationale: |-
-        Mo. Rev. Stat. section 143.011 imposes tax on every resident's Missouri
-        taxable income, and section 143.021 requires residents with taxable
-        income to determine tax from the section 143.011 rates. The official
-        corpus record overlays the Department of Revenue's operative 2026
-        schedule: zero through $1,348, intermediate rates from 2.0 through 4.5
-        percent, and $263 plus 4.7 percent of excess over $9,436 in the top
-        bracket. This narrow composition accepts completed-return Missouri
-        taxable income and the active bracket's cumulative base tax, floor, and
-        marginal rate as caller-supplied current-authority inputs. Deductions,
-        exemptions, special income classes, and credits remain outside this
-        rate-section module.
+        Mo. Rev. Stat. section 143.011 imposes tax on each resident's Missouri
+        taxable income, while section 143.021 directs each resident with
+        taxable income to determine tax from the section 143.011 rates. The
+        official corpus record composes those provisions with the Department
+        of Revenue's operative 2026 Form MO-1040ES rate chart and supplies all
+        eight brackets, including their published cumulative base amounts.
+
+        This narrow module accepts completed-return individual Missouri
+        taxable income as its only caller boundary and applies the complete
+        unrounded 2026 schedule at Person grain. It does not construct adjusted
+        gross income or taxable income; allocate income between spouses;
+        aggregate Persons to a TaxUnit; apply return rounding, residency or
+        nonresident sourcing, credits, withholding, recapture, or lump-sum
+        tax; or compute final liability. Every executable version fails closed
+        outside tax year 2026.
   summary: |-
-    Composed Missouri individual-income-tax schedule for the 2026 ordinary
-    full-year resident wage-earner slice. It normalizes supplied completed-
-    return Missouri taxable income and applies the supplied active sections
-    143.011 and 143.021 bracket in cumulative-base-plus-marginal form before
-    credits. Its closest PolicyEngine 4.18.9 / PolicyEngine-US 1.752.2 analog is
-    `mo_income_tax_before_credits` on the six-case childless age-40 grid:
-    single at $30,000/$60,000/$150,000 of wages and one-earner joint at
-    $60,000/$120,000/$300,000. PolicyEngine supplies completed taxable income;
-    expected outputs are independently hand-computed from the official 2026
-    overlay. All six differ from PolicyEngine by about $0.563 because its
-    modeled uprating produces nonofficial 2026 thresholds, including a
-    $9,399.29 projected top floor instead of the published $9,436 floor.
+    Missouri 2026 individual income-tax schedule component before credits.
+    From caller-supplied completed-return individual Missouri taxable income,
+    the module selects and applies every bracket in the Department of
+    Revenue's official 2026 chart, preserving the chart's published cumulative
+    base amounts. The unrounded result remains at Person grain for downstream
+    return rounding and filing-unit aggregation. PolicyEngine-US 1.752.2 is
+    not the numeric authority because its projected 2026 thresholds differ
+    from the published schedule; exact oracle parity is not claimed.
 rules:
-  - name: mo_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
+  - name: mo_pit_pilot_bracket_upper
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: Mo. Rev. Stat. sections 143.011 and 143.021, supplied Missouri taxable income
+    indexed_by: mo_pit_pilot_bracket
+    source: Mo. Rev. Stat. section 143.011, official 2026 taxable-income bracket upper bounds
     metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-mo/statute/143.011
+              excerpt: "$0 to $1,348: $0"
+              table:
+                header: "If the Missouri taxable income is: The tax is:"
+                row_key: "Missouri taxable income"
+                column_key: "upper bound"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 1348
+          1: 2696
+          2: 4044
+          3: 5392
+          4: 6740
+          5: 8088
+          6: 9436
+
+  - name: mo_pit_pilot_bracket_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: mo_pit_pilot_bracket
+    source: Mo. Rev. Stat. section 143.011, official 2026 taxable-income bracket floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-mo/statute/143.011
+              excerpt: "Over $9,436: $263 plus 4.7% of excess over $9,436"
+              table:
+                header: "If the Missouri taxable income is: The tax is:"
+                row_key: "Missouri taxable income"
+                column_key: "excess-over floor"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 1348
+          2: 2696
+          3: 4044
+          4: 5392
+          5: 6740
+          6: 8088
+          7: 9436
+
+  - name: mo_pit_pilot_bracket_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: mo_pit_pilot_bracket
+    source: Mo. Rev. Stat. section 143.011, official 2026 cumulative bracket bases
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-mo/statute/143.011
+              excerpt: "Over $8,088 but not over $9,436: $202 plus 4.5% of excess over $8,088"
+              table:
+                header: "If the Missouri taxable income is: The tax is:"
+                row_key: "Missouri taxable income"
+                column_key: "base tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 0
+          2: 27
+          3: 61
+          4: 101
+          5: 148
+          6: 202
+          7: 263
+
+  - name: mo_pit_pilot_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: mo_pit_pilot_bracket
+    source: Mo. Rev. Stat. section 143.011, official 2026 marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-mo/statute/143.011
+              excerpt: "Over $1,348 but not over $2,696: 2.0% of excess over $1,348"
+              table:
+                header: "If the Missouri taxable income is: The tax is:"
+                row_key: "Missouri taxable income"
+                column_key: "marginal rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 0.02
+          2: 0.025
+          3: 0.03
+          4: 0.035
+          5: 0.04
+          6: 0.045
+          7: 0.047
+
+  - name: mo_pit_pilot_taxable_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Mo. Rev. Stat. sections 143.011 and 143.021, supplied completed-return individual Missouri taxable income
+    metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -54,51 +185,44 @@ rules:
               excerpt: "Every resident having a taxable income shall determine his or her tax from the rates provided in section 143.011"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, mo_pit_pilot_supplied_taxable_income)
+        effective_to: '2026-12-31'
+        formula: max(0, mo_pit_pilot_individual_taxable_income)
 
-  - name: mo_pit_pilot_schedule_tax
+  - name: mo_pit_pilot_bracket
     kind: derived
-    entity: TaxUnit
-    dtype: Money
+    entity: Person
+    dtype: Integer
     period: Year
-    unit: USD
-    source: Mo. Rev. Stat. section 143.011, official 2026 resident schedule
+    source: Mo. Rev. Stat. section 143.011, official 2026 bracket selected from individual taxable income
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us-mo/statute/143.011
-              excerpt: "$0 to $1,348: $0"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-mo/statute/143.011
-              excerpt: "Over $1,348 but not over $2,696: 2.0% of excess over $1,348"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-mo/statute/143.011
-              excerpt: "Over $8,088 but not over $9,436: $202 plus 4.5% of excess over $8,088"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-mo/statute/143.011
-              excerpt: "Over $9,436: $263 plus 4.7% of excess over $9,436"
+              excerpt: "The tax shall be determined by applying the tax table or the rate provided in section 143.021"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          mo_pit_pilot_supplied_bracket_base
-          + mo_pit_pilot_supplied_marginal_rate * max(0, mo_pit_pilot_taxable_income - mo_pit_pilot_supplied_bracket_floor)
+          if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[0]: 0
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[1]: 1
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[2]: 2
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[3]: 3
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[4]: 4
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[5]: 5
+          else: if mo_pit_pilot_taxable_income <= mo_pit_pilot_bracket_upper[6]: 6
+          else: 7
 
-  - name: mo_pit_pilot_income_tax_liability
+  - name: mo_pit_pilot_income_tax_before_credits_indiv
     kind: derived
-    entity: TaxUnit
+    entity: Person
     dtype: Money
     period: Year
     unit: USD
-    source: Mo. Rev. Stat. sections 143.011 and 143.021, resident tax before credits
+    source: Mo. Rev. Stat. sections 143.011 and 143.021, official 2026 individual schedule component before credits
     metadata:
       proof:
         atoms:
@@ -107,6 +231,23 @@ rules:
             source:
               corpus_citation_path: us-mo/statute/143.011
               excerpt: "A tax is hereby imposed for every taxable year on the Missouri taxable income of every resident."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mo/statute/143.011
+              excerpt: "Over $9,436: $263 plus 4.7% of excess over $9,436"
     versions:
       - effective_from: '2026-01-01'
-        formula: max(0, mo_pit_pilot_schedule_tax)
+        effective_to: '2026-12-31'
+        formula: |-
+          mo_pit_pilot_bracket_base[mo_pit_pilot_bracket]
+          + mo_pit_pilot_bracket_rate[mo_pit_pilot_bracket]
+          * (mo_pit_pilot_taxable_income - mo_pit_pilot_bracket_floor[mo_pit_pilot_bracket])
+
+inputs:
+  - name: mo_pit_pilot_individual_taxable_income
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed-return individual Missouri taxable income supplied by the caller.


### PR DESCRIPTION
## Summary

- replace caller-supplied active-bracket inputs with the complete official 2026 Missouri eight-bracket schedule
- accept completed-return individual Missouri taxable income at Person grain and expose only unrounded income tax before credits for that individual
- bound every executable version to tax year 2026 and preserve published cumulative base amounts
- add every-threshold fixtures plus two independent Person companion cases for a dual-earner situation
- update oracle-coverage pending classification and refresh the signed manual composition manifest

## Explicit exclusions

This PR does not encode or claim return rounding, spouse allocation, Person-to-TaxUnit aggregation, AGI or deductions, residency or nonresident sourcing, credits, withholding, recapture, lump-sum tax, final liability, or exact PolicyEngine parity.

## Authority

The schedule is grounded in `us-mo/statute/143.011` and `us-mo/statute/143.021`. The corpus record composes the statutes with the Missouri Department of Revenue 2026 Form MO-1040ES rate chart.

## Checks

- pinned Axiom Encode 0.2.1200 / `3869d66d009f52258be35901edbef370e65a399c` compile: pass, 7 rules
- pinned rules engine `ffd8213271947b0189a9dd61a055c1e0e78908a0` companion tests: pass, 17/17
- proof validation with money atoms: pass, 8 atoms and 0/3 missing
- high-level validation with reviewers skipped: pass
- independent Decimal recomputation: pass, 17/17 expected outputs
- focused pending classification: pass, Missouri 7/7; combined ledger 1703/1703
- signed manifest hash check: pass
- secure `guard-generated`: pass
- `git diff --check`: pass

The repository-wide pending CLI is not meaningful in the intentionally sparse worktree because absent jurisdiction files are reported as stale; the focused exact-set and global count checks pass. Citation paths are unchanged, so the reverse index is unchanged.

## Review cycle

Draft only. Independent review-fix cycle is pending and required before readiness.