### PR TITLE
Encode 42 CFR 435.552 community engagement paths

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/552.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/552.json
@@ -1,86 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us/regulations/42-cfr/435/552.test.yaml",
-      "sha256": "264092f51da1d7f62d57199b37d82a2f4a35a9558001e4e1f804cca00de3d7dc"
+      "path": "us/regulations/42-cfr/435/552.yaml",
+      "sha256": "ab79d3780430366cd22844dfe62215da3d9727d9adf7fe14235e6581acd12136"
     },
     {
-      "path": "us/regulations/42-cfr/435/552.yaml",
-      "sha256": "97d60f73fc264b92afbb20d3a9ab4da582df5885ff998c57bccf3712b5389576"
+      "path": "us/regulations/42-cfr/435/552.test.yaml",
+      "sha256": "902ba5ac026b70da14ef9de5f73dfabf45e0159e81be33a15e4e0610d0044456"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "ef3cf99b5caea4f21e8697503baf100cb85cfea2",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3869d66d",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1325",
+    "version_commit": "ef3cf99b5caea4f21e8697503baf100cb85cfea2"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us:regulations/42-cfr/435/552",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-20T17:29:04.436280+00:00",
-  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/552.yaml",
-  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
-  "generated_output_sha256": "97d60f73fc264b92afbb20d3a9ab4da582df5885ff998c57bccf3712b5389576",
-  "generation_prompt_sha256": null,
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1325",
+  "backend": "openai",
+  "citation": "us/regulation/42/435/552",
+  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-sol/us-regulation-42-435-552/workspace/context-manifest.json",
+  "context_manifest_sha256": "1d51a7b6d0edf5d64b0955f0b94680491b4d09aefe32124d94d9da954b869c68",
+  "generated_at": "2026-07-22T16:41:43.051276+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-sol/regulations/42-cfr/435/552.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated",
+  "generated_output_sha256": "ab79d3780430366cd22844dfe62215da3d9727d9adf7fe14235e6581acd12136",
+  "generation_prompt_sha256": "c3519552dc44fdd9733444179d8e57a11ee1f4dd401a8c86dbd8ead9d68699cb",
+  "model": "gpt-5.6-sol",
+  "run_id": "745c458d",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "663130c5f50f23c7bed37fe6a77928cecd5feab717cd3b042b44b78eec54cfdf"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "sMwdSjseOmOKNTOX+M5maiEFcdnD0zPgS91FjZxbG39gnvr/66noN3s/P4vl4FPtfQP21aFwLi8M0LinRraTBA=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-20T17:25:29.311009+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "77b89ce4cc5ca8b869ff5c691c111f7424a1155202c311a0a2b6275cc1a16f03",
-    "prior_signature": "462770d9b8b62f36a5a11cb3d2094fbbcb40db7a5d6f747969c6e4a0858e7b67",
-    "run_id": null,
-    "supersedes": {
-      "backend": "manual",
-      "generated_at": "2026-07-20T17:24:35.317547+00:00",
-      "generation_prompt_sha256": null,
-      "manifest_sha256": "09d300bd49ec94c8c44c8618ca8bb8cb782b3e1b2934b63617d42063839df32e",
-      "prior_signature": "2466354cda0335fededcb3a285d59800fc119d80b15c0a7c3ddb1cd3d9438549",
-      "run_id": null,
-      "supersedes": {
-        "backend": "manual",
-        "generated_at": "2026-07-20T17:22:54.453911+00:00",
-        "generation_prompt_sha256": null,
-        "manifest_sha256": "d55cc6ab9fe4671b2dba1d09b9e909af2ca3e55b09e35c3e7a87abe544d6a22d",
-        "prior_signature": "506ba9ba9fe7970b121f3b678d852a0f79a4d9ec03f4028d244157da2ada2398",
-        "run_id": null,
-        "supersedes": {
-          "backend": "manual",
-          "generated_at": "2026-07-20T17:21:52.074402+00:00",
-          "generation_prompt_sha256": null,
-          "manifest_sha256": "5bce8df83ad20a8669931699981f0336ca8b4d70c0f37cb4bdcda4ddd8b1e067",
-          "prior_signature": "6c228f77c4921886afb23184bbca08a3601fcaee287c09f66a58924d7168426e",
-          "run_id": null,
-          "supersedes": {
-            "backend": "manual",
-            "generated_at": "2026-07-20T17:18:52.857090+00:00",
-            "generation_prompt_sha256": null,
-            "manifest_sha256": "81514d184f1d0e55a0c3450e7c5d544bee31acefe1abc7651e8a7d3fb687e363",
-            "prior_signature": "2e43527dc25bfbde78d1679378f9c02b0626614dbe7505c88b07ede4d3ec410f",
-            "run_id": null,
-            "tool": "axiom-encode sign-applied-files"
-          },
-          "tool": "axiom-encode sign-applied-files"
-        },
-        "tool": "axiom-encode sign-applied-files"
-      },
-      "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-22-current-la-status-fix",
+    "corpus_release_content_sha256": "6bfd97b24cb63cb709fa52e9a5e6764c916dec95c5557447e11f47778ee4768f",
+    "corpus_release_selector_sha256": "18211b6f6b23fb698994abfa2726d7e483ba97c9315814bb87788996b891441e",
+    "corpus_source": "local",
+    "expression_date": "2026-07-31",
+    "generation_input_sha256": "7b988e1c29315671eb1b19e63643a82e0485442a1f1acb299476a0bbfdc9ba57",
+    "provision_file": "data/corpus/provisions/us/regulation/2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup.jsonl",
+    "provision_file_sha256": "d19f16b3ad8ddc761ab798d486e9309ab8a510c4592470f76e5c01c7d6e5eb76",
+    "requested_corpus_citation_path": "us/regulation/42/435/552",
+    "resolved_corpus_citation_path": "us/regulation/42/435/552",
+    "resolved_text_sha256": "7b988e1c29315671eb1b19e63643a82e0485442a1f1acb299476a0bbfdc9ba57",
+    "row": {
+      "body_sha256": "7b988e1c29315671eb1b19e63643a82e0485442a1f1acb299476a0bbfdc9ba57",
+      "citation_path": "us/regulation/42/435/552",
+      "document_class": "regulation",
+      "expression_date": "2026-07-31",
+      "jurisdiction": "us",
+      "line_number": 3,
+      "provision_file": "data/corpus/provisions/us/regulation/2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup.jsonl",
+      "provision_file_sha256": "d19f16b3ad8ddc761ab798d486e9309ab8a510c4592470f76e5c01c7d6e5eb76",
+      "record_id": "f2d661e4-3045-5b3c-9951-849e36f34f3d",
+      "source_as_of": "2026-06-03",
+      "source_path": "sources/us/regulation/2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup/official-documents/release-scope-us-regulation-2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup",
+      "version": "2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup"
     },
-    "tool": "axiom-encode sign-applied-files"
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-03",
+    "source_sha256": "7b988e1c29315671eb1b19e63643a82e0485442a1f1acb299476a0bbfdc9ba57"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-sol/us-regulation-42-435-552.json",
+  "trace_sha256": "4ab6469b63ecad35b6a31b94fdd5c5fbe790361bc2d09c2204015c1fb41933e1",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "ef3cf99b5caea4f21e8697503baf100cb85cfea2",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1325"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "b5c65a417f88e10d11841046769fb630b48b8791a6bd9c50318b23d33016e132",
+      "pre_apply_file_count": 1480,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "d21c47231b50fd4fd0920bb759b437491e3446e59944e9fc36dfffd9d1e2dc58",
+      "validation_waiver_set_sha256": "bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3"
 }

--- a/.axiom/workflow-toolchain.toml
+++ b/.axiom/workflow-toolchain.toml
@@ -1,9 +1,9 @@
 # Immutable checkout identities used by validation and generation workflows.
 # Signed corpus release and waiver evidence remain in toolchain.toml.
 [workflow_toolchain]
-axiom_encode_version = "0.2.1309"
+axiom_encode_version = "0.2.1325"
 axiom_compose_ref = "fabe0b3b3fd6e90d3e8f075516f9b668f524f711"
-axiom_encode_ref = "c7eb9fe291d5fc0c5d12b7689c68db18aa8dde12"
+axiom_encode_ref = "ef3cf99b5caea4f21e8697503baf100cb85cfea2"
 axiom_rules_engine_ref = "05eac9d2f89dabe5c6673176260762cef3a58f47"
 axiom_corpus_ref = "01e00777cb05db84792c0de004b4fa24cfd453c3"
 rulespec_us_ref = "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5"

--- a/tests/test_encoding_manifests.py
+++ b/tests/test_encoding_manifests.py
@@ -56,7 +56,6 @@ KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({
     ".axiom/encoding-manifests/us-wa/policies/income_tax/pilot_liability_pipeline.json",
     ".axiom/encoding-manifests/us-wi/policies/income_tax/pilot_liability_pipeline.json",
     ".axiom/encoding-manifests/us-wv/policies/income_tax/pilot_liability_pipeline.json",
-    ".axiom/encoding-manifests/us/regulations/42-cfr/435/552.json",
     ".axiom/encoding-manifests/us/regulations/42-cfr/435/555.json",
     ".axiom/encoding-manifests/us/regulations/42-cfr/435/557.json",
     ".axiom/encoding-manifests/us/regulations/42-cfr/435/558.json",

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -176,9 +176,9 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         "workflow_toolchain"
     ]
     assert toolchain == {
-        "axiom_encode_version": "0.2.1309",
+        "axiom_encode_version": "0.2.1325",
         "axiom_compose_ref": "fabe0b3b3fd6e90d3e8f075516f9b668f524f711",
-        "axiom_encode_ref": "c7eb9fe291d5fc0c5d12b7689c68db18aa8dde12",
+        "axiom_encode_ref": "ef3cf99b5caea4f21e8697503baf100cb85cfea2",
         "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
         "axiom_corpus_ref": "01e00777cb05db84792c0de004b4fa24cfd453c3",
         "rulespec_us_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",

--- a/us/regulations/42-cfr/435/552.test.yaml
+++ b/us/regulations/42-cfr/435/552.test.yaml
@@ -1,11 +1,11 @@
-- name: documented_work_hours_path_meets_requirement
+- name: documented_work_hours_meet_monthly_requirement
   period: 2026-06
   input:
     us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
     us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
     us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
     us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
-    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_age: 30
     us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
     us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
@@ -24,29 +24,25 @@
     us:regulations/42-cfr/435/552#input.work_program_participation_hours: 0
     us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: false
   output:
-    us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement: 80
-    us:regulations/42-cfr/435/552#educational_credit_hour_weekly_multiplier: 3
-    us:regulations/42-cfr/435/552#educational_monthly_week_multiplier: 4.33
-    us:regulations/42-cfr/435/552#seasonal_worker_income_average_lookback_months: 6
     us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
     us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 80
     us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 0
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: not_holds
     us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 80
-    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
     us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: not_holds
-- name: income_based_work_hours_and_noncredit_education
+- name: income_based_work_hours_combine_with_less_than_half_time_noncredit_education
   period: 2026-06
   input:
     us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
     us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
     us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
     us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
-    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_age: 30
     us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
     us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
@@ -61,110 +57,128 @@
     us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: false
     us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 0
     us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 20
-    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 80
+    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 0
     us:regulations/42-cfr/435/552#input.work_program_participation_hours: 0
     us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: false
   output:
     us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
     us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 60
     us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 20
-    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 160
     us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
+    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 80
     us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: not_holds
-    us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: holds
+    us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: not_holds
     us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: not_holds
-- name: credit_hour_education_and_work_program_paths
+- name: half_time_enrollment_is_independent_and_not_combined_as_hours
   period: 2026-06
   input:
     us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
     us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
     us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
     us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
-    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_age: 30
     us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
     us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
     us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
     us:regulations/42-cfr/435/552#input.applicable_federal_minimum_wage_requirement: 10
-    us:regulations/42-cfr/435/552#input.individual_monthly_income: 700
-    us:regulations/42-cfr/435/552#input.agency_uses_income_based_work_hours_calculation: false
-    us:regulations/42-cfr/435/552#input.agency_lacks_documentation_of_hours_worked: false
-    us:regulations/42-cfr/435/552#input.agency_uses_reasonable_method_to_allocate_work_hours_between_household_members: false
-    us:regulations/42-cfr/435/552#input.documented_work_hours: 0
-    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_less_than_half_time: true
-    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: true
-    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 4
-    us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 0
-    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 0
-    us:regulations/42-cfr/435/552#input.work_program_participation_hours: 80
-    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: false
-  output:
-    us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
-    us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 0
-    us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 51.96
-    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 131.96
-    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
-    us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: holds
-    us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
-    us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: not_holds
-- name: half_time_education_and_monthly_income_paths
-  period: 2026-06
-  input:
-    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
-    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
-    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
-    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
-    us:regulations/42-cfr/435/551#input.individual_age: 18
-    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
-    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
-    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
-    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
-    us:regulations/42-cfr/435/552#input.applicable_federal_minimum_wage_requirement: 10
-    us:regulations/42-cfr/435/552#input.individual_monthly_income: 900
-    us:regulations/42-cfr/435/552#input.agency_uses_income_based_work_hours_calculation: false
-    us:regulations/42-cfr/435/552#input.agency_lacks_documentation_of_hours_worked: false
-    us:regulations/42-cfr/435/552#input.agency_uses_reasonable_method_to_allocate_work_hours_between_household_members: false
-    us:regulations/42-cfr/435/552#input.documented_work_hours: 0
-    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_less_than_half_time: false
-    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: false
-    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 0
-    us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 0
-    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 0
-    us:regulations/42-cfr/435/552#input.work_program_participation_hours: 0
-    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: true
-  output:
-    us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
-    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 0
-    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: not_holds
-    us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: holds
-    us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: holds
-- name: half_time_education_blocks_combined_activity_path
-  period: 2026-06
-  input:
-    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
-    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
-    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
-    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
-    us:regulations/42-cfr/435/551#input.individual_age: 18
-    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
-    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
-    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
-    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
-    us:regulations/42-cfr/435/552#input.applicable_federal_minimum_wage_requirement: 10
-    us:regulations/42-cfr/435/552#input.individual_monthly_income: 100
+    us:regulations/42-cfr/435/552#input.individual_monthly_income: 400
     us:regulations/42-cfr/435/552#input.agency_uses_income_based_work_hours_calculation: false
     us:regulations/42-cfr/435/552#input.agency_lacks_documentation_of_hours_worked: false
     us:regulations/42-cfr/435/552#input.agency_uses_reasonable_method_to_allocate_work_hours_between_household_members: false
     us:regulations/42-cfr/435/552#input.documented_work_hours: 40
     us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_less_than_half_time: false
-    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: false
-    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 0
+    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: true
+    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 12
     us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 0
-    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 40
+    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 0
     us:regulations/42-cfr/435/552#input.work_program_participation_hours: 0
     us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: true
   output:
-    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 80
+    us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
+    us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 40
+    us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 0
     us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: not_holds
+    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 40
+    us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: holds
     us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: not_holds
+- name: credit_hour_combination_and_monthly_income_paths
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 30
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/552#input.applicable_federal_minimum_wage_requirement: 10
+    us:regulations/42-cfr/435/552#input.individual_monthly_income: 800
+    us:regulations/42-cfr/435/552#input.agency_uses_income_based_work_hours_calculation: true
+    us:regulations/42-cfr/435/552#input.agency_lacks_documentation_of_hours_worked: true
+    us:regulations/42-cfr/435/552#input.agency_uses_reasonable_method_to_allocate_work_hours_between_household_members: true
+    us:regulations/42-cfr/435/552#input.documented_work_hours: 30
+    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_less_than_half_time: true
+    us:regulations/42-cfr/435/552#input.educational_program_uses_credit_hours: true
+    us:regulations/42-cfr/435/552#input.educational_program_credit_hours_of_instruction: 2
+    us:regulations/42-cfr/435/552#input.educational_program_class_and_educational_activity_hours: 0
+    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 20
+    us:regulations/42-cfr/435/552#input.work_program_participation_hours: 10
+    us:regulations/42-cfr/435/552#input.individual_enrolled_in_educational_program_at_least_half_time: false
+  output:
+    us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement: 800
+    us:regulations/42-cfr/435/552#work_hours_for_community_engagement: 30
+    us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours: 25.98
+    us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity: holds
+    us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement: 85.98
+    us:regulations/42-cfr/435/552#work_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#half_time_educational_enrollment_path_demonstrates_community_engagement: not_holds
+    us:regulations/42-cfr/435/552#combined_activity_hours_path_demonstrates_community_engagement: holds
+    us:regulations/42-cfr/435/552#monthly_income_path_demonstrates_community_engagement: holds
+- name: auto_positive_community_service_hours_path_demonstrates_community_engagement
+  period:
+    period_kind: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/552#input.community_service_hours_completed: 999999
+  output:
+    us:regulations/42-cfr/435/552#community_service_hours_path_demonstrates_community_engagement: holds
+- name: auto_positive_work_program_hours_path_demonstrates_community_engagement
+  period:
+    period_kind: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:regulations/42-cfr/435/551#input.individual_is_specified_excluded_individual_under_section_435_554: false
+    us:regulations/42-cfr/435/551#input.eligible_to_enroll_or_enrolled_under_state_plan_section_435_119: true
+    us:regulations/42-cfr/435/551#input.otherwise_eligible_to_enroll_or_enrolled_in_section_1115_a_2_demonstration_project: false
+    us:regulations/42-cfr/435/551#input.demonstration_project_coverage_meets_minimum_essential_coverage_requirements: false
+    us:regulations/42-cfr/435/551#input.individual_age: 18
+    us:regulations/42-cfr/435/551#input.individual_is_pregnant: false
+    us:regulations/42-cfr/435/551#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
+    us:regulations/42-cfr/435/551#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/552#input.work_program_participation_hours: 999999
+  output:
+    us:regulations/42-cfr/435/552#work_program_hours_path_demonstrates_community_engagement: holds

--- a/us/regulations/42-cfr/435/552.yaml
+++ b/us/regulations/42-cfr/435/552.yaml
@@ -4,425 +4,438 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/regulation/42/435/552
-  summary: |-
-    An applicable individual demonstrates community engagement for a month by working, completing community service, participating in a work program, being enrolled in an educational program at least half-time, combining qualifying activities for not less than 80 hours, or meeting the monthly-income pathway. Less-than-half-time educational hours are calculated by multiplying each credit hour by 3 and then by 4.33 weeks, or by counting class and educational-activity hours for non-credit programs. A seasonal-worker average-income pathway uses the preceding 6 months.
+    source_sha256: 7b988e1c29315671eb1b19e63643a82e0485442a1f1acb299476a0bbfdc9ba57
+  summary: An applicable individual demonstrates community engagement for a month
+    by working, completing community service, participating in a work program, or
+    combining qualifying activities for not less than 80 hours; enrollment in an educational
+    program at least half-time independently qualifies. Monthly income must be at
+    least the applicable Federal minimum wage multiplied by 80 hours. Less-than-half-time
+    credit-hour education is multiplied by 3 and then by 4.33 weeks. A seasonal-worker
+    pathway uses average monthly income over the preceding 6 months.
   deferred_outputs:
-    - output: us:regulations/42-cfr/435/552#seasonal_worker_average_income_path_demonstrates_community_engagement
-      source: "42 CFR 435.552(a)(7), (g): seasonal worker, as described in 26 U.S.C. 45R(d)(5)(B)"
-      reason: The seasonal-worker branch requires determining whether the individual is a seasonal worker as described in 26 U.S.C. 45R(d)(5)(B), and that cited definition is not available as copied RuleSpec context.
-      source_values:
-        - us:regulations/42-cfr/435/552#seasonal_worker_income_average_lookback_months
-    - output: us:regulations/42-cfr/435/552#community_engagement_demonstrated_for_month
-      source: "42 CFR 435.552(a): one or more of the listed conditions"
-      reason: The complete one-or-more community-engagement demonstration rule includes the seasonal-worker average-income pathway, which is deferred because the cited seasonal-worker definition is unavailable.
+  - output: us:regulations/42-cfr/435/552#seasonal_worker_average_income_path_demonstrates_community_engagement
+    source: 42 CFR 435.552(a)(7), (g)
+    reason: The pathway requires the seasonal-worker definition described in 26 U.S.C.
+      45R(d)(5)(B), for which no copied executable RuleSpec source is available.
+    source_values:
+    - us:regulations/42-cfr/435/552#seasonal_worker_income_average_lookback_months
+  - output: us:regulations/42-cfr/435/552#community_engagement_demonstrated_for_month
+    source: 42 CFR 435.552(a)
+    reason: The complete one-or-more pathway includes the deferred seasonal-worker
+      average-income branch.
 imports:
-  - us:regulations/42-cfr/435/551#applicable_individual
+- us:regulations/42-cfr/435/551#applicable_individual
 rules:
-  - name: monthly_community_engagement_hours_requirement
-    kind: parameter
-    dtype: Count
-    source: 42 CFR 435.552(a)(1)-(3), (a)(5)-(7)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "not less than 80 hours"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          80
+- name: monthly_community_engagement_hours_requirement
+  kind: parameter
+  dtype: Count
+  source: 42 CFR 435.552(a)(1)-(3), (a)(5)-(7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: not less than 80 hours
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '80'
+- name: educational_credit_hour_weekly_multiplier
+  kind: parameter
+  dtype: Decimal
+  source: 42 CFR 435.552(d)(1)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: Multiply the number of each one credit hour of instruction by 3
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3'
+- name: educational_monthly_week_multiplier
+  kind: parameter
+  dtype: Decimal
+  source: 42 CFR 435.552(d)(1)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(ii) Multiply the weekly total as determined under paragraph \n\
+            (d)(1)(i) of this section by 4.33 weeks to get total hours in a 1-month\
+            \ \nperiod."
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '4.33'
+- name: seasonal_worker_income_average_lookback_months
+  kind: parameter
+  dtype: Count
+  source: 42 CFR 435.552(a)(7), (g)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(7) The individual had an average monthly income over the preceding\
+            \ \n6 months that is not less than the applicable minimum wage requirement\
+            \ \nunder 29 U.S.C. 206(a)(1)(C) multiplied by 80 hours, and is a seasonal\
+            \ \nworker, as described in section 45R(d)(5)(B) of the Internal Revenue\
+            \ \nCode of 1986 (26 U.S.C. 45R(d)(5)(B))."
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '6'
+- name: monthly_income_threshold_for_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 42 CFR 435.552(a)(6), (f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(f) Monthly income. (1) An applicable individual demonstrates\
+            \ \ncommunity engagement for a month if the individual has a monthly income\
+            \ \nthat is not less than the applicable Federal minimum wage requirement\
+            \ \nunder 29 U.S.C. 206(a)(1)(C) multiplied by 80 hours."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
+          output: monthly_community_engagement_hours_requirement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: applicable_federal_minimum_wage_requirement * monthly_community_engagement_hours_requirement
+- name: work_hours_for_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Decimal
+  period: Month
+  source: 42 CFR 435.552(e)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(ii) If the agency uses the option under paragraph (e)(2)(i) of\
+            \ \nthis section, the agency must calculate the hours for work by dividing\
+            \ \nthe monthly income as determined under paragraph (f)(2) of this section\
+            \ \nby the applicable Federal minimum wage requirement under 29 U.S.C.\
+            \ \n206(a)(1)(C)."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement
+          output: monthly_income_threshold_for_community_engagement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if agency_uses_income_based_work_hours_calculation and agency_lacks_documentation_of_hours_worked
+      and agency_uses_reasonable_method_to_allocate_work_hours_between_household_members
+      and individual_monthly_income < monthly_income_threshold_for_community_engagement:
+      individual_monthly_income / applicable_federal_minimum_wage_requirement else:
+      documented_work_hours'
+- name: less_than_half_time_educational_program_hours
+  kind: derived
+  entity: Person
+  dtype: Decimal
+  period: Month
+  source: 42 CFR 435.552(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#educational_credit_hour_weekly_multiplier
+          output: educational_credit_hour_weekly_multiplier
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#educational_monthly_week_multiplier
+          output: educational_monthly_week_multiplier
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "if individual_enrolled_in_educational_program_less_than_half_time:\n\
+      \  if educational_program_uses_credit_hours:\n    educational_program_credit_hours_of_instruction\n\
+      \    * educational_credit_hour_weekly_multiplier\n    * educational_monthly_week_multiplier\n\
+      \  else:\n    educational_program_class_and_educational_activity_hours\nelse:\n\
+      \  0"
+- name: educational_program_hours_may_be_combined_with_other_activity
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(5), (e)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(1) The hours for work under paragraph (a)(1) of this section,\
+            \ \ncommunity service under paragraph (a)(2) of this section, and \nparticipating\
+            \ in a work program under paragraph (a)(3) of this section, \nneed only\
+            \ be combined with educational program hours if the individual \nis enrolled\
+            \ in an educational program less than half-time."
+  versions:
+  - effective_from: '0001-01-01'
+    formula: individual_enrolled_in_educational_program_less_than_half_time
+- name: combined_activity_hours_for_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Decimal
+  period: Month
+  source: 42 CFR 435.552(e)(1)-(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: the hours must be added together
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#work_hours_for_community_engagement
+          output: work_hours_for_community_engagement
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours
+          output: less_than_half_time_educational_program_hours
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'work_hours_for_community_engagement
 
-  - name: educational_credit_hour_weekly_multiplier
-    kind: parameter
-    dtype: Decimal
-    source: 42 CFR 435.552(d)(1)(i)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "Multiply the number of each one credit hour of instruction by 3"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          3
+      + community_service_hours_completed
 
-  - name: educational_monthly_week_multiplier
-    kind: parameter
-    dtype: Decimal
-    source: 42 CFR 435.552(d)(1)(ii)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "Multiply the weekly total ... by 4.33 weeks"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          4.33
+      + work_program_participation_hours
 
-  - name: seasonal_worker_income_average_lookback_months
-    kind: parameter
-    dtype: Count
-    source: 42 CFR 435.552(a)(7), (g)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "average monthly income over the preceding 6 months"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          6
+      + less_than_half_time_educational_program_hours'
+- name: work_hours_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: The individual works not less than 80 hours.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#work_hours_for_community_engagement
+          output: work_hours_for_community_engagement
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
+          output: monthly_community_engagement_hours_requirement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: monthly_income_threshold_for_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 42 CFR 435.552(a)(6), (f)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "applicable Federal minimum wage requirement under 29 U.S.C. 206(a)(1)(C) multiplied by 80 hours"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
-              output: monthly_community_engagement_hours_requirement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_federal_minimum_wage_requirement * monthly_community_engagement_hours_requirement
+      and work_hours_for_community_engagement >= monthly_community_engagement_hours_requirement'
+- name: community_service_hours_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(2) The individual completes not less than 80 hours of community\
+            \ \nservice."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
+          output: monthly_community_engagement_hours_requirement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: work_hours_for_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Decimal
-    period: Month
-    source: 42 CFR 435.552(a)(1), (e)(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "may calculate the hours for work ... based on the monthly income"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "by dividing the monthly income ... by the applicable Federal minimum wage requirement"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement
-              output: monthly_income_threshold_for_community_engagement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          if agency_uses_income_based_work_hours_calculation and agency_lacks_documentation_of_hours_worked and agency_uses_reasonable_method_to_allocate_work_hours_between_household_members and individual_monthly_income < monthly_income_threshold_for_community_engagement: individual_monthly_income / applicable_federal_minimum_wage_requirement else: documented_work_hours
+      and community_service_hours_completed >= monthly_community_engagement_hours_requirement'
+- name: work_program_hours_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(3) The individual participates in a work program for not less\
+            \ than \n80 hours."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
+          output: monthly_community_engagement_hours_requirement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: less_than_half_time_educational_program_hours
-    kind: derived
-    entity: Person
-    dtype: Decimal
-    period: Month
-    source: 42 CFR 435.552(d)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#educational_credit_hour_weekly_multiplier
-              output: educational_credit_hour_weekly_multiplier
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#educational_monthly_week_multiplier
-              output: educational_monthly_week_multiplier
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          if individual_enrolled_in_educational_program_less_than_half_time: if educational_program_uses_credit_hours: educational_program_credit_hours_of_instruction * educational_credit_hour_weekly_multiplier * educational_monthly_week_multiplier else: educational_program_class_and_educational_activity_hours else: 0
+      and work_program_participation_hours >= monthly_community_engagement_hours_requirement'
+- name: half_time_educational_enrollment_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(4), (c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(4) The individual is enrolled in an educational program at least\
+            \ \nhalf-time."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: combined_activity_hours_for_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Decimal
-    period: Month
-    source: 42 CFR 435.552(e)(1)-(4)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "the hours must be added together"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#work_hours_for_community_engagement
-              output: work_hours_for_community_engagement
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#less_than_half_time_educational_program_hours
-              output: less_than_half_time_educational_program_hours
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          work_hours_for_community_engagement + community_service_hours_completed + work_program_participation_hours + less_than_half_time_educational_program_hours
+      and individual_enrolled_in_educational_program_at_least_half_time'
+- name: combined_activity_hours_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(5), (e)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(e) Combination of activities. An applicable individual may \n\
+            demonstrate community engagement for a month if the individual engages\
+            \ \nin any combination of activities described in paragraphs (a)(1) through\
+            \ \n(4) of this section for a total of not less than 80 hours."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement
+          output: combined_activity_hours_for_community_engagement
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
+          output: monthly_community_engagement_hours_requirement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: educational_program_hours_may_be_combined_with_other_activity
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(5)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "States are not permitted to combine educational program hours with another activity if the individual is enrolled in an educational program at least half-time."
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          not individual_enrolled_in_educational_program_at_least_half_time
+      and combined_activity_hours_for_community_engagement >= monthly_community_engagement_hours_requirement'
+- name: monthly_income_path_demonstrates_community_engagement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.552(a)(6), (f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/552
+          excerpt: "(f) Monthly income. (1) An applicable individual demonstrates\
+            \ \ncommunity engagement for a month if the individual has a monthly income\
+            \ \nthat is not less than the applicable Federal minimum wage requirement\
+            \ \nunder 29 U.S.C. 206(a)(1)(C) multiplied by 80 hours."
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/551#applicable_individual
+          output: applicable_individual
+          hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement
+          output: monthly_income_threshold_for_community_engagement
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'applicable_individual
 
-  - name: work_hours_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "The individual works not less than 80 hours"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#work_hours_for_community_engagement
-              output: work_hours_for_community_engagement
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
-              output: monthly_community_engagement_hours_requirement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and work_hours_for_community_engagement >= monthly_community_engagement_hours_requirement
-
-  - name: community_service_hours_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "completes not less than 80 hours of community service"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
-              output: monthly_community_engagement_hours_requirement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and community_service_hours_completed >= monthly_community_engagement_hours_requirement
-
-  - name: work_program_hours_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "participates in a work program for not less than 80 hours"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
-              output: monthly_community_engagement_hours_requirement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and work_program_participation_hours >= monthly_community_engagement_hours_requirement
-
-  - name: half_time_educational_enrollment_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(4), (c)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "enrolled in an educational program at least half-time"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and individual_enrolled_in_educational_program_at_least_half_time
-
-  - name: combined_activity_hours_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(5), (e)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "any combination ... for a total of not less than 80 hours"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#combined_activity_hours_for_community_engagement
-              output: combined_activity_hours_for_community_engagement
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#educational_program_hours_may_be_combined_with_other_activity
-              output: educational_program_hours_may_be_combined_with_other_activity
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement
-              output: monthly_community_engagement_hours_requirement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and educational_program_hours_may_be_combined_with_other_activity
-          and combined_activity_hours_for_community_engagement >= monthly_community_engagement_hours_requirement
-
-  - name: monthly_income_path_demonstrates_community_engagement
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.552(a)(6), (f)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/552
-              excerpt: "monthly income that is not less than the applicable Federal minimum wage requirement ... multiplied by 80 hours"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/551#applicable_individual
-              output: applicable_individual
-              hash: sha256:cca95e1fa04f699fa6772bcb8f861f973d78bd86a027414e6be1cb26467e2c01
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/552#monthly_income_threshold_for_community_engagement
-              output: monthly_income_threshold_for_community_engagement
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          applicable_individual
-          and individual_monthly_income >= monthly_income_threshold_for_community_engagement
+      and individual_monthly_income >= monthly_income_threshold_for_community_engagement'


### PR DESCRIPTION
## Summary
- replace legacy 42 CFR 435.552 encoding with a signed RuleSpec v5 artifact generated by axiom-encode 0.2.1325
- encode monthly work, community service, work-program, educational, combined-activity, and income pathways
- add six monthly executable scenarios and exact proof imports, including the pinned 42 CFR 435.551 dependency
- remove 435.552 from the legacy freeze and pin the validation workflow to encoder 0.2.1325

Parent hard-cut migration: #911
Protected generation: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/29938007193

## Validation
- protected encode/review/validate/apply and provenance guard passed
- artifact SHA256SUMS passed
- structured audit passed: 15 local rules, 6 monthly scenarios, exact applied-file hashes, all same-module formula imports, exact external proof hash, and exact (a)(6)/(f)(1) income evidence
- exact pinned engine compile passed (18 resolved rules including imports)
- exact pinned engine companion tests passed (6/6)
- `python -m pytest -q tests` passed (78 passed; existing unmanifested-module warning only)
- `git diff --check` passed

## Review cycle
An independent artifact review initially misread a removed diff line and claimed the less-than-half-time input was false. Current line 56 is true and the exact engine produced the expected result. A second independent review inspected the complete current files, verified the disposition, and found no actionable findings. It specifically confirmed proof imports, subsection evidence, external hashes, periods, formulas, and the corrected 42 CFR 435.552(e)(1) combination semantics.
