### PR TITLE
Encode DC 2026 individual income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-dc/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-dc/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-dc/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "bbcab1856d23c41e3aba206aadfd44b5b22a7c639e01f9fa402f82b8a4b7fef0"
+      "sha256": "1a8d5efbabbcf7cb5b5c7f43e0723c57edc669b19c41251c6dfca5d03794d802"
     },
     {
       "path": "us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "f3e21d4f78e933fb2d36ec7ad2f780302f12ecbd5d00a5bf05791828d1046aa5"
+      "sha256": "75cd25895ab43a1d68d7d9b73fc74f4a9f8548d44d16c9dc0d64862f6e7ad6c3"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-dc:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.866932+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "f3e21d4f78e933fb2d36ec7ad2f780302f12ecbd5d00a5bf05791828d1046aa5",
+  "generated_at": "2026-07-22T16:24:43.511362+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpootek8ki/sign-applied-files/us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpootek8ki",
+  "generated_output_sha256": "75cd25895ab43a1d68d7d9b73fc74f4a9f8548d44d16c9dc0d64862f6e7ad6c3",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,71 +34,80 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3b0a266188c9e090e31055caf0a67a836157af41d9dd23fd09910a5f5708ced0"
+    "value": "e75a239b38c8d382f139eb43620d8846f7560773af244970fea641582a759756"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.893581+00:00",
+    "generated_at": "2026-07-21T15:45:46.866932+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "60ced2915bbb863724756fdcc71dc999758d6c82504a4243a473d336bdd1d3ab",
-    "prior_signature": "4038043442125570b19ef526af7bd3c49d1f88af0c025fedad7750f5d082c804",
+    "manifest_sha256": "04377aba96d0cf3594fb1962e9fc48e944fcd6e9d2789f5ca81b25a97dee5d37",
+    "prior_signature": "3b0a266188c9e090e31055caf0a67a836157af41d9dd23fd09910a5f5708ced0",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T15:48:15.195753+00:00",
+      "generated_at": "2026-07-21T15:44:47.893581+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "50f2fa9ffbbdea9cd82735068c53f2055e55d4c59ebe9c458cd2c86f2f192b53",
-      "prior_signature": "6e7796183f1c230857f63567c04c081595d9ab6b9fbb3b1a9763ec0e377de7c2",
+      "manifest_sha256": "60ced2915bbb863724756fdcc71dc999758d6c82504a4243a473d336bdd1d3ab",
+      "prior_signature": "4038043442125570b19ef526af7bd3c49d1f88af0c025fedad7750f5d082c804",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-16T15:22:02.264107+00:00",
+        "generated_at": "2026-07-16T15:48:15.195753+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "527a45886130c23bda9922780527f1a472cefa2c67ed152030cb8d13af8aeb34",
-        "prior_signature": "43a06f6bc896fd1c2802b01bc26fae3c20f62604f21e3d62a2d10611b9f2e2da",
+        "manifest_sha256": "50f2fa9ffbbdea9cd82735068c53f2055e55d4c59ebe9c458cd2c86f2f192b53",
+        "prior_signature": "6e7796183f1c230857f63567c04c081595d9ab6b9fbb3b1a9763ec0e377de7c2",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-16T15:09:31.547290+00:00",
+          "generated_at": "2026-07-16T15:22:02.264107+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "5ea6551de34642ecce3359541cf0274584ca709e6585ff4382816a1addd6144f",
-          "prior_signature": "c555444671e0547cc8c3cc867c2aa867e11f49b4c76d707a743184bba0714101",
+          "manifest_sha256": "527a45886130c23bda9922780527f1a472cefa2c67ed152030cb8d13af8aeb34",
+          "prior_signature": "43a06f6bc896fd1c2802b01bc26fae3c20f62604f21e3d62a2d10611b9f2e2da",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-16T14:52:20.234980+00:00",
+            "generated_at": "2026-07-16T15:09:31.547290+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "6460cfca77bebf6413f2b6c59381c36b11445b9ec4a52186dfcc69a8c6f719a6",
-            "prior_signature": "c0409c52cecc88e000870a568a6e40ab945703d43410c133801d1af315f2fde7",
+            "manifest_sha256": "5ea6551de34642ecce3359541cf0274584ca709e6585ff4382816a1addd6144f",
+            "prior_signature": "c555444671e0547cc8c3cc867c2aa867e11f49b4c76d707a743184bba0714101",
             "run_id": null,
             "supersedes": {
               "backend": "manual",
-              "generated_at": "2026-07-16T14:39:34.871944+00:00",
+              "generated_at": "2026-07-16T14:52:20.234980+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "908d9fb8c16dbcac5eaef2d9d18a02dbac995f3e9f54344864b672913362b958",
-              "prior_signature": "19c6c1c60175b80c51a7310e684b9cb030536076b7ab65ee5ba32073c8108304",
+              "manifest_sha256": "6460cfca77bebf6413f2b6c59381c36b11445b9ec4a52186dfcc69a8c6f719a6",
+              "prior_signature": "c0409c52cecc88e000870a568a6e40ab945703d43410c133801d1af315f2fde7",
               "run_id": null,
               "supersedes": {
                 "backend": "manual",
-                "generated_at": "2026-07-16T14:29:10.616700+00:00",
+                "generated_at": "2026-07-16T14:39:34.871944+00:00",
                 "generation_prompt_sha256": null,
-                "manifest_sha256": "52d18d84cdc098579bcf24a9023bad56ca266819aec6eb9f56f5ea39691f543c",
-                "prior_signature": "8ede01e30755b59542f76e23f49099135dd3baf8cab28623aaf11be831d0fede",
+                "manifest_sha256": "908d9fb8c16dbcac5eaef2d9d18a02dbac995f3e9f54344864b672913362b958",
+                "prior_signature": "19c6c1c60175b80c51a7310e684b9cb030536076b7ab65ee5ba32073c8108304",
                 "run_id": null,
                 "supersedes": {
                   "backend": "manual",
-                  "generated_at": "2026-07-15T14:31:12.050588+00:00",
+                  "generated_at": "2026-07-16T14:29:10.616700+00:00",
                   "generation_prompt_sha256": null,
-                  "manifest_sha256": "0115c636898fa27559fbd24ec935cec3c7c2c3802537449cd4eb208c9ab6a38a",
-                  "prior_signature": "9768d59c0d484dec2eb56c08ff37971392ae057e36113ad999dcb24632548060",
+                  "manifest_sha256": "52d18d84cdc098579bcf24a9023bad56ca266819aec6eb9f56f5ea39691f543c",
+                  "prior_signature": "8ede01e30755b59542f76e23f49099135dd3baf8cab28623aaf11be831d0fede",
                   "run_id": null,
                   "supersedes": {
                     "backend": "manual",
-                    "generated_at": "2026-07-15T14:18:32.181641+00:00",
+                    "generated_at": "2026-07-15T14:31:12.050588+00:00",
                     "generation_prompt_sha256": null,
-                    "manifest_sha256": "84063cfb2375491362440798fb511faab96a2cb31c3ab404d8cbb9b8c6fd6ce4",
-                    "prior_signature": "e21301c6a562441af2181e849f9f4b2f29ae3a62d99180bac6feb8800950ea46",
+                    "manifest_sha256": "0115c636898fa27559fbd24ec935cec3c7c2c3802537449cd4eb208c9ab6a38a",
+                    "prior_signature": "9768d59c0d484dec2eb56c08ff37971392ae057e36113ad999dcb24632548060",
                     "run_id": null,
+                    "supersedes": {
+                      "backend": "manual",
+                      "generated_at": "2026-07-15T14:18:32.181641+00:00",
+                      "generation_prompt_sha256": null,
+                      "manifest_sha256": "84063cfb2375491362440798fb511faab96a2cb31c3ab404d8cbb9b8c6fd6ce4",
+                      "prior_signature": "e21301c6a562441af2181e849f9f4b2f29ae3a62d99180bac6feb8800950ea46",
+                      "run_id": null,
+                      "tool": "axiom-encode sign-applied-files"
+                    },
                     "tool": "axiom-encode sign-applied-files"
                   },
                   "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16349,25 +16349,18 @@
         ]
       }
     ],
-    "us-dc/statute/47/47-1801.04": [
+    "us-dc/statute/47/47-1806.03": [
       {
-        "module": "us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
+        "module": "us-dc/statutes/47/47-1806/03.yaml",
         "via": [
           "module",
           "proof_atom"
         ]
       }
     ],
-    "us-dc/statute/47/47-1806.03": [
+    "us-dc/statute/47/47-1806.03/block-1": [
       {
         "module": "us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
-        "module": "us-dc/statutes/47/47-1806/03.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,14 +6,26 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1728
+ceiling: 1732
 entries:
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
-  since: '2026-07-15'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax
+  since: '2026-07-22'
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_base
   source: manual
-  since: '2026-07-15'
+  since: '2026-07-22'
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_floor
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_rate
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_upper
+  source: manual
+  since: '2026-07-22'
+- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits
+  source: manual
+  since: '2026-07-22'
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income
   source: manual
   since: '2026-07-15'

--- a/us-dc/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-dc/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,100 +1,145 @@
-# Hand-computed 2026 fixtures from the supplied schedule. PolicyEngine supplied
-# the case taxable-income subtraction and active bracket inputs; the expected
-# values below are the shown decimal arithmetic, independently executed by the
-# Axiom rules engine rather than read back from the oracle.
-- name: single_30000
-  # taxable 30000 - 15300 = 14700; schedule 400 + 0.06 * max(0, 14700 - 10000) = 682.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Expected values use independent decimal arithmetic from D.C. Code section
+# 47-1806.03(a)(11). Every transition is tested at its published upper bound
+# and one dollar into the next bracket, with an interior case in each bracket.
+
+- name: negative_taxable_income_normalizes_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 30000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 15300
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 10000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 400
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.06
+    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: -1
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '14700'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '682'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '682'
-- name: single_60000
-  # taxable 60000 - 15300 = 44700; schedule 2200 + 0.065 * max(0, 44700 - 40000) = 2505.5.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 60000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 15300
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 40000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 2200
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.065
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '0'
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 0
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '0'
+
+- name: first_bracket_interior_5000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 5000}
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '44700'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '2505.5'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '2505.5'
-- name: single_150000
-  # taxable 150000 - 15300 = 134700; schedule 3500 + 0.085 * max(0, 134700 - 60000) = 9849.5.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 150000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 15300
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 60000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 3500
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.085
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 0
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '200'
+
+- name: first_bracket_upper_10000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 10000}
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '134700'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '9849.5'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '9849.5'
-- name: married_60000
-  # taxable 60000 - 30650 = 29350; schedule 400 + 0.06 * max(0, 29350 - 10000) = 1561.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 60000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 30650
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 10000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 400
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.06
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 0
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '400'
+
+- name: second_bracket_lower_10001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 10001}
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '29350'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '1561'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '1561'
-- name: married_120000
-  # taxable 120000 - 30650 = 89350; schedule 3500 + 0.085 * max(0, 89350 - 60000) = 5994.75.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 120000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 30650
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 60000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 3500
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.085
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 1
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '400.06'
+
+- name: second_bracket_interior_25000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 25000}
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '89350'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '5994.75'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '5994.75'
-- name: married_300000
-  # taxable 300000 - 30650 = 269350; schedule 19650 + 0.0925 * max(0, 269350 - 250000) = 21439.875.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_adjusted_gross_income: 300000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_taxable_income_subtraction: 30650
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_floor: 250000
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_bracket_base: 19650
-    us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_supplied_marginal_rate: 0.0925
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 1
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '1300'
+
+- name: second_bracket_upper_40000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 40000}
   output:
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income: '269350'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_schedule_tax: '21439.875'
-    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_income_tax_liability: '21439.875'
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 1
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '2200'
+
+- name: third_bracket_lower_40001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 40001}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 2
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '2200.065'
+
+- name: third_bracket_interior_50000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 50000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 2
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '2850'
+
+- name: third_bracket_upper_60000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 60000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 2
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '3500'
+
+- name: fourth_bracket_lower_60001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 60001}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 3
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '3500.085'
+
+- name: fourth_bracket_interior_100000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 100000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 3
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '6900'
+
+- name: fourth_bracket_upper_250000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 250000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 3
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '19650'
+
+- name: fifth_bracket_lower_250001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 250001}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 4
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '19650.0925'
+
+- name: fifth_bracket_interior_375000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 375000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 4
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '31212.5'
+
+- name: fifth_bracket_upper_500000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 500000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 4
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '42775'
+
+- name: sixth_bracket_lower_500001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 500001}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 5
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '42775.0975'
+
+- name: sixth_bracket_interior_750000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 750000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 5
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '67150'
+
+- name: sixth_bracket_upper_1000000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 1000000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 5
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '91525'
+
+- name: seventh_bracket_lower_1000001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 1000001}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 6
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '91525.1075'
+
+- name: seventh_bracket_interior_1500000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input: {us-dc:policies/income_tax/pilot_liability_pipeline#input.dc_pit_pilot_completed_return_taxable_income: 1500000}
+  output:
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket: 6
+    us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits: '145275'

--- a/us-dc/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-dc/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,92 +3,230 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-dc/statute/47/47-1806.03
-      - us-dc/statute/47/47-1801.04
+    corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
-        - us-dc/statute/47/47-1806.03
-        - us-dc/statute/47/47-1801.04
+        - us-dc/statute/47/47-1806.03/block-1
       rationale: |-
-        This pipeline computes the District of Columbia individual income-tax liability
-        for the ordinary resident wage-earner slice at tax year 2026. The
-        supplied-current primary authority establishes the graduated tax
-        on taxable income and the relevant standard deduction. Values
-        that vary by filing status, bracket, annual indexing, or the choice
-        between standard and itemized deductions remain declared caller inputs:
-        adjusted gross income, the AGI-to-taxable-income subtraction, the active
-        bracket floor, cumulative tax at that floor, and marginal rate. The
-        module adds no numeric tax-law literals; it wires those supplied values
-        into the statutory taxable-income and schedule mechanics. The six
-        companion cases use the current values PolicyEngine applies at 2026 and
-        compare to dc_income_tax_before_credits.
+        D.C. Code section 47-1806.03(a)(11) imposes the seven-bracket
+        individual income-tax schedule for taxable years beginning after
+        December 31, 2021. The populated official corpus block supplies every
+        threshold, cumulative base amount, and marginal rate used here.
+
+        This narrow 2026 module accepts completed-return District taxable
+        income as its only caller boundary and normalizes that amount to zero
+        before applying the statutory schedule. It does not construct taxable
+        income or deductions; implement the separate-return allocation or
+        election; apply credits, withholding, return rounding, or the optional
+        filing-method minimum; or compute final liability. Every executable
+        version fails closed outside tax year 2026.
   summary: |-
-    Composed District of Columbia individual income-tax liability pipeline for the 2026
-    ordinary resident childless wage-earner oracle slice. It computes taxable
-    income from supplied adjusted gross income and supplied deductions or
-    exemptions, then applies the active graduated bracket as supplied
-    cumulative base tax plus the supplied marginal rate on income above the
-    supplied floor. Credits and special income classes are outside this
-    before-credit core. All tax-law amounts are inputs so the composition is
-    source-grounded without embedding an unencoded annual schedule.
+    District of Columbia 2026 individual income-tax schedule component before
+    credits. From caller-supplied completed-return District taxable income, it
+    applies all seven statutory brackets and preserves the published
+    cumulative base amounts. Deductions, separate-return allocation and
+    election mechanics, credits, withholding, rounding, the filing-method
+    minimum, and final liability are outside this module.
+  deferred_outputs:
+    - output: us-dc:statutes/47/47-1806.03/b#mayor_tax_table_election_tax
+      reason: Subsection (b)'s optional Mayor-prescribed tax-table filing method, including any table minimum and rounding mechanics, is outside this direct statutory-rate schedule.
+    - output: us-dc:statutes/47/47-1806.03/c#single_person_classification
+      reason: Subsection (c)'s spouse or domestic-partner living-arrangement classification is outside the completed-return taxable-income boundary accepted by this module.
+    - output: us-dc:statutes/47/47-1806.03/d#section_applies_to_return
+      reason: Subsection (d)'s fiduciary and spouse or domestic-partner return applicability rules require return relationships outside this schedule-only module.
+    - output: us-dc:statutes/47/47-1806.03/e#separate_return_single_person_treatment
+      reason: Subsection (e)'s separate-return election and spouse or domestic-partner treatment are outside the completed-return taxable-income boundary accepted here.
 rules:
+  - name: dc_pit_pilot_bracket_upper
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_pilot_bracket
+    source: D.C. Code section 47-1806.03(a)(11), 2026 bracket upper bounds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $500,000 but not over $1,000,000 $42,775, plus 9.75% of the excess over $500,000"
+              table: {header: "tax determined in accordance with the following table", row_key: "taxable income", column_key: "upper bound"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 10000
+          1: 40000
+          2: 60000
+          3: 250000
+          4: 500000
+          5: 1000000
+
+  - name: dc_pit_pilot_bracket_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_pilot_bracket
+    source: D.C. Code section 47-1806.03(a)(11), 2026 excess-over floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $1,000,000 $91,525, plus 10.75% of the excess over $1,000,000"
+              table: {header: "tax determined in accordance with the following table", row_key: "taxable income", column_key: "excess-over floor"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 10000
+          2: 40000
+          3: 60000
+          4: 250000
+          5: 500000
+          6: 1000000
+
+  - name: dc_pit_pilot_bracket_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_pilot_bracket
+    source: D.C. Code section 47-1806.03(a)(11), 2026 cumulative bracket bases
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $250,000 but not over $500,000 $19,650, plus 9.25% of the excess over $250,000"
+              table: {header: "tax determined in accordance with the following table", row_key: "taxable income", column_key: "base tax"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 400
+          2: 2200
+          3: 3500
+          4: 19650
+          5: 42775
+          6: 91525
+
+  - name: dc_pit_pilot_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: dc_pit_pilot_bracket
+    source: D.C. Code section 47-1806.03(a)(11), 2026 marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $40,000 but not over $60,000 $2,200, plus 6.5% of the excess over $40,000"
+              table: {header: "tax determined in accordance with the following table", row_key: "taxable income", column_key: "marginal rate"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.04
+          1: 0.06
+          2: 0.065
+          3: 0.085
+          4: 0.0925
+          5: 0.0975
+          6: 0.1075
+
   - name: dc_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: D.C. Code section 47-1801.04(44), taxable income after the supplied subtraction
+    source: D.C. Code section 47-1806.03(a)(11), supplied completed-return taxable income
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-dc/statute/47/47-1801.04
-              excerpt: "“Standard deduction” means"
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "there is imposed on the taxable income of every resident a tax determined in accordance with the following table"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, dc_pit_pilot_completed_return_taxable_income)
+
+  - name: dc_pit_pilot_bracket
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: D.C. Code section 47-1806.03(a)(11), bracket selected from taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "In the case of taxable years beginning after December 31, 2021"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, dc_pit_pilot_adjusted_gross_income - dc_pit_pilot_supplied_taxable_income_subtraction)
-  - name: dc_pit_pilot_schedule_tax
+          if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[0]: 0
+          else: if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[1]: 1
+          else: if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[2]: 2
+          else: if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[3]: 3
+          else: if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[4]: 4
+          else: if dc_pit_pilot_taxable_income <= dc_pit_pilot_bracket_upper[5]: 5
+          else: 6
+
+  - name: dc_pit_pilot_tax_on_supplied_taxable_income_before_credits
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: D.C. Code section 47-1806.03, graduated tax using the supplied active bracket
+    source: D.C. Code section 47-1806.03(a)(11), statutory schedule tax before credits
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-dc/statute/47/47-1806.03
-              excerpt: "there is imposed on the taxable income of every resident a tax determined in accordance with the following table"
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $1,000,000 $91,525, plus 10.75% of the excess over $1,000,000"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          dc_pit_pilot_supplied_bracket_base
-          + dc_pit_pilot_supplied_marginal_rate * max(0, dc_pit_pilot_taxable_income - dc_pit_pilot_supplied_bracket_floor)
-  - name: dc_pit_pilot_income_tax_liability
-    kind: derived
+          dc_pit_pilot_bracket_base[dc_pit_pilot_bracket]
+          + dc_pit_pilot_bracket_rate[dc_pit_pilot_bracket]
+          * (dc_pit_pilot_taxable_income - dc_pit_pilot_bracket_floor[dc_pit_pilot_bracket])
+
+inputs:
+  - name: dc_pit_pilot_completed_return_taxable_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: D.C. Code section 47-1806.03, tax imposed on taxable income
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-dc/statute/47/47-1806.03
-              excerpt: "there is imposed on the taxable income of every resident a tax determined in accordance with the following table"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, dc_pit_pilot_schedule_tax)
+    description: Completed-return District of Columbia taxable income supplied by the caller.


### PR DESCRIPTION
## Summary

- replace the five-input pilot composition with one completed-return District taxable-income input
- encode the full seven-bracket 2026 statutory schedule from the populated official corpus child
- expose only tax on supplied taxable income before credits and explicitly defer filing-method and return-classification mechanics
- add negative normalization plus every bracket boundary and an interior case per bracket
- regenerate the reverse index, reconcile the oracle pending ledger to 1,732 entries, and refresh the signed manifest

## Scope exclusions

Deductions, separate-return allocation or election, credits, withholding, return rounding, the filing-method minimum, and final liability remain outside this module.

## Checks

- pinned compile: passed (7 rules)
- companion tests: passed (20 cases)
- proof validation with money atoms: passed (7 atoms; 0 of 3 missing)
- validate --skip-reviewers: passed
- generated-file guard: passed
- git diff --check: passed

## Review cycle

Independent review requested; draft remains unmerged pending the required review-fix cycle and exact-head CI.