### PR TITLE
Pin corpus with Maryland and Kentucky sources

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "34febd18466aa814b86d21cd4558d2780f9af1a5"
+axiom_corpus_ref = "dfa47fb05bd1d3abbadf0ff17ce4a04bdd5c8085"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- advance the pinned `axiom-corpus` commit from `34febd18466aa814b86d21cd4558d2780f9af1a5` to `dfa47fb05bd1d3abbadf0ff17ce4a04bdd5c8085`
- make the repaired Maryland authority and the latest Kentucky intake available to downstream RuleSpec PRs
- change only `.axiom/toolchain.toml`; no RuleSpec, generated manifest, reverse-index, waiver, or oracle-ledger files change

## Checks

- toolchain TOML parses and all pinned refs are full lowercase commit SHAs
- target corpus object exists locally as a commit
- Maryland-related corpus paths are unchanged between the previously validated Maryland commit `1a296e0cf88d73b2c621eb482e4a708f6ef7ca92` and this pin
- `axiom-encode guard-generated --repo . --base-ref origin/main --json`: passed, no issues
- `git diff --check`: passed
- exact diff against main: only `.axiom/toolchain.toml`

## Dependency

This pin-only PR is required before Maryland schedule PR #998 can be rebased into a module-only change and have its validation fingerprint handled separately. Both PRs remain draft and unmerged pending green CI and review.