### PR TITLE
Waiver-only: protected-base approvals for the strict-cutover bind (#911)

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -1403,7 +1403,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:09741ae409415206206cb9f43045605668349a5e03d2022d0bba11699d62b70f"
+      fingerprint: "sha256:3b52718399b6813a7a0626010ef3455c3514978d6083b9ba9f07205abb56033a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1612,7 +1612,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:6b0b22e0bf00d675988a8ae11060507d52af5c38f603ef87af29de46a7a68984"
+      fingerprint: "sha256:6fbba4d5b8e99cebeb8dd9ba216ad7601a3c265ed2b136f121a963d5ecaaae9a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1810,7 +1810,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:059041ecf3183f84ef92b8c3c3c25ac1f6a2163a8d90ee270fe24b4169559973"
+      fingerprint: "sha256:819c5b6926ba31817e28f78b4359064725418173b868b4326cf9aa936f491f2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -14,6 +14,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5d10d3dd3e1cefd2f3e50875a4e079b6688c48876127ee3b4ca3bd9d0a4c3a7d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/415/i.yaml":
     active:
       fingerprint: "sha256:02ccbb5f461d70876b3493dcfe2e8390e7f33894f2aabd5e5f43e57b84bb8e73"
@@ -44,9 +49,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dafd2712c54d6386cb6fc85ca2321996d39132423868365f151892ddf622d0a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/21.yaml":
     active:
       fingerprint: "sha256:8891960ee2295f5f1d1fe0e927afe361a5631a3b3443ba6d4b2160608b5ba6b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5f6274daf7efc2bbf939a4cc151b0d24fbb2e144df9927b1643789afc372bef0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -56,9 +71,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7508426f95658aba1746002744f41ba3981fca6a62b67901def63c6e0cd7b9bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/232.yaml":
     active:
       fingerprint: "sha256:c3cee438fb4582d7543f7cc90dc80658d1dd6ed22af691843773fe937757fff4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e5f2bb743159fd7609a95778a5d8370eab45b083ceeb80e1a8330071f6f1c7b9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -68,9 +93,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1aac4f6b1f104f4f9dca9e530ef9f22d2508789a015cfae31f038e43fa672683"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/234.yaml":
     active:
       fingerprint: "sha256:d671173f8aa3dc7ac90a260bab3851fa49d666af87a8236e54c417835d2e53d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:40656e84528f312d8a27f668ddaf9e641f7f726bf2f68c94e821564a03decd5a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -80,9 +115,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0cfac43efb988d08ccffd08f1410f97cdb9cbf9925463d1a885e32edcb9062b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/25.yaml":
     active:
       fingerprint: "sha256:a79b074afad207a37f34fd00b286cb3d3ba445c905f076be2100688cbf52d7ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4dfe2b2acd34acbae8be457f4f6995cb946ebc3c7ae01b82ca7cbe8aca749696"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -92,9 +137,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:24f1409b29a50818ad9e28e2167e50c3c2511dd4c2e9bab2fe8163b531d574ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/31.yaml":
     active:
       fingerprint: "sha256:1df47b8eace1a4125ccb8d402bc6973c1974eb0db73d1f74fb28c3b0c6a8b029"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2b824e7be5dd6a9cf37d3b9731802a06201649fdab2d2acd3e48188945d1f565"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -104,9 +159,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e8abeadacdc1296dac0708d104a77e977f3f057c32c06fd105acff4fd24c4f38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/321.yaml":
     active:
       fingerprint: "sha256:b6cff65cdae8518e4382266b026bd8dc8dce0adc370fd4d337daa30c8525b893"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5aef7f194dfd31f6b63acabd2af9c3387ce536f40a876637f4cea6cc68244f92"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -116,9 +181,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9628db9ac878e4b14c196f0440894a005cba43e31977713c3310d164b62c082f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/34.yaml":
     active:
       fingerprint: "sha256:fa5d5f54783469aa3edd9ac659586bf66ce17ce7898f8b34f4b1b00b5d6506b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7c24b73d4f9b4bc6be945096695353daa7a7eaf67ae2b443476f27c71ee56927"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -128,9 +203,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8773d2895029bba35d75a05c0a1414f6dfddb4558266d0ac77bab06144bb4447"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/37.yaml":
     active:
       fingerprint: "sha256:54c2b6bada50e179a3c2ed5f3be1046b6916cdce6bef23668b9f3613fd1fc916"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7c6e0656ca867c78903997b0e2c55bd36311dc352394805abff772ac6f9ca78a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -140,9 +225,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:74efea23d293804a6799b2045a199b7983a14f8131b44a5213ad4cdfdb55d96a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/42.yaml":
     active:
       fingerprint: "sha256:7c74e4a1b95f8c6b0d3594c04f56b5f96e85a24e89e59c0a2ae8bce71e63552b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cfb11317040a78c430d3b29fc622410f87f76fc629c53beea10c89b45ba5d434"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -152,9 +247,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c91a9dd84c0a6e5a105b455abb44f00cd88c28be3ff7502f6882549f8b358b1a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/44.yaml":
     active:
       fingerprint: "sha256:9efa531edbb201c2f3f26a5d94254214e31b8a425a4538ac0954ebff9e26406b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d8928d8b56dc413f14be8a34d78c344de9e2f9d72c91399598bf8dbf99a072a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -164,9 +269,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:af9bdf80dad3236084a30a18e6675870577e39db444242d9d352b5c9cea10d42"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/46.yaml":
     active:
       fingerprint: "sha256:0f5607e9945e5f16643fc7aec729d3d5a3fe60d05993d1d629bbbc2d84fe4cba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c8d17c89a40513a1bdaa2133723bd501b585efb57ea6f8350be659dc43da0fc1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -176,9 +291,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:de6686a17e6484a02235546589d2be05492cab77213589178f7d9ebd7c5ba264"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/462.yaml":
     active:
       fingerprint: "sha256:d45fbcdbfc61f446d492cdc27820ad18b48752957c5c7a2abad8690c79e7b103"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:47a4cdb2f327d977bbcc3a72034d158c6075282b66b68a372b46ae196be5cfd5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -188,9 +313,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:21d0466104fe9a59850d2c509730cd5fa2531a87b2411dce063dca4022bfba89"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/464.yaml":
     active:
       fingerprint: "sha256:c137a9446603ba849769afc865284d8c68f8a1e45a3392389ce118735e8fa384"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e85c890fcc68f54251b321afda33e27c450ef6dfd6ef4f69c9ae1e635294e9bc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -200,9 +335,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:be4302c39c5cd91eecebf53b4169ccf00df44f01144747a42ef392a2812c0a0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/5.yaml":
     active:
       fingerprint: "sha256:c94c2728a4f84b023cd88a24f0a5479aeb0415952414311bf7810b34bda50a8d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:04c66c733b7c723a663ccfacd3b9bdc552e2746afc6d1c3cdaac46183ea72d1c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -212,9 +357,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6074a06c7bdb2459170b4b1681023db96db57616e58b88a6562186cefa81e18f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-300/622.yaml":
     active:
       fingerprint: "sha256:b7a7da44a8d992257d14834429892847ac3db9b55951f0ff98a502d4a53f9f45"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:132f105212455d9293babdb32111cb2c7f04b12f512328f4ea5d82edd5456937"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -224,9 +379,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ec0c508bb23df41abde9d6525952be602a28d6e16094ccf02c47c805d7030582"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/1.yaml":
     active:
       fingerprint: "sha256:d9177a947f63aae47e23f2198049d2a3525808b73435484547aafd73d4de5323"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:70a794d89c4463480adab29b39a2084cb5a4ebf15acc6a23e4f4ccd62c051331"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -236,9 +401,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c0d597f9b152aae0e1cb8b09dbc775f3726b2bacb559a678350f6f56e588962c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/3.yaml":
     active:
       fingerprint: "sha256:56322ee4dfb171c023beb0002c3dc715eb6f9896c100d99711aa50a60ac1f241"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2e18c268d2eb2e663aa0992ef9049f5a61bbf1ce659dba875b4ebb04dde3c546"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -248,9 +423,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1566ca24ba229297f6586b640fd79aeeaf0b177223d0ec8ade5bff8959fec900"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/311.yaml":
     active:
       fingerprint: "sha256:1eff92f6773c1f38bc4411e219a9d44d731e8d09634895fa0c9e329c6ace580a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:323efb1e83c7c3c43c90ea767b57f374531ec773cac6f0db9fcdf8787106152a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -260,9 +445,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3e44036f594677f99b762a4f6c0f523ea9f2dec8ab5a536c01e353fa584cfdce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/4.yaml":
     active:
       fingerprint: "sha256:48fa6ee300d6fe393b7460b9978c74090590ba019499d504410bc7f9202a13cb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e063133ea50cec86dba8b29f0c9ff4318e6811b45fefb0f74a03667cd220ec86"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -272,9 +467,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:839a2385161723dc202463ce72fda193dbf0b63df602e0dacab7ceb0327982c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/412.yaml":
     active:
       fingerprint: "sha256:2213b9373c075f0aae3f15f2ee82ed9efff00990171f1e50d4d824c6a81afc1e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5cfe77a4dc26e0746f268ebc4a5fde17ee637522595e258b5ef9ef7f97872090"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -284,9 +489,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c0edfc5b177b4a7cd989d3fd1f0db18a2c8ccc0381d9043b5f44691071d20ff3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/421.yaml":
     active:
       fingerprint: "sha256:fa75627a4a35f0c837bfb949ea76c6bf776686fc9b176030303b18f6d4edcc4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c116ea55b6e1cf0ba4070c3d9c90e9b434c928c6c5dfaabfe899fbf5c66f7bee"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -296,9 +511,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9dfecde40b52e751f654060da44cece409273b0b88904cb989e37ee0b2581442"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/423.yaml":
     active:
       fingerprint: "sha256:4c23cd91985eb6c33f2d5270548f688baddc6a553c888fa9c8bc10b495f3f468"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7569bc3a207040291538defba17afcbfdf6d01a7f9e0fde3865d49c1b4a081d4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -308,9 +533,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5aa3f9a533b3059b82ec7dd6f0f252dffc8887e590f9b1c66742e0df8b25c9d8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/431.yaml":
     active:
       fingerprint: "sha256:b51fa9770d919d371ac7f866a1d855e9de0192c1e118cae03a42d60349c46476"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:91ca72fef8652aac8c449c3892e56719f88226b2d78124647835b358242c9adb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -320,9 +555,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:99cd4882edba2ccb2aff3c89c0f9a70edadce5c3160103ab7e0ad7078b56564c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/441.yaml":
     active:
       fingerprint: "sha256:071b22292b540108fad90af8c833f0162c5b314b29d8f1990ad9ecbafe1d48bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:11d29facd635f659247383673e82eb140ecc0a0b9c59df24cca8ce5c9d967e11"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -332,9 +577,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:471836ac2b9427a6f19bf3a89c92e4ba399fdea521a8bf323a4968ef9c523b6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/511.yaml":
     active:
       fingerprint: "sha256:1e0f3574b1ffa47c15455c4d2ffe8fd850a838bfa3d18e4e18f96dcca68ad639"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5ebc82e0694c82d0a57dfe309f80c187e42825716247041b0cd7c763942e0f12"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -344,9 +599,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e8247b185ab78f7367b8770700b662d8441a9b64ebeb132479c009e288297df6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/513.yaml":
     active:
       fingerprint: "sha256:19f0a9f6fb3d667737b8a29f2b42abe1edf63c8affe705016d3e96cd595d9a8d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f2ca40d88245fffab107656970cc9f04993b56e25887c998d0860596d538e65"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -356,9 +621,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a8202521fa3a4afb89ea83b9a4a2e8c5acaf12aa484d6ab9edd44fb9c07a86e4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/531.yaml":
     active:
       fingerprint: "sha256:2344428457aa0114a5c18bff4f7958989cf671c1d905199e8862c051b5e5e0e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c650592562953100731f302230cf5e2741ee5d4e32f0ba2ed603d4e791a947c3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -368,9 +643,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9235f801df7a328ee8ec1e9f1020e46049c96f36cf5e5ed27c575536a45ccf07"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/533.yaml":
     active:
       fingerprint: "sha256:1b502ac90944befecf9d77aa58fbd3b14b39d6534aa70855853d97ddb2134b02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3b24a7e5addb94867bfd12c1227aea50735298312d976a6df9161721da7bef92"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -380,9 +665,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:44d439e57cb75761d5e9f2e2591c6367f02042137782d8e863d6ab4d84b8a4b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/542.yaml":
     active:
       fingerprint: "sha256:2f0c80fe952e08ca54f57b2f011317c8e10e5ac0f311b73b55ad65232f959ee3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f034b5a9d7514549b1d7ecdc432cd1e30bb2bfaeb3daeabd424645de5665fb81"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -392,9 +687,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1e687c1296ef11e34279d1429ec043ed3d8e142da3a8fe8635396e0f5acc9faa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/544.yaml":
     active:
       fingerprint: "sha256:e0ac9c5d96dc78d9ee9dca9e420ef4a177960c6c4b360c5f64a69075f76667ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8fdb38c8b34de184d1c501cda1ff3163068819c8e3542d1aa8ba82d4375386d4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -404,9 +709,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fecbe9201a3d7f6efee777a6b8ce1da7b4f84c2f8e6f50098aa9979446bf8177"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/546.yaml":
     active:
       fingerprint: "sha256:5a5c64b92d376de263c3ce5a3bfbf852fa6fa3943748dec1ce51b6632db22615"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ffea4fe4fa6f1afc73c8d241a0a29947cb60616ad5f9055cc48d77addb223a5a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -416,9 +731,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6ba871b1ae793d3cfd17b5e4d19c74bb881fc5d627dda2c6abacf4ab9a81d065"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/548.yaml":
     active:
       fingerprint: "sha256:7be57a3a820ed27d396ac203fa4f6a9bff46d98b506d12c1a91cac214bb37e19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0f87d45f322769610642713d9d9caf5af6f99fa5d147723040e67ee2253becd2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -428,9 +753,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5ca84e4c0ad3f94b8873b5e70adc17371a16c84ace001c56710d4538b480da1b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/611.yaml":
     active:
       fingerprint: "sha256:672b6f24346ca1dcd63c1ce25ab587f906eabeebcfbaeb3f3a680f573fa98fba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6fad97cb5b53ab4c1736d11c22ef8b283a6d0824ba2d9076208013d77ec5fdef"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -440,9 +775,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dc2a1efb25f04eb3cc88e0a545e9d65281cf871800b88ca355e275655413884a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/63.yaml":
     active:
       fingerprint: "sha256:59657a0c23099629b30e726fa2399f073b9a04ba3763db63477f9d03b60d4921"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:81f7a5004a7f741d004275b9ff71d9ae7b9dd571438163ffab88d3be5b71b8d8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -452,9 +797,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6d98261b1f1cd16fab74f09808c15fd5573e2d0c052556496d63fceadc41d8f6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/632.yaml":
     active:
       fingerprint: "sha256:aa817e99164c92ce8dc0e6f9b4e4f0fd56766dc8b43597520e96b0fbb643450a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ee87b1def443563854c0086a5b6ae59ce1cdb9c31c233222e8b46f561233bd7d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -464,9 +819,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:002ad0d1eb8bb7911ef71ad51376923b3b81d645f52064d338cbd40050c5a405"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/71.yaml":
     active:
       fingerprint: "sha256:f1bda9784a5a344a3c83cfd7b87d4bb62f558d9686de1d5e054ce4f65da63905"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bb5010ced6ecbdd5b82625cca8ec85b6f8398458bf829f3cf7f8759a5d0adad7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -476,9 +841,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:855232e5018b7c9d5ff20826f0260c948f06dc2c3959bdb05c34c15eeef73d53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/73.yaml":
     active:
       fingerprint: "sha256:f98495cd28d4e56a33ac2239d2f81b3c4f7a54df07dd1d2d7bcf0d9e8922758d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9a64f56c3469523cd90419c26f202a345b314f461aaf73333feb67713ff00635"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -488,9 +863,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:041d069c8250105f9eeed920f3c7bbcceee206b39225133fb813f76fac091017"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/734.yaml":
     active:
       fingerprint: "sha256:411481083756d1344cd103770de820bf3a9881d6363aca30d509828154507b35"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:58ba1b46acc553da5fdf62628ea27529e48b39e3e3b9aad56140bd57303df95d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -500,9 +885,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7085d07198ff97f746fa0c1ff4a283e8ef6fc41345ebaac3c871c14902100f21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/751.yaml":
     active:
       fingerprint: "sha256:20c7b3e8317742ce1f6bea9708ecfaf42c08620faeece37c79a21bbc82ee0fe8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:91749afa8d2b9e65ba8ba91bb866f2657c156c42db73c2ab870ad68c8406a23e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -512,9 +907,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:46969ae15c8b42e30e6e09d9df8e5ceba56b7a41466f49349a83c607832b3810"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/753.yaml":
     active:
       fingerprint: "sha256:2068f652834430316a60fa6d96e07dd5c78199892e2f96698359d1f0191758b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0378f8542580a7188924359c1842d48594b7a49c15fd71caa042e3b5f663382d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -524,9 +929,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0486787d0f9cd886b0f8d8ebb3257ba3c635cd1515f9f8418e27c5f5423f0bcf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/756.yaml":
     active:
       fingerprint: "sha256:cff8fe17276b3acaf6851cf5162c5c21bc0495d48eba023cf191c413adc4bf67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9603174116b2f68015a2d84dc2acd0bb6996b955c6b1f4ffb6260ee1d2116380"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -536,9 +951,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5fa2ae1c982213f2eb2a9ed06cbb8eb4758c365f0df5b47c3a7ec9373c1e6ef0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/81.yaml":
     active:
       fingerprint: "sha256:156b9e16ffeb02f3287292f9b85706c2f2d3001be2e78f3bb6db9335a5cf4d3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:86909b281c6542b9d9eef72f62a7443ecf1f74e277e00b4b01125f0aec887abb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -548,9 +973,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:57499d80ef845e93b3b0d46d31ac945d64cc2d3c27c4cd7971b5f7a96e5192be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/821.yaml":
     active:
       fingerprint: "sha256:4a10bf850ae97892a9ceb9981a10970fcaa8cb5ed0b172b7a226cd28aaf7a469"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:275702ca82de75edb5a706b6596e2ecfef7f77b517cfa2bc92599f7232431a61"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -560,9 +995,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cb871f863922c47282cb618170bae558aa2cc004e91550c24e5d67c763184bc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/824.yaml":
     active:
       fingerprint: "sha256:c30358eaca32bb8f0869da4310258617bdebc581c946f4bcaa176309c82a8382"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8590ac61442df9d3fa28a6677263ed2c1a7193391553f111d36ef40b5973f1de"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -572,9 +1017,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ce56e649f97912dce5a1c0ce909e203b82a5cab4e16c6a6333638062f808f71"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/9.yaml":
     active:
       fingerprint: "sha256:31133c9eef91d1dbda7b54d742b055286b4cea860ac34260c8c55d51c1b6f9ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2ad8d959f462b304b3860d33337806ed288aa690f807cee280c5d25bd97d2f54"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -584,9 +1039,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f3aec372cf77fd976e7d84b6678a24adfc093d3ea9cd794cbba8a926567f1c4c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/92.yaml":
     active:
       fingerprint: "sha256:ba8f62134d366c0504066c373e41bcfabf0a27af5868db47bf994ca7b9ff8dae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c3f41aab169cc89d5332367d0a64cd035849e4a00f65ec2207ea1572e061788a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -596,9 +1061,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6e6944889af668630bcc3a841cf2838efeae754ffb9b6af1198e3fe35c01d5ba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-401/2.yaml":
     active:
       fingerprint: "sha256:40d96db44813d2fe53a96a4ab06d577b8ad77399568aa46ee20e1e9bd603dd00"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9cc8e85791381dac9442aa986f13b2bbb7f4ba588715d1d66ab7920c5d63a99a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -608,9 +1083,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cac9ca5938fa20f8f004db8fb5c29b20d24b04a0d258346cca45d895d2501f96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-401/5.yaml":
     active:
       fingerprint: "sha256:346f09d77ff7a708cd7e0d4efcec0aa81e5be6a45c415cc5ca8eec3796d78271"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8592c3878547a63b3760cac887e5dce7e97dd6074efb9e0fd3ab1ca07903dba7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -620,9 +1105,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a0c875169fd17c6ac3f6e460ddd47fc75035f56924584f9110a2cd639691525d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/1.yaml":
     active:
       fingerprint: "sha256:b38ee361224fbbadf2814fe09626cf3d6aeaa63864a64317612a6eb0a31c05ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:338c33bbebb237e27ce62cf7e672cd9f650769544543e61f2c4830fac607d409"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -632,9 +1127,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:56238ac40e10d4ce3cae0fdfe2e0c85683a86a04e9292f400d154dc595d04fec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/13.yaml":
     active:
       fingerprint: "sha256:f8014cfa0ecc12f8c13a579ae2d42b3af7c53563eaca758582dd3c46b227b1a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fd9cfc7e141cc1b50f0b7280ea72198f93900e032d757bfda236ffd42840b229"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -644,9 +1149,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7aeb25d757176e1cfa0382b9b0f636bb614ecbc21b103bdd9700a8bcc0ce6feb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/141.yaml":
     active:
       fingerprint: "sha256:8bc5c5d183675c6f4339dc13ef5b099d6d66d878d5f76c49f5a9cfcdec5c2341"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c75ed777a7f21ec99f57a2d94661be11d49e6391d07b0f4246c6e68eddaea62a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -656,9 +1171,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ff86a1e1c6558e89051b72cd83f097cc70493b5f58ce36d59ab5dd06fc75cbdf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/143.yaml":
     active:
       fingerprint: "sha256:9fbec893bc8fe21fa2521363c5885c622cd840f10756dc2f968c54353b4c59bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e4f7f36495356a55a9ff3f3782e969d7171aebd36b09603b73893d6f4583fc0b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -668,9 +1193,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2f4756911a1c35948e71ea484ff32be47fdcddc92542d6e501896396e5e08e0e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/146.yaml":
     active:
       fingerprint: "sha256:79dc68c1fc733feb903ec1888fe82f607df4a53029be792cdfdb7ddfd8c34840"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b51cb25d6493709dd702f54a8bdbec9203a0d7dd67cab0c6822750ea3eb99e1a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -680,9 +1215,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e3d1b29195ac5cb99d8c7244c35c0e87ef99a93d4694fc623370e0b52042d2da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/151.yaml":
     active:
       fingerprint: "sha256:4e88c0fd82a90321f2c9845d01b382fa11e6ba9bfc8fc6b98977247eb6610bf9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:99568ec63896c6dc3ca7e1890f4c028afee417058b0f2a8fd9c787eea438bf22"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -692,9 +1237,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ea29b47071f449980d6054c404ee038224286d58ac57b725f29589537adbd110"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/17.yaml":
     active:
       fingerprint: "sha256:ac7288c337ea11901af8d749f349398fae0c2313ce8daa6cd1e8086ce77331c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f5c19cb5604e444780e3ee70d1e50147243ba5d729ec00823b712d2eefc9682b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -704,9 +1259,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b4a6169c10d6b71341cd526100aec68ab4e5fb59f7a85727fe3b444ad43d92f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/211.yaml":
     active:
       fingerprint: "sha256:925ba06515533a24fc0026b0c2c10a4edccdb0d8b7cabdd5b8e992402965c1d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a27fe173c240b3c5395b08d168d297f228a4e5b34cfdd7c060043beef2e52b5c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -716,9 +1281,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aa0b386553c883092b69c60ed035a9c216dc139b596c876ad6b280a950287ad4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-403/2.yaml":
     active:
       fingerprint: "sha256:1cc656b4b9c0edc280a750633083c52bc818e27c3100c13f021a0c394d227b0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:958dc02b1fad6589760b5a3a9dccb595d53aafc26fe49f21f49e514bad8460b9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -728,9 +1303,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:55282f391db753079047c39f82ffcc09010e906d0ba565aafbc344cdc5883095"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-403/31.yaml":
     active:
       fingerprint: "sha256:2a62bb6c128b85acfc729a0b2c9b73cb3942741809d552888357e5779c9238d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e1310032da3c440ddb4a210b042d7a0ba08ee3fac677c3e83d3604c6c16492f5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -740,9 +1325,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9b6cee9a536f579ee0de11723ad9116b96d741870872c7986f680f9f469665ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/1.yaml":
     active:
       fingerprint: "sha256:8c6c4cf5ebc8f22793a0afcd704dca390d5ea3ed3f7aa77e564d84cb003b0e79"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:518c17dda0a2c3a925f44741fcaf864a2ed206d609adc410405cbbd6d7511f8f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -752,9 +1347,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ad7f53ded612ef8fff07212e4c05cb7dd79d53d75604dba112b90d54d9f4ac75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/13.yaml":
     active:
       fingerprint: "sha256:e6eedf1f453aa24305d4853d7a8c84b78c44cbf2cff6f6996f1b754e78c91086"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:069f59dcbe2e7bd9dec6ef11aec71789adc35005ab39bf71a75e61292795fb09"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -764,9 +1369,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9b7d8b3590bd49ee68d86b90b963c22602ebef0f4f272d942ddc693cf6d7ab9b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/31.yaml":
     active:
       fingerprint: "sha256:cfbee4e9555937bca79f6f7ee4698678270e78946fca753ef94b9153d6179f1c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:20501bc6c27a597ee29a757121c667cda6a90312650661615ceedb2d9a1194c6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -776,9 +1391,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:689d793617473d589ff24c1c1638568b6fbfaf59da93d85a511cc39fa47341eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/34.yaml":
     active:
       fingerprint: "sha256:7ec0c4c2efd7d291b82b9fab825b88819a14130ce98da111936b0e994ded2808"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:09741ae409415206206cb9f43045605668349a5e03d2022d0bba11699d62b70f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -788,9 +1413,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cac5ee0fb222e4f5aff4e82d1c10e32af8bd956a494e08c43f328d9b4b1eb888"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/511.yaml":
     active:
       fingerprint: "sha256:d58d3395253f13d72b8082ccaf3c0ef3cdd8df6088dfd474065449ea1a71b1c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fcd3305083018849b0db50b548b6b378905813c404ad8b25d331842d3f7097f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -800,9 +1435,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fe003c1e57daf6aee9a7f5c0721060651af4755f745450e13ba995db95e9d4a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/53.yaml":
     active:
       fingerprint: "sha256:c2da170c2f3581dc4567c59b465d4fe25e989c22fd2a4a111fd13887f7f02923"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ecfa47fef1674f3bcb1b7ef016ff5cb4dae4451981ced5174763bb356c900660"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -812,9 +1457,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:922e7cb19e713b1549d8a83756ca8dfb32e259e6fdfaeffed2fd72fe232cf8ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/63.yaml":
     active:
       fingerprint: "sha256:ec512ce11d2821e22eb57e4d82ba0aa5899853a87773aa88276e708f4b6e25b8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e82174dd7c5ad3d02e8bccd062e0015f76d2769f5fe104e191ffe2f9a9e6cd10"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -824,9 +1479,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:74949650257296b5f65d71708f24bfbf1a8f6b550665339161c852a474dfb668"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-404/7.yaml":
     active:
       fingerprint: "sha256:bda64c0fc331a20d67af9c8e01c16aef5327b44b24cbddb5d93f9ceb96649e48"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b188d181da163c2576dbad886f0fb35fac75b522ad7d13611abe72f88f0df319"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -836,9 +1501,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:20ecd14df56c857c318929f3dacbf112d1999edf124472cc83daf9d00854ca5e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/111.yaml":
     active:
       fingerprint: "sha256:03dd91a19e9c3e633b51f064021ac1ecad9948f103f60c43572e6041512ba34c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dc10d7772fdc8a04988c53cea304c61374c1e29c595ed89d5034fddcf8aafecc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -848,9 +1523,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1f0ec9e4fa1de60144cb5b70cad1870db4fceb46842a2864babe0457d42a562b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/113.yaml":
     active:
       fingerprint: "sha256:9975bf79a7e3fc4666bc530792fd91a1da2c5fe820acc4da1a38a6c494c26ca0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d70054cba5b8cdc768d0561010112092e304b0fc5c6e116a0fa098abbe30c649"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -860,9 +1545,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9bd6b3a31056e727737c7ad431f99aad066a6f9a57675a97dfdfe616e3ea6c6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/115.yaml":
     active:
       fingerprint: "sha256:9243ff684b9c06310cec072730341ae34df4ea4b90a74c6995a17659e40fcdeb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:78baf493125bab6bc83534592773f0bce12763019b050cadf80ece50ea53a024"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -872,9 +1567,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:59df76f8355b70d9e1bc48969ce3553b2fd6291f94efd06c321ff002c7a4226d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/117.yaml":
     active:
       fingerprint: "sha256:537c825a7104c67433e07cb9ba7947d819d694eaf0d05f8ab1e9adb74aa26370"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:74cc5707e53f4ae335d23f2cba464d949ce30f8cedeef4b15504fd8de267ec05"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -884,9 +1589,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b33a2cbcceab6c6fb72a4ae4504b18f8501249aff7c7bdb6882edb0dc7dc23be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/122.yaml":
     active:
       fingerprint: "sha256:2467614c5fd3a47f27d007a5c75d52cb441b9d8c061bfd7dec5f22853d049325"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1f4028ce527134822b19d58b11e09529a70abe7d03ecb622b7001cce00680410"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -896,9 +1611,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6b0b22e0bf00d675988a8ae11060507d52af5c38f603ef87af29de46a7a68984"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/124.yaml":
     active:
       fingerprint: "sha256:888705969e3ee54bd2df8bd1d54bfc418acffb43ebe44230478a1363d36ab064"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9ea33455cdfb4cfd59a052738f76175b1dbfc101b8486a87bb16057bc3a88ccc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -908,9 +1633,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:53783a58c015a639fc165337372e919988070e3f7ee1715d2d44d688595b66b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/126.yaml":
     active:
       fingerprint: "sha256:bd5406742496c7cc2ddbb4d2ee25628548d1aa344844db35e0b8a50d476ce827"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3df7e461ff370edbc19575bacb9053c33769a7d2006f106c4c8f5474c48a27f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -920,9 +1655,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fdd0242a40651fec4ee0b60345b49e98e56176db6808c0c8ffb8fecb0fd551df"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/212.yaml":
     active:
       fingerprint: "sha256:34191422d8eeeb60c65c9a90143e8544aec0212a99974fa62209c4729a1c96d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:91a57618bba7689430bc7a72616dce2495b1411bd97f235d1be9fa514c9a84b3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -932,9 +1677,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e10dc67ce51a15a32e98c7249994b1c0f4e80201fe837a2421f5de4725dd0067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/222.yaml":
     active:
       fingerprint: "sha256:c5c3cf13ebffdc92d27ee6557a061b1d430b5d3243b71276f4240c5c2578f2f4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c4c5f2eb2589b7b21de650fde20ba59cc0be6e7a2e5c14f758b63cb3236b2305"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -944,9 +1699,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:54d01c2943f7c13ec04d1977c7305dcf8b16e930e23a55e9db135f152e6bf039"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/311.yaml":
     active:
       fingerprint: "sha256:b25a3a21e3eba94d083f1fa300a05da8f35ed7743b379bb3764b6d86a24b9af3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2517f10dc79c8092acde57bec0c2bbc2b9b8642106b615de32709f75b1db9239"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -956,9 +1721,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:588d870c0c5ee10d19506e57ba716bbb8da4bf7f4b4e69c268bf7854339d2444"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/331.yaml":
     active:
       fingerprint: "sha256:fc48862381420c305228010dd43b265b179371e8e7d8770078f9a09071f68a92"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:45cfc0157b14351588c4ade984ebf444704a56eb6d616e2659c20337bdda6334"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -968,9 +1743,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0755472526f6a9c5af8bbb2858ac79440a22709321c7a54d2ff43aa1e8618d6a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/333.yaml":
     active:
       fingerprint: "sha256:78fa7afd36f7aafd9d1d7e2f935142ad7965f1918e6646cf92140ef964081d23"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:23e6eaf06687868cbdc1a5ac87263e1cd9c0043f0cb695a97ef80e84974480ac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -980,9 +1765,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f368acddb5368ef5f79307c1a72a55b5c8df812cb273ebb70fd6b878949c42a4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/411.yaml":
     active:
       fingerprint: "sha256:1a03ccd2718082e6879795a8ca9c48bd298dbbccbc4a31a309edd14094d7f4c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b18ff85ce29c6de76da80d82cd673255bd423edbb9865be97dcac1b586936ec0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -992,9 +1787,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:47f18e7b4b01e2501aee78d11b67afb91ce6b72d0ef203ea6faa71b71df8d77a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/42.yaml":
     active:
       fingerprint: "sha256:ad3d6abcfb19a6e780fc40cdb258df6224d5289f2d8f663e6c176aca193b8631"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:af58decd3edaf96ba2865e45fbe1f11f7589bce189dccb7f80dac1b8639164cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1004,9 +1809,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:059041ecf3183f84ef92b8c3c3c25ac1f6a2163a8d90ee270fe24b4169559973"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/511.yaml":
     active:
       fingerprint: "sha256:c06f29d36d322c26770955db339a5273b059bab52924cf187b5ac5a80a04a4ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:20c02eeb64ffe4304b69e89c8fbf7d7f55739397071adfa82cb2df5e9fb34969"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1016,9 +1831,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8a62a830ccfa62cb9bc1249d0aeddea8cb4a4897a6a5e75c4a71ab40865bfde8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/52.yaml":
     active:
       fingerprint: "sha256:b84b9d72a03f301e625fab658706cae45e6adb786781e46a3c251a57237b7a9a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b2b5ee416ab1a0a394d413a39b55f814e80a0dc4cc18c0a7c8a3680d321ce655"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1028,9 +1853,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b5963ae386f071f86101348cfad79d3e679128216daf97f93894eef80c458b52"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/53.yaml":
     active:
       fingerprint: "sha256:d9f6279006178431cfa69fb1fc4bce451be6df4ef77aab109184278e959e9b0d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9b724515981650861472b82685623c89797cf6a8a8c27987950aae0f57168a63"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1040,9 +1875,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b64688365b255662ad3cacbc19553ee7c4f3e6a1559d877acbaeafcf9acb6d47"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/532.yaml":
     active:
       fingerprint: "sha256:69f0781e745cfaf31b9bf7fcf04eb7e9dbd29f5f23742b54d30c4e2123d27462"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aad5b62324d8b09a81abfe46db998c2d0a4a8e706a52c607503308e34cd1870f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1052,9 +1897,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b176e20819f75f35eb9f129f8d9908e2948a7dd76268bfe6c2f9fa7c680039b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/552.yaml":
     active:
       fingerprint: "sha256:5345e260613c57667e18aa6e60c869d7af5cc5a957d17be9ee6528d984b76722"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:15ba55ad5442ca4ccab19ac3ac588b1c2cf6932b897728c6213d11c65d3d36df"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1064,9 +1919,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:72c6e8bbe2e4f0b49a2fe0345b9429ee0b99d246fe24da577663a80258e147bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/555.yaml":
     active:
       fingerprint: "sha256:90d7c02d76f747c422b913b0d3dbe89e97a7f858b43f73ad23aa46a658c928d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:56cf27594f4a91688e8467a1e438f4fc23754674b8d43d375c5177eb0c09698b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1076,9 +1941,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e94347be06169c72aa2175a73ff20c80a1cf272d9fc4ea62a1f337ebfcc017d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/557.yaml":
     active:
       fingerprint: "sha256:bd84e7735e4a4d8055a07d7b6a14f631a1ba5a825c781bb06833712a1a1eb515"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:95ea180acf9907fe75ad8b687c3c347379abc755ae83197a3e2b17b15729f4f2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1088,9 +1963,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a44de3572442db52af039f6d62ccd91b2d3a3542b6ca4dba5c80c241b57ecd2a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/71.yaml":
     active:
       fingerprint: "sha256:0f95b112b26a473b4083af5450e688d6c94d6a8335301f7eb3c5ceec6d8a065e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0529c871cfeeb9e7afb68895179f62340f64081bde601810f05dc6ba63c21630"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1100,9 +1985,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0ec542eff0e9b99806371b0027f5cd1fc20e8e3c981a9d75245e9222c07412e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/1.yaml":
     active:
       fingerprint: "sha256:5282940d6007b5982201fcf151dc415588dfcbf47d54ee14b4304d363a0bee4d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cf9b68aa249fa911718edc1dcb43278557d47c7bb9047c047ad2fb5eae53388f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1112,9 +2007,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e79dff7c3bc5bde098e363061b15c6df0ad71e92251f0b1682959e53e56b6e63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/111.yaml":
     active:
       fingerprint: "sha256:7bbbbeb76cc286a89fb3a06bbe0ba5f9a54b384e86fa0efe258e05cbb90e6eff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:32982940a2d7fef7ba4389a123801ecee8a9ab7b8c61cf6a3cd8851ee1a0ed3b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1124,9 +2029,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1291cfda6e385716da7e1921d8533994f8fa42f8ea7b6a6010368b24b3388503"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/122.yaml":
     active:
       fingerprint: "sha256:aac633f9c44c6f495ad90554449e585158ff65d7febede557e5a8f41bd346fb0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:675ba25a1d377231abcc80145c997d74039aa02b1c8229aa26b87f088a1d49d4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1136,9 +2051,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7acf8bec0dbe0f93b1b13101eb84d979515645bcf817be701a61d0a55805c104"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/212.yaml":
     active:
       fingerprint: "sha256:3f17024a2ff6e658ef10d5eb50ffe709bb9b18ced952a3dfc22332176358f4c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a8ebd3dd81f221604790a202d33bdd83cff410d34747c7c2b08248bdbf55fba6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1148,9 +2073,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:229c319ed8f9022f2c2beabb3b83a363f6e020c52fb60dbd42b3b382c3af3554"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/214.yaml":
     active:
       fingerprint: "sha256:b3f3917a6e0224bc377621577473be0a581e9a0c90a86d3633efb6f849eb47b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b1c0cec6e607c0fc754e57619605f8e3d4bdfb9a26d7b8526e80e4838fc513eb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1160,9 +2095,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:12b5dc5404c02c8a20cdc4e199cf844bc05ad4579dff5afe4b89f3c41ab95129"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/216.yaml":
     active:
       fingerprint: "sha256:f52b1e674cd61a93b37f021a9ed22134c32cfded879f209d5f342b3d0464cfc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:354985815e47840986acaea44c7372bb7f573ab59a366d440e56829058a51e46"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1172,9 +2117,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b0d3387ba1621414201ba4a1754ab3be0972aa81981d356d26a72dda966218ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/22.yaml":
     active:
       fingerprint: "sha256:cdd4207bebcc19d55f48c86deb780d70bababd15f4ad433c0fc9b52f22ccb27d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:48c4f8371f266cb3317e98d35ab74157a3f17005d92b904599b906b8d531381f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1184,9 +2139,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b48fbdea26a94182857fea1890f1494df60e016f11d74bc63281369625d17ee8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/232.yaml":
     active:
       fingerprint: "sha256:82968ea87724347aed86dc435afd1a9d892962bb1adc034378f86c57a2fe141c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ef7737da23d63735260d151b8e970aee9c36e37a126442a01365d7e3cdae9997"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1196,9 +2161,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c4c7622be404dce80e84ff26f17f4be54df17121480a74573923fc5795ca36d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-406/3.yaml":
     active:
       fingerprint: "sha256:d4273f578a56cd9d1e5030643d0eda1bde108ea03f08cc725110390248357c96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:704621a52a262c5a359aff110e8a5f352568e771a716d543a3eea4b6f6f6b20b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1208,9 +2183,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:973ba204cb5e29bbf739455fb8a705cc780a7c4dac5f35bbe8adb6050fd20d37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/21.yaml":
     active:
       fingerprint: "sha256:4668c60c19bd9c2c840a82952c68bea57643d638cb99aefb7987974ee0652c38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:adee266324be9516e9754fd66c9729e2720d6a2078a002dcf18bd1b7ac5d023e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1220,9 +2205,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:584ef3e51d36a97b88797068e1dca161ffbcd143c5a4336e3e2a9f9a6ddc185e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/221.yaml":
     active:
       fingerprint: "sha256:a60bbfff494320e6f5a367d752cacba7a345efdfa3adfb6496de976ae0446c02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4986e513326809afdcf036d948560dba4520d0f82bd75d467730038772067dec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1232,9 +2227,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:eb626e2ab2dacb48e9ca869091212b33e30e5bf568e0048a960dafcd63d7032d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/23.yaml":
     active:
       fingerprint: "sha256:c8af50854425d3339e4fc8cb455cd30bc67debb60e15c8830383deec5b1e21ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0bd0b03e738e5343573125576984c154b9bcaf638268d8884f3409ecb340e248"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1244,9 +2249,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a7b48bf06fcc0e18bcd55fd9b20c1eb331c1c3e40941be8c385622307aa0441a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/24.yaml":
     active:
       fingerprint: "sha256:b9fc71182f2cb0707926bc6632731398c7e0139509d26b3fc86a03009b961eac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5006dd15234aff6a10d6c9076b155fec073ae321bed46e946f0b2205b9e33d8a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1256,9 +2271,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:281960277ccb40c278bc339be7ad1743f4e37d874af2a2c5c46dbf5ebe2e1012"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/242.yaml":
     active:
       fingerprint: "sha256:b20c66864283f8da5a883f09ee2843e50b1cca9c343a9bf3ccfc2e063b4b5dca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:961914d251158a0d4b1edb2ea3dbfc4bc7ef7bddbe7445a0d72af499096e0da1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1268,9 +2293,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4948f7f0b5207ed9402accc2cf6496d9fd11bd338bad005bb474be6b5d65f95a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/313.yaml":
     active:
       fingerprint: "sha256:8e797c3adc3bfe2da7005d40368176a82e372f352d26aee433887f1d221ed029"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:da66577e70488ab0a45a70b5e497ed3500e18cdc222b2c0ff0dea14bdd5ab63b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1280,9 +2315,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:697fed335863bbff539af7689852ee3f5a28d9391a3fa0ccfc518bd61e1cd02c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/42.yaml":
     active:
       fingerprint: "sha256:9ac8d33a206b7e4e2fcc945efb2fbd62ff8818d4a82b282781cf0e05b94388f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d1fc3e32d9ac10a64462d4fb5cc6f11cd5b649ab6f2eb743f8cf05a84a544ae8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1292,9 +2337,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f5bb595fd562e952458e975ab00cba5c16e57e0c4d433ce82eb8d3cb970e702b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/44.yaml":
     active:
       fingerprint: "sha256:3aa8c9f85d4be43a78be1ad21b68c731232b908563b937ed8f76290d69b9db0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ccbba2a23c9cddbe3b8cc9fe193b47e24adc6a5656d4cc0c93ed3d346a94db6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1304,9 +2359,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a0a32b50bd002027ad6c57ba95e1df0bd634331481a0fe467e0216cf1fd20d93"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/53.yaml":
     active:
       fingerprint: "sha256:cbaa0b5dd7254705828fa9813da076573a5dff0ddf6181f48b71ae9584b666d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c53ae2cf90a20f847e0747071ce89ad785f85f81ba707f0a6461e3850b0e3c25"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1316,9 +2381,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0a46ecb4742c7960a543e9fd0c7badae4187e317d3451a608e8614e096790b4d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/532.yaml":
     active:
       fingerprint: "sha256:468e627415cbbe262e82d28983a66d8b9a276b6a69db2d34896eaec317d4a7b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c66ddb92ace402050b69abec19b35b1aef560097732b2f9e282f52d98ddf73f8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1328,9 +2403,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:79e39d65aacc4dee26cd78c1f0ab2ef2361a07b126537142ea334a8c30ee1191"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/54.yaml":
     active:
       fingerprint: "sha256:b9106400f7c9726d0512d7c8454f656c3559b1e247e1aa875f20e37800ebf8e8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ac368497f26b06f3686feeeb9c749e49723d4016814ed6edef0119a8931fff8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1340,9 +2425,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f93c508fad8bd763517b44b3d7c075bea7409d0685cbd48d43ad81f7546bc48a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/543.yaml":
     active:
       fingerprint: "sha256:cf1d9ab4b95fe04bdf3449f33f031273e24eb2bccb00d511894538594f3512b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3e171db2cf6a69cc933563c6228a4015c6004b000ff018a74357aa8bc8bde06f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1352,9 +2447,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:84274ca22a1f6af12485d583eead25de8810f229ca1e16ecb6a2dafb3ec447b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/62.yaml":
     active:
       fingerprint: "sha256:12da782c0d99294d149031767bc7c7e4d7a0a3cb312222d86cde793f67a61c95"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d9292fca45d53f11901b1d6d1bc7a717f85b07e590cf497a8f753edfe9df1801"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1364,9 +2469,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:64a29900d65c20ca6fc24ef9d623cabbab254337641019d2fe10cedef0a5f1c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/713.yaml":
     active:
       fingerprint: "sha256:cfb98d19236b0409922543ef25ae7f203243e759db4d1a08c57b3d2cd0bc866b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8328073d59c6f4b3f6800b89a68335f36a50f79859afa0366300639f242ba4bb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1376,9 +2491,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c47619a2650b2995511e8a3ca64f1211e6e5a936c6f0556f2ca7a69391257070"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/721.yaml":
     active:
       fingerprint: "sha256:2e1e48b94fd8f79a54ecd0b51a699932ce48063c5583c6ae209236b9764d6ce0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:898369cf95213b5395e140dcead6346a34880be9d507284a9fcf7f714f6c2d24"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1388,9 +2513,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:97605d9b1ba57e6c1cddc8421d69b66a8808d9484822c8c3784a52adac0feff5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/723.yaml":
     active:
       fingerprint: "sha256:913d31cf4c6b2cf534a2c145f20b6cc17559f3390221a07fdfd11c23c1e7815d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0920f4ec16db6d4d4a7c640feaa45b18c2baab892ded5d964233f4d1f102d319"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1400,9 +2535,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:10e3d9af9925819bb94f54b16fbd84b1386a828cf10f666a7ce71938d7247205"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/725.yaml":
     active:
       fingerprint: "sha256:8b36d20b14d89eefe8912fc886c57f624ef41ea3e64c24b4f8864db535c6c19a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9c588ba22fde29797c7aa331d9c2991627a0fd3b9b914339563b041c5b0baeaf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1412,9 +2557,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f83d3f0ebe10d8e655dca5dfae2766d18b7b0ca95dda1d2f0e80155681eb33b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/811.yaml":
     active:
       fingerprint: "sha256:831231581dc005ac9e0222ddcc293d4c70971f928f3f9010e2ef48c66c23d4d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:708ea52688d54b5e9569c44d0eb00ecda58cf2bb31f5ec8b3312e6575f649f72"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1424,9 +2579,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:771311ee1bc8c3bf4ccb481682a86b98b0140a9460378804442e80cdf03fd067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/814.yaml":
     active:
       fingerprint: "sha256:de24b3ae7c46ae3d3f99c6a6ccbd2788ae8cb79baf4a3be76ba2678bf64c0402"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e68f8258e7c3b4e2d20533856d31bf3c9c871b30ed1056c1d389e73dc50c160c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1436,9 +2601,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8ca676a644caf471e6055ef2402ca6f9d48ad259e547ea7c4591aae2192c8147"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/82.yaml":
     active:
       fingerprint: "sha256:a8785bfbe6aea4d1070d144f5895a8f12c32f839f88f545f9e71c9ac73122f66"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f2d7f55a231a8ce099738935a2756c48fc3882cdef19c261cb66e8c851420cf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1448,9 +2623,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9044a53159af7cd93b41eb85513b1e8631eb040177c24b0bbddc770fc35a4459"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/83.yaml":
     active:
       fingerprint: "sha256:2935d5627fa8ddce0159072270330efeabbec22ff7f58d340cf5e56786f0995e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dc462da8b15476f340160bca4174e26a2cb1934e87a6873524be4dc61b8831b0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1460,9 +2645,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:53409d424492ce6328c3b9683ea903ecd70d736a5f51ffad8841ecb0b9da79dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/842.yaml":
     active:
       fingerprint: "sha256:db769ab17869c23015575824f97a6b0a8a7f267a920131dbe61bb81bb58e0f6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:57521468d4d3ae42279c32f28259de70fa907ae1553c14ed303220c0d443dd78"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1472,9 +2667,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:de0f64aecd6610e587c07738f5e6540366fe05c8dd90facf95e479690dd3f169"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/852.yaml":
     active:
       fingerprint: "sha256:5adf1a16665b1310341526519287f3f4c415e103e7e78967d95a994c9c72c5d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2a397dc510ed117d6adab921301c57fca2dd916c1e82f64a6274beece0519c2b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1484,9 +2689,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4224ab55ff75e2da7ad718fd3861876b9f8fb8dbf2e424a05b55b308fae50b26"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/854.yaml":
     active:
       fingerprint: "sha256:e3ed1ff3181ef3d6722e01a22ac6b2fd9df6443a965600f861dcfdfd34da6adf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fc00fd4ec20719c36717faadd4c46f44f6a2ae53f0c5a4ce9bbb38b7e014cb54"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1496,9 +2711,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:903e8f0c598f7bfe971ae75780d61c19eb4c8430962d4591eb708521ae6cf1ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/856.yaml":
     active:
       fingerprint: "sha256:0a685885e5e98f6d2ac390451e7fc7a46cdc4251b919a473b80b71dcd67391d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2e49f87a2fd95c15fa4eec7f53d7b1a8fb110f0de8dc7cf639c97b13afc9ea40"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1508,9 +2733,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fb15288b6856a6eb943979802bb35b36f695c55fab27d72462881132487d8f76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/861.yaml":
     active:
       fingerprint: "sha256:90177f65b05b39bea49794859c8d45d2dafa5537de6bc6ecd5625521f5b544f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e53fc3990d9d2f7d4506a5bca636dcc9afa04a9431a77f6fe5dfbe0095ee79d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1520,9 +2755,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d92d7dec415e13a451b95b606cd48ef935471bbdefed55216fffea2ada0ac010"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/863.yaml":
     active:
       fingerprint: "sha256:31c43c636535e22efc40721932e8d121309ae78e51ddb51f8ed6e44fc75f3907"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8c5ac09000f18468d5bb236846632adf75a3e4fa6f350eb1a05546d777de98b3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1532,9 +2777,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1d3fdd3ab1afd3dd6399d3ecd693c98307175619ab160862dc53cd4691ebe86f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/89.yaml":
     active:
       fingerprint: "sha256:5831f013ac5e495ed44a9b449fc681459258e327e7e41c51bf52cbefb82585c5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2a7bc449c0fcb3c228cc7aac7b9a3db6a9d4a05bc1001cdcbfd11a680f5c30f5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1544,9 +2799,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d985ec347baecda4cf567aed36bda110b3391a3d5638f57c58d064dc58d6158f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/893.yaml":
     active:
       fingerprint: "sha256:a91d23fd38faa4e77f96a59ddcb7f0f05a7601651eb7e473b00e7ff67c64a2af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:24d432b6972e9ad2584e95b3cdf79995d24fc778503924923292f9bc53ad14be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1556,9 +2821,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a853a0427e07e62e7318d43d41f87877d4c41177e2a8799077360cd8d9d3edaf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/11.yaml":
     active:
       fingerprint: "sha256:dbf1903c7058a09facb624681ac8ad78464410c6a177492793cdb5141ca35fc9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0cc5ca75b1abaa74cc6b4a6498e5958595aaef1a61761ffb0e0e9cadb8cc6874"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1568,9 +2843,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1cf97ae111a26616e5c9548c99ebb8874b49c1f350c75ca877f0860f70f08bf0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/12.yaml":
     active:
       fingerprint: "sha256:e85448eadd6b20f707b365ca01ea20bd480705dba569c14b1ea308997b9a9cac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:260b307f459c5f1dfb10c9142504d0fa65e16c70c5f63ac5c24a8afe7f2668f4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1580,9 +2865,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ef38e1429288d6b1a2088d0c8fdbcf0ca3670d89a1ece52993e62ed204e2f423"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/211.yaml":
     active:
       fingerprint: "sha256:deeeeca835ef032a3411f7eb8fdfe8836e21c25e7e72822623d8731298670b63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:19d7645314395769752c209a5807fa886732637220c0edd3e9e36bbe6cf3e024"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1592,9 +2887,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dffa7f64f83fea493e2e40f415d37fd9b14c726f8ca1c5a63676333e810e8157"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/214.yaml":
     active:
       fingerprint: "sha256:b6f9e7f466419afe2dfe368787bc5937f686e5b15de5ebea448406b1d37a5404"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c5633bc648569726a5996d23ecd3c8e36a88fea8ac5de4f3d0f9d8fc2b48632f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1604,9 +2909,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:161c6afd581fcdb49a8558fd53f97bc6428acef81de7ad7c668c833d8e7d6006"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/222.yaml":
     active:
       fingerprint: "sha256:541661dcae8501e583d5f49098164f33476c6b4c3d7b277d89c307c86b8a4b14"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:162a1198d99087666288717df136737f1d3e2f8b5fcf60be946d4cd709dcf107"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1616,9 +2931,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:681af401c2d983be07fde672b76efa185febf50f605bc513a53b0a1c1b751f50"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/225.yaml":
     active:
       fingerprint: "sha256:6114a05a12d4fce8051c5666e1789c60d7a8afaccc7d13ad75595a793b388067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c8055698c3ddc4102de08ecea90db5e5a27868359e8a48af9a35659033c2abd8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1628,9 +2953,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:86dd51a75e314e939456f76040fb9337841cbc00e6215fa9ee96c2b6b1d6bccc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/4.yaml":
     active:
       fingerprint: "sha256:9571989514347b697e2e29dee620841f01eac59ee79cb6e9f8922efc74ab1d12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f25b3d4d8354eeac2bf2e2ab8d0b1caa28892b352c0f9cf272a48f782f6f90d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1640,9 +2975,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:38373035b2d5ce5e27e1a0188f7204a57d01ecf97066b5432b9416df6b1bf846"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/42.yaml":
     active:
       fingerprint: "sha256:89380c542c3326b888c8fb12376f9afd2c4e1af744e188dd67ac07f88161f72d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:795cdba2394bac5f56aa0120f8800315d1587dd450e14cbbbdd4b5b55137517c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1652,9 +2997,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aadb95a8994e10aa7c9d47a3eefbe84088e3b7e3ef0a558bb6c8f0d8076f3443"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/61.yaml":
     active:
       fingerprint: "sha256:ff1dfd9c1511f67eff24845d1577b66f851c7b09a06bd5c402d3b1130f7d1935"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c930d67c60ac08200fbb0921e9125cf2af26514e99001424e30ac2d3771c4933"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1664,9 +3019,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5ab04c52b6ddb23bd4a43e43c108192c7327ff2462af90dda49642fe0c76c2b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/63.yaml":
     active:
       fingerprint: "sha256:207bd1dfbdd0ac6db2993f42981a1deff459f25b742c0d1cc8363740ed04f903"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:820ae705ce7c4e93a2c106d20813458bc8717869363e77272651a3f26ff29449"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1676,9 +3041,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:35f1d487fd0615b254832d43f63950f611ab92632f93ef491d8835b377e693ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-409/111.yaml":
     active:
       fingerprint: "sha256:af23ebaafdb5f552661b344c0cd5487d737dfbf29482ad86efa717f4412b7ba1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f3dfaaa0cf7498755b1be9b46e56ab48ca6a224d364b8e0a3286109bba61752"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1688,9 +3063,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:138b51173cb08bd471d0cda4e892d0f862dc541b9eb7f62b9b64581be4ff9e65"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-409/12.yaml":
     active:
       fingerprint: "sha256:611484fed946e905e2b5b37e7f0d0b154dbb2500a2d725589d4596f27d7ff740"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c36e6912ea3c3ed917e1a94d05c40e776bc4369caaecb5847dbe43b36d3c3018"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1700,9 +3085,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:143935a8e4c289edc74dab7fe752cc6ed3f161faaac98036f9c4ec362616d5c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/12.yaml":
     active:
       fingerprint: "sha256:5d3950e74506da2dfa935532cef64f4b5102fe4dc75f6ea1eaec3b7bea327fca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c1c2e89085dd6efff09a11c7421645d7879a48555ead7341bf78049a01f29e2e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1712,9 +3107,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f8cf0d33f2335bf8e8f1faca1a5f7293b594ab69cf92941f3cdb06e6841b4f53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/14.yaml":
     active:
       fingerprint: "sha256:29e9fff08220642535b853cd425eb72a8f990f398af7dd97b548d677ae0f61ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0be5fcc6b06d46aff8c2611bc62c2bec400f4cf21740ef58d2b7c1ad1617b1db"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1724,9 +3129,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8fdd5bfb9230c55d1032d7d0b72b8a00d90e26f29798a0a08a1991878e80ec02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/212.yaml":
     active:
       fingerprint: "sha256:8e354a899695a9bd209e76e649292e81c3317856239ed1f71396460d3f46a963"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:75c63f71becd0416ddf345ab86bb803627f2d493489e9d5f54113bff61060852"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1736,9 +3151,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:99d704f9fb14688b85d4fd706edf5570abb4c0c1876d5bde7d5e24bbd45393fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/221.yaml":
     active:
       fingerprint: "sha256:262055122bbd0bf9d52535bde798f2422299cb213ff29175e03a1b07dfaa20f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d352aa6a51cbb61fdc3768ecb864dc8776b62b092522f97ec6ea64f21601f9b1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1748,9 +3173,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a214d007aafe9ce5a69ea727ccf77c613082da81c932daf8259421b4d31f2362"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/321.yaml":
     active:
       fingerprint: "sha256:ac58b72eb321c463f33454a3cbaee705efac27fbe609e733bb3595ed13ad16bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7db8e583207465f1e54ec0bca09cc7d291a8523156dac773f0009bb8fa8ce04c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1760,9 +3195,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f4fd3bd77272afc532e593e7f2f9b5c8c23ccddc49d970667e56fcc1592c08ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/323.yaml":
     active:
       fingerprint: "sha256:6d15b02c50079c68aedec5a4a3e1f394efd6b968c5a34a5fa577515acb7d3637"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:af17133055b9130b999abb30c060dec16b9150674df98a1e37f76c7d2d1ddb02"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1772,9 +3217,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b9e520d77ef78832869fcd7ba3c3f2af91156bd6121178cf1eb8a8a3de07c762"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/34.yaml":
     active:
       fingerprint: "sha256:965a0999503c7e91205d34fc6032b17f1f8cb8a098f04fa586c1d121912aaeb0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c46df1e149584b6942c252dbeb747f8ae77a8482c1832b6cb0ac253d4ff8ead8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1784,9 +3239,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a56bcc4ddb4b9be7d8d69aaa8fb81fb3a6f442bcd2fb3fd5b3030c5b86790b64"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/41.yaml":
     active:
       fingerprint: "sha256:f13d2bbb10cb38b2d79e2112b726f9f5569947abdc0e15693e7c196031956942"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:04e2ce4d34e1d6d59e4b91456f91afa52cbb435125306950c026a3f4058b79ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1796,9 +3261,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bdfcb5e994ce394994dbbcee86375af0be3c501968b08e1142c65b87938b3862"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/412.yaml":
     active:
       fingerprint: "sha256:4fe152ef0e97603cecb8707fdf5d6538aa8a46796fb215665adac51a38626dcb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:530457cf12d466ca1b7686a3792b08d7a6d224eab2e3e5a30a7b63c472a8dcf2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1808,9 +3283,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:becbb8d8a3b781fdc3b968d7cc1e023db151151802427460bb87d0aa373b79bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/42.yaml":
     active:
       fingerprint: "sha256:d1718957f719b5a65fc01b1a030213b8f36f89be75212072141acac9281c3951"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f33d9039feb95eae2c52bee603e2d6f33698170b45cc3d2d84402b717ce4bbe7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1820,9 +3305,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9403fcaa0101a4040654a7fe8a46095f6ff33f0559b043550f64617306667276"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/431.yaml":
     active:
       fingerprint: "sha256:086e94a0f40f39df05fe1174dcc676cd76dc8af205033ebf724f7b18064b3a41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b2250bbaa5f5fde310e25916e7df358d3da9188e4daef5b9c24d0abe24b12493"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1832,9 +3327,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:21e526d1e97a2e864b8e2d62a44f1e36b7089165c68448e99c814b0c0f195969"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/51.yaml":
     active:
       fingerprint: "sha256:196abdc9f119574cc59279f3f005e45f2dd5279e0d6cfca830b6c8bb919a75db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e513c857c420e2f471ed9355af4170b290c391bbd879019abf8a28601c0036bd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1844,9 +3349,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6e098d00b9292c8a3a4e05ec883e79ff39802e6714763cf3816a21f035e194e4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/512.yaml":
     active:
       fingerprint: "sha256:208fde43d7bacb9d771cba602e018a1de0bf6b8a739837eb0801b81701a5b13d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6ffb366009ed0d141cb3e0ac8e045338336af405c84fd02bf04df0d1e0c86608"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1856,9 +3371,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0b383f785282591adb8730cb7401f41dcc620b156ce1ce6ea0b003983fdf3dc6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/52.yaml":
     active:
       fingerprint: "sha256:c28f2e495fca544702c4a064e8f8a0a9508c2bf7d779eb561180d4541e147ca0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9ceac3dabf5f87103cc06d1cd762c5715aedf44925c54f416ff73605fc612ea4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1868,9 +3393,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e64f3558a03a63a01dbdf8cc39f9cbb2e977d07c2b4aa2ffac07abf479ec874b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/53.yaml":
     active:
       fingerprint: "sha256:f81cea7da3ef0df4938b25cb37facb77d5270e561d3604eb0c01a1d3608879b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f48e66fe1fb30d0509d674ecec4637a49be097281717650bf761de97c7d6d6b0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1880,9 +3415,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:605ef3b745375c5b8a518269ebded4577b95d99654c907bda1a61c7fe40dd024"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-411/1.yaml":
     active:
       fingerprint: "sha256:cd4318b3b5a5d277b5db53b2656042b0ea1f68d52059bd1cdcc73ca2262880c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2eaeea8f9a0663afb4d219f4986dafc4391fd1bc1cfa7553b76edc545482f348"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1892,9 +3437,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5537d8e530627086a6de4f2c6d0eb2bd7e4500a176d9268e4a9ea11c38cff3be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-411/2.yaml":
     active:
       fingerprint: "sha256:7d54c6e5fc5a305ad761881b6e714d0e8b110fdd6dac6e6fb93d533af0472638"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cf0a77b487df07dbb77bf2820d860472dda39eb9ccb0a7bd0ecccfe7d73dd410"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1904,9 +3459,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:73473f469c7ef2e7f31752bb631b56ca2553a579ae4497f22514c3fdc5a59e1d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-411/22.yaml":
     active:
       fingerprint: "sha256:623999753055822cf2a40ad79d6ba999ca3afcde8397ac7092fde4019ea69efe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:32468ca2329a9759d544ee1155cf69c25cfebc6c4773088d33ea5b1d340d825e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1916,9 +3481,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cbfe7abef01407ac9a231f62e14ed75e42ffef2a7de06e51289e220940a9d7fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-501/11.yaml":
     active:
       fingerprint: "sha256:9331dfadc10f2a375ea1d1d5f48e043d5f5b80757d8135035834a39ea17b01f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6b2dece0d47a4e95003674d5f4484bd0cf26528d87f5882f07299f3cae816580"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1928,9 +3503,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:60c096d9e191be170bb99c5ad9396c93826a53cd7f0426c74332c08f4eb3ee3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-502/1.yaml":
     active:
       fingerprint: "sha256:b448afe663786d8e6af95f293ed3dd45d2e2f4961e727760ded8854e875f4249"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d942d941dfeb462b42488e3746d9573db5bb9abd0bb64e709f7202aa17ed6fb1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1940,9 +3525,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1fafef708484293044c11dc4827e10f633e067c1a3abb1700a74dcaa8f15395b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-502/111.yaml":
     active:
       fingerprint: "sha256:a91114e146915158a8a3b5cee2fa356cdcb328d5c7f5d79435b78ca807463cfb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ef22054e5fad831c3d329359decb444f18dc6d390567b8ea81416d2729939e51"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1952,9 +3547,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c2a2a29f7a8b119edb43b208182a9d357abea0b3807aa5857da02b7cf4a0b83a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-502/121.yaml":
     active:
       fingerprint: "sha256:7809ed461dfe835776ea212794dd547e9f22079e3756f7cb69480d13d661ab25"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f46652f9d3d92eb1d703a58572e7b20969bba9f40c6c5fcabd457206f49e0340"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1964,9 +3569,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:46c007c5272be69d2b05d77be19e6ab41542c03f66f9c9d9f1dca5eb7193b2cd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/131.yaml":
     active:
       fingerprint: "sha256:2175bb1b77a532f341a080cc205aa8ff594a520207b41d079dda69cb7a8f5116"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a1971ac28832a58e0e0a4c66844f61b51f42bd9023e23ab0a9db3669fd644239"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1976,9 +3591,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:22f4252288013e7515b5956868abe02f4fd83e72deaef983814d6c99fab856a8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/14.yaml":
     active:
       fingerprint: "sha256:5acc4eb20af098da82c434a1e525e62800621ab5401fc8607c8b7abfa0c91b72"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c66973bcb1ec9e352dcf12113dceb563d768446492e39f9c2543bb2c97575df5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1988,9 +3613,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4ef42ebd41b5108c9252add3daf42dbe27fe2733d3b722f02678de9687232fc7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/15.yaml":
     active:
       fingerprint: "sha256:ffab2b9da2a09211942834013efa4d369a5290c4486281eb3d7ee559ed1be13a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f1533efa7fbbead0fcb4cef72e98308136c89d146f49d9ba8d5e9eb9abfc0613"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2000,9 +3635,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5e66500020d70edaeb900c3779e8fa0733c67a80992b302c5416255f013248c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/16.yaml":
     active:
       fingerprint: "sha256:220708bd8fb9d46f6e7e0341eec9fa21108b030f415cef5415de9217e5e1201e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c00e4e5a0981078cd7491062be3fe7ce3051eb41698f824fb59546818e0291f6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2012,9 +3657,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:70edd0a493cd8f8237e34df602871fa66f6c3c56b4b41709e0a6a1141e27676e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/241.yaml":
     active:
       fingerprint: "sha256:56bb7c477068d5b1e8c792172feae7094aa1501e91e77f05051e2b1e5afb1d0c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4e137a75f0532affdfca0b393e0d278a850661778cce1a8141f07b3695f7ad45"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2024,9 +3679,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b786478674d0ba29f59391a5abc9e7ae984f5d6b66d952336a0bee5a8e97809d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/253.yaml":
     active:
       fingerprint: "sha256:20f5befe0535cd671c9de6b7e7a78de64b3684d018b2aee69d9cba6da087d71e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0dc5e1bd1b61a250ba518c023a35ea99da658ad933e8029f40c8b4ffb4c35401"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2036,9 +3701,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7602553a3b25671073102ed9aebc5a693b0a70fa6f4b9b0d9da652821fc9468f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/255.yaml":
     active:
       fingerprint: "sha256:d6dcedf2c1298d31bfa0abb630b02e1060d61d21cf1b466d922d5f8f84a2163a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:04d20cd9125690e82739a1880eca17abdad694d68c2f8abad380e72ac63390c1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2048,9 +3723,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:79b47ec106d5fbf98026c782539a40a7a38881ca0f69c997af502d383a9d4857"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/311.yaml":
     active:
       fingerprint: "sha256:ba4900f21cb0f3bbaa9c051fbc09b35eb34f28aab9cdfe81513decad47dff79a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ade7d2e733f7d3569eede2709fa7d2d0290ae44e8d8b12f7e4c96208054ef534"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2060,9 +3745,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:08b3042ceb366532ba1166a368b5727e7a55846694d660684ad071ecaebc5002"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/321.yaml":
     active:
       fingerprint: "sha256:89ed01f661388c240237a301242fc42be90cfade39b48264cf08df90604eb63d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7cdbbeafcdbff68ed82a219ab0c04a0d00e3efbbdad2da39561531c029494be4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2072,9 +3767,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6cecee56920062711f3c03d956d2c534062fea8cdadada60b7ac21d28cdb1fa1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/323.yaml":
     active:
       fingerprint: "sha256:87a53ecd732480294f060e0a747df7bdd0ace5b6e82983e5e09853d534e86a69"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:61d9226454a4c520a4dddc9154a5a47bff1c5c31b9bcd0d27e9e1c7d3d6e5b7c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2084,9 +3789,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4c424ce0ef8059ea91f11559f58351a7782d0128dcaae73ea7f480dd30283944"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/326.yaml":
     active:
       fingerprint: "sha256:0c62705d87a5f3a837eca3419427eb2bb21cd41ee0214cc5fa253afe65fa1f75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fa4f033cce4f1935279f45863422e86b9d2ad63085c1d934a9b95667bc8548ca"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2096,9 +3811,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ec89dd802f2106849b5c42a4ccfd25b9f499951649c3400e3735e3ca12ddcfa2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/328.yaml":
     active:
       fingerprint: "sha256:39de5c9211fa5694ef16b3894cc44f272e63a1b68d7933974608d7dffea07bed"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:41688574a4d29f28baf53f5895011e39ab30f7248e200d78a26cda9092642b46"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2108,9 +3833,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:170af384b5dfbca989ce0bcd1d7086adde4e6d1219791f41d5fc55c1aae40dcd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/41.yaml":
     active:
       fingerprint: "sha256:20ec7367b6b241b796583fb0d29b6c82320b322fdf0706ebf6ec24b15b1eecc1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:14b7715e1898c59ad134205f269e63c9ba30627a00882ea2d844335214154fbf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2120,9 +3855,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6799738d93e3a5c60cdd21c2ad5f865177f54cd374b12171eec94b2d3ac7ddc9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/412.yaml":
     active:
       fingerprint: "sha256:3c72844f2f6cc274c7af9ad348d41175ca7d7ef89207ae9919b7943324321c2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cadc6fc0f2c20be6287a3b8adea7c66ad147796b393fab3dda0d1cfffb51e851"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2132,9 +3877,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d9fc242d5b095e26c20b1887a50ee0cf391e1c19880ab14fb954b38fb0b2119f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/414.yaml":
     active:
       fingerprint: "sha256:d01e7be8aafbf72d2c3eb9fc4b6061e08c01787f4788a50278efd355719313ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bde1a16cef5edb6609d81633bf4f54ad75d64d1af6dced1be2e1b07ab1b983ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2144,9 +3899,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d78f7667d669f116d5d89ef6d9b49ad56e1463a32b1310613374a14673d0394f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/421.yaml":
     active:
       fingerprint: "sha256:ab23f1ac86fe5a535216251f1a7d01a34aa77a0c49370cea3ec946ff74bd68f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b6e5210e372810043a3d89bc04366e609178a81d608a9498be2c23ad61b02bbe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2156,9 +3921,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b9f86faba3c78746f249c2abed9fad4204534c5c6b23caf75e9400109aa7e50d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/43.yaml":
     active:
       fingerprint: "sha256:34c431faeae943b72f34cc657d1b5b1e8b9999cfa45e8164dacf33c75537b500"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fe596881af4c56dda7449488eee694a89739a61ff3434fb86ca5fddecb34d608"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2168,9 +3943,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:73446906e9e41cae7c5e293a5ae20b5de630f34d2d71f2c44ef580ea8e642d8b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/432.yaml":
     active:
       fingerprint: "sha256:a3b8fd427355aa8b8b07bc71ba39b10449728bd576a7c6c6c8cd21e192c47b38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:42d0b89fb5d756a1082040b63e1b5f126e399c5ce53a2c5d24d1e521d8f750ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2180,9 +3965,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:96a3811c16c1ac15b08297773cafdc7c59e67f0a5adf25bd75689646aff25b71"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-503/434.yaml":
     active:
       fingerprint: "sha256:292cbfe786e2e0c479c9d3d451df9c28b7f07a93cc0e50df5f11440999803d11"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:65f37ffc1a020ba7c38ca4d6981c0060d77199be3910fe051cf9883220050390"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2216,9 +4011,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b4cc1c781dea7d3ca96043fcc8165edc6bc95b2d99fcaa6b9170f59ff2b4664d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-6/3.606.1/F.yaml":
     active:
       fingerprint: "sha256:63719eb46d5471f3410c1f71fe7bae2e43b901405b383b1b3eaa04613312bec5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5737f1cc0ad920873b546935588a901f07525621937a03a4e3384cea7746f0fd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2228,9 +4033,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9740986efc6338f0c392f57ba7b42efddebbc56de5e06a00d1aa243f9bf01b88"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/dfcs/snap/3614.yaml":
     active:
       fingerprint: "sha256:8ea5d5ab2b9ed1cfd300460127a6d17da2d7c6ed45ab147792a941b2211cfeac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9331d574ec86c6e782e7cf092ee67bf2e2e4b6c1f776eb56c6d64be6e2291324"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2258,9 +4073,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b05ce15c601ed05da8a980c76ffcaf7f82d9d4ee6fab9f3cb2e3273929efe97e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/4/z.yaml":
     active:
       fingerprint: "sha256:486d4ae2a845cfae939add76d87c111b165e53e7d1bde9e1c7c8664483a51af8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3ba88a6fc0e863ec29951ed7b45ce32dd6288120250a28841f79ca90befcf3fb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2270,9 +4095,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cc70c373bf0fe4fc7e86d1f6c02f4e93223b45be9cead0251b1807c3fbbf2936"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/362/220/block-1.yaml":
     active:
       fingerprint: "sha256:9d24181076a17b12d8e0bb31fcfadf0d006d03a43b35c46cbf1d541d7093e7c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8cf2841ee10ee47ef9c378677b68257bcb653b1dcd88aea96b4d3bebb1e6c9dc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2294,6 +4129,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:528f257d99fcc879fd43a6067f13f5f75db0f08f138a833b4fed76f20a52b246"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/366/150/block-1.yaml":
     active:
       fingerprint: "sha256:60200ea858f3edee0966cd9c0bbf38ee576a8f92b8ffba6132b2b8d3efbdb778"
@@ -2303,6 +4143,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/366/200/block-1.yaml":
     active:
       fingerprint: "sha256:5657c74a3284cfbaaad56c1c91c77b6640bf9b9dc030f68d2c8872cac049ad06"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ny/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:3d812a02cedc20a5fee110a59660c251a77cdee3692e1bae2d1bf77b6435121c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2318,9 +4164,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2dab9532f756c49907cf74ad4ffafc7bfedc146b28858b03455d06361b80552a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/10.yaml":
     active:
       fingerprint: "sha256:d369487fc459ea0fa0f0a78cd069f780e8acd93cf336b2f67568cc43fe300152"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9a63a2bebd4eae18977fed1bb899c2512997362969ec5c0c8c9d878d58b038be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2342,9 +4198,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1643f7e5042a2942cdce4f8f7387cbc3fc0ebd929b636e540a442a7e9461f6bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml":
     active:
       fingerprint: "sha256:d808f0bb924b9e9600f76638ef8b7093f1a6fe6fbc20d854a412682ac16d89c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bd3d8da1a7d42623f070d259989982e2eced637247b7655c7da81516e2c82c30"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2360,15 +4226,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dc4e2160a3ea8c25e1bf3409353b695ac3333a7deb409856b3ab9a04f1a840c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/14/a/1.yaml":
     active:
       fingerprint: "sha256:908aedd922588a1c9c71a500565ccbd1140170d917034a1c173473be4947de65"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:29f4a198620cc7015a4cd15c09d98a6dd35ec06c3185a52b0de2b561adbe3015"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/14/a/5.yaml":
     active:
       fingerprint: "sha256:3631a5f5f71c26e988d8ba2895f6f42d8767f41ddcc2d976b8103d829fe4b30b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:40297939f335ef39f3cdb97741361f50d6eebb25961094589f35451226841bf2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2396,15 +4277,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fedddd8f6f80fa14e864988b994c2490d2f11eb819564365cb5b4d5c2cfc5bc3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/ssa/quarter-of-coverage/2026.yaml":
     active:
       fingerprint: "sha256:d3a3a4282e6b777c6233cb48dd9b030c3848321dd1b385ba4da40e3ebdd4006a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9af5820da7f1a33c3a513c7e88cc87e885239a78cee67e39784ccf16f19b9b56"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/ssa/retirement-earnings-test/2026.yaml":
     active:
       fingerprint: "sha256:67dad39297d8c5ac06afb6d071c9f55068560d214c0d652f35489fedc9a45ec7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0ab52b6bc99fc1cefc5ff0da4c2268e085fce752b23a23279636412e314dec6a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2432,6 +4328,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aacb2af7bfd4e64ae36f90e8b684e33f5216051cd4b562b504e251d76b55419f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/1402/b.yaml":
     active:
       fingerprint: "sha256:faf6c47edafa4d179deceb6545c7aec0c8f25d3b59b63c261ec48d40c90ff325"
@@ -2450,6 +4351,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d0bc32a9bdbd8923fc2965cda7568ee5f4561c6ca39dbc57c760b372de03f0a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/225.yaml":
     active:
       fingerprint: "sha256:a219ad7589c35f79737b6453c6ad9cfcd9bc5a41736c219e4dcb7df6a61d2c3f"
@@ -2459,6 +4365,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/24/d.yaml":
     active:
       fingerprint: "sha256:0e7b209649ff6cedf46b5f75e4d84adb23054fde3ed991637cac9e1c7f33a277"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:988da5c59a8fe5c15fe1349922433c3504c553b0374af92dc1c20220a60c6494"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2495,6 +4406,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/3241/a.yaml":
     active:
       fingerprint: "sha256:a3377538a56cc7aaf505ab1048089ee00c892c41c91e4e059feaa437feb29595"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aabaaf590398be420b7b3c8a71c17bd47b6c660839a46d9717c81c349dd29717"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2762,6 +4678,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0523216af81c35fbf8838b2f315ef061be8c5aa95eb9c88c3c7fd6b45b15971a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-az/policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction.yaml":
     active:
       fingerprint: "sha256:490860199a0e69dd9706b6699891dd998ea63e44feeffb30df11ab68216bdbcc"
@@ -2792,9 +4713,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c5bb260f4ac8e67b6c66b62a0887d303354ead1595064bd94d86c56e58079900"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-6/3.606.1/H.yaml":
     active:
       fingerprint: "sha256:bc0e2e49bf1736af142dba2340c084f16f721d13feb13a7a7c87863416cb2109"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:44a3796fc807397fca2e3fa5039ef079612a155eb10fcdf463a1f76f8c69e38a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2804,9 +4735,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8ed92951663398f975da443851f649ea77197a640c82ad513e6e64c1041821fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-6/3.606.1/J.yaml":
     active:
       fingerprint: "sha256:38e5539d105b0a3f95583e5cc84421fe7c0b0c924c74cbdb8ebf96643d984031"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f2044f05d0e714b53eb5e38a7d82757fd29e99b43054f1758cded085e0710c15"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2816,9 +4757,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0ed2ce23ff264219b2367888cbe13620e17c22e6c70a731007e3e81af440d827"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/3/d.yaml":
     active:
       fingerprint: "sha256:78919d7c5bb4799c662b2ddec76b851a6be33abb37d538bb459e21cd51a157fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8da16ce391cc2de38c753311a4ddfd17cadeb219fb6f91540c74bdabfee6a5e5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2828,9 +4779,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3f216a003998a7231a9b55e1fbfccc7086ce7a9c658cc3b0770c19ff09c13cfd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/3/p/5.yaml":
     active:
       fingerprint: "sha256:b49bfa5ccdd0425b89e61cfb4759a4053406589ec4f35ad7f85b29c4d2fe9866"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:30dd435a234b238fd3a76da0d61c5c65fad6d1be3aeed298854ade018b2cf95f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2840,9 +4801,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6b666af35a9c71455a5126428e1ba7834d6093c9dddd049f50b44d4657b884d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/4/f.yaml":
     active:
       fingerprint: "sha256:6dc5b0b5be8498f8339a9db5bd9f2fa732bbbe3927ed84854e8bc39ac796168b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4415fcf8346ebaea099eda08adae42a5d4578121c57efca9bc8c31e351d123d8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2852,9 +4823,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0e4f2b04d5b62acbdcd2eb16ace1938e40a629128329ef2413fa185f8d7f3726"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/4/m.yaml":
     active:
       fingerprint: "sha256:5a6e3c17d7972ead2dc596cc33fbf44a13acf5885338e72a8decfe4dfca7dd2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:65cba017235d0f84091e90f273f1aeed65b4047ee248a6a6a25ae17b1d906fd5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2870,9 +4851,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5714add04da250b42adeed449abf05a46012aeaddd4c1742dda44f7dff848ec1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/4/x.yaml":
     active:
       fingerprint: "sha256:e76e243587a1c97a015603d422c454c451615d206f656eae48932f521cfeb40d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:51d0819410cc74367be983d8121a2df87f307d2030ea0e4c1bdc2655c828fb40"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2882,15 +4873,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:963d7d0b3970c12cdbb2cf0d76a7111b7f8431719bc4e89d86d7df1381accd90"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-119.yaml":
     active:
       fingerprint: "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6148fd5e4730e3815ecd273cbe8abda5bc3c18a4f98a92775f0e0f557b4ba771"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-22-123.5.yaml":
     active:
       fingerprint: "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2734630a88c75b99d0fa5e1cb1e34f506308c25e2ecd7b5ec8c31d7a8fd03017"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2915,6 +4921,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/360/600/block-1.yaml":
     active:
       fingerprint: "sha256:6a6999ec7fff235bae7cc5761233260f08329726534dd8da8a323fe1224e61d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a196574ebbf56fbe69f5c0110a6ae5c4359dda9774e62af3a740d4c569578d2d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2954,9 +4965,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2a5a7d45235c3f81ec3f9290f2436900cfbc420f8b9dd78e5ef791fa94d87362"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/361/200/block-1.yaml":
     active:
       fingerprint: "sha256:d32fbcf7f2a762ca3cd0e8e3fa5e3d0a2a53fd5fe5555b74c52eb531216423b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:21d07e74b1404a09efd58ad5df2ab79a5232675cf8e20fa292346d34ce146625"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2978,9 +4999,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5f7aac87cf9a5daf1a099ce3ffcd88a76618e2bd5cd5095e1fa82302216d4891"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/361/310/block-1.yaml":
     active:
       fingerprint: "sha256:291e66af9c79345f8645f56b4e3e47f4ae0e5cb6f6300aca7eee4549ad2422b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:120752b602e9977973068767b48892727c251cc6852ddaf4a338620f198f1641"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3026,9 +5057,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ca8d63a11c0add3e74fb0ffcd4fc6eaf71a517b1b905c2e6d590946269719a12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/361/620/block-1.yaml":
     active:
       fingerprint: "sha256:17a2294aecbad5b7eff1b599ee2180a5aad0c458075b919ebbe944530eeb8291"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dff7eacff25b48dd6793e184f054726824646daff06a48b16118c20b6b1fb9cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3056,9 +5097,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:05038f2a0239c0fcbe33d41c8edaa00cc7dd0c56f386e09a82ded2de00d3fa04"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/361/940/block-1.yaml":
     active:
       fingerprint: "sha256:7b123705ed6f5778fe7a89975760fc07eea503ea8111e9b7df874efc91b553c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a6932856c5d3c3261a6c009b2a1cbf9345fd618309568f6a878cd85ee8e28c78"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3074,9 +5125,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4b7522ae5cb5528dc49f5f1bef0efe89f91a36a10b9b4bda83ee315a0857af18"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/362/100/block-1.yaml":
     active:
       fingerprint: "sha256:2e47e459065d4ed1751fb5f15ff7776e6d7a4ac326a478192fb28a6698ea6c90"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ac5167ebf92db1159fa28815117c08e3553f12b9f79d53b250b58ff179152a67"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3086,9 +5147,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:54f21a8ed7b45ef993545fb2f27ecb1efb44ba032425e6b89b7d7479ee4d7691"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/362/210/block-1.yaml":
     active:
       fingerprint: "sha256:b520efdb0ac89916699a46ad2836f2739afa33ed882886a5a2795f1387c84b96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ab8a39ebd0c9fe3ad9628f1e460d466242c4fd990a84157c336e2ff5da7a996e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3098,9 +5169,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4517db02ea9976738cd9ac2971ca68e601cea84015d28225d0d868dfeb744c57"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/362/330/block-1.yaml":
     active:
       fingerprint: "sha256:76120daa0367c4d9b640c192ec2b4ecb8af41c45923b6340829b51937b622c87"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:32b273de3c171786e9c52db4c745237edd6bac93374e5aa7eca3e50471660d34"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3128,6 +5209,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e7d489fd7767f7958b309c3b56404d8b6a5b255caf8be87a66d62d57ccf82d1f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/363/100/block-1.yaml":
     active:
       fingerprint: "sha256:7c22a86ef128ac0d735575e4f480c1c54ec136d648bfe628195e972a76d09bc2"
@@ -3137,6 +5223,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/363/110/block-1.yaml":
     active:
       fingerprint: "sha256:79a9b174481518c8c778d76a8a355ce444f217892e78b229dad7cf6aeb0cd1fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0ddc7810e824e53a573b6f0ac1b03038af150a7b3b9af57a8e64852d9f2c7ff4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3158,9 +5249,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ceca5e9d38db1e20deaeaa4cd45458eabdb4bc168db76ce9e6c374538a26a2c7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/363/210/block-1.yaml":
     active:
       fingerprint: "sha256:f9c473127924962d490e885b635a06d2f034fcb004a2419faf072ebb8d3075a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:751bbff1dc3b54e0682fe32b274334cecf9c6b44844feef5fca99fbbfe2fc1cb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3176,9 +5277,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:046ba887409f8eab32d39bbb08389543c45a424fe3a66e2b4950c44069066da4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/120/block-1.yaml":
     active:
       fingerprint: "sha256:d1c707ae67e60356632918cdb8acd72d277acbddd8f0ee005c5e70f56186d2cd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e734f3af8ce51de3a9266ae6f643501174b0645a3b7aa419951eb4b4740cc51d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3200,6 +5311,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a4d3efd228ee7f769400e753dba6a31de86461a0c97953ac57130586d0fce75e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/330/block-1.yaml":
     active:
       fingerprint: "sha256:e3c4a020ef1675c13037e09916d8711a07b0ffd5c49311c9592c9878acf4cd8b"
@@ -3218,15 +5334,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5aa7dc34b0ce13fe3474118169aad8ce8575fed0ed71283f73067e8aa72634ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/370/block-1.yaml":
     active:
       fingerprint: "sha256:701b530d396ef91ffc519178801a03d61e23b78473c3c96d7a2e4caa3ccefc41"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c9a2066dd32d8e3534d2e9a04899501cd07f21b207c6e04549ab9347ace301e7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/400/block-1.yaml":
     active:
       fingerprint: "sha256:e20c21076f2794abb70e9da78ddd069cb75f831245f899addb729179beaee230"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2f4289a43c159cfe034e22c7a20a101bdd67877eb7eec601733f454ff1af0973"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3242,9 +5373,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e98166db92d71b2ca72d880555052ceac756aeb1853501f6ce23ba464e667afd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/430/block-1.yaml":
     active:
       fingerprint: "sha256:c0ee5a033560f5ea65669cb7a7c878e17f732b4e655d9af3e16b97d2e32085a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ce588af14670ed279322324c76fb59daa21edd51a6edd60075a41647eb5fcebd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3254,9 +5395,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7516f20bd2bf384d4b372b9c5b78f66580bb3fa8de777305b08f5543c36c787e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/364/500/block-1.yaml":
     active:
       fingerprint: "sha256:e10b7829c8ddc130148646d20c3133b29a8c5e86b2017c8b76550e104d40c226"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dfaec6247014f87a7bc28a26fb559d1d3d2cb9f90c70274c0387b951f3298696"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3275,6 +5426,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/364/650/block-1.yaml":
     active:
       fingerprint: "sha256:e3417dbf79315890bef6f3a4de721bf41d82cfa9706a26ffde5653fa1ddb8977"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b13d00215d1a7648494bd1f2539e4f06e14d371f7c8490ef2c107646cf5a238c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3308,6 +5464,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4b29124644fad0bce6ce28e74a4944c59611b70142414ffe3b0b1bcec8a8eeb0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/120/block-1.yaml":
     active:
       fingerprint: "sha256:f0d92bc988cb03b90c83b5553662c0172157856ad7ff4319e3449ba0a09f1ae6"
@@ -3326,9 +5487,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9a5bf2c7fd70252cef05bd748b140ee1205d6f45fbc73f1d3b43db72be240c72"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/150/block-1.yaml":
     active:
       fingerprint: "sha256:3eeb45a36e9613905fe4813c3d288696be198a9708848598e20ed5a3aab5c1d6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:94a0c87c6d0b63c0674fa564b88215e5fd9439dc12a1338e9da5272e00fc56e3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3380,6 +5551,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e86d884f912ff918224419461c81a6fd67f83722c253766dae3fa6ddd3ba1b57"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/610/block-1.yaml":
     active:
       fingerprint: "sha256:b5ac921f349f5fe4a645792758f1ab0584c4dcb39b95cda818739706864be12a"
@@ -3428,6 +5604,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:087f619f014c3a92f2a187bd640ab90f298c61e15dc776e246f4e4c2458e6f32"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/850/block-1.yaml":
     active:
       fingerprint: "sha256:92b95e7f76237d29b5b5a7bfc517619ecd02f8b0f7ff768c680ffcba8702b24f"
@@ -3443,6 +5624,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/365/920/block-1.yaml":
     active:
       fingerprint: "sha256:bd3b4a76321488855b4b27f0bdfab715da2008e7cf957298493c84924c45194d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2c54b2ee9811704b86998dc1927ebc1981f224875317a32afc0b58dc6bbe32a5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3464,9 +5650,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5eb445bac5ad514eaabca66036915d66064e3641b9f5a7b78bd78509b32d99e0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/366/130/block-1.yaml":
     active:
       fingerprint: "sha256:6612ceb93989bd90c2605b59b1306ccc8ecec08b4ad15e0bdc8dbb9f2b1aac76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a2fdecd9e0418e3f9c90a1f5ddb16531d278753b2567b32929bcf666a5a6a469"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3494,9 +5690,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:18eb0be69494080418c1cb335f7ae9e6c8bc814e187324f1876a7afea7cf2954"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/366/330/block-1.yaml":
     active:
       fingerprint: "sha256:63a435be0b59fc0eb568c066f0b368309e75494f888b0bbae91c917f19bd3322"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:85e84e5141f7bd86b2d02dd0aa13b4a5bd40cbb89334498f29e8c44ae5bc0280"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3560,6 +5766,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:86741575fd3d7cc3e2b79457a23a344602202051c3197797fb0bb6be994f2f13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/367/275/block-1.yaml":
     active:
       fingerprint: "sha256:e73e6a1f702f44112950ba75b6f035f3ab40527ab25c982c75248782d92c4dfb"
@@ -3617,6 +5828,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/regulations/106-cmr/367/800/block-1.yaml":
     active:
       fingerprint: "sha256:1e4ef4814903235dd0f5dc59dafe82673a08f1950e315a254140a8c546857560"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1e3a376e8d6ef79c9c10b0c90656c7361a8b67f23bcb665119daa63203fa3cd8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4190,9 +6406,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:36c1bbd2adf9e793e3ca3f025a02f1b7a1df94dfff9ebb2cf966bbdf87a7f887"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml":
     active:
       fingerprint: "sha256:0bfb06cbb0bd853442b5d360c460ffd5cd1c27aae3aa5b4a376029bab4d2f410"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f96e56414c70f8c49c87b49d1707826dd5442cd577c9ac467b96f382ac813ae8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4202,9 +6428,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:33446dc2051e3cab5e31882db17e1bdbec48b87b585dc8e1cdb6114a635f4e4b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/statutes/NYC/11-1701.yaml":
     active:
       fingerprint: "sha256:5b8e0003d0a6063b9b7c800fae244bb95daeddfcd1ed48a288c1d667b59b4a9d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ff2bdbcf21676688527e8063003c8d61d13776d087073d3f2e85ca8ff2c09c8f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4214,9 +6450,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:65999eda50199d35e743749e9061a4ed8dc79dc54283d093139ccebea8427cb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/statutes/NYC/11-1706.yaml":
     active:
       fingerprint: "sha256:194b38dbe26ffe48a8b30ab2c630effd4199c03cd44f09eaf801c8f40b3e4fde"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bc8de961b79da8d6351c11eb04f490531a4aab51144de4299263afc835a4d157"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5270,6 +7516,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:014ef635d95a9c1af7ac4fa10b8ef50c7975161af591dca8c2e8d918fecec937"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml":
     active:
       fingerprint: "sha256:8f72bcc7b637b099d5dd2f7d9de34f3873daef77cbaa13bc3484c7777f47e157"
@@ -5330,6 +7581,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ded2d44fef7a4e9d7f7597fc8ec24b6f46e29a23925c4ae02b626ec7d312c5fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nv/policies/dwss/eligibility-payments/a-600/page-38.yaml":
     active:
       fingerprint: "sha256:78cb6b409c0150c5b45515f12804f19a981b76b5e58f09b8a03e2d49b2636974"
@@ -5378,9 +7634,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8340fe5d6d5495965e529791da6a011ec69d59d5a1abeec3437103e9b4511624"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/ssa/substantial-gainful-activity/2026.yaml":
     active:
       fingerprint: "sha256:d8d3d3a0c3234903f927b12e8027aa038cad2c96aaff3803209166157f801bf4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:24e4910572ae46654c9c81f5e36c7456b770bd33731d096188d4e0114ffd9e21"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5434,7 +7700,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-al/policies/cms/alabama-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:4cd2257588114dcdd2df7c0e4d4b386f6012f2c36347044c102dc371f88fbb76"
+      fingerprint: "sha256:d52a750541f767040650e6346868b6963d6a600a9c126ef843273872c1cff40d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5798,6 +8064,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-al/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:460932504f00aac2b12a7e5b954ffd8bc974006f6e8930671a3fea58ef1e5d67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-al/regulations/660-4/1/01/block-1.yaml":
     pending:
       fingerprint: "sha256:a4c62ea708f74f3896bab3962af1abd5b5cbd9a349c2429ecb3157f8c7928355"
@@ -5944,7 +8216,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ar/policies/cms/arkansas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:b3429291c9bea3cb0ee084cd4f602c45792138b4156658f0bec5ffb8fa071b6b"
+      fingerprint: "sha256:6c9894f3c587f3580fbcd238464445854950b827eb2b164090207d9c5934c6a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5956,7 +8228,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/cms/arizona-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:47e3aac62f4ce656aa54f6d31002a7fda0dde8f6b2f71e384dff48cf8f9a369a"
+      fingerprint: "sha256:0b40725f2ab06768efd34a40fbba62d467872dd82706b73f577ce8633b99f0d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6028,7 +8300,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/des/faa5/na-categorical-eligibility/categorical-eligibility-benefit-calculation.yaml":
     pending:
-      fingerprint: "sha256:2946bf81554649534ea53c77db7118c58953c992d8f4a0869cb5578959402479"
+      fingerprint: "sha256:9f6dd57d2fc2beb674b8cd6265a7cb1b6c136ce66f16928f362dd9aed86b62e5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6052,7 +8324,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/gross-income-test.yaml":
     pending:
-      fingerprint: "sha256:7d079a5c26649d20a8166fa38e947994f54951712c3b08559baec2f7962146f8"
+      fingerprint: "sha256:c2c52639afb4ef74b5313b65bec2ed1287ff730d3566e98323a8091ec3ea5673"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6086,6 +8358,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-az/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:4f60a295158605be9a6f0a631ad31615119920f97189f7ecd7e20dcb897a7091"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-az/regulations/aac/title-6/chapter-5/article-49/R6-5-4911.yaml":
     pending:
       fingerprint: "sha256:b0439168d4897f50ac32811db98849d0c169d62a228acc4856cdf4a3e0c49c68"
@@ -6106,25 +8384,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/statutes/43-1011.yaml":
     pending:
-      fingerprint: "sha256:5bc0aaa65057310ca3f0f82ef8dc3006be3f8784730a7ce48c188ae73c1996a6"
+      fingerprint: "sha256:a4807ee8926748927f21fedc00651900b9541cefce4830f1a4613db5d1406655"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-az/statutes/43-1023.yaml":
     pending:
-      fingerprint: "sha256:36b4ef8da96471141d067339286cab2909c4efa2086f0314a4f160aa6c8d3222"
+      fingerprint: "sha256:4381a9d0648e8d20df0c89f055de9f89a4a34c6f4253a0fc1bbb4c02aa44f7e2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-az/statutes/43-1041.yaml":
     pending:
-      fingerprint: "sha256:98640cd704cd754fa8f320b625aab9f862c814ad52a7bb504d9be9b452122de1"
+      fingerprint: "sha256:f88233370d200d58ec6df00c1a79644b661cf7a2c04e942826e8f4ff20725120"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-az/statutes/43-1072.yaml":
     pending:
-      fingerprint: "sha256:20bbc50624e0625657db18bb02cf38f849dd527ff30d71439d809159e084c6cb"
+      fingerprint: "sha256:ce008d72ef6e562d4978915f5dc4949cf3de6f3006a3f08a7ce74fbcfc107a3d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6136,7 +8414,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/statutes/43-1073.yaml":
     pending:
-      fingerprint: "sha256:bd77e2f960707d91614f1b1863472c2f97e345ccc54067a9e737152375ee2e39"
+      fingerprint: "sha256:f59a0a220477d39640035d3bb3e440dee39dc245cc9ea6a3f677f9fa836026e8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6154,25 +8432,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml":
     pending:
-      fingerprint: "sha256:c10662a3abd9e9bf44e975b9b3a2d10966201650ab1e55b2af87eaeeef5192fc"
+      fingerprint: "sha256:aef37b20677d59b800f61c0797b2485c36f654adfbddd1059c9bc76c2f0727f4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/monthly-aid-payment.yaml":
     pending:
-      fingerprint: "sha256:83e9a3db0391b5e4d9768634dd1f9642d3cb8b3edf36c821e35a89fc0cb1b67d"
+      fingerprint: "sha256:6734dfc183b5b25ed364bad9d2df4da2332211f07d17c8c56e311d2c9f125d7e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/recipient-income-disregard.yaml":
     pending:
-      fingerprint: "sha256:e41028014eab5d4496b5aefd135922b81d4acdb9d48a095b6d25bacc827c0fe6"
+      fingerprint: "sha256:cbcabacb06d106386067e2c8fda9f699908a580af5b5b60a7cd0f2ff769bc233"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/regional-minimum-basic-standard.yaml":
     pending:
-      fingerprint: "sha256:770cd63f21eb7bbcc4f9b90a5308a6e6ffa698d88bd0c87ff75b161a6d618a13"
+      fingerprint: "sha256:b7463d5c238f67a924af2863989df71736ea0b8ea4e43e0555a3055833ae21f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6190,7 +8468,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:a42b8269a9edd1863ff6ab831f0b19a5b3ee64666fb61de861b23d6e03ce18a1"
+      fingerprint: "sha256:b156021da63599575025a5a768fb7d484ba833b5f8808703914de84a7903a476"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6256,7 +8534,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/statutes/rtc/17052.yaml":
     pending:
-      fingerprint: "sha256:077ac05123a1f0b23284ef81372840c9d22e49fa06f3a0190c46a976d43ed576"
+      fingerprint: "sha256:fde8910e975fa488f08039794f2b669df6badfb1798a4cfd9f325986d8f504cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6268,13 +8546,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/statutes/rtc/17054.yaml":
     pending:
-      fingerprint: "sha256:67ad90abe807539a5ce18634e751c3d0b0030c06d4292982ab68a051101afd8e"
+      fingerprint: "sha256:b0b022b1d5e1f51845142e8fecc04b8f97262b794d60ef72eeedb79deaeb7fdd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/statutes/rtc/17054/7.yaml":
     pending:
-      fingerprint: "sha256:7ee0bdb8551c1f4847b0fcee3416cb90d92bd6268eb3b1de2679d9a50c7ce6bb"
+      fingerprint: "sha256:897e302d94dc448b875af9f6f2868bbadb33c4cf232864ca62d90161231a2604"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6310,7 +8588,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/policies/cms/colorado-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:abd7df7554d0ed54e21282b91af5fd786abde45240312df444eb596e6b32db6c"
+      fingerprint: "sha256:23944cb9c34904e01113f246b5f58cea3b42df20421464fcaa2a993674c243e1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6352,7 +8630,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.130.yaml":
     pending:
-      fingerprint: "sha256:08a3a233c4dc7ece26e69897cb36eb5dcfda8e27b48c68c058273c0aad6d97c3"
+      fingerprint: "sha256:cd5b5c56cbed725a888e9cc4f0e09e4a10429764ce5a5ebda02dce37cc85f99f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6364,7 +8642,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.150.1.yaml":
     pending:
-      fingerprint: "sha256:a61d6796132175d43c45424f9da6ef5184f2837f4963e823dc2dd47df6973823"
+      fingerprint: "sha256:a212aaa4f6647c4a9326aa5afb880ed1585ecbf9185c0643f8d4e3218b5aaca3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6382,13 +8660,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.160.1.yaml":
     pending:
-      fingerprint: "sha256:3fc323e6bb6b9558acc21f4ec18672b488988993b73d9dd1d85320a6c0cef4c7"
+      fingerprint: "sha256:b3763ca20d66474ef9fa887f00621400f5b0c8b077700d840822d3ea89285e49"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.160.2.yaml":
     pending:
-      fingerprint: "sha256:913c8b0e29613f4be1adc51b9720072a1de55017c7f87bfa3b03b5eb761bc21b"
+      fingerprint: "sha256:68da4826be386a093f2ac8644b24d66e051fb3a5ab10fc1f06ec07d501914805"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6418,7 +8696,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.201.yaml":
     pending:
-      fingerprint: "sha256:7f87c1a8dd6e78926b23eb134c3db366a151104b3c2369f0cde7aab830fb8cdd"
+      fingerprint: "sha256:8eac1570e6293007953520d0bab2dc8e9c1f592b3ddbd14d5d54f98997711b42"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6448,7 +8726,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.202.32.yaml":
     pending:
-      fingerprint: "sha256:b1fc14cbc451742d5f9b758098ed566db41deda4bac1c6a287d64274e0600e49"
+      fingerprint: "sha256:313be5a814e01b760ec2ef956cb56ee746d379b8e6b5411801e0124eb7235981"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6484,7 +8762,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.203.22.yaml":
     pending:
-      fingerprint: "sha256:81ae7bf12227af82ea4dde8223a925e72ccba4a8c63e823bf8457c24c0dbb04e"
+      fingerprint: "sha256:5cb83455745015b30c93546c4250dde513ebc5bc8778eb8b32089a74826239f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6502,67 +8780,67 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.204.yaml":
     pending:
-      fingerprint: "sha256:cd4c77d48ae2b0cfa24abafcb3931235c3ab6896b9882b0a56f8d8a3ef37f01c"
+      fingerprint: "sha256:2d1f1f21511bd201edc1056149907040e302f102e9869ca5e8b85040d57beded"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.1.yaml":
     pending:
-      fingerprint: "sha256:fb62c0d780be56a022f79a85e06b8f629529d85a6dcc33dc9166277b29668f7d"
+      fingerprint: "sha256:d6e35dc74f225f0b0ddcbf0629cffd6ae5f455dbd889c9429a118bf5db59e73e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.11.yaml":
     pending:
-      fingerprint: "sha256:2bce60a16e00e4421b44057f8228979b0dcc0adb1a3bc242e0a41c630d169be6"
+      fingerprint: "sha256:1ba94d334a7bd4f98e6c9ff35b2ce8fff28779886ea664e4ca716e233fcafee4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.2.yaml":
     pending:
-      fingerprint: "sha256:f58a2639549499a3b174034066eeab40f1f7e51f9344733d6a1cf49d125e8e67"
+      fingerprint: "sha256:c73bc22163c1f5f42198519781e0dbe14917e19496fb56477bc14e4034cafaf5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.3.yaml":
     pending:
-      fingerprint: "sha256:d0ef2c7774f528294933503c0cdccf3d00cafb8bfd25e17b112612d33c73cb74"
+      fingerprint: "sha256:1c696abb61d2f6b9e474a1936737ef04a08f9e7bde79afd895bf821c061d59c8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.31.yaml":
     pending:
-      fingerprint: "sha256:c8f56e20325b4db677dca7709410907ce081857a519390636fbd459b1ffb6217"
+      fingerprint: "sha256:bab779047a7ae81fba3511746cc0b63040b6ff2bceb61784a89b8c01fdff54e0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.32.yaml":
     pending:
-      fingerprint: "sha256:c3653812ff63145146a83892a632f2f3dbc687f56668efc35144c8c7368e0c9e"
+      fingerprint: "sha256:04717d4966273751f0f314b2f14b353e541e9a7773adee207f495cddd7b4e360"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.4.yaml":
     pending:
-      fingerprint: "sha256:15b53993ed77b7865d08dbbc38e811b5014906e7af15192ee0edc15fe9ac6e20"
+      fingerprint: "sha256:62ede5b3b5fab50919d3829c51b2780a80805a631d6b945856c84e3f80cf0216"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.205.yaml":
     pending:
-      fingerprint: "sha256:b60959bb8eed779e7f90a80ca8eac5b43d7416325ce6878c7ddbed59b63da03b"
+      fingerprint: "sha256:5667e00a21966754589fbb51d2fec038275ef07899d7a1662ca08a110e2197ac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.206.yaml":
     pending:
-      fingerprint: "sha256:e4919ba847625606c08a3945f15d8e167ccb54fde6978e753ca121856e3fcd0e"
+      fingerprint: "sha256:7398c867e9117ea114c5b462915f7ed7e0eb48c135a6bc7aae8c7877c1109464"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.207.1.yaml":
     pending:
-      fingerprint: "sha256:0efcc37a48300f537ac215bc0f1c99ac96101c5d7581e7e53e5cb228064649c8"
+      fingerprint: "sha256:f4d563a1a78ad01dbe61f4fd2d4f83bd2b4b36ca297aae8938a3c92e572ace2c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6598,19 +8876,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.209.1.yaml":
     pending:
-      fingerprint: "sha256:17e8f2321fd6bfe78abccd5b9c0c5f96b636ad171d6ceee7b6b41cc4d158a09b"
+      fingerprint: "sha256:91dfe754422e1cd49485667512e3b2111e4f6c775cd37a05037367fa90a2c305"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.209.yaml":
     pending:
-      fingerprint: "sha256:cf2b09a79d3837c70ea20c9c264b4fc1bd3fa8bc7a4b156fb528c12a0badfa49"
+      fingerprint: "sha256:05cce88c2afed8a3ee2119f6044f6801b94087214c1af5fe0be97158b5060d97"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.210.yaml":
     pending:
-      fingerprint: "sha256:1125ca7e8aeda427b5826c164150d786ff6383d2e477fbce37ecc71afa4a41cb"
+      fingerprint: "sha256:1d876d5935ff839371e705b50997f0118ef7d09beb5b40eaaa2f26b6945e09a8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6628,13 +8906,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.302.yaml":
     pending:
-      fingerprint: "sha256:d5f2f397174890588880c7e23ca989a47106d695a9b338b2df57eb98e3eca9c5"
+      fingerprint: "sha256:13e53de9874ecb3446437f2283539b891eec2db36f9a7c346886bbce286204bb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.303.yaml":
     pending:
-      fingerprint: "sha256:3dba685774f0bf3e2969fdd4bf27cece4d677a8116198a7a26bf2ed1b0ab73ac"
+      fingerprint: "sha256:311a55510ae32b5ddb1815a025f14313f6d301d691fac9ba487cc67fc108b903"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6652,7 +8930,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.304.3.yaml":
     pending:
-      fingerprint: "sha256:664bc2a79bb408a061f3299713c368b6601ae93da0af8b58b6aea98f0f423d76"
+      fingerprint: "sha256:8f7b253934724d228d960ce5ebacc3fc5ae43da8917b980a84097564daa15c8d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6670,13 +8948,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.304.4.yaml":
     pending:
-      fingerprint: "sha256:5ca271f7c3da05a16adeca0f089e39036cd940f82233ff7e6a204fbdff769228"
+      fingerprint: "sha256:6fd2ccf237cb8e8014809c0c0db763e67d0696ebda9f0d9a9a72030c031a2c68"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.304.41.yaml":
     pending:
-      fingerprint: "sha256:e3aa34c114ab8f4614cf216118a23c3a17c3548cba5946fb7c624ccdaaa8ef98"
+      fingerprint: "sha256:f454f7d46330f42a3f47d78a57fadddffb38251742bdde5bde8b0fcf36364d8e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6694,7 +8972,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.305.2.yaml":
     pending:
-      fingerprint: "sha256:d3de4f44a9b7c0a2bbd72765f6ffbba4e49b9d1b5213d087f7f6f5206ae9be10"
+      fingerprint: "sha256:6c3d450258773f264625230beae3e1b064cb94c067b8f29e418eafb16156efa4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6706,7 +8984,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.305.yaml":
     pending:
-      fingerprint: "sha256:02edbc4a0c2986a33db9e06f288129767957aacf4caeb259e1f9ffdca5219b70"
+      fingerprint: "sha256:8a4ad2d6ba7f19cb70906ae27a19b759f65aeb574f1c00f84581023d8aab4c2d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6724,19 +9002,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.307.1.yaml":
     pending:
-      fingerprint: "sha256:799c5225cf1b46982025cc225c6858df22942cd8154c59bf6ba368bf6844ba63"
+      fingerprint: "sha256:1a64d440132e925dfbe4d46609db652285b45af705f631fa7d43c19603e9a069"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.307.yaml":
     pending:
-      fingerprint: "sha256:6a6f12d36bdecdcb89ac7f7b560ac99fcccac0ba7c6e58ae4a109b09cf21a557"
+      fingerprint: "sha256:1c5e1b8af62222f426d6d9a314a32e60f052392f594c44d6cc3e07c65f9db867"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.308.1.yaml":
     pending:
-      fingerprint: "sha256:00a51ada9a736f6ba6828a3cad357e51d43f2729f8cab00c6d60e067cf119555"
+      fingerprint: "sha256:25028157f7033c023ae1486b067957ca5bc872b942cf0bf624ca10f715dcd791"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6766,25 +9044,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.309.3.yaml":
     pending:
-      fingerprint: "sha256:9496e55ebe08410edc59eb9a727760fba480c6cb42190daba0539d7116ac8f7c"
+      fingerprint: "sha256:6da107b9dc33b330126c49f5ba5dc4ceafa43a23e7515f8792c9024824da5e15"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.309.31.yaml":
     pending:
-      fingerprint: "sha256:07816bb0079f14fe11b90d57c25592596f642e31e581768c28a5425b804381ce"
+      fingerprint: "sha256:5443e9a717c1057aa239c9873abcdf241f116e5d00c30120b36034f480765f44"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.309.4.yaml":
     pending:
-      fingerprint: "sha256:839a6e995c9ffc6a79d05d9413a30b3f4e3a95f50d876a66a48bdd80917fe710"
+      fingerprint: "sha256:dbcf03cbe33b5a090f892f07618612bb317e834208d642fc57dbab61ee8e5312"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.309.41.yaml":
     pending:
-      fingerprint: "sha256:1902356acf4c5236d15dcc4a6f213eeb7db8e829b456917e9f7fa8efe85a7dda"
+      fingerprint: "sha256:1ce60ddeaa234b184885f37474268ff0091ec3a258c25cac054e35d168e23db2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6826,19 +9104,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.310.5.yaml":
     pending:
-      fingerprint: "sha256:250a3ecec4413a1209b6fc4463231697e32fdb03cd8f22c4f02f852e60609e0f"
+      fingerprint: "sha256:4a66e57d1931d48b6c4b99f1a4dac14308ade2cbdb1753cee9f10412f44ccd9b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.310.6.yaml":
     pending:
-      fingerprint: "sha256:150cabe419d35f280dd1efb6f475f6daec81918f442bf271d4adada3b9a6033a"
+      fingerprint: "sha256:be479eb629f8f36b5bac441970d94c55276afbeef91a6b6c263f073b0b320798"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.310.7.yaml":
     pending:
-      fingerprint: "sha256:b3fa6f0e99c7d832cd3a5b8ea6f038f2f2d9fa5662460a25518acd988684ac70"
+      fingerprint: "sha256:e75ab5e30c9b6ab488e56f0a01e77ff221ded95e63648b81246f3eecdf68881a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6868,19 +9146,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.311.3.yaml":
     pending:
-      fingerprint: "sha256:fb46c526f1cdddc53f6567153e80347ca28118cdcd73e1a2b62d76c5c194ff5c"
+      fingerprint: "sha256:79aae90db743001f52d8a9a6df01c9c864e20060b1371618a8f7a6640d5cff78"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.311.yaml":
     pending:
-      fingerprint: "sha256:44cd29b932d244086e4b5f183895b837fcaa0aafbc5bd6513f714644afa69642"
+      fingerprint: "sha256:eecb9822d827ee7394a7fd7b4e4c2b383f8fe5728d9de3f74a8757abe0535d22"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.312.1.yaml":
     pending:
-      fingerprint: "sha256:1ccc041e83c5f57080bf5ec4b6961c6bc7dc9d6020375f984d2ff20e6bc7842f"
+      fingerprint: "sha256:51cb868faa3dbdba02d52a37a64ead25e168f569775a0c7d4a853b7efb4f67e8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6946,7 +9224,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.403.1.yaml":
     pending:
-      fingerprint: "sha256:b46b66535527941ffb89233803ebc5cf0c782ce50518da94ab3b3ed7d9e9b919"
+      fingerprint: "sha256:f0f19d285ed178b246da2275e450be24fdcb14857b87b22740b4ecf68f7f99a6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6982,7 +9260,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.405.2.yaml":
     pending:
-      fingerprint: "sha256:b2b8c8d925ae837dc4d5b9db122fd4bcc34cb08706af2c3f418ddd2e4bde0785"
+      fingerprint: "sha256:f1585b9890fdd3c83a7194d2386ce27102ea3cbf971ad9bae0a9fb08d70fc61d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7084,7 +9362,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.411.1.yaml":
     pending:
-      fingerprint: "sha256:fb5b60ae0fe2ae7346cb0418f0f18e81b63c5fa4a31913ee842cfcd1464a544a"
+      fingerprint: "sha256:340b3e23e8b8956486fee06821a51eb4de144687e74ff19869c0f24c40213c66"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7114,7 +9392,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.502.yaml":
     pending:
-      fingerprint: "sha256:60aabb9022409c44e8dd3a236bd6e0b03afa592a539fb43d51f5e9bac6850df3"
+      fingerprint: "sha256:294983b6ba01efc339b28fc4375b490087ef55091dfb83c2cddf8e485e8c582d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7150,7 +9428,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.504.5.yaml":
     pending:
-      fingerprint: "sha256:8b74974a536a6ba0382669685cb2f5db0d4628cabfdee0a5fa25fba90ab85ef9"
+      fingerprint: "sha256:da2801e6ac4c7212919a7ea4737ebb82d2fbc4416e72c571eb70ffa66c0f2cee"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7210,7 +9488,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.505.6.yaml":
     pending:
-      fingerprint: "sha256:b2e8a3fe178563bdbc61cd36fbb4bda28098c5a8d6dfa0efbe8fa7c11a02ea76"
+      fingerprint: "sha256:581c7bbd60522c0afaa46b32745d87ad6e7f52fd5cd21d5a6ebc85bffac323d4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7228,7 +9506,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.505.8.yaml":
     pending:
-      fingerprint: "sha256:e8f510cd724db2a955fb3f4f4e44942f9b3263d41e6e22f1ca0b1049fc84086b"
+      fingerprint: "sha256:05c4057b2575b5adb444439bd58e46fa6474392c439afb5ecc26b756f8cfd5d9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7240,19 +9518,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.506.yaml":
     pending:
-      fingerprint: "sha256:3248f2acaebe0d079b2e0fe0713ba3e6794fb0540efaa403eb30922d04aaf47b"
+      fingerprint: "sha256:f182803bf09ba8b7f9b337c6aaccaad483a316d27c493f1b1d3e8ea2145c68e1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.507.yaml":
     pending:
-      fingerprint: "sha256:c5bd8e0886d18c8a7312f546b48c11ee55974a1767b05cd2c9f4cea9671e8397"
+      fingerprint: "sha256:a949931db35cfddeb001aa1076253a965f0ad5a936bd50ce72f71a69d968e6ad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.601.yaml":
     pending:
-      fingerprint: "sha256:4efb0fcd2a7c15dda2df7e8ea7c9eeb9385298e758ebde57c6146fa04f019b2b"
+      fingerprint: "sha256:755775b880be4c27a7b734fbaf7b20500051d4aaf78f7648427cc8f60a32673b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7270,13 +9548,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.604.1.yaml":
     pending:
-      fingerprint: "sha256:5360cbf88469501a8285ea8eadfdba8bcccf659bbb9744859572bde39fb2f038"
+      fingerprint: "sha256:7733583ed39cd332577f277d73310515f6c3dab20fa0c1e546210b4b101a1bf6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.604.yaml":
     pending:
-      fingerprint: "sha256:0f0d48ab8d511bdc833e4c420a9af82966f7a016ddc07c65e3fb24888bc48fe6"
+      fingerprint: "sha256:43f321aad3503d2c5971e3271799dbfbe73fe3762fed15d62f81f9591a2bfdcb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7294,7 +9572,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.607.yaml":
     pending:
-      fingerprint: "sha256:21a3a70c293ffbf22e5c8638dd8831f2941e1e79e3c55cb49859f184fb7967c2"
+      fingerprint: "sha256:ba6d8bf97172ffcdff78c45c0421edb8a07275fbd1a89f106b707947d0a5d6a8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7306,13 +9584,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.608.yaml":
     pending:
-      fingerprint: "sha256:1aa506bdb0031fe4eefe95e3d3ace2d5a6f6357e4ca1d677b785dcc9ecd148b4"
+      fingerprint: "sha256:e73afacf0fd9629790b2a4939a6885340ac031366b4093026a433ef7591a61d3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.609.2.yaml":
     pending:
-      fingerprint: "sha256:2d5dee58a07b4a74f7a28bcf9b4ab15eb20675009f31bff0199590cfccb748f8"
+      fingerprint: "sha256:d2f8229ba248bf5df8f2cb7eff677a19abcbbb1b74e6e744bd2a1bd7e740a320"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7330,7 +9608,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.609.5.yaml":
     pending:
-      fingerprint: "sha256:ee4bfa754e00f2720ca14683b69cafd1e88434741745b5bda549611abeab4865"
+      fingerprint: "sha256:9724b5177e748f8f39d7b54f3de37268c23748e21a137f371870ba07df6e8f72"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7342,7 +9620,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.610.yaml":
     pending:
-      fingerprint: "sha256:ff7adacf26a75316349d7a6555ddfa45e42259b2d94ce71aad509543797589a9"
+      fingerprint: "sha256:6b4c2bb915e1bcdd988ab86ab1b9a63e7cd9ebccc48ec75eacc2190082363a90"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7360,13 +9638,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.701.yaml":
     pending:
-      fingerprint: "sha256:c33a5c730f166591e598b7e3dc77fd5ce5e1495d292b1922052abe66289cc01c"
+      fingerprint: "sha256:1944e18100ecdd850b5c14530f83cbaa75c3bd2d340bd4a8d62116e2166eca54"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.702.1.yaml":
     pending:
-      fingerprint: "sha256:7b0c85a485803157592a1234945ca375230601aae28bf735d7d203369619c564"
+      fingerprint: "sha256:8ec1a03a4c902ac887fc31d33138ecf1c210d46d3d8f3566ccfd12735609d1ea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7378,7 +9656,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.702.3.yaml":
     pending:
-      fingerprint: "sha256:63e34365b8af98db86d08fb00bf8271bee7d53785c964f6fdd075872c321554d"
+      fingerprint: "sha256:2cad176516c776839809937462046d67fc3f3140992698d3fa72544fa27cbb90"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7390,7 +9668,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.703.yaml":
     pending:
-      fingerprint: "sha256:64e2e61d9c4007e41aa808146ae2a899f353b5bd22dd7865d3f4fce397ad5782"
+      fingerprint: "sha256:6dd91c59e27c00746ccb0352767ef1907a70cbdca7ba93292f659bc805ff7527"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7426,13 +9704,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.706.4.yaml":
     pending:
-      fingerprint: "sha256:721af7f4b98b8da571fb3ff9583e4f7d71b379b52a0ccbb8916e74771d4badfb"
+      fingerprint: "sha256:33c38ca6192fdceb673cab214d926c5ee1a70bfa891f111f7ff7c038ea633cd2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.706.yaml":
     pending:
-      fingerprint: "sha256:6fc1ea516bb838f321b2d92af10aeb78f10e7285d42c66273b3ef5cd2d0e5b53"
+      fingerprint: "sha256:ebc619255324e27887306c002fce89503c11cb3da78ce338f01902399406de29"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7456,25 +9734,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.3.yaml":
     pending:
-      fingerprint: "sha256:fbefb25da380876a244fb7f88a68bc91c8d2eef95646cc13556db0a2c659cc93"
+      fingerprint: "sha256:9fc4156be305a972600257c801ac8b96c730792a88122762f7ba64d675712b28"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.4.yaml":
     pending:
-      fingerprint: "sha256:573c43a90911719f2c8a8a9b5259f7c31e94962ed37b9d23bff55e85882c79c6"
+      fingerprint: "sha256:249f5cf8af4851683cfa90854472aadc2156eace1542323f476c6cb35022d90b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.5.yaml":
     pending:
-      fingerprint: "sha256:847dc22acd54308330f1626dfcfd306d7583e86325de978acc24a9b0a427e990"
+      fingerprint: "sha256:6b3d37c2674dfcb3011890e8bb31283d01068d7c89f52b5e1be504fd77b13ce9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.6.yaml":
     pending:
-      fingerprint: "sha256:38e3c19c7c8bc15c8074d175b2ea68a45e7ac13a85d1c68e8838dd03972cbaef"
+      fingerprint: "sha256:92de966f96a99d1143126633f60507c0f1fa59f739139822c30a54dc67a07cc3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7510,7 +9788,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.83.yaml":
     pending:
-      fingerprint: "sha256:81d1af9d96570f15fec8694b5ecd6aa809965923470e136b912d43c0a3c3a4d5"
+      fingerprint: "sha256:9f350c4115fbebd08e6f8d0e399c271cf2771e5ff6c039793eb0258d444bf678"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7528,7 +9806,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.707.91.yaml":
     pending:
-      fingerprint: "sha256:db5e72051eeb84eaf8ef4c6d2e686e0f060ab93ebd5ea853b2e59a2e94c78a6c"
+      fingerprint: "sha256:56696e4298a04d85a9ea80342f547fcaaf02803f92a2594388a502efe5331214"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7540,13 +9818,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.708.1.yaml":
     pending:
-      fingerprint: "sha256:52ac8e6aaa5509f8d402dabc62501eecce145ef0513e5518990ab9dc7f4bf7c8"
+      fingerprint: "sha256:a5e875a6027d3c5f1f5d7af3ad84ecec28d4fcafa51112e5b3f65d8b6b6e943b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.708.2.yaml":
     pending:
-      fingerprint: "sha256:77b1cb807822b4bc9fb92dc41ac3f69e3fa521baa7dd28e233fa34032f0a59d9"
+      fingerprint: "sha256:82ce236850f2c2bcb54772b7aded9895434fc1cec64ca81f31a3cbf15f029ee3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7594,7 +9872,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.709.1.yaml":
     pending:
-      fingerprint: "sha256:dd62087069463ae8b8e64444cefa2a555cb96e37d39f7803a644a54114499231"
+      fingerprint: "sha256:99450bec018ad24db0d44c7b7a5ba40dd00b9aef9ca0abc43b9e37fe4182a96e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7606,7 +9884,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.709.yaml":
     pending:
-      fingerprint: "sha256:ecb253f2b72a7b5a1eae689e94a44425e334057d6312f6299a782f836b8350ff"
+      fingerprint: "sha256:1685f4dbd60c746a27a4dc7d52b65c029a778c907e7eca75816b5953273ff7ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7624,43 +9902,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.2.yaml":
     pending:
-      fingerprint: "sha256:87afcea1da7ccaac3124b70a183bc60496f09efece9473b8eb20296d592daf8b"
+      fingerprint: "sha256:df06db68269f89f113e10186abf991a7eeb9abc29f42959458e7736dff5ba5dd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.3.yaml":
     pending:
-      fingerprint: "sha256:530f54b7eb61920d2bddc93cd60bbaff8329444c67b754b12d709214c1edc068"
+      fingerprint: "sha256:220b2c2706693754168105f5619d2ab2c4969d498cf7e64c2cb39cbad4155f07"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.4.yaml":
     pending:
-      fingerprint: "sha256:3275c692b1ba0c338fb3ba1082f1e626b4df760b5d0b743bf575b0e11ade1769"
+      fingerprint: "sha256:79ad9ec2eb3d40d127d50f023adab149c591c3760fd5d51c9112080497cef9be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.41.yaml":
     pending:
-      fingerprint: "sha256:d9e469854dc12e0139f56d8d469d586081d6eca5cba1a705e7c47982c81902be"
+      fingerprint: "sha256:677f3b77e7c97aafeec4c416adf4d083f17efd8b9257ccc026344835cc83e67c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.42.yaml":
     pending:
-      fingerprint: "sha256:d45bc993a006244ccabc855f247c452706cf56874347d574d4076cd6b48831a2"
+      fingerprint: "sha256:c06be2e42709dcd63af9ca3d806d79fc5315f53d43b2a7e70a76f6e460c70273"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.43.yaml":
     pending:
-      fingerprint: "sha256:d827f77133547510ce51cee463d1643a7b5024119758372af1a0f86a6c41bcf8"
+      fingerprint: "sha256:722e50ce6bb91dbbfb9263d6009b22529087e32e1122b1036c0f65baf327d36e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.5.yaml":
     pending:
-      fingerprint: "sha256:a2db860898049e1f1c36765764d7410a0723a80de5d5a4a35f9cbd2d286319b1"
+      fingerprint: "sha256:b094c3e2c4c10e30bc5cb7bdf19b69723262210c1638fa65daac0d57900abe54"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7672,7 +9950,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.7.yaml":
     pending:
-      fingerprint: "sha256:7ee8cc4c93a9682218ee84a76a637eb8c4dfeee0ca29ac142590688988832513"
+      fingerprint: "sha256:b27d97b6cf7bceaa848c4b6794d9fa88d5a98604d4ee3ad95df1b5f28167b30c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7690,19 +9968,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.1.yaml":
     pending:
-      fingerprint: "sha256:2cab9b836c1084d1a44e94cf8446f329d33e572e5acd5d19410d566a7e1c5c03"
+      fingerprint: "sha256:90dab63da5ce547319056bb39e5be55d85424ac123784742cffa210450250c9a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.2.yaml":
     pending:
-      fingerprint: "sha256:a37c668a830d7887ba307874c9ba359919d8717ccf6273d448c1a4f57d8112cd"
+      fingerprint: "sha256:bb7273a70dd8c3c887437a87f61d77c0ebf14781ea6fae401b04ea1541d62d53"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.21.yaml":
     pending:
-      fingerprint: "sha256:4226a7cacfc6f0a8f1976660ddb65dd39340d918482619631da44d262e1c253a"
+      fingerprint: "sha256:9bcbf2046956790e8cc94950e63b80e4b2dff47f907fee5ae2a277a31d452bbb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7726,25 +10004,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.51.yaml":
     pending:
-      fingerprint: "sha256:057b8371eba8537b5ece03987afd3b65ee249e152ddc6dda41d6703b229a3438"
+      fingerprint: "sha256:1b75037c7aa435212e20da75dba56ab9b1e3a51ad8940b2414bd7e0b0813abf8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.61.yaml":
     pending:
-      fingerprint: "sha256:ba868e607ec36fd89975d0111b346cca9db98d488259a63ab80cf20c67ffa9ff"
+      fingerprint: "sha256:e25bcd1eaf0c441b5a5778261c511a425e655951d29c2850005ba6bb622c2cf8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.62.yaml":
     pending:
-      fingerprint: "sha256:facb83b2d72090298c4424bc3a54ffc90b203251d35c3f900e4fa5917cd343cf"
+      fingerprint: "sha256:5abbba50e074b7f9e05a124a0dc2d84a69818bf9b0a9ac3f81d53d16901aecfa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.802.63.yaml":
     pending:
-      fingerprint: "sha256:b0c263ccde2be6b73288a10a9587c5430ec6ec4c6b3c0c114954216cf4a9406c"
+      fingerprint: "sha256:b653f60c5e21ee045fed228ffa5c11b06ef7f39abb14da757d560628d7a66ba3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7762,37 +10040,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.2.yaml":
     pending:
-      fingerprint: "sha256:af114715a519c9a95886114d6ed4319d3b6186771d84ddac006178ee5a7223b4"
+      fingerprint: "sha256:4a168740dcef2013f6a20619a965212294a4f61c88f60071b090fe9919310763"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.3.yaml":
     pending:
-      fingerprint: "sha256:4bbad3aaf8698283fdfa961267c02a7da4dee7a37ec5003232738752d00b143c"
+      fingerprint: "sha256:86f1bf73884ccbf45a983c8b1bbefc7a72046e20106c9640379d79fdddd59535"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.4.yaml":
     pending:
-      fingerprint: "sha256:c917ec50ac5f7aa8950dd2fff286d8924aa3a5eff09ffab2d10d60f90f506b54"
+      fingerprint: "sha256:9083d94abeb67aad62d156ffd7e1cffb2bd78001c962f775b7d3f906fa543463"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.41.yaml":
     pending:
-      fingerprint: "sha256:75e9bf108a3b8a9a1df6f463e3b9dff58cdedda1608902e46b9cfcaa5407184d"
+      fingerprint: "sha256:addd1f1d0e91965cf68189e73455943b6dc53b5e33a7fe4dd2293475209fa809"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.42.yaml":
     pending:
-      fingerprint: "sha256:92860bc6ec56819ba4c06bc4511bd11aa419aea6984806cdf897451c1fd1d507"
+      fingerprint: "sha256:194fa4871685ff3c7e2c497458c31226cdee338ee463cce8c97379a5db96656e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.43.yaml":
     pending:
-      fingerprint: "sha256:bca7a583565605389eb7552aaedfd1d8d96d9db8301a9e094971822e5c414b07"
+      fingerprint: "sha256:f6a4839b7f21670e188eddb8d3a64bb6bf8d2f97975d052553ece8268b53166f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7804,19 +10082,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.45.yaml":
     pending:
-      fingerprint: "sha256:15f2a6357457ca2fd090be32b6139f602917e84087371b6ec45b7dbed3ca281c"
+      fingerprint: "sha256:b4eddb54a4d9b93819202367982e8a446fa2a2b54afd6237dabea27fe9f5455f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.5.yaml":
     pending:
-      fingerprint: "sha256:32c3c1f646b82eb658e5131634d03afc4cda92d15f8969e49551234639e18e79"
+      fingerprint: "sha256:d3669168a3020b2c841f795451b4b71529aa0cf992866f685de37e9d8e15f567"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.6.yaml":
     pending:
-      fingerprint: "sha256:92245bf0652f83e9a542eddd40ffb781299c3896ea9157e245a2fc60574aa637"
+      fingerprint: "sha256:5fb694ef179fb17df877a96e6188916103f1d6652f0f7959cedf288165f51017"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7834,13 +10112,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.804.1.yaml":
     pending:
-      fingerprint: "sha256:58fa8571e949618e7678099d2d043d413bed26fc4972d2c6fc2866aa5789a01a"
+      fingerprint: "sha256:03396ef0426aab59c8c6cfb0101e3379b2f76afe45531c6309490e4a2f0595ab"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.804.yaml":
     pending:
-      fingerprint: "sha256:a4874acbbe7e1dd1ed8c713b0b7d6159a6603477981486aae27239603f801efb"
+      fingerprint: "sha256:642a620d7a07b39d58304f796280fb8639787a8425f61b49dfe8d9639daec3ad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7894,7 +10172,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.902.5.yaml":
     pending:
-      fingerprint: "sha256:48df814e9fe9ed3545106e339dfb0d353f52dc75fcf4e7a4fb1b93a5624a9885"
+      fingerprint: "sha256:44b7821f50446d2f617e643e235e5b38a7d4a1b0d6e490329f6c3f764236e3f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7924,7 +10202,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.903.31.yaml":
     pending:
-      fingerprint: "sha256:f9a9b53344487ed25e54c0b2c0233512baf651150329112ea63142c1100271ec"
+      fingerprint: "sha256:df005b01c50dfb5442ee72256993bc2f193bedfd67ebdd059582beb99bb53ff6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7948,7 +10226,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.903.42.yaml":
     pending:
-      fingerprint: "sha256:092de2922f82692b0bbad559e685bd280b1023bb56bef9ecc211f6a58ca3ed23"
+      fingerprint: "sha256:29c260d72f2fbd9095cc4e5adaa140c3478a7802990c201125fa09d599f768af"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7966,7 +10244,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.904.yaml":
     pending:
-      fingerprint: "sha256:f8605aa0a5a0b795bf509f08abb9e49f4b576b6debfd3e91526319a95cd3ddee"
+      fingerprint: "sha256:28768e420bcf0d360c4340c4f6528359db5cb893766b3f2d99d584d2dec58c46"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7978,7 +10256,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml":
     pending:
-      fingerprint: "sha256:20afc1a791cba2d0dbe3b112c493893b51dd93cb41947273f810041a822f7587"
+      fingerprint: "sha256:eccac935993a72fe7b83a828a35ba4e0e5ff88081ea3e054896bf3ba8d7d3509"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7990,13 +10268,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.510.yaml":
     pending:
-      fingerprint: "sha256:3c59d5fdd775dfc00e6d825ac9426908d0440f2f76735225f1b3d779a7a14e01"
+      fingerprint: "sha256:b306fab689779a6826427a3735e0e66fed37e8946bd7ad31e95c94f7c725b571"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.1.yaml":
     pending:
-      fingerprint: "sha256:0dbd967d9d0e4dcd5de25f43a9386384631a2a4f73fb4ac094307a07c662a1f4"
+      fingerprint: "sha256:a79f78589341d2c63c0f89fe414195afe28f102235fd30a6223ef9cbe9ffc4b9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8014,19 +10292,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.4.yaml":
     pending:
-      fingerprint: "sha256:dd0b5718437fcf9b6850e88a9a3b2a7c6021fe7a097d8ee78133f4b91c29528c"
+      fingerprint: "sha256:a9446b68bfa2dc58df10e5c865b49540aec87a7feb7220030fa09442899346fd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.5.yaml":
     pending:
-      fingerprint: "sha256:b9e93a87455f0f2aa19619f686fb932b6a4a687634c49370224f93ef9842d6ca"
+      fingerprint: "sha256:d51b2e5dbb67eb4b98dbb97c53a27182d945f8b636367ccfd1db34c32c94583d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.61.yaml":
     pending:
-      fingerprint: "sha256:16d98a472b8db5e6200c945184a75cb062891e1d882b867e226e5b5aaa854bb5"
+      fingerprint: "sha256:9b2e347cb8ac4965d4c74befc1a999a713b42c305ee74c6319a68e80578b1278"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8044,13 +10322,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.64.yaml":
     pending:
-      fingerprint: "sha256:0b0b4ef36672dfdd8339516fde9c9a9856a8a0bdeaa2cc5fd5491cc7aaa1fa2b"
+      fingerprint: "sha256:5b278ba3575d30737c45ac494e363483ea8ef224e8349365052ecc080088364b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.65.yaml":
     pending:
-      fingerprint: "sha256:d6c920ab5257d550c01fc26039d9f0e3a3750a8d191c6668985a16047a94082b"
+      fingerprint: "sha256:0dbda748600a0ec35352d9f2c4929450f54646dd849cd6786f15dd2752db9563"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8068,73 +10346,73 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.68.yaml":
     pending:
-      fingerprint: "sha256:f460edf675e934685025c00ee7b2811b256978f58ca4e1ea5e668317bd6c867c"
+      fingerprint: "sha256:2d7427a2a2b5f803670bd3e3c679f8d8965f40d8e8840f3d3c6b57c1fa51563d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.69.yaml":
     pending:
-      fingerprint: "sha256:d342ba9ca9ee43c4af30a070fa8c93201139d106a33e89a161827f50459007cf"
+      fingerprint: "sha256:42193a1cfe465f85c2c3bfe12ba35269468612b3b1fe5f5a60a7758e69e869a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.71.yaml":
     pending:
-      fingerprint: "sha256:42b62638a17ff78cdba724a5ddca41d51c4256d382188bf634d49372de14a9e2"
+      fingerprint: "sha256:ab489e93df13ce6fddba5b4a6f004b5bdd159552a42ac9b26abd2cc13f35ae1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.72.yaml":
     pending:
-      fingerprint: "sha256:65f7c7d1614ade9e101494c95aa239dcf813dee39874aa156f6d91b729cb2cc1"
+      fingerprint: "sha256:39bad003fd38bb407555dc80abff41a6af0622387ded383ed0abb794c0e3b0bb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.73.yaml":
     pending:
-      fingerprint: "sha256:77c55f5078b8a70d3c497e7e577d5c75449223fc371a93c2432493639f7b002f"
+      fingerprint: "sha256:ee1ed28227e0f760fae27e7bd16e0e3d13ebb7dd06711d26a737610de5809894"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.741.yaml":
     pending:
-      fingerprint: "sha256:32b8e255795d7058cf3ca51ab842d9e2a8cd5399f7a5e7f5b86094bb88b7f695"
+      fingerprint: "sha256:35f2f6bcb4129fdc214a13c876b1d2adac94d9779daa94f47151179fc51c343c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.742.yaml":
     pending:
-      fingerprint: "sha256:c55b88e0c16dfffe8fabf57a72cee54f4d9cabf492c2f39e695dfe33686f7c2b"
+      fingerprint: "sha256:7f0ac09ec4690ae0a1bd5f070db28835026ec6c50adebb2124fec5ebe1aaa92d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.75.yaml":
     pending:
-      fingerprint: "sha256:c718c44ff30312f6ce505eda9e6025e58975d53c3e0c434235bbd0c8596f2c39"
+      fingerprint: "sha256:0943aa2982f6eae957698ebc38052e1117b1248cc2a6c6f50c26593830c195b7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.76.yaml":
     pending:
-      fingerprint: "sha256:12f0cd3d0709c890e9dbaac45b32f677d696e1aae6b58cbdbfa44fd289d2d686"
+      fingerprint: "sha256:13a69b88a7b31159a05d496c5424c52a10fe280d88c4a91d78029628fd7ed929"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.77.yaml":
     pending:
-      fingerprint: "sha256:7c1f872ac56ea378590276b5a361b97879db0c58dabcbcf275ff711d26f1010f"
+      fingerprint: "sha256:d8c813a43a189fd61e46ac474b4c712c4268e7def370fb26ba1acc637bd0783e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.781.yaml":
     pending:
-      fingerprint: "sha256:b2c3e83efb9a4bfd2fe5d528ef061b7ccdf770206a60ee850781932739989355"
+      fingerprint: "sha256:194b61c275e1171489eef857cada21c53931ef3b023760dda7d263cba50916e3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.782.yaml":
     pending:
-      fingerprint: "sha256:83d62538b05df857d03cba69db71ee7e6b1e54426437811bfbc7f64e3712079d"
+      fingerprint: "sha256:5ea455ab8035023bcfc82357c04561ac6fea7bbda9b4900aa79c6c971f83fb96"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8146,61 +10424,61 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.784.yaml":
     pending:
-      fingerprint: "sha256:dbe9fd19f10893d372b0d3a13ed28499fd7de2b69511d814f95f096198cd9223"
+      fingerprint: "sha256:4f469f8ec58f97135288ab049ded9a333fae941531c06d0c215148ca6bc866ca"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.785.yaml":
     pending:
-      fingerprint: "sha256:b8f88f5fd766fee57e9332aef8c0566c46352ef9189f84ef2d9a98e9df6983b4"
+      fingerprint: "sha256:ca4b26be28c936e16e97ad7e1d8cac865f15520a0305b7f6d96dc073b76a29b3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.786.yaml":
     pending:
-      fingerprint: "sha256:d0ce920439080a87824217e67d26d410fded305af1aba4eb26a180b9be44e5ed"
+      fingerprint: "sha256:7c11a0fa9b6e6b8fab8b2ae24f62dd2838fb385ac9fbd899c27cc9413237205f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.79.yaml":
     pending:
-      fingerprint: "sha256:b8ddecd7873c8860f8579af953fed01bcb5cac4a22a5f91f068e76894fa72cbb"
+      fingerprint: "sha256:9e3b8387e12252d5cdfc47e70d803bc54a20103efbaf5afc6512264f76b556fc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.530.1.yaml":
     pending:
-      fingerprint: "sha256:0dddbfd57e3809de6a971f0594dd2c38cc10b6802f2734964825144b42b77566"
+      fingerprint: "sha256:80b5ef2d675f1238027bc6cc0994f5f50b97194a0242395d714e26d72141620c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.530.yaml":
     pending:
-      fingerprint: "sha256:c2df9929de91cf5aac6bf2f6623a9ab25d05389fea70b75b25cd666f7ae10750"
+      fingerprint: "sha256:7b495c22546442023ae34c400478ad739ac22c2299ee9edd0784927d5d59c687"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.531.yaml":
     pending:
-      fingerprint: "sha256:2bc68c0d30c082c0d9f0fd6e907fde2231e63c07fa18bcc585dde1c85a7f833b"
+      fingerprint: "sha256:6bb757a71d7ee3f0854f4d292f01cc1b1d9e0e8d63c2b92f497adc19908b55f0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.532.yaml":
     pending:
-      fingerprint: "sha256:f7d23afdbc71348e65271475b646d68a4f5f53505c1b7cba09a914590e2490dd"
+      fingerprint: "sha256:3b4a7226c87b7e4b2e5a3ff2d13adc35ba6846c365f3ba81d485f76b16df449e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.533.yaml":
     pending:
-      fingerprint: "sha256:eb9f9d3f2ed7852738b8cf8116be55b0c7e6192d3854e1f54bb1e68609e67ac4"
+      fingerprint: "sha256:8319f37fc9d9b24c2bb7d1e673f2b8da8a44baeafbc85f83e7f201d27603bff6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.534.yaml":
     pending:
-      fingerprint: "sha256:e3aaeef881af4619a345655149f84e3f88da5635569805ac5557678e09fb8235"
+      fingerprint: "sha256:b6bf9b6bc921848200adbcc24b72167ac9751059dd5ce637db10ba18ab6403b4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8212,13 +10490,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.540.yaml":
     pending:
-      fingerprint: "sha256:9006388f7080c3ef54a035600ae36959e33413a12036738fe681b8c91597eee7"
+      fingerprint: "sha256:1827d21cdec776012499bf2966df205f7ac90a4db203c9321dd8c93eb8114e7e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.541.1.yaml":
     pending:
-      fingerprint: "sha256:728dbb1020b22cb36a69619efb479aebf69a143afc484cda6b82fed944d08867"
+      fingerprint: "sha256:2c4621e7d7779ffe9f7b6221b6efac599fd8c1443ab0ac2953f575d5a614585d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8230,145 +10508,145 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.541.3.yaml":
     pending:
-      fingerprint: "sha256:6003f9c31242dea99690c520f8b355613560750186bb7b3bdee6ab701f29f18b"
+      fingerprint: "sha256:0d50075b9c8abdd3ae2c5b5d94e3316eb0816d9a6832db06530a582d9b26a3fa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.541.yaml":
     pending:
-      fingerprint: "sha256:8a92257a7c9384a8f308dce3a9ee59835a315ee494e04370d96bdcfab01334c7"
+      fingerprint: "sha256:6a6b39bd3b8da42ba70384fb56da311ead9844841d174921eecc94d7ea4ac34c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.542.yaml":
     pending:
-      fingerprint: "sha256:0fd5067a940c557efa882aee5a77a196e1a78c2d1baa2a7dbbdc62237a8d6bc0"
+      fingerprint: "sha256:d0af862ba5befaecdcb334666cc84c1774f6fcb48c666d1104693ef93637ed45"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.543.yaml":
     pending:
-      fingerprint: "sha256:5ba9ed1a4c77cb17029d1176feb24d638105b44eda395df70884454af0480c0f"
+      fingerprint: "sha256:9718f7e6860f5b8ca82c693f7dc18bff13edbe558ed426e0e636da7ca572e1c0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.544.yaml":
     pending:
-      fingerprint: "sha256:edc40c7a81485e668ed81698f97be3ab5203ffd25bfd5ddad1a616f676d1010c"
+      fingerprint: "sha256:0df41c986cc3f992b0875e3dfe813f8e519ceb01c4599dd78e0237f0cc663b52"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.545.yaml":
     pending:
-      fingerprint: "sha256:7e364c9e100fba6ff8a13cfced0b14b0050b4d711049758759c5de61c5281346"
+      fingerprint: "sha256:436cc5512cd006b12459b4053926e18ef7acdb59fa1c762fa8a35ab626444a6a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.546.yaml":
     pending:
-      fingerprint: "sha256:407a3beb9b667bb4b575ba0d1b37f9d97a73afc068748acba617b3235c8ac41e"
+      fingerprint: "sha256:60e550323ca37ef10b6fa828c8e0bb959ffa03a2e244583ebb296b09dc823254"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.547.yaml":
     pending:
-      fingerprint: "sha256:5e2ffdbe56b5c347718c7eda6043bbf57c8558c8b503035220214e5efd79bd80"
+      fingerprint: "sha256:a6507fd92d1256eaaa5f940f16ca7b9d7093520f0220a6e53dc362c77afa13b2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.548.yaml":
     pending:
-      fingerprint: "sha256:2476dd417aa7d7daa3a820dec48717286bae84498ba16194a13447a9619f0c63"
+      fingerprint: "sha256:9e3a06a2b3c9acdc06116587da9459205ca07373913cdf7e8259d835bf8b0569"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.549.yaml":
     pending:
-      fingerprint: "sha256:cae8699ca81e21fc3df8865c2df7655d47e7f54da21ad0bc1fd21b13bdbcbb5d"
+      fingerprint: "sha256:f6a8b4349dc012c3d84319f6d83637b7ccc4ff1936be38bf9a054c1882639fc7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.550.yaml":
     pending:
-      fingerprint: "sha256:f67e5cd70ba7a58b5bf2fb59ecd84462032e7117ec48cbd6a647d624e0715130"
+      fingerprint: "sha256:b6c07c24b1d786c71fc2bc627c26366af81bde9e421b251b53b31649b2194fd6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.551.yaml":
     pending:
-      fingerprint: "sha256:051af534af95144837be5806970834467bb4a449a06d85d0c491387e400e2d8c"
+      fingerprint: "sha256:e89d8b1801ff6ce90a20acd5fb818be9b6ec9123a937e026df7ae7bf308d0e6d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.552.yaml":
     pending:
-      fingerprint: "sha256:227a69dfbe3caf5903d028e90ea471609bab89252f46c8f3bb74df71830528a5"
+      fingerprint: "sha256:9f5808a322fe59bb94e78978a58d70c8a0a9d43626294daf3d438ed2dc28333d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.553.yaml":
     pending:
-      fingerprint: "sha256:54ba5354a36ed5b611491b6df0d5297d2338f1149b4515e9a035525be0c8709f"
+      fingerprint: "sha256:fd4a7bc58afd02b479b089b4e00cb73c9d92056e6e9a28d9b1bb6293f3dcf8ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.554.yaml":
     pending:
-      fingerprint: "sha256:dba8b41319c90259cf825adc7b156099bbcee51b139ffd29df674226296d4688"
+      fingerprint: "sha256:1795f270b0601770e89e659879edd7874dbad2af7f747009a7476d2fef5bffa4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.560.yaml":
     pending:
-      fingerprint: "sha256:7cf5ca080abdce821bf14819f317a2a6edb11e0e5dca886d88d889e83555c4f3"
+      fingerprint: "sha256:a7c8d2a0a2cfff996d24816940414346017238de59604dc7fdf08616d009664e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.11.yaml":
     pending:
-      fingerprint: "sha256:785e6f499899b31521a5655ed1fe13d459572d5a8d4bea5bf4f6a3c57ad1ffdf"
+      fingerprint: "sha256:e9c3434fecafff55a364e35541f95324066299f7b8001e8149edd32042fbae7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.12.yaml":
     pending:
-      fingerprint: "sha256:3dd82240a4f21ec33461789246d96011d4a66e67db9d7aa8ff88ce077f568e07"
+      fingerprint: "sha256:eaffd37f1ac316782d8cf076cd060f920a3bb7a34fcfb3ab2cd8d50a243f3a42"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.13.yaml":
     pending:
-      fingerprint: "sha256:398ee1bf41f9eef929b57ef766211f35b9c841de2a3badf4fd61eba07850c6b9"
+      fingerprint: "sha256:549781b47c16562682046d1b77bffde70c896b42b9363ea25fd787acbfe0ff00"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.14.yaml":
     pending:
-      fingerprint: "sha256:29910f4eb3083075816c677a21c4aa71e0b845bb48bff31c5abe66e479c0ad51"
+      fingerprint: "sha256:c157a2cc1c8fb354eb1664d646352061d7a8e20367526e44769102283c5976d6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.15.yaml":
     pending:
-      fingerprint: "sha256:237ca9d14b20c72aa4e71c961a79d99a41054fc1c30668db28938af1abf67502"
+      fingerprint: "sha256:5e754f4200eb7fb670e0bfe7a2c92d4eec679f0467e00289c2469d5b1be717ed"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.16.yaml":
     pending:
-      fingerprint: "sha256:8ef329a6dd277d4bb8b822fc11723edf5c7820f10ff7510216fac93a98cb35b8"
+      fingerprint: "sha256:36183d434956049b03444907151673e68336ca5f2340a2e92fcf8644339c290d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.17.yaml":
     pending:
-      fingerprint: "sha256:e0fb0ae97882e3cb0c9b1b48a19f0f817a0a5e17cd1546e6bae3509cf01b9f07"
+      fingerprint: "sha256:1c7d399bfb93efbb52c76a929e49f6fae92c08806aee573cf9016c53480f90b8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.18.yaml":
     pending:
-      fingerprint: "sha256:2c2562e253d1644984e655a7b468ad24a92ab1f51d52893cb0879f99d35a1a66"
+      fingerprint: "sha256:913c9debed544875583b38b11699efa1c23b0bc3f1fce01fe2b6fff4bf4d5e91"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8380,19 +10658,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.42.yaml":
     pending:
-      fingerprint: "sha256:1ca58e81dbd43b063f9176224ffd0ede99f1f2102d4ddff39cbf0085158f0abf"
+      fingerprint: "sha256:b3b1d9fd7ad31e0dc7f196670eeae2e6a5178ab1434c4be4b048b3821105d7aa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.43.yaml":
     pending:
-      fingerprint: "sha256:356291fb2e059a4753679461b418433c64763c38e3c8a207cb9bf7f0d0de89ef"
+      fingerprint: "sha256:e373632fde93e914b9435b032b591dded8bc121d1e894616b8fd05b14a947446"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.51.yaml":
     pending:
-      fingerprint: "sha256:62933d7f9db3f3514796b703a6f889b00f2bed9e313267ff1a5344dad67c2476"
+      fingerprint: "sha256:1c7991c5d3632bf6a61d80ae1ba7cd6db4e25972e04d99ff0ab78c5132bb2d42"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8410,19 +10688,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.581.yaml":
     pending:
-      fingerprint: "sha256:34f6070323c732fab194348c6dd628e8c07c5f9a2173ab0fe11f4b9dfaa98ddc"
+      fingerprint: "sha256:e5adff61f8758f33beecbd0c7f70e8a1d07b529168eaaacf63ec98347dab99b2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.582.yaml":
     pending:
-      fingerprint: "sha256:4d3a4bddb78c5fa3cf4977813f566b2f1307c571e76282247eb3f4b7b9d34dda"
+      fingerprint: "sha256:a25a8e7cc14f5901c114e4bbe74dfdda505da88f453ba72e7052a2f9b7ecbb45"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.583.yaml":
     pending:
-      fingerprint: "sha256:425a66b431be52d755c59767277ffd0167b00a220d339193e55ab8b2eaf2328a"
+      fingerprint: "sha256:2f74df0a04f06391b38fad393e49eecc24ae482a1935efe070710dcb2df4dc31"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8434,43 +10712,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.585.yaml":
     pending:
-      fingerprint: "sha256:6530178342c064312cdb2ff089ec334458e12770015fa152deaf0c0529c6c5b5"
+      fingerprint: "sha256:e5eb3e728a1ad686b999c73911bc2115a4516604835ca8927484df316ae42b56"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.586.yaml":
     pending:
-      fingerprint: "sha256:1b59b73e3e0f5708ed167b99db2caf157a3a80e883a572a5d4bfc2e41ad22481"
+      fingerprint: "sha256:0348614ae15603c44598340fadef43611eca5ee3e566441f2efa14d46389d6ea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.587.1.yaml":
     pending:
-      fingerprint: "sha256:04cad1804a762fec2d7e3f192223149b9194d08366c1df3b0d2bf7b907996330"
+      fingerprint: "sha256:5c7e214a8611df3e62223bda0cf095413072a78505197a4be4e292e02ef784f8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.587.2.yaml":
     pending:
-      fingerprint: "sha256:ae50a01a37ff88aa87ae11103bfe75522aa8f47ac4222ec7cf411c33766123d2"
+      fingerprint: "sha256:513b61dc4a07ef6a15a806dd72ab5fe248b6139b96c198708ab36b513047ebec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.587.yaml":
     pending:
-      fingerprint: "sha256:e2d2a187d975c3d8f13e6baaa077eddc75c6dce2a430c140d7be003eb8abe660"
+      fingerprint: "sha256:b638573cec4b50fb97db95e8c686deba961c9659b43e49580a53663fc5303681"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.750.53.yaml":
     pending:
-      fingerprint: "sha256:674c2b9203484ff22362d076253f964caaabd1664b4d9185068ee2bf862e30f7"
+      fingerprint: "sha256:50d72d16337c49100ebe1f89dcc85ecba9f67a231ee1cc3a006d6676d1eea02d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-6/3.606.1/K.yaml":
     pending:
-      fingerprint: "sha256:b3fee0310dd42cbf20d214d7f6fb98a3eac64e20f8d7b315b9eb7d9e23d811e4"
+      fingerprint: "sha256:cab9b79a7fe61079c7bcb89fe2cabcfbb0cf06adb10a5a9d0dfc31850f913504"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8488,7 +10766,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-102.yaml":
     pending:
-      fingerprint: "sha256:929acc3ee3d69ccab38fac6386935c26c7e36074cf7a138533cb36d06b15cc50"
+      fingerprint: "sha256:643ce95c0ebe689bf05f5633f3abb0a860b0a6e330b71d938cfe194e57821c7c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8506,7 +10784,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-104.5.yaml":
     pending:
-      fingerprint: "sha256:804f1ae293787a2b59047b33de36c114a6c7f64b76822ecf3eacb897ba97cfc1"
+      fingerprint: "sha256:8cbd3c6f0975946b940483480807b7857f927dcce6ec788e621c596caf7feae5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8518,7 +10796,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-105.5.yaml":
     pending:
-      fingerprint: "sha256:41b2c37542855ca2c16eb3227b32caf9300ea749c24612746bdaf1be71b9ee01"
+      fingerprint: "sha256:5fc56ff6379d7cb9ea22c92376e0d285782a50ee050fd36dcb14e9990500399a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8560,13 +10838,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-111.5.yaml":
     pending:
-      fingerprint: "sha256:40bb2e0d2f9fafd4f670c746f539657cebfc97f2ee4f03c0c5517f9531f84168"
+      fingerprint: "sha256:32a60c8a0b00390d35a19d80f9ea8defe3ef67a760f2932a4f3fd9344ea7e1c8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-111.yaml":
     pending:
-      fingerprint: "sha256:4641d2b3b9100a213344d41f699ef98d3bf82ff78abccc3da2f83931f4e38006"
+      fingerprint: "sha256:5eadb8fd8f1e83d12279605b2bb430cc45fa15e3f0baa7d923a68b565bf68c8a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8578,7 +10856,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-113.yaml":
     pending:
-      fingerprint: "sha256:6a11023a6ca0db507d8cbe2b5758821d857363d57c980bbda9116bd7da7db69c"
+      fingerprint: "sha256:d7e9781f56f59a60cc0a88c1c1ada50501411a2e7d0d1374bbe67b54ca076c91"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8602,25 +10880,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-117.yaml":
     pending:
-      fingerprint: "sha256:5e7b8466787125b970567734cc67472a89ea288d44c155b46a3fc0369950f0f1"
+      fingerprint: "sha256:5aff5aeb414364b528e39ac09fa25a259ef01e6ba96a781e9a758cd0f1986aea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-118.yaml":
     pending:
-      fingerprint: "sha256:e68f8c6c3eaf7ce4cb6a6866f39a8c35f57827b2979c1d04574b2fa1f8a0b1c5"
+      fingerprint: "sha256:7f05523b485749b740d955312217d5a8e2e22d1a251cd0d0eff400dbcfefb7eb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-119.5.yaml":
     pending:
-      fingerprint: "sha256:e71cd3db7bb26220d10aab28af27bb1dacd754fd42ca4bd124bb50b5782be866"
+      fingerprint: "sha256:dd1285c05b54617fa23905cf7841fbe61e24b6924f162ffa21718a2c7ee5be3f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-119.yaml":
     pending:
-      fingerprint: "sha256:b655bab7205d8a070ad3b0c69d62a0dc430f209a677dfbd4bcd5fe144388025e"
+      fingerprint: "sha256:d53b077eefc89733ff26a6d469b01e3c68cd7cdf45075fdcdddc0484629f0b19"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8834,6 +11112,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-22-627.yaml":
+    pending:
+      fingerprint: "sha256:71f243ea1d6040b013ffdb2510a02d1d152e0ac4b266123891a25f2493f353ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-26-102.5.yaml":
     pending:
       fingerprint: "sha256:9bb252d466f12075d658590f0f66516a93a159dc37bf1431f245ae77449768c6"
@@ -8848,7 +11132,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-103.5.yaml":
     pending:
-      fingerprint: "sha256:d678eb644d891e3300107a9feb392cb2e04504b60d17feda84be4f7f87a824e7"
+      fingerprint: "sha256:d552fcbff4e77769c0a2e24099d28d8c670e0b474256fd92403a12fef3524cc1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8860,7 +11144,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-104.yaml":
     pending:
-      fingerprint: "sha256:2990086ec43bedce152514588a221df7e2709e49e9987bd67eaf1a0568d0b61e"
+      fingerprint: "sha256:e63410f47f8f059324cf6baf832faf60bd1c9ca86a46a7dce741409589344676"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8872,7 +11156,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-105.4.yaml":
     pending:
-      fingerprint: "sha256:b45bddaacafb388a0d2350b201caf8f6470e98d7a29943c27e6982649844fe5f"
+      fingerprint: "sha256:230d9507e197f3a5f43413e09fef95963e8b57a01f33826a17e58c5de8a9c487"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8884,7 +11168,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-105.yaml":
     pending:
-      fingerprint: "sha256:7da332daa65d899a2ebd018437ed9ecf31f4b3d16cc6228f17bd7e70b9e95568"
+      fingerprint: "sha256:546cad23b1cd2e4b003f804222de897e736c46c8224e0ef95eac1a3be24985c6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8902,13 +11186,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-109.yaml":
     pending:
-      fingerprint: "sha256:1e2bec288883049e7a7eb465820f047b1c801ff84deec81a25b10a1c24b011ff"
+      fingerprint: "sha256:d97caa188e98b58ff93f6ffddbbb141ac41594da598b3e79769eaea839e0f42b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-112.yaml":
     pending:
-      fingerprint: "sha256:8fcf525fb47eddc34a1f7cf0c2d60dc701027c9759d37006488097ff3d34e022"
+      fingerprint: "sha256:488c650289ea1e38e02c885ce4b84b3930a4804f06c9000a824d7f2c8f67169a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8926,7 +11210,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-115.yaml":
     pending:
-      fingerprint: "sha256:a29ad31d792ecd57d3c3596c1aead69dcb931cfd4ccb1f922e0ea18396893e0a"
+      fingerprint: "sha256:b795c94481bba2d595c00cd16de6608b8795793f56ce450f5948ebd130f78e4d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8944,7 +11228,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-118.yaml":
     pending:
-      fingerprint: "sha256:d121e62a80af1518aae9762521029621e53066589f998a4d20abdf6538f367d9"
+      fingerprint: "sha256:b1c1234cc28dbfaff837537e74c00433f6d643478052dd30bdf418db9d8fed84"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8968,7 +11252,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-125.yaml":
     pending:
-      fingerprint: "sha256:16aeafc57dd3b945655655aedeb3c1f8568cc8954cc7e7aefc5df86d4f1476b7"
+      fingerprint: "sha256:252769ffc31b0129f7ed18c92d672630c730ef0f644223091a1ee6755019d517"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8980,7 +11264,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-127.yaml":
     pending:
-      fingerprint: "sha256:07bdb6813278227facd0c3aba6d8454b5b00a1845bae2b4e5e0dcff97ff2d564"
+      fingerprint: "sha256:fab830070b43332f825444bf97be9fe5a3d9dbd7285ae9c4425a8f2395f8a0f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8992,7 +11276,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-129.yaml":
     pending:
-      fingerprint: "sha256:c7aea8f8dc698ff5d34dcbdef6f424a8c063c86ab3ab7e4dd7e3909002a5bf78"
+      fingerprint: "sha256:56df0f127f2751e6c13ddc2f8c05d81be26e79ac0a5a678a412498198c9c2424"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9004,7 +11288,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-204.5.yaml":
     pending:
-      fingerprint: "sha256:4b8fd51e1c0b2965db7c1f956c8ad165bdd4a41219fadda38a78000af2a9fb62"
+      fingerprint: "sha256:e7faac7694bb171fdea6f873984d9fe635bd996eb5378c8c69ed9acc0696b029"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9016,13 +11300,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-204.yaml":
     pending:
-      fingerprint: "sha256:4c4f322c98f80bcf37ca39d20280d7837c3ae78e693c8e15e4700987550a8ba1"
+      fingerprint: "sha256:c010c765a07a980439774ae266cfa17cd0337d01f17d8a6289454629c478d12e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-205.yaml":
     pending:
-      fingerprint: "sha256:5697fa0a3e9e2976c7b6904fd92ce788b3e28b0b208ba6fb8e88b174e3a0f62a"
+      fingerprint: "sha256:107b629ada3924b5f733770c1892689e14174f5221c9c19afdc3fef4daa3d205"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9058,7 +11342,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-212.yaml":
     pending:
-      fingerprint: "sha256:cc7f927a7fbc42cf3c2ec8bfaa87debc76277a7f4ac2e3c2c7251cf0ebb4aa83"
+      fingerprint: "sha256:33fbdda212c93d5113f4959e093f8a7943093d23c9142e5a7cd721dc79dd1a94"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9070,7 +11354,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-402.yaml":
     pending:
-      fingerprint: "sha256:f8c3ed1a7834c04326375131d354fd2ac359caf95a27b435e4cd35dafd3e231d"
+      fingerprint: "sha256:2ab8ed14a84b05741ebd288ff11a4f2d5ceaa0568c5befa5bbd2cf78a28fdf14"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9082,31 +11366,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-703.yaml":
     pending:
-      fingerprint: "sha256:57dc449478db2c0be9c108ec133edac94ed52965a8dcfa2b135dd9e87cdfe714"
+      fingerprint: "sha256:2ecfd78437e2d600ce31b931c1bef4946ccea8d8abd6b490cec02bfeaff15d48"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-704.yaml":
     pending:
-      fingerprint: "sha256:7f9ecdc16099b60386d4f893ea1e25d0d122b82560ab9a6e00d48c1f52f780f1"
+      fingerprint: "sha256:b819d2d3052e9c7a20495c08f390216cfdd63466f70197f8bdea23ae19b98383"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-705.yaml":
     pending:
-      fingerprint: "sha256:aac22ff347e75b222d594403284197c73d03b74bb183df4fb132d9bbc3fe104c"
+      fingerprint: "sha256:58f6b7f014a001a3e9f6f4536f74a90e6331e909fe48c09f030b8391be8974c5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-706.yaml":
     pending:
-      fingerprint: "sha256:e47af324f5cc6a5593c716da89c858be07e8ffce012fcac47385c95c0e924783"
+      fingerprint: "sha256:1f2c8bc6d49b5fa2c66a05418b946ba7ac5e49dae7b0fccde34c4337bcdaa363"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-707.yaml":
     pending:
-      fingerprint: "sha256:c620f2f558b2fee4d4ddb8680afbd198a481446268efcd6ff624d585e31bab62"
+      fingerprint: "sha256:1ff52cba9a6c4dd12206b2b19d977e0ecc9f6104cbd048c7bade1cd6d5b41733"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9118,25 +11402,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-709.yaml":
     pending:
-      fingerprint: "sha256:d02168b59146e7b3c2af05f91aaff82ee1d3e61882a1f1e8412ab443c79d2ba8"
+      fingerprint: "sha256:221eec8e0a4caac8c4ab0885cb6cd4555a6c5840b8495084714ce8b53b148586"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-710.yaml":
     pending:
-      fingerprint: "sha256:f6743c84fc553e7203185f2d9acd9bb3d24e3ed0d7c93a212e2c53c795ba4197"
+      fingerprint: "sha256:b80c807a7aab48a5582528981492a09836deb83858f59a79c16635ac2919c298"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-711.5.yaml":
     pending:
-      fingerprint: "sha256:c58980ab70fb050e172d659fab21848923140434ee77a9d65505c0856bfc8d0d"
+      fingerprint: "sha256:f30acdcb53aeeabedd52bb7a50858725d145b3b0e5fcec73a30058f27fa5f62d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-711.8.yaml":
     pending:
-      fingerprint: "sha256:e7f93b95ec10d5267365ca5989a0ee5232e56f80cf75472b5433b8d45a37ef6c"
+      fingerprint: "sha256:57feb474b1074a3c5e6b17c0238a3dc11e02b0487b35040a20d614882b9c087f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9148,13 +11432,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-711.yaml":
     pending:
-      fingerprint: "sha256:549bbe18008f679a3ae0a0336b9e0cb899ed70a5276f106afdee4f2b84379135"
+      fingerprint: "sha256:fdf72a2b4ed30979bb66f50a4192c10223727b339b8fd9ace4dd500a8b778b9e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-712.yaml":
     pending:
-      fingerprint: "sha256:1b42cc9dbe6aa3d82cb57b54db5b5703b2328371db7a7b4abadc35bfd4c4187f"
+      fingerprint: "sha256:4e69ca7710c1c40f06984fa74a40b6487a485cecc37001cfd340382b8df911da"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9166,7 +11450,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-715.yaml":
     pending:
-      fingerprint: "sha256:307e8c7b96b7fc42db2a4baeaa38e171498ba722d0faece4ce9453c18e4aeac4"
+      fingerprint: "sha256:45f31b8ef28fe3742ee61ffe1b41acf832739a934b5a7f7e8b29e6cade3017e3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9178,19 +11462,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-717.yaml":
     pending:
-      fingerprint: "sha256:d33f89e6c8b4606a2998bc0917e94e74c0c7aa1bf63768dd5cf9fb091fc74489"
+      fingerprint: "sha256:aef164a0348e0d322be3929f86b73c07b3ae91ca9c2a969d3ebfd88dd86f7cc0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-718.yaml":
     pending:
-      fingerprint: "sha256:6728ed79575a266ab5676eba5de1a070871b1ae0854a35c819fa5ac6aeb84408"
+      fingerprint: "sha256:91b578cc8ac45bbc83eba20fadf1e28a18edcf6e46dd4a8b4c3b17077e7816aa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-719.yaml":
     pending:
-      fingerprint: "sha256:56db02349663472775635f7d9d846ad8e21436c7bea04816dd0b77c3e4bc6fe5"
+      fingerprint: "sha256:57b9b5af794b49f9445849f8f9f9dace710f31b33532f9a99b5ded40b9bb2a50"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9202,19 +11486,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-721.yaml":
     pending:
-      fingerprint: "sha256:9345a2b9f482fa9d5e12e9023a3075c569f3ec09a63d9245dfe7bb57b46f82ab"
+      fingerprint: "sha256:43571763eb53c32f3c5fbc6cdd50cf9571992aceee6508b10ec3ca97fd9e4066"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-723.yaml":
     pending:
-      fingerprint: "sha256:bf712f1c5d11dee30f8220c26b8a0f0e6cc64bdb09d5da7ef2798a58fdcdc352"
+      fingerprint: "sha256:699ebc9a8ea140ee351d1a32bdf05f30bb4e33b1e3f688309711d4320a1fd2e0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-724.yaml":
     pending:
-      fingerprint: "sha256:aac278acb39b0eff64f5ebacad394d28c5e837958d3ae2219738ed828aa5b6a6"
+      fingerprint: "sha256:ee60764774cdfce656481efde9684f2e4db4be6aa875bd2139c636942a13932f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9226,7 +11510,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-727.yaml":
     pending:
-      fingerprint: "sha256:70658e153e13c7070e8c9d8808aef490f25e37cbb1f8160c40e49a316cf470f1"
+      fingerprint: "sha256:e265e9ac8c7a3eb036194897cf2f38a9373263185ba9f86bb3a9ea787f119afc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9238,7 +11522,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-729.yaml":
     pending:
-      fingerprint: "sha256:22db1b815552f44c9419703fc92e07b7d31dc81d22617296bea673395201b042"
+      fingerprint: "sha256:6656649b5d69409b194145bcab01e76710ecb8644a1c85bda929a81fd7f92464"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9262,13 +11546,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-733.yaml":
     pending:
-      fingerprint: "sha256:1673a935bc6d9f8dfdf1dcf3a57641e08363525ce1cfb32bf0424f73c9b4a503"
+      fingerprint: "sha256:28460da8aff2425a866a9056535be6d09336cc36b348f3bca40f581c817fa7ad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-734.yaml":
     pending:
-      fingerprint: "sha256:ba405107a1d7cdf1368414f6d05d56e4ed874c6e791efd9dd10783e14be6da33"
+      fingerprint: "sha256:d3298c58e3e79314c199aa5c253a04337b05f50349acab5d5714a4977dd6b79a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9292,7 +11576,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-802.9.yaml":
     pending:
-      fingerprint: "sha256:b5d7d8646a4a1ef5c709d7dc283278234efb4a51e3efc7ad97330890327a98fb"
+      fingerprint: "sha256:2d2bbb68a9d03901c0d951171422f69a74938c76e9923e89c96af4bc332ea580"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9316,19 +11600,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-102.5.yaml":
     pending:
-      fingerprint: "sha256:9f42aae47bbcbdbc3799ae9ad0e8495d7183f5c9423ebad7fa216ea5d7d1af31"
+      fingerprint: "sha256:859682ca0573eb54af461b08375269f81178b26c3c44c154fdb7466b3cbdec81"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-103.yaml":
     pending:
-      fingerprint: "sha256:f2933073e77503e150be0569c2b1fb687fc131dff1fa965bc4831883a09c3006"
+      fingerprint: "sha256:40a441f8f35038b271a78835318adfc4dec72bcc25f292bf1a85b0c33a99dc7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-104.yaml":
     pending:
-      fingerprint: "sha256:5fd26aa0e4bb336623a75b8b6f889552be977ee9bdf21c8e7b8b3cda03af8b21"
+      fingerprint: "sha256:fb1ea712e1d882a025cd60a5757dbda5a70aa1546d4bc63ac32990bb068ee36f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9358,7 +11642,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-110.yaml":
     pending:
-      fingerprint: "sha256:694c719bdb57c1042df747079fa66c441a562a831d644297303c70bc7fa53aee"
+      fingerprint: "sha256:412f70be881c7641540dd656d51d89b67c999313b79e515283390fb1665f1bdc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9442,7 +11726,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-306.yaml":
     pending:
-      fingerprint: "sha256:8b4ec9c3c9cced8b5f314a7ec7d765ed5a9bcb0701d65f4254f9177deb6ebb6a"
+      fingerprint: "sha256:4305e42e77ac1e1939083198fc30930f15d461631dbcca0f15741cb0f4ab573c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9472,43 +11756,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-102.yaml":
     pending:
-      fingerprint: "sha256:8e6f8fadb3d100df321417b4f8a1a89759a40441d3ea0cef8755cdf700c5d878"
+      fingerprint: "sha256:f119419bae89428d962c4b7b2b8eae79d3df2f5ff22147bffa20835a1758ce15"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-103.yaml":
     pending:
-      fingerprint: "sha256:aefedfb1d8a69f81190f2d6b84f7aca070b342532bbf917546cd69529b549c62"
+      fingerprint: "sha256:8ea353edc45f9d20a2758f8a4a13f78429cbdefc016aa65ec568499e5ccf357b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-104.yaml":
     pending:
-      fingerprint: "sha256:fceba58b54b8e2a80469f51bf834e6143cf7ab53c10380bde87d3b8786f0c18c"
+      fingerprint: "sha256:c6f9009e568c2cec43f32cc3ff285024cd88fe856ef3e47482045f75e80a33be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-105.yaml":
     pending:
-      fingerprint: "sha256:0ee4fdf63cfd1ab4802137d8f6b40aa673b07a6dfe02aad2141e2deca9e65dc8"
+      fingerprint: "sha256:03cd57c025a1e71902ea573f7b81784fd8d319e7e6c9e5c161ef50e1ef660c1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-106.yaml":
     pending:
-      fingerprint: "sha256:68a9e30b033bdd2a878b84708654c4f3feb894b9db3978fda6ab16b32c6b2743"
+      fingerprint: "sha256:05cca45a62426951d66be40e4baa277e500de2ee2b72eb42287a0c779ba9afbb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-107.8.yaml":
     pending:
-      fingerprint: "sha256:8c38ef3f1b816cf1f4d27d61845a447c42551bc7eda8d61966fc9666ed184b1e"
+      fingerprint: "sha256:3ed1406cdcb7a242e36e0110cef8a3617a231bebb38b22a185f2c33459899932"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-107.yaml":
     pending:
-      fingerprint: "sha256:31d8c05954f82dc12d6722f7f28f8eeb59e036869f2418585f8ecb2bf416564b"
+      fingerprint: "sha256:e91841850990c3477bba14e0ac95c5b16c9feb8d12234d760cf056d174dda222"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9520,7 +11804,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-109.3.yaml":
     pending:
-      fingerprint: "sha256:4c0b7d8b37e4c6a62bef0572b3510cf60491416e10ddeabd3855f19f9b091123"
+      fingerprint: "sha256:5909e953e49cc33d2d225eda00cb93ec1865393c49557b915968b9eb0cb70491"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9532,25 +11816,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-110.yaml":
     pending:
-      fingerprint: "sha256:bc390cac1c4cd4a8af945f1cfe26ad89f6dd0c85437df9d0b7493357b11af1be"
+      fingerprint: "sha256:73ee77dec5b1c07706e34b2ef69177051d6433d7ef54e04f3afd3eb5334c7ae7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-111.yaml":
     pending:
-      fingerprint: "sha256:a8bf7ab45ac1b5c5878b91cf0f27311b343410f5173daeb5c4048ca4266456fb"
+      fingerprint: "sha256:55c4ada3b8ece61e7df7b2e438e016a36966dac74b608705cb2d2b2cb810db6a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-112.yaml":
     pending:
-      fingerprint: "sha256:4dfa280279da58539f721a725ad7c176bfa6ebe5f06533c48a95acca3e0cd1aa"
+      fingerprint: "sha256:a043b1dd61a594379dcbb62ebecfbeca1eb6211a49b29132fb82a163ea9a7a32"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-113.yaml":
     pending:
-      fingerprint: "sha256:6c6b854cbee28a3ed871abdc075df3ba179335acb962eb65192337410780c04a"
+      fingerprint: "sha256:66f3e270b0545341d8bf2ec7abee24e5e373a7638a10a0c6c245f5cdfc5a4381"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9562,7 +11846,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-115.yaml":
     pending:
-      fingerprint: "sha256:a9291f0eba2e9523d78ae6fbde073a3d862d4919510a9a4f4b50027bd83bce2d"
+      fingerprint: "sha256:22564419cd5fb981885da7f37f55c046bc03ae0e653b8fd1a327f6552bbe2330"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9592,13 +11876,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-3-205.yaml":
     pending:
-      fingerprint: "sha256:935e1c366e5a7e94f1260d8bd4a3fbaf87d92a1fd2cfb618c301affca55fe594"
+      fingerprint: "sha256:c388d8bd5aed0195993aac4ac8f2b17a7854e88dd746ae455fdbd6b0e23f446d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-3-206.yaml":
     pending:
-      fingerprint: "sha256:b90c272fc7f20c623a7f5ef8344811c22e0dcc9ca22f4125fa26af932534d836"
+      fingerprint: "sha256:b0fc40493932d9da7facd169d420e4520263db1d2c386e1b8043738f1b641558"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9616,19 +11900,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-3-209.yaml":
     pending:
-      fingerprint: "sha256:e1d0929cae0a5faee48f9bffbae78234f5e2c56271d36a6e18c3a381e85406e8"
+      fingerprint: "sha256:bc7b6e1cbc77858fa7439dc22bd9fb4f3893b89958de5991f8c39cf688c23e2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-31-101.yaml":
     pending:
-      fingerprint: "sha256:85826047cba383209ef8a822e48ffb7740214e7f03e66aa1846babe37f700374"
+      fingerprint: "sha256:f7af6b6e976a8dc4b869e09c8c52453f36720adc05a5bcf93271e197c4e67199"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-31-102.yaml":
     pending:
-      fingerprint: "sha256:55ebc7f6458f4af4eaaa943f40b2c3c07dddd1b8adbf15d8c6103ce79f3b8692"
+      fingerprint: "sha256:c3fe07f2e95efa1cc48f85140846f80c8a591d4255a24f3667ed5efcc6a6f92e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9640,7 +11924,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-31-104.5.yaml":
     pending:
-      fingerprint: "sha256:a3018eef76536498d4385274bd7cf26a5d27a1bd46ee8c27d67337b9ee20bff3"
+      fingerprint: "sha256:39ff504d54c993770ca2150f9cdaaab0de9eecf579c4c0e9392cbe1f69c48fa2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9652,7 +11936,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ct/policies/cms/connecticut-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:11a96cd2004ce9a42fdf803fa7fa7de1c32fa69339b4192f1c03200e81c96667"
+      fingerprint: "sha256:983bfdd236e763735a6670e3a1ca9f5993038f2a4afc6b6a7fe4d47bf3b16823"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9698,39 +11982,45 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-ct/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:7c3eb88e74ea63fd57319a4f0f9d5b25b83821dcc4f1b8af84530b40e8b2ea85"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ct/statutes/12-700.yaml":
     pending:
-      fingerprint: "sha256:d083b175999d565ab3d8767a3e8891f2d44b7c6ca8b3ccbdd4a27c4d3d8be082"
+      fingerprint: "sha256:015228f885475fa0717750055ffeb8d72d9db861bc93908e81e188cb0bdb998e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/12-704e.yaml":
     pending:
-      fingerprint: "sha256:bd198f3bd1705587a565e87ea2112d17e4d1490816cca5b6e47b6fb7f43159a6"
+      fingerprint: "sha256:399540d2b4debd2709c6717f126b92dbdb8bf798b674d5b3097a0ea1527499cb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/12-704i.yaml":
     pending:
-      fingerprint: "sha256:a986fa45d2b5f9f256d6540a36f6d7a181d35f28b7dfcc88c5414cecc3fdfc33"
+      fingerprint: "sha256:1b6178b1af00b413403c98b777675dad266533e340d86af031665f4503779576"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-104.yaml":
     pending:
-      fingerprint: "sha256:297f7438ebd1d309ce40e1afab0f1830e0184653b023a863e477f1817dd2cef8"
+      fingerprint: "sha256:ea505c3d133e8cd6a78715e3867b2bbca0eb968efb9533d3a8ddea48bcc1d40e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-112.yaml":
     pending:
-      fingerprint: "sha256:ac887556fcd4666219e246e6b54e2cd8ce528b6c2fd21faa1e9d4bf529db07c7"
+      fingerprint: "sha256:cb9870255de3acae32e12ebcb16354898e03558768c3ee0aae2fd236b8eb93cb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-600.yaml":
     pending:
-      fingerprint: "sha256:5e369b3779a0ec36064d31a4dde55e236f7ae98b0d7f32f97de2aa80a8cb361d"
+      fingerprint: "sha256:fd9df09da5a525bbeabdbbc3be51ef706f52b919fb74dec08b2853f6ee8c529f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9760,7 +12050,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-de/policies/cms/delaware-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:9770cff022ac4b963eba9fe3fa141a158638c468fda1241b708e6504ed629fad"
+      fingerprint: "sha256:d707ba54aaef0866b54ac0f8407928bbfdd5ab0ae6024166bc22436d9ea84615"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-de/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:fa3965880ad932e2db93cafb5a29ef42f9933f1e87c40a2c7bbd2c2feeae0f99"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9784,37 +12080,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-de/statutes/30/1108.yaml":
     pending:
-      fingerprint: "sha256:f20fe073c0fd6712c4cb420aa57117f491d6583b6311ea0967b0cadc0ff9b64c"
+      fingerprint: "sha256:9bda110ae1909ee26c7a7e27caa668d470080e355143b26881557940d188ba69"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1109.yaml":
     pending:
-      fingerprint: "sha256:6a56b004e5d7745271d8ed767caa2a2ec7d3032332749d1752144821ca7d4468"
+      fingerprint: "sha256:2eeb3069a444ba4f5f9fbc419a3ed221f7c91a1509d438e99308d2c0e8920e05"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1110.yaml":
     pending:
-      fingerprint: "sha256:aae73fba1a37a684a0274e6b4ab2590c5cededb9777f2396c0ceb6d84bf09aee"
+      fingerprint: "sha256:831ac985b9aea213778c9efb08ac9995daa1e55fb4edf32d8421ee7062321314"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1114.yaml":
     pending:
-      fingerprint: "sha256:049344fd976adea6096ec26c213a2d5e3a288a78387ee84f5799c8ee65abe61f"
+      fingerprint: "sha256:17334a4bd47add3ee7aa8b4dfe5e624b03b00494e3ee89e8cd158db8ea951b6f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1117.yaml":
     pending:
-      fingerprint: "sha256:d8ffea634035c41fa6d4a0c58b837b5f8647adce5fb20b30ed891dc664696083"
+      fingerprint: "sha256:678102165d27aa1a310d58aba8052124beffa0cd8801ba9b9740e3495fc999b0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-fl/policies/cms/florida-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:6a329e1327d4172b9735b2404f3b9840cdbb1467b088490b33c1f08be312c065"
+      fingerprint: "sha256:77d7e41c59ffc066c0087e31c32905aae0f9975326d96a84414453e6d4694c6b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10294,7 +12590,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ga/policies/cms/georgia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:d011dc8dabdf1efaeaca67e18f12f68c776be12671f0edc7afc97cfc0660df13"
+      fingerprint: "sha256:202dab1602b63d439bb069bcbe8c9ba050bfbf43cd738e447e0c0f8ec1896074"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10324,7 +12620,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml":
     pending:
-      fingerprint: "sha256:333f922c9b21f7835c424b473bed2e461b2a8a62430eea8f98efa0c439c74ba9"
+      fingerprint: "sha256:a963ac2c3cf5b48586954414aadb988ee5fbe87ddaf42234d188ead2c8ca0728"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10342,37 +12638,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-hi/regulations/har/17/680/17-680-12.yaml":
     pending:
-      fingerprint: "sha256:7b0807567fce456ceab6a9ae44f29f8c5f9b8b8a8b2d84043f48ef4dd3c73bfb"
+      fingerprint: "sha256:51fee9c9ecdf8dc73aaee122128fecd7bb80ba8a6b5f4033eee69341e519c515"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-hi/statutes/235-54.yaml":
     pending:
-      fingerprint: "sha256:a5ac84f7faacd6394799c919b30849e598961c66b4e60d52b41ba7b4f8e70bce"
+      fingerprint: "sha256:b587cb84800d7db2064670be7377822dcec793e35438a31730c5a595b4f4eabe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-hi/statutes/235-55/6.yaml":
     pending:
-      fingerprint: "sha256:48ee33ad4678472271c031238d0b3a0408d3bc51054eedb4386fe090551726ad"
+      fingerprint: "sha256:cacb7fef3f50f5297a802455ec03745e567b39c0582bddf69539b3500a81a4eb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-hi/statutes/235-55/7.yaml":
     pending:
-      fingerprint: "sha256:6870795917a849c82ef850955d21af645da5b5aed034731a53f7079aa66b4f26"
+      fingerprint: "sha256:08959dbddd6cf93cd3bbe9c9b20abc27f0a0eb839018972a4c5354dc0be6c210"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-hi/statutes/235-55/85.yaml":
     pending:
-      fingerprint: "sha256:bb7250c589b0452ee70501e06faa979b6509fe7b05dc9e676abb23090da0e73b"
+      fingerprint: "sha256:a56a8fd22413228e0ae1705f9cce7ac78a6af526b7a401047f3d7fa19d84684b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ia/policies/cms/iowa-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:19d31a903a27d959d18766bdfb2d9ec4b91020b8cec99b7efb5416192f5086f4"
+      fingerprint: "sha256:29c75315d77a6f04fc0da21e97fa398aff39a8b6b2116b2ecaf2fdbc88e62e62"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10390,19 +12686,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ia/statutes/422/12B.yaml":
     pending:
-      fingerprint: "sha256:0dbce5b64469f088834f891743832316802c967099d1793101e3f7d3ae07982c"
+      fingerprint: "sha256:afe24a29fad3908dd294bb36bce5fec43a8ec440dc4e8968d5f08620ea69b573"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ia/statutes/422/12C.yaml":
     pending:
-      fingerprint: "sha256:1fc1a3f06cc6df602c52731cc03e42e6d42555896858dd497f70af1abea1e8db"
+      fingerprint: "sha256:1a89f8e38dccb626c8159dbbdc1fc59e34b682c7d4ccd5ab5b65cb20e1ba5064"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/policies/cms/idaho-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:88105b96ece2d70053e5da23461075ede5ffc81cc6afec3ead6353bda585e30e"
+      fingerprint: "sha256:0f5bbcc56b42a0c5e41f209306e0eaaada8d69af8686a4d4e5c4de8d88283132"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10414,7 +12710,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:8e530cc395c60036bb0aa623e7e50a517986a66f25a5cdbb7cffd4aa96dbd8c8"
+      fingerprint: "sha256:6ca089b2f0ced2adb339b6684dc655e50d478bd82d52c84e07339b4972cde5fc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10522,37 +12818,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/statutes/63-3022D.yaml":
     pending:
-      fingerprint: "sha256:8e0113bf153f3d096b782e42ab31e2160f9af10daadb496847ac6c52aed98f7d"
+      fingerprint: "sha256:2c3b62f0bf8c017be858b6a26a2050681189294c4c5a5b5a9091c32faabff655"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3022E.yaml":
     pending:
-      fingerprint: "sha256:a12152b5d7c0b6c69dd1d0cca9efb2e00df9946fae73746bfe8cc1d8244c1f6f"
+      fingerprint: "sha256:3835131cbd00b851374b2319e9854d80fe594935be5e5f99c2974f22b7d00965"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3024.yaml":
     pending:
-      fingerprint: "sha256:f11d67c17e994e7d72eb63403c0fbcd1aa80b33bc8a3cfd0f631389fd3268c99"
+      fingerprint: "sha256:ed677c90d81b54723a03daec6bb1f1a25117705a38b3be699f57c39903219ea4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3024A.yaml":
     pending:
-      fingerprint: "sha256:1b3d363063d919ee6d892338a359322b841e277e5ba086c70412655685cd384d"
+      fingerprint: "sha256:493748717208e04c3f35440af30c888899b10ab08e7785ce369cc2be1d6ac83b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3025D.yaml":
     pending:
-      fingerprint: "sha256:70999ae2e0b5ce1d7cfc0aff5b7b5205307cfeb73ea1f6c9bf2211cf7a875a75"
+      fingerprint: "sha256:d01c9b04d54ab7dd0fe1082fe8b636b82f5eee7305ad4c355b210d78d693714b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-il/policies/cms/illinois-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:7baebc956485e02f71a7bee3202abbdbdacbfa238f81540632c3563f180cfa80"
+      fingerprint: "sha256:28aeacc70e26818c36c65851581da5ea17cfbe18414c18bc989d1d6957a6793b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10570,7 +12866,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/statutes/320/30/3.yaml":
     pending:
-      fingerprint: "sha256:49ac47407b24ab68ee5b9505b908cc46141e3ed215e8bcd6693fa228348b9b58"
+      fingerprint: "sha256:ac03671ea216d2c17a2bc28337aba766a74ee90b85b39cc7fcd1392b83262615"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10588,7 +12884,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/statutes/35/5/201.yaml":
     pending:
-      fingerprint: "sha256:3f5a08777355e9ccfa0298155e1f9c8bf82c448455cd0481e67da6a98b0f7624"
+      fingerprint: "sha256:10537c0806ce8de1675bd1e803fcf625ac7a586350047f0b316545e7de51c223"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10600,7 +12896,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/statutes/35/5/206.yaml":
     pending:
-      fingerprint: "sha256:368640bc1488c331254a99a7dc41ea5623c9a12f5c801d8522baa33a0c9d74d4"
+      fingerprint: "sha256:a2613063810de1aeb0a1a741728ef5380604976e368559fa8f230d85fef91247"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10612,7 +12908,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/statutes/35/5/306.yaml":
     pending:
-      fingerprint: "sha256:ae8ecfc3e175a3a4212a54bf5b72fdb15fe902e7d7253b548af23bb4daa12b89"
+      fingerprint: "sha256:febf52f164276b5c17288e0d0a878058fc2075d9154ab35817a191ccef6c87f5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10660,7 +12956,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/statutes/35/5/706.yaml":
     pending:
-      fingerprint: "sha256:ba987f9742dcd6cc303618ccd6828c2838a288339e6daa5d2b43b4029cafceac"
+      fingerprint: "sha256:41545497383435f4446553c6f99210954ceeaee992fdb4b93bd82eef8e6a9ae3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10696,7 +12992,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/policies/cms/indiana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:bb4a2b4f81d3b956f1e271e035b1b57aeb4c31eeb7bbff6da04b031d1a729970"
+      fingerprint: "sha256:19cc449233bec72f5034d7e8faadb2f12fc374642ba1c830bc60370b51ce6b99"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10726,7 +13022,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/statutes/12-15-32-6/5.yaml":
     pending:
-      fingerprint: "sha256:9d93ed725747019d66a33552a2d07f56b7a779289ee5a636aa7c1c7e98f878c0"
+      fingerprint: "sha256:b2d0f16e1bd33fc45d1a7387f810d7e9ff7200130cf7cf029b70669e2637106b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10738,13 +13034,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/statutes/6-3-2-22.yaml":
     pending:
-      fingerprint: "sha256:a74a76c5043c0c045ab418ed0e1bc8a93ab358aa502c4bfe1fcfdaf77be3f8b1"
+      fingerprint: "sha256:b968d2dd87e35714432bd38353538d3b1e05e8b4f99743cd3f721052a2cd1636"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-in/statutes/6-3-2-28.yaml":
     pending:
-      fingerprint: "sha256:1acbea3c4ac1e267bac6f5c48c326d7c2e302382403c6436d9ea2d0f2e042d7d"
+      fingerprint: "sha256:d352a52cb7f695e61e438a4b6a2b4582f3a9eb49e83dd88c10380ee7e65a34d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10768,7 +13064,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/statutes/6-3-3-9.yaml":
     pending:
-      fingerprint: "sha256:b55dc7c2953e017835e467b12587065d716b8538b1e865a18fba9fc606a0b0b0"
+      fingerprint: "sha256:7c000b7da63cd2acf8b8aca7adcad364eb1d2f91e3e60468333792def2ab80ec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10780,7 +13076,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ks/policies/cms/kansas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:27ff5fb08a396a0cb009c451efbfacb035ba818137299f0fe2d456dc15232cf1"
+      fingerprint: "sha256:06d48e81dd5a712b8af45ff2d9316b3da5c6b814d80b63b5d0bb51eb4228f2ea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10798,31 +13094,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ky/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:67673276a216702a8439e3875d167352cc548a2cafbf95842ac0410b038fbe75"
+      fingerprint: "sha256:c5479efb88dbe2fdcc7e6820e5fb4ce99abf9844fe57d894a2cb5e37dbde09ba"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ky/statutes/11/141/020.yaml":
     pending:
-      fingerprint: "sha256:61155c04b8856959d4a9a1e6ac6dd97682c72bcdc3e621ab9aa5cdaa27ba3395"
+      fingerprint: "sha256:a54f7cb7579c44f914fa7d62605a24617604ad1bb1f555a26ea58d60485b9fc1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ky/statutes/11/141/067.yaml":
     pending:
-      fingerprint: "sha256:d9056c84aec7c578081f330f0f194924097f23690e471bebc15c77bffb5049f3"
+      fingerprint: "sha256:f8e8a156ef6a7ec43e5baf6dbc20e26d321f3ad1d9409f621c72836d4c3758ba"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ky/statutes/11/141/069.yaml":
     pending:
-      fingerprint: "sha256:aa6501e5ade0a7e6237543fd1fb53f2dcd8d07a5c8a15efa39bd1814f895373f"
+      fingerprint: "sha256:d1ed31f094c6f3562fea02f7b53ab08cd68812a5a2b8d5ec36764b3ea6b9d756"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-la/policies/cms/louisiana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:749f09a92602ab4c11e90836900f2b4cfc0067796692b69b22310ba24f3bb064"
+      fingerprint: "sha256:aa25a8f48d4bf46e067dcf3cbef4cb9f8495eaf17e5e315d846584aaf63a98c1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10852,7 +13148,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/policies/cms/massachusetts-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:9fd546aac23e29a9f59278d75ecd87e6fb1f6e6ab599d6c9153f2f04d5a67ea6"
+      fingerprint: "sha256:45dcfe16cc7aa38d38246ac3e40e42b7894a69d3ef92c570deb306ea2caa5b77"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10876,7 +13172,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:7e31c48f3da5c195aa6e8996450e19c76c115d2fba36db0369f3c6b79e6ef067"
+      fingerprint: "sha256:caa362d34ec667700697f2d495b3ffcb0b9a193cf2d1fd0cfe65ca523efb508a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11176,7 +13472,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/030/block-1.yaml":
     pending:
-      fingerprint: "sha256:ac71ff83db39c7fd19eb1479752597c81f897f799a698538ba9106f98b327f1e"
+      fingerprint: "sha256:b014bb86f592abc95ff96f0385f4c0cc1fed28507bc188e0a024d50b212e59c4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11422,13 +13718,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/statutes/62/11a.yaml":
     pending:
-      fingerprint: "sha256:84b894a23cc07d0ae37a3ef9bdbf289d5783190b38f3baf11f2c86a87d4e5c23"
+      fingerprint: "sha256:a8c78ef1e0ed2b8229b7f5f6ffd744795993515ef136d929ca5f74cb277604e5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ma/statutes/62/14.yaml":
     pending:
-      fingerprint: "sha256:3c34272645858fbf7090e41fdb6573c8e1ae88dbe3c8585e8c3ec9a3fdc3578c"
+      fingerprint: "sha256:4081448f11753b486ea273edf943f3595d0dbf7aa99cb0f8fa7c7cd7cf51f5c8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11440,13 +13736,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/statutes/62/3.yaml":
     pending:
-      fingerprint: "sha256:0ffecad1b618e11f2b1b7144de594cf3b907f840caa258fb0ef97cd0b1148ff3"
+      fingerprint: "sha256:a8137fd3789f082f31d89f25376096ac49cca319a079cf69170f636faf6d0558"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ma/statutes/62/4.yaml":
     pending:
-      fingerprint: "sha256:bac69a4be3d68bfd478d7cf171afb4cd8c32a7737b9a428df2438d282f67387e"
+      fingerprint: "sha256:24c26da31b62a11345f31fe7ec030e1bec611d3e13026b3292232701cedbeed7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11482,7 +13778,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/statutes/62/6l.yaml":
     pending:
-      fingerprint: "sha256:3c7882fa5319199f681e4d72757ec063ffdded9189566f157fe30d3914dba766"
+      fingerprint: "sha256:2b7f4f726d58f8f112fd0c2a85041d5c66275c9d908c2b30d6e7da9e446319b1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11500,37 +13796,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml":
     pending:
-      fingerprint: "sha256:863d7798d37b1215990b7422a7c47b536656c6208da401eccd540e3dd17cdf91"
+      fingerprint: "sha256:90a35e6eee464f18c0e7d0cd047df3ee375364f2379a065e9ba4eee9bca0c794"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-md/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:1ef562dd4c1950de8ab866b557b928183ef0aa201379eee12ad71f701b7b5024"
+      fingerprint: "sha256:1b4d7acca34a3c9d03c1b8b2deac31011054bea42b7e3a36ec423926ecc3d314"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-md/statutes/gtg/10-105.yaml":
     pending:
-      fingerprint: "sha256:3c6386d4bd84c22bbd86b9e576e2b1361667acc41e2a64a73557a4f9e64e01d0"
+      fingerprint: "sha256:8ea8b5880f49e328d55d31535e78549abc390adee11b9cd9fcb6dabb9c915f48"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-md/statutes/gtg/10-211.yaml":
     pending:
-      fingerprint: "sha256:36207b16c1dbd40c8f765cacebb3593c67bfde3d68694bf8c60216b5e1acbb31"
+      fingerprint: "sha256:a1cced0f66ef9de8ec2f8ab1dab4a9a19c6a3cab4b6b7fc945649952cf7a2ca3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/policies/cms/maine-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:cc22b13a488675b117b12130ca5c6da7417eba4ede0266455a4bfe37cca35554"
+      fingerprint: "sha256:f810361994fb23061931a82b0c6509e1c48a0b189d5ef1db4e0cc33f28c0d597"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:d41cebdafd27edb4354ea6726b596dde9f07c84301164894c2999fee640134f7"
+      fingerprint: "sha256:fd34302a6cf7596cba8149ef9c8dff4983049781dfc933bb89f56c60a55c1192"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11542,37 +13838,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-me/statutes/36/5111.yaml":
     pending:
-      fingerprint: "sha256:f097af5c142d0512971aac20be5fe7f946155bbef46a5eeeeee069ca79169318"
+      fingerprint: "sha256:b8f07e6522c3a0512b634831da0c76206ef7ffc1f7673b800a4dfecad8bd89ec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5124-C.yaml":
     pending:
-      fingerprint: "sha256:7790dc5f33e018dd7beef38540007f749b411bd977d37b6b8592211d4fac1ba9"
+      fingerprint: "sha256:f8e9ae8d4619cfe26902b9ca9f3d27d9a3c8fc355a57d7bc046b92f2fdf66ff8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5126-A.yaml":
     pending:
-      fingerprint: "sha256:8a99f9a3b52765ee7bd2b5904b0c22d3846152a6f1e7e18aed464a71c9e5c857"
+      fingerprint: "sha256:71ee5bfa4fcec8077672a4cfb6e0a3f693c6d37ddea3fced401ccc222ec4539f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5213-A.yaml":
     pending:
-      fingerprint: "sha256:5fbc7deb335567f40d5866631ab8da61c60f67e754d4969fcbaf89e22562c19f"
+      fingerprint: "sha256:a461b3d0f559d584615f843c6687017ee7586b70d444acb00b132189c142ad19"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5219-S.yaml":
     pending:
-      fingerprint: "sha256:4fcf4664d9bddfac6ec6d48c651728a3c7d93592f819b9b6bca3583798364bd8"
+      fingerprint: "sha256:b299f292676755ee4ecb88ae1f0e1b842d437c0304af86c66b407f28f4bb7147"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5219-SS.yaml":
     pending:
-      fingerprint: "sha256:fe2ef1b5274288140b476cfda8f900ffabcf2e34bcf07d945a331d0e4e887f11"
+      fingerprint: "sha256:7c156bea8a2359369816d891a208447fd14a9c9b7678421dc8585f3007b0e323"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11584,43 +13880,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mi/statutes/206.30/10.yaml":
     pending:
-      fingerprint: "sha256:4882820e8eb3c5c2f9a9f2847b7be4548fb507831ba6d2cb7f718b1f0a843303"
+      fingerprint: "sha256:2a89dc212d6fa5ed82c7f3fb7fd4d95ccecb88a7bb100e876b417bea8cd8b28f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/11.yaml":
     pending:
-      fingerprint: "sha256:30f242d64981f116374e3419019e108a318f3f703ffbddf83eb0dbf3aabb41bf"
+      fingerprint: "sha256:1d2755f8b5a6462f8a371a6c6d74f6349892872e77a8ad7a7de8d6917f653da5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/12.yaml":
     pending:
-      fingerprint: "sha256:7e810625d789a957441ab3519ca13e1e507d1e3ccf00972e8fb5fc0240eddcde"
+      fingerprint: "sha256:5e0d3f8fa6706b2b079e899f36dd38ce56554fdeaaf31aa6143b9765d3dde48a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/2.yaml":
     pending:
-      fingerprint: "sha256:76f223771f19f5e42fca9567acba594c2b8609b9956e82170b6a9f1866ff4316"
+      fingerprint: "sha256:03018a9a9390dd1ea553888a7274042f8d16a98f0d4ecf34a5591914b2aa1978"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/3.yaml":
     pending:
-      fingerprint: "sha256:21760850f2c5fbc23b63f7add860a6fd19be0de3df814e5aac8272935e9bf049"
+      fingerprint: "sha256:d45a8f4bc794a703fe78f05ac4decfcd534a9d78b6f2984c3bed213fd9e7d4c9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/7.yaml":
     pending:
-      fingerprint: "sha256:d9278a385ed32d97f3a2d7ff2a4617269d5638317458a6ef89a61a822517b6be"
+      fingerprint: "sha256:843a5c33ba56d741ad26ad2554f25ea082b6d844e42e371f72e2abcbcab2f85a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206.30/8.yaml":
     pending:
-      fingerprint: "sha256:8294f58934880c01b2709f99fe7c32260ea41ce7ff43ab137a4fab30c819a8f9"
+      fingerprint: "sha256:80d8dc7484325d1e624dacbdb661a72454a181352fba53cfd0e898932746ad80"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11632,13 +13928,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mi/statutes/206.51/6.yaml":
     pending:
-      fingerprint: "sha256:c398f7542fa132f1c4efa8fce7fd4ed56aa37ef26771270ab4c0702c334aa223"
+      fingerprint: "sha256:70fb148c4853f5c3d9622a92f8aab8666a2b11ad81b92065a83e3e8c0209368e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mi/statutes/206/272.yaml":
     pending:
-      fingerprint: "sha256:dab23dc802544a1511a974d3e72b3d61eea63221fbdcc691158a8b53e3969fdb"
+      fingerprint: "sha256:b7224cb5fcf34cf248d985f30a3117acecfeac3b21572a892c713929272ab282"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11656,43 +13952,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mn/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:0a42efc0c48e318f080fe9caddffb355a5c26af986040a5c1a68864889e0f1cb"
+      fingerprint: "sha256:e71b0de04947fdc750303f74101ce7cd0585cabae6c5f407b55bfda3ae58dd35"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/0121.yaml":
     pending:
-      fingerprint: "sha256:e8b70c959f77efc32c52adeefcf24d51232aed8d07ef4d83563ff0455aefec8b"
+      fingerprint: "sha256:757312db07924c40384f1c506855c059c0680a4ff89c92a9f3280943bbd97e6b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/0123.yaml":
     pending:
-      fingerprint: "sha256:c6c320d6d918e5732574bd21ffd0e872ba3caec25a54a17920e6930299954d98"
+      fingerprint: "sha256:66100c87bb9cf4801afd6d4e91611f757ff7f5fba1f3445d2e42de49e36e156b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/06.yaml":
     pending:
-      fingerprint: "sha256:432ec1840c87812b7f472a723d66cb3fac1ce5859654672a6207ed3dbf7fc942"
+      fingerprint: "sha256:db548af4187d1c17e22deefb91b9eccb23aa06797dba029960aa5bb6b03f53cf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/067.yaml":
     pending:
-      fingerprint: "sha256:fd4e464235c9b0cd4965f9e4efb2e9b17a80badcd279cc11888ff99b69872558"
+      fingerprint: "sha256:9a4b7cac0a66bdfd98b2747e618ff6688d7f95affd4e5cd2259a2b71b2535dd2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/0671.yaml":
     pending:
-      fingerprint: "sha256:928da3dc819c3ba04892b42b977f63a3cf5ff8e797579077a060c55abc7d069e"
+      fingerprint: "sha256:6ea5af97f55f9cee93b1e2bd7589c99c8357aa550383249e7c5bc402b036605e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mo/policies/cms/missouri-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:c137e07b9950d4a6ea8c181295e92bed654890cd06479ad77ed21fb06f134bb0"
+      fingerprint: "sha256:888111fe137619c9d314e941ad12ed0f155a33fad10bd30295ff4df340a6fb34"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11722,19 +14018,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ms/policies/cms/mississippi-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:9dbd0a814489767ca654c3a4a66c65bab7768d6028a17c045ce7ec5986805e5e"
+      fingerprint: "sha256:ee0eb1420e1b3391b8a46eae209d9c0fb978abc2a264055e8d69a5dacc59e91a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mt/policies/cms/montana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:4a0d66ec09150fcdf28cb9e7c16f5a4547cd62857fd79badf0cc4459cc8954b7"
+      fingerprint: "sha256:fe6ca2ea7b257f33a846c9c4a376b55a121f6e9ab4e5d0aaf621bf5ef8218727"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mt/regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml":
     pending:
-      fingerprint: "sha256:53bc664aa4ae248bc510ff044e4fb24991b6783cc6d2230bbf5cbb2828750f24"
+      fingerprint: "sha256:7507f0c54d8f7dd3a4e9e1fe63cbb1398a065e0f6fc6c5aa5133b53c87b6cc93"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14188,7 +16484,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/statutes/105/105-153.5/a.yaml":
     pending:
-      fingerprint: "sha256:e3abb67a82ff101271412c41deda929abcc37bf32f027cc802fa6bc1a1e209a5"
+      fingerprint: "sha256:7f4f1f81285adf09e3751aaf1ef7362ceecf99e10d4a9ed625d3b1d0ef9e1295"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14206,7 +16502,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/statutes/105/105-153/9.yaml":
     pending:
-      fingerprint: "sha256:aa53a10b513f65031e1964ac23501a123e8fc292f37a01061aa373d222027f3e"
+      fingerprint: "sha256:06003f08fab06b8f28e125c68e71310aab6e793cd182cd831af3ef589f84bef5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14218,7 +16514,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nd/statutes/57/57-38-01/28.yaml":
     pending:
-      fingerprint: "sha256:d34bff3eae65b44d52529f38dc5bf62100d8522ab272869433eb57e71b4d0ee3"
+      fingerprint: "sha256:2d58f6e65dbdf911d2e3c794f4c0704bed7695aeef59e94bdcb883c53df70448"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14228,9 +16524,15 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-ne/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:ae3f3c0b43d8f24dcaa20799cf5a680eea5b7fa74ba201fd044f211a938ca461"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ne/statutes/77/77-2715/03.yaml":
     pending:
-      fingerprint: "sha256:4c81bb416931fd10d134bb62a50fc8e28e8e56e5f02fa9c3f6e1d618fb0671bd"
+      fingerprint: "sha256:6d25293faa50d61b8409ff4f91f1a1c88b12861587db188106e820a17426dde2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14284,43 +16586,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nj/policies/cms/new-jersey-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:e1c4adfc35cd700e0cdc9393e4a7dbdb3a1db06f2cd0edc4814e9112c4f1b005"
+      fingerprint: "sha256:cf65846332e30ea8d40a3a92651cfbe5fb0ea9cf797f4ecfaa7eddc4d8c19d28"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/19.yaml":
     pending:
-      fingerprint: "sha256:962942e4c2fdb2d2626edc508cf229daa9d19ae62ebd6d96bff9f25e3b79be57"
+      fingerprint: "sha256:18404489bf001b9ca4e2329974ff66b013b731f2144938cb7371c3106ca5b461"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/2.yaml":
     pending:
-      fingerprint: "sha256:26488bbea2d245c96522c514489e48a9fe55fb6de18d7732ae8c5346d976e2d9"
+      fingerprint: "sha256:9c875a5b4704406b76e32584228e1893c4f3b6eade48c5ef4ed9a7cecd629e4a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/20.yaml":
     pending:
-      fingerprint: "sha256:fb5ad7a04c4f87fd679b4a973780d85586d2fae28ccc09b4113dc37932f7e013"
+      fingerprint: "sha256:0784b6e419faba191bb8d00ff6390ad333938bf0d45fd74e44ee941f3a09e14e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/3.yaml":
     pending:
-      fingerprint: "sha256:b98d77ccbd73ed6629204cbdf67786bff26daece2a68b2b5127409959644a2b7"
+      fingerprint: "sha256:01db8a9eaecfeff91acc5769b6d3d30ff99735802c9d28a4e40dfa4e08bde78c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/8.yaml":
     pending:
-      fingerprint: "sha256:36860aebf81722ccbaae8c92b0be27134bbee9d81e27c1bf2a32256241a521d2"
+      fingerprint: "sha256:b3d8550623b80c85b9c2142ddb12e9c3066ce49eadf3eac5be391907d07fa1b2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/9.yaml":
     pending:
-      fingerprint: "sha256:dba1fdcaeeea00cb1788d458350a041b694229c5e87a13ae2bdb4ab969f1dbfb"
+      fingerprint: "sha256:99c1ed33f6492fb573062600c8bff8280c78bcb44a27e25d524c5ec10eb61bb8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14338,7 +16640,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nm/statutes/7-2-18/15.yaml":
     pending:
-      fingerprint: "sha256:8d5b07e97dcf75ad25fbd3e22a31144657dbc2367477b3457592841844832a30"
+      fingerprint: "sha256:f774d8ebd39a09a3d0ebdcdeaa717033847909bb9852d1778be01153367f8480"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14350,19 +16652,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nv/policies/cms/nevada-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:1a71f714a9a24e8d4bc533dfb0585f705ed2ec4a76564e2c210c51d4dc828063"
+      fingerprint: "sha256:98a57a01dd8d840d9cd02b7fddbbc5a917dff52145d0d902eb8da291d1d56f02"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/policies/cms/new-york-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:06b854e796171ef6bc767c08c373e7ab59172394e39f013f98430decdb89c985"
+      fingerprint: "sha256:dffc89bf089e62eee8997a902ac57ef68e3ffc2d6973993579123a8d018068d6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/policies/income_tax/nyc_composed_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:6775fd7bf90cb7103b5fe4792a408a039c73742dd647f9ed1c2b2d1c8cd70b38"
+      fingerprint: "sha256:107c6999f7522eab5912336130cb99e2e1740a40200765c5e0a5058ed16f46dc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14386,7 +16688,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/9/a/2.yaml":
     pending:
-      fingerprint: "sha256:14b3b3c64d97b5170afcc4e77f41de06c06284078b0971860246dcdd8be9d424"
+      fingerprint: "sha256:b76db6e9b1e4a2b4a4739f156f05d6ee586319cf529eb72401779cd66585cad5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14480,21 +16782,27 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-oh/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:51834b7517a7c7314c023029881a88d7d9bc12a0bc70a36c320eb853b45ec25e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-oh/statutes/5747/02.yaml":
     pending:
-      fingerprint: "sha256:53206ab9c3e9641fc552898e4de3f0afc818778a724d17e2b347caf0927e1555"
+      fingerprint: "sha256:45a2b1fdcc3dacd8c78afa5fb3477b7ab89e991ce36563863015c5b7e6750fbf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-oh/statutes/5747/025.yaml":
     pending:
-      fingerprint: "sha256:f1a7fc5f03692af06b4e889ba82158438a8aeedc408cdf36f5529d955e3cd412"
+      fingerprint: "sha256:64acfe3ab816885471f3f71434bc394755feb365aa5157064890e99bd2692f74"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-oh/statutes/5747/71.yaml":
     pending:
-      fingerprint: "sha256:3cf6602db0b1111812a3f61faa0058bbcade89ebf1f21842971290f21ec0e2b9"
+      fingerprint: "sha256:8470c883bf24466b262f41ea992f1f3ecb5e2bc07c498d95c69b38e98d06c365"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14506,31 +16814,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-or/policies/cms/oregon-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:71e754dfe0419c4c46dead763e1b22f12542bcc0b05c3607fe67f26e93ebcbb5"
+      fingerprint: "sha256:7052f2fa1588aa1d301bee4015fd478aa1d232332d01adfc1e02ed29b39541b6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-or/statutes/315/264.yaml":
     pending:
-      fingerprint: "sha256:73fb35e67f0f0d2adc3f3a18065b9d61e2408553341211e1b67e45379da7997e"
+      fingerprint: "sha256:c548831fcfcda0f6b2aa8e3fe02ff7f387d99fb9e03d461a7004c2e4df0bc722"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-or/statutes/315/266.yaml":
     pending:
-      fingerprint: "sha256:ad227456021eba6904342c702c15b8c9ccf1bb10975314c2abf12dad44a5a7cf"
+      fingerprint: "sha256:b681336150b9e0a71f7a11eea30706524ab1d91067fd07ec2ed5a7290a03e661"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-or/statutes/316/085.yaml":
     pending:
-      fingerprint: "sha256:91efdc05d40b16a0cd0c088f93ad44b62d4ae1c1f510d14ee7e66fdb9fed966d"
+      fingerprint: "sha256:779d77f872b1cadb1d8540b254bb255345746959d2966cf96b0bd2bbdeb43e5c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-pa/policies/cms/pennsylvania-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:cbcf3dc081873765dc5905fd67e883d188438070819af68557d5834786c9284c"
+      fingerprint: "sha256:2a20bfd272631113d99dac5ca6222ad561a6f687614321d9dbac908724311f9a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14590,19 +16898,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-sc/statutes/12-6-520.yaml":
     pending:
-      fingerprint: "sha256:888831710466e8e51495513cd18867b8d1c8be55fa741cbcefa3977772e09545"
+      fingerprint: "sha256:8322c7a9a29cf8a0d32831394f60986548415e4fe14ae87726d0d265c127411c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-sd/policies/cms/south-dakota-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:edda51dd4a7c79132e53025fd79a8b438567e5212434541bed9ea1ae003599e7"
+      fingerprint: "sha256:ce6920a61808bfe777afebcc6ff775ab4588e212d6d3b42ff733436e95f2a5cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-tn/policies/cms/tennessee-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:ab32cfa445bd4da92855597cd60d75f6d9f32ee35399502c5d753ab9e40bf565"
+      fingerprint: "sha256:b11432f5c92a2d75b1fb65b74b3feda3c50d786a8647c07d30ff06af4cb09121"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15286,37 +17594,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-tx/policies/cms/texas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:fc1601d57e9c617076561712fd7dc33dc9177ac51653c0fe2a07a2ae49a3bf82"
+      fingerprint: "sha256:3e41ca4c486b67e89cb645b21b0de4f9518a8ac3c3debb81db08995d7bd0f306"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml":
     pending:
-      fingerprint: "sha256:0adb0689f2c8c5dd7f4ea6cf5dbbb40d38d651eb28593e8be9f2b67f0bdbda95"
+      fingerprint: "sha256:79d6778169bdf9987b1c2bc1914f82da31ce64c4efc22da5907fa1c568f02cf7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml":
     pending:
-      fingerprint: "sha256:e6a2b4a8cb2455a4136119779add3f9ca0aebdef893e24d7c6b9ae9dda92e582"
+      fingerprint: "sha256:ef17146664a8a4a6f045010652b852a3b2d4e9a1a5edb40a5911a30c5fd52dea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml":
     pending:
-      fingerprint: "sha256:e1ed48ca6e276360856b29a5ecab5c4f8b98eb1af40c11d726ae9aa485b956b3"
+      fingerprint: "sha256:79491be1e93e448acf07678bd4f35f8e71ee1ecc39bcc7c08f2c59d44cc464b2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ut/policies/cms/utah-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:d673885e920d920b2757546a727bff8489e02e2bf9c81c43af23b59795d55c0f"
+      fingerprint: "sha256:068d9a21bb29148035009e608474035436a6268c252562c0b0a221801ef322fa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml":
     pending:
-      fingerprint: "sha256:052af0838ae408218e7e201480f1c47d058cce33828733b8c4707cd477f51feb"
+      fingerprint: "sha256:d9af1d0cc1a5ec661157593f0780703b99020bc14097021428b3c03086382eec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15334,7 +17642,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ut/statutes/59-10-1018.yaml":
     pending:
-      fingerprint: "sha256:837677a5c1c183017cb9395007253f31b90baa6aa374a06e2bda794b8c2d503e"
+      fingerprint: "sha256:7252fb133a959df98c0df7d319dbabbe0c2f0792509df462060ed04526f0be98"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15352,7 +17660,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-va/policies/cms/virginia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:689243ab05d200f1ac0e44d7003c16c788e0aa4bec2aa3492e577547675494ad"
+      fingerprint: "sha256:b93f9902e529a540cc02893d431e376561725f3f39a2ea1fb357990462d1a516"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15364,19 +17678,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-va/statutes/58.1/58/1-321.yaml":
     pending:
-      fingerprint: "sha256:45e5c9d2c46cabd74992037c628b66e68ffe7f41e704fce85441fcc3d1cad722"
+      fingerprint: "sha256:64aa18bf803ccb75428e22a0ef16ca524405c3fb1f6fadef3aaeb4816ae42f86"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-va/statutes/58.1/58/1-322/03.yaml":
     pending:
-      fingerprint: "sha256:25ae68d8cd742452bb9a0ae0364745ebde50cdd9dc53add707bd4c22c8c1af9b"
+      fingerprint: "sha256:c3562c5b84b1f8a4078698b12bdeef1552ec8f82f545d5efdd2760f07d59a93b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-va/statutes/58.1/58/1-339/8.yaml":
     pending:
-      fingerprint: "sha256:5d42d76844d45bdb1880111222d0dfd6b9504735af7f71dab48be6cba8e66279"
+      fingerprint: "sha256:c493ffb64033c8fbfc1aabc6b2831d7f465b816b346c6e934007fc84faa70d02"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15388,7 +17702,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wa/policies/cms/washington-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:bdc6476067601473af42f1e3c9ad2898f3b5138b3a2d38936aab53ec698ab811"
+      fingerprint: "sha256:582673cbaad3691e48f4751d8c834bbd18e324e0b8f3fc5015cdebbf72b96b2f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15418,7 +17732,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wa/statutes/82/82.87/82/87/040.yaml":
     pending:
-      fingerprint: "sha256:ea71da5ecc6e24328e362365ab858e2be67a48b34b3c48bf2027d37ef8baaecb"
+      fingerprint: "sha256:8dd002405b930fe6d251403c89c87578673d79cdbf0291dedc9f20d1bba52e22"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15436,31 +17750,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wi/policies/cms/wisconsin-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:e6c0c6dbd3f6ddf4e09655b3a6c74d4ede042c5cb04a7d9f987a58b61382bb7f"
+      fingerprint: "sha256:44eaae27d672fba5f6a9d8ca05fb02dd127d7ae5b2ba277d99cfd20f42b8eacd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-wv/policies/cms/west-virginia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:84320fdca59f094bce1db772fb9470c48b683c69f6b9dcee1fcf4f41f15736db"
+      fingerprint: "sha256:200710e4d9ad33b486d4e3c21bfec956cee9e6d280a7fccf701c6b779106f288"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-wv/statutes/11-21-10.yaml":
     pending:
-      fingerprint: "sha256:cee59e02e95774b134ee0ab5e325ac99d349f0068be65e3c42ea37d2e9651472"
+      fingerprint: "sha256:3910be87ca4b02c1d4659a9b6d6d0c335a4ed8907d87878c7596ac2a43f0d50a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-wv/statutes/11-21-16.yaml":
     pending:
-      fingerprint: "sha256:13a3a64087a56d9ad94c5822bdbdf4ed217f887a8fad4d6356b89adeaa1d2c42"
+      fingerprint: "sha256:29600975b83356eaf009b7bd469ccd7d1d55ae9c80633f495e5eaa4c6b6a8f92"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-wv/statutes/11-21-21.yaml":
     pending:
-      fingerprint: "sha256:fb8e232a4ccae8656dbd1fde4aa75c81157cbfbc1b2d21dd75012c863f6227ac"
+      fingerprint: "sha256:32cdd2690449667ce945a2e6bc2895fb829369201cb27d319d6e1ec482009c83"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15472,7 +17786,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wv/statutes/11-21-3.yaml":
     pending:
-      fingerprint: "sha256:f72197efc3f3014673d3ed291f739d1d49f8473bad1feeaf61c88cbda0cad049"
+      fingerprint: "sha256:1f9deefeb945f66ada90c13fb9669b00bb7856c6d88a1e634a2908dc3b49527c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15496,7 +17810,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml":
     pending:
-      fingerprint: "sha256:8463a2139aad273cd60cea721e08358a7f7690e07272930d2ad73d81de5fc3b7"
+      fingerprint: "sha256:0f7f75a8555cd01228569d79ce295510a72b6d7f9adf7872ccbb823766e645de"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15514,13 +17828,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml":
     pending:
-      fingerprint: "sha256:019113f18a8c213bcded99cf0801f39a3830fad0aad08207f73b9a1339bed08d"
+      fingerprint: "sha256:737b7a41cc85dd1380a86d5703f0fe71a0bb561c6fbc6a1e2c2ba6e5a55e1e0b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml":
     pending:
-      fingerprint: "sha256:629a0520fcfe66fe8b646c9a60951a74baf57021594da565511bfb81bc1dff44"
+      fingerprint: "sha256:af8df97ee8f749d8617e254f0ae089cc582ad36786c240418995fb15986d8334"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15532,7 +17846,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml":
     pending:
-      fingerprint: "sha256:bba910dec8b0a2c65102a26ba3657a9a3277d9914535f583dbc5e9010854ff67"
+      fingerprint: "sha256:885396c2d2a36b5598e62835c1f1e86a7d6d802c84f6211ec9ad3546d4078742"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15550,25 +17864,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/maximum-allotments.yaml":
     pending:
-      fingerprint: "sha256:2b89adbf78b98374e8d41dea529cdd497af428f6884d9abf924a6a87b3f9596e"
+      fingerprint: "sha256:2ca090b5dd7bb9a8e08d6c6b447fd816c7d48ff56b6567fcac76d56887435023"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2026-cola/deductions.yaml":
     pending:
-      fingerprint: "sha256:53b182a6b94d68105d984cdb572e517b102800f3362676e0807340fd12717b50"
+      fingerprint: "sha256:2c006059146d21eff02f5950376a5f94d5ba1349ec2e1ebbfbda835decacf1ff"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml":
     pending:
-      fingerprint: "sha256:3b53567070f3a4c1b8ac96ba9a64e905f5c63cb987a8f27733dfb5d4186b8892"
+      fingerprint: "sha256:c7d21af674096b7f121aa24e09b491cba348778b17a6404abf8c75f7e8217e53"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml":
     pending:
-      fingerprint: "sha256:1b1bdace35ebf2870fc462e60f8f4a92bbe0b7ecacb8f9c5d68272f8623ce162"
+      fingerprint: "sha256:707b5a2be330d73a622938d4438a519f4e691af294a86eec2bd6d4af0d92bef4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15580,13 +17894,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/431/213.yaml":
     pending:
-      fingerprint: "sha256:72f8390351044f4ed252dfbf1ff8d1c408b81847070c633072329a76268b1b6a"
+      fingerprint: "sha256:f13c93bbff2b543e85d6a7f46db23e805ca1013b529ae5a4e22179420e2de4ab"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/431/231.yaml":
     pending:
-      fingerprint: "sha256:6155c750bd40266094100592f7e15409ae1d3c2115c4f857ec0171f7a85eb50c"
+      fingerprint: "sha256:29ebcbbadaea4a75c99a18137ea3e8f1733d1586982adad65f335d82eb7c85d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15598,7 +17912,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/116.yaml":
     pending:
-      fingerprint: "sha256:33fbb10ae43ba1d7726d709c198c7a47ec01e530385b507c3f86baa7826e5798"
+      fingerprint: "sha256:30c37e774533809e3656e60d9395353a26fce70228881e40fbabe85d274a6e8f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15610,7 +17924,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/119.yaml":
     pending:
-      fingerprint: "sha256:e5788b755931e8403b851f94d63093ea2c3ec5129d0bf6a8ac112842cf570547"
+      fingerprint: "sha256:e2eb8f745b436135713f9a90f89f5fa230e8570d1ba94a6edd650576af9c62f6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15628,7 +17942,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/121.yaml":
     pending:
-      fingerprint: "sha256:f37e02a65de868d60a053507043041c653afb08b15915993ed5546df5cb162f2"
+      fingerprint: "sha256:2186e00c2c06e6af924db600e2a46c58b0a9fd36bf587b5aba213cfad32cbacd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15640,7 +17954,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/150.yaml":
     pending:
-      fingerprint: "sha256:1e3ba1004cf2c52a7d509b02f31f8c31f269288d8901c67294b1ff4e6a7b695a"
+      fingerprint: "sha256:ae99bfcb778dd564dd9c5955e89ec500b7db2e6e9b73572e1966b10b1b4c9964"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15754,19 +18068,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/553.yaml":
     pending:
-      fingerprint: "sha256:484dca39e45028d844efa6e8fe3c8e2d5895c65be8a6a9a8adbd88e836371b8a"
+      fingerprint: "sha256:290dedeb22e10a38229664771cc487fa2098d7d6348c68dae3471de925d7c339"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/554.yaml":
     pending:
-      fingerprint: "sha256:88475b9fa28452212f9934a3ef2b1856784cc859702759a26546586f80c17f7c"
+      fingerprint: "sha256:c6bf4e9d360ac15f6938cebbc561cd35233dbd1634bfd80c0288aeddf6d1e5b4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/556.yaml":
     pending:
-      fingerprint: "sha256:49182810d73c7ca0e3bccf89a4cb9c1cea7b9c7027727de5a0a75f906589bf2b"
+      fingerprint: "sha256:fe8e512ba00d5e019918bf0b94637f4bf3cd425bb5d99ffe45422209985f8839"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15820,7 +18134,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/602/a/1.yaml":
     pending:
-      fingerprint: "sha256:30db2bee37fc6df05b1d5053791294194e0286d5c9d3d10ee4e821635cf064d3"
+      fingerprint: "sha256:73228fa50f08f231b8c5848a792e6c604a414a59af698c21d5b9f4e289845871"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15874,7 +18188,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/603/c.yaml":
     pending:
-      fingerprint: "sha256:73bc1f621dd86cc020c9dd60332264f601c4c7603adff3d1ee0066c3156c8a4c"
+      fingerprint: "sha256:137ce7d2a83dfcd01d0d515c35639b2ce1b9066183985291256c3f1e02e4aa52"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15922,7 +18236,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/603/k.yaml":
     pending:
-      fingerprint: "sha256:338a7ec8cbc727eb06982a2934b19f0eea8a3e734691670ec8393e0d0ddc2a65"
+      fingerprint: "sha256:67fead3f624d966fddd5f4a255a76e2b3b065ba27b0e53e2fbfeb0156fd92634"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15946,7 +18260,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/840.yaml":
     pending:
-      fingerprint: "sha256:a6ca0c8feb81014c8df1572d1d37601fc3d2eb708d507096a15b119aec00a48a"
+      fingerprint: "sha256:7d24b8c823fe3508d96cd08675cda638fe23da5d5ec13d4ffdc2abb8c4d4203d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15964,37 +18278,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/438/58.yaml":
     pending:
-      fingerprint: "sha256:744ee0bb6059927589833a37a0ded5e7b057076102232164df49113872248baa"
+      fingerprint: "sha256:7394072e887d3c95f3c386637a50205c74fbe76767cb89e11a572be6ed5acdd5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/457/340.yaml":
     pending:
-      fingerprint: "sha256:1c233c193f5c5d6fde90f8615180aaf98533bab4c08cfb4dcb709cc9760fe4c5"
+      fingerprint: "sha256:0e3ad99fdd93db3efc46c4438fd7dd98c9ce237a6a64d744969497422420d588"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/457/344.yaml":
     pending:
-      fingerprint: "sha256:83070fcc149cb288b49679515bf0a87094ca6d46e80cee0b94c74764a761f3f2"
+      fingerprint: "sha256:2052c82dfaa219efe66891a8e00bef016d2804327391aadebe76637bb97e5890"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/457/960.yaml":
     pending:
-      fingerprint: "sha256:562a6958a926ba8cb03267093655f347859aafabd028718506ada71bba0f22cf"
+      fingerprint: "sha256:205f02bbecef597a9d47b8bffca10f7ff49d93f06edbdd7eeca98017bf5c2e62"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/42-cfr/600/320.yaml":
     pending:
-      fingerprint: "sha256:595f2cca6607b7e04d17a20a73c255973c47761490faee51fa88dd77de2a4471"
+      fingerprint: "sha256:30daba8f62dbb3bb41b247c902504af0b1232d8439ff27b644d0ab2a13022337"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/regulations/47-cfr/54/403.yaml":
     pending:
-      fingerprint: "sha256:9fbbed8c7e4b169e5010f3645dc1ed29572bc5e9682c70e29049a754ee6e2b4d"
+      fingerprint: "sha256:3b0fb4d480d177343d3b0ce22f452e6493a8d6f4edde9c72b394ca589def633c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16030,7 +18344,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/7-cfr/273/11/c.yaml":
     pending:
-      fingerprint: "sha256:baa6fd6b42a4d8d85bb9992238b9e79f7423b916c26cbd330b8d9031c6881720"
+      fingerprint: "sha256:2a7c97c3b5cc9b7a7b2cfa0579a878c484f6825b4833deb6b2f581d37e71716e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16042,7 +18356,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/20/1070a/b/1.yaml":
     pending:
-      fingerprint: "sha256:679ff36f0cb4ec1788d50ffa2cf8394d28b2fcf388d046f42b3b5c6eb9901855"
+      fingerprint: "sha256:4bd23e3031712f019979f3d4f751f8f4008c73efd4346d4378587e4003f15139"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16054,13 +18368,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/20/1070a/b/5.yaml":
     pending:
-      fingerprint: "sha256:a28efd0cf0978830bd10772b131e79a9b0bb692eb319d509bc011151148cb048"
+      fingerprint: "sha256:3d78ae8b79ca2e91b38ffb7088333a4281039a8fd8bbff6813fa46d112b9e53b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/1/h.yaml":
     pending:
-      fingerprint: "sha256:3d1b9bbfd40ad28ba705958276219457dfde9761f23ad10eac594633286687ba"
+      fingerprint: "sha256:4333820da52fbd46a4a0d31ab20df1bae2ea3cd72482bb67e847093422ee8c1e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16084,7 +18398,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/112.yaml":
     pending:
-      fingerprint: "sha256:77d08dd2a2f0860f331d2c205f6ef3c7175f69ffea73a344aa5224d3ef941ab6"
+      fingerprint: "sha256:bf8f5ea89e98eda61437aeedb0a48cfe515dbde8610be7488630257d2ce55dc7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16174,7 +18488,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B.yaml":
     pending:
-      fingerprint: "sha256:0c942ce645458b7c42c3b847193a4a3d307a50eaa8242c62364b4807d85f35ed"
+      fingerprint: "sha256:b325711e9212dab658e6f4d1549c8425ede9150c9580dca750c59cb1b884b6f8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16186,37 +18500,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/ii/I.yaml":
     pending:
-      fingerprint: "sha256:bef47938317fc95938bf21f6196a7baf4b608c3d46cf5a959915cacba60e6c4c"
+      fingerprint: "sha256:065d09ba097829650bd083dd0fda236a4ee09aa8e929019d2103b12f7ad9a0a9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/ii/II.yaml":
     pending:
-      fingerprint: "sha256:5b05fa255a4b188f8a3ad29dbabb7261004b5ea9781eac0359384056928d6218"
+      fingerprint: "sha256:4ec64afa28a35010721c83530d251376f4fd924ca4f616e683d49b14f715a9ba"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/ii/III.yaml":
     pending:
-      fingerprint: "sha256:1ea57cdc9cb5f066c7cf879f9b52239cdae28eeae5188c29cd899cb6e4aa1683"
+      fingerprint: "sha256:3e70af7a16c63e533fe4f79a24bd8d47fa438a4e708a662d97f94deaf95febb2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/ii/IV.yaml":
     pending:
-      fingerprint: "sha256:c4b8fb0ffe1a1c44f7c91b1935a355a13febb8da9df084a8ba292eebfd385c4f"
+      fingerprint: "sha256:ba86bc5e62028320483873c7d083fd09696160f2aa8fe645c8f47dc61cde0e5f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/ii/V.yaml":
     pending:
-      fingerprint: "sha256:73ff5d71046effb668a2cfe8c35ce06e4bf555b9ae7444bf3105c38d4a6eff39"
+      fingerprint: "sha256:b9ec27988494204166c5d7a24c79e16da8c77e3a7baaa96eec7eb5fb2f93c3fe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/B/iii.yaml":
     pending:
-      fingerprint: "sha256:6068406b4d8fc5e1ed79842d3f28d4984f59f61cf93a773b67e56bfb5550aff6"
+      fingerprint: "sha256:673c80540f01ab350d386bc862e66dd1f470b532b9a64983cea5ef11d0d70d56"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16234,7 +18548,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/163/h/4/C/ii/I.yaml":
     pending:
-      fingerprint: "sha256:0d323d8be6c363a8b3b3f4b564c62ac71fbae98dbab666dfb5abf2d458afda46"
+      fingerprint: "sha256:68b4420bb7e1dacf85a8e81aa32682d6d7ad2666f9f8bd663022577050b2cef1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16276,7 +18590,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/199A.yaml":
     pending:
-      fingerprint: "sha256:faee3d62a434faf1dde3f9cf6264953cd4534052b8b958964a24152800c6bea7"
+      fingerprint: "sha256:d6b6d805f857670ce7cb2aa39ebb89f7f138ea7a549d7103f299f9911c586886"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16300,7 +18614,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/212.yaml":
     pending:
-      fingerprint: "sha256:cc1c18672edd9904831f6d46f763e2653365464fbaaba735f0444ed0d6590659"
+      fingerprint: "sha256:eb967018f2bef6c2f146b5d66d9c6430f0a6e7b7b2f728283bfae0f05dc1e5a5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16312,19 +18626,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/219/b.yaml":
     pending:
-      fingerprint: "sha256:d1d92ebcecd07295358d1f0fd00f9f87e360250da26f08555bed80e3990e2a68"
+      fingerprint: "sha256:1ab890729f55bf9e399c7906b78c6819bbb7be64812011d1e1a0c3e1d071b324"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/219/g.yaml":
     pending:
-      fingerprint: "sha256:f422dde6b8b47f57e4423b6a2c7903abb41cac14dd795c3b383dd9e6ce652d8d"
+      fingerprint: "sha256:043947bf19eddc38f22c97a7cfab9302fe701812436691c6f50108f609f95add"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/22.yaml":
     pending:
-      fingerprint: "sha256:94ecd2793d42c366c7d48cadec3d1e9d570b703663130e2728af2d926e3fa5bd"
+      fingerprint: "sha256:9656a54de4e435d94bf9b4e1bff3c924cdc33f399d9ad71d26964aa8071af587"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16336,13 +18650,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/223/b.yaml":
     pending:
-      fingerprint: "sha256:84e5ac474d36f31400ddec317bac53be421c928840f0dada112776d1d5065615"
+      fingerprint: "sha256:b89c5a2fcc8b4f6cb8bbb91c26861cb03cdfd253e6392ca1e45bd978e02a0ba3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/224.yaml":
     pending:
-      fingerprint: "sha256:4add292846c77e8187e55ec7b384b396c334f8fa523f0bd4bf750993721d4118"
+      fingerprint: "sha256:a7e8a35840ebaf679eb95363018b30d742a8c415bdd436ba829b5c5203b079f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16360,19 +18674,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/25C.yaml":
     pending:
-      fingerprint: "sha256:76f4ae219f94079eaf1c04b758e3566863d86b0e4527a1e0514589a18852410e"
+      fingerprint: "sha256:e28acd22c840d9322380a5fb500a6d535f562a31942a4fcc989a45dc6a2c6910"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/25D.yaml":
     pending:
-      fingerprint: "sha256:21f7895c30a8727fbd7ad3fc0c796129b725be86ff6af4a8be851a9647f7c1ec"
+      fingerprint: "sha256:52ba77c8989b8c8ca9d4cadb7938c1d7de4e4583f9c402409d246eeb3fb7efcd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/25E.yaml":
     pending:
-      fingerprint: "sha256:f33ac26ea557d544f5ea2d7581d33ac73f295066dd451500bc5a67a10d42ba63"
+      fingerprint: "sha256:9c1d0e45bea6925708445e39f1d880a7a72a94078b971bce6491811aacf664b4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16390,13 +18704,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3101/a.yaml":
     pending:
-      fingerprint: "sha256:799c43de630141d73fb4a61bb1df677c839b6a2f17bcc334c418be5b87472652"
+      fingerprint: "sha256:b9d6070af79a87ec06ce59a0f6e35e25690398772b5a0dd3d8319ca0ea685b2c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3101/b/1.yaml":
     pending:
-      fingerprint: "sha256:7a9010948c1653e68e7a1778720949ba159304e6744528a39c573ce670ea038e"
+      fingerprint: "sha256:71e2bc158cc3075a050cf171253a46c01a3c3d77b8729cc4e8f93c0e8eac7480"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16414,7 +18728,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3102/a.yaml":
     pending:
-      fingerprint: "sha256:1d11a0445f617c35d2e4558ee3d0fa2ed11cc1f190d0b9978a8a32f736845401"
+      fingerprint: "sha256:f53efc0325912d229efc20fdf243de1a67f3efc9a36db80ebd5e48f5717faefc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16624,13 +18938,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/a/5/C.yaml":
     pending:
-      fingerprint: "sha256:1524144bdb41d97c9a5de008d0ffc6b1efa4977365ce9dfa1330e7fdb69fad76"
+      fingerprint: "sha256:ea9353ca3d4061d0041a3a5fc1f0c751a4715bb8fb82ac4d1c5787c9a900206a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/a/5/D.yaml":
     pending:
-      fingerprint: "sha256:facee294c76576f828ad69d79a4f2bc10065a40a549d90f16ad351b05e63ce1a"
+      fingerprint: "sha256:bcac2d3f366288025dfad00f2bec73836d8b47541c0791000623db4bb2a6e27b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16642,13 +18956,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/a/5/F.yaml":
     pending:
-      fingerprint: "sha256:44a7ee8a68c2995b75a0ad10367d0780faaf56f4c2a045ba854a2354684e3071"
+      fingerprint: "sha256:1067c19b81b212264c782ca89fd4d9da073e98d507ad21f74c98dfe2c1d80d27"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/a/5/G.yaml":
     pending:
-      fingerprint: "sha256:3f08205cc3e5d49cc1c1a05fc152eef04e5a678b0b7969db72364f8839e04919"
+      fingerprint: "sha256:5d09e7d07b8f42e7b742d37b2dba419e84afee919c705bb9f63a16a2419f7f41"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16660,25 +18974,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/a/5/I.yaml":
     pending:
-      fingerprint: "sha256:c9e00cbf706b26aae433944bfc582cedee639db2ec0a82f0079fa34c4f7ce77b"
+      fingerprint: "sha256:4845c81577058638155acf1ae506abe6662d13e1bfc0e9991d33745d64ce0028"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/a/6.yaml":
     pending:
-      fingerprint: "sha256:6fd0e5535080a0485a0d129314c9e86bccdbed7df4a756b05301b211885340ed"
+      fingerprint: "sha256:362ec16d34ab86ceb18c42edbf07a4a97f8e53e9d7581c86c87d41acfaa197b0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/a/7.yaml":
     pending:
-      fingerprint: "sha256:c94df3ff58d37008c168ac5680415d7859a3abc15da883823e0c974dcc3f4ad0"
+      fingerprint: "sha256:25045168413b2c88ca849e24be4e556a094ef53599738b58ae3a0815bb70d22b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/a/8.yaml":
     pending:
-      fingerprint: "sha256:1cb1cc7c4682d8dd2aaa2a20c0e6becd223383c827b96f3e4a9ea7303424c76a"
+      fingerprint: "sha256:a98abb73c0c40cc1ff82e54ac67ae74cf35f7931299dd6bca7fc70eb149f300a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16690,7 +19004,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/b.yaml":
     pending:
-      fingerprint: "sha256:478fd02ef6c413f896dab3ff74834711c40540ee97f66557840cc845ca460d7b"
+      fingerprint: "sha256:633f985dd2dae1921772b4aae8acc8f52b9ef63b5dbeb570daca1fe4ee33e354"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16780,7 +19094,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/b/3.yaml":
     pending:
-      fingerprint: "sha256:fd76ef0c7a79d25e1b9d5985d14db88d0f5107dd18558d016e3f0671e8c1ddc1"
+      fingerprint: "sha256:2c98f940bed723ad7506d05eca5e0e28f5fbc295fef9406c42b63023c575ff3f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16792,7 +19106,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/b/5.yaml":
     pending:
-      fingerprint: "sha256:b9eadb24aabdb81a213b1f41f620aea430772d6a5f0edfe08b711106a8b9e7bd"
+      fingerprint: "sha256:eac5227a77c9fcc406df80463ba12c8978115ecaa0692c2b3c33cbd380ccc1d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16804,7 +19118,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/b/7.yaml":
     pending:
-      fingerprint: "sha256:7c5833f7e79078f5893a4a58c9e982512ed320495be478f401c10c3260b8a16a"
+      fingerprint: "sha256:70fdc2c5a15da441a0c3e3f0f0b118419b24dba614ca23b57a5a97191380dde3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16864,7 +19178,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/j.yaml":
     pending:
-      fingerprint: "sha256:262a751707ee59c52d7ef944f4084577ee6a007ad559f3d96c9b86ed9959eaad"
+      fingerprint: "sha256:0695b029ea6d0547862ed396c8dc5a4b6658acc4ce0b8ffac52d75563fa42d85"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16876,7 +19190,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/l.yaml":
     pending:
-      fingerprint: "sha256:0b28e23272355e7a3deabd73c8ea0bfe043ea1e188fca61f0bcebdb09be28836"
+      fingerprint: "sha256:0de14429dad1fcc2f7ba47a1b5057282bbc558f1b36b9bc58dc7f4a03b90bf2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16888,7 +19202,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/n.yaml":
     pending:
-      fingerprint: "sha256:5f845e0b94c7985d7035d9de1d573e37c41b2e4b24b22a2243e9a9b56fec2c9c"
+      fingerprint: "sha256:def7ae77c1ccc8338d55f81500fdc21a1c3931315bc4581a1e7bbbd0801e5372"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16906,7 +19220,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/q.yaml":
     pending:
-      fingerprint: "sha256:f8e239d2c4ea39a27352c2205c989cefd89c246f868a3f7b971933eaa7638f63"
+      fingerprint: "sha256:a46e09a1b4a3328d8325173c83b2256e8e6f952df0157fd51e78b339a9e641b8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16930,13 +19244,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/u.yaml":
     pending:
-      fingerprint: "sha256:49f2434592be816f23c7df4d525ff615c1e32c669eb151af9a6315519971b32b"
+      fingerprint: "sha256:67b064dfad150974644d511749f52ebf4d69e15ccb4cd412f6c54ec2e1a331f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/v.yaml":
     pending:
-      fingerprint: "sha256:ece00bdc5a85894b88f063bc3068118549cf706ac8604bf3f95db6a08864f3fa"
+      fingerprint: "sha256:ac51e41a7f1350a319d9d0845ffcd2f965add28b26c2844366dfe50a9d39052b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16954,13 +19268,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3121/y.yaml":
     pending:
-      fingerprint: "sha256:0027954d1a6afcd3ac0110c9cadaf15d83eddf704215b193a33e7c208f26e028"
+      fingerprint: "sha256:658a15a7468ab9abae28b55732b02192985138be2224ee65a92736046b9c82f0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3121/z.yaml":
     pending:
-      fingerprint: "sha256:b38c54960a8c58c6973b5de3ff4f2f6f208a0e4adb10c52005b79b7bb91740da"
+      fingerprint: "sha256:0a2326493d859779d30edf0e3c8d94cfa1728aa8bfaf2c518c3a144a271fcac1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16984,7 +19298,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3131/b/1.yaml":
     pending:
-      fingerprint: "sha256:47c5da5b0954b90621fd54bc1952efa3f6fa3dd37932866c54271a0ae85a3573"
+      fingerprint: "sha256:285215b6e352f2ad9c9191ccb9272f1d89450b4cda964b3adac95e63b0e8b67a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17014,7 +19328,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3131/f.yaml":
     pending:
-      fingerprint: "sha256:8de5875b4aa6f65a7c798b69341a7f282e2093ea0e511233a74322ef64afaae1"
+      fingerprint: "sha256:48c108cddf0c37f9c8c890eda3eac8830606ce9fc6237a1377ecf713d5517098"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17026,7 +19340,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3131/h.yaml":
     pending:
-      fingerprint: "sha256:432e315da09adca6b26d4280164ef14bf94d9ddff1b51319d83ac5d1252a6c17"
+      fingerprint: "sha256:42a906b3d2ea19b90afeedc2a455f5bf4b71cbbcec54cc546e60518ebd92d881"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17044,7 +19358,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3132/b/2.yaml":
     pending:
-      fingerprint: "sha256:40aed5eca6132742c0b2458cd7e05b2e11530f301bb5381c94c68155967ac00b"
+      fingerprint: "sha256:cae5c1f2333f822dba3383ee1bf3e6f9e787c1576c94c02beecfc4c792ab4cd5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17068,7 +19382,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3132/f.yaml":
     pending:
-      fingerprint: "sha256:f90c6c7de06ba41eb0bdd4121564d94e22623a78ffe3a9f2c219a95c37b63eee"
+      fingerprint: "sha256:1c416deeec8c06a282481fc3477d043f18d24a64a71f67028a497a2af0ca1748"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17080,7 +19394,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3132/h.yaml":
     pending:
-      fingerprint: "sha256:c729693f5507f72fb7fe237a0058136640c500af4b8ff2a12264ecf3a3686043"
+      fingerprint: "sha256:b7e201722135b8f277588c316aa95db4a6f4fb12637db73bec16612d7725df4a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17110,7 +19424,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3134/c.yaml":
     pending:
-      fingerprint: "sha256:e772e657ab36626a35f7a2bddc45fdd4f56eefef9e80ab31595ef0c497c3fa9f"
+      fingerprint: "sha256:85a697ea542b357af421510c16f9ad35ed646432909b39666a09ad24e8959e56"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17182,7 +19496,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3221.yaml":
     pending:
-      fingerprint: "sha256:c743e94bc278a3e8e4869361dfce94a9c75e6897053ece5413e16f2b8464b167"
+      fingerprint: "sha256:7f271ee379a2a2b2fc6d76fd6ff29bff360d8c13bc47999498e5a6ca42b617bd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17218,13 +19532,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3231/e.yaml":
     pending:
-      fingerprint: "sha256:bf0387b8f5f5d9ce5a98c6b07a87195e0695c06c2741a64ac190ae7d91b5e656"
+      fingerprint: "sha256:d8867ead46f6f359b0900d954838793b9bf63c90db69e7266bb20789d213ebf7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3231/e/2.yaml":
     pending:
-      fingerprint: "sha256:f01882a62200ea90bfa20ce2320d1d4d7b775274f91cf539d7828def32d9e87b"
+      fingerprint: "sha256:8cf0ff9ad9ebe4c928f89f4060383cbc57f544dd8b486d8b84c83533024198ce"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17248,13 +19562,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3241/b.yaml":
     pending:
-      fingerprint: "sha256:d3e310d93d9a4ff86967168ebc6d13f00077119917a6acf7cd917419f770de23"
+      fingerprint: "sha256:cc9a7543bbdd9015d5891ced3aed3503f1651a2df02f6363dbf1de0f1b580827"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3241/c.yaml":
     pending:
-      fingerprint: "sha256:47471bb5e45a61150f5ab7d03a0956552034c9d0022119fba4c18b211dfd9ef1"
+      fingerprint: "sha256:1379ce3454732a9a0be58a0a81fb53130cc1645fcd6ef7532109f1fdf920a508"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17266,7 +19580,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3301.yaml":
     pending:
-      fingerprint: "sha256:a3416831388191b87d50bdd4ecefab18b64c19872e31c5ec41ac5adf6ee3c309"
+      fingerprint: "sha256:dd6b0d96a8e21a81566a9b2feeadfa49c4849db3a839163d93f318c19940e10d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17278,7 +19592,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3302/b.yaml":
     pending:
-      fingerprint: "sha256:33ad19898beb713f33bd985b2cd8b4799b989efee1006b1f2d4dafc5614b4653"
+      fingerprint: "sha256:962584e37c3409066c5f7618b1c481189aca8646fe3dc8eb1310ae2e89ec683a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17296,19 +19610,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3302/c/2/B.yaml":
     pending:
-      fingerprint: "sha256:67cb419e062a7e63f2720ca6e7508c11656168ebd909a14626f203541518c1e7"
+      fingerprint: "sha256:a4e0dbc87f426a9b05eb556298d6697f90abf893fc75303a923238ae8c656e53"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3302/c/2/C.yaml":
     pending:
-      fingerprint: "sha256:ef1fd5bf664355e41a48cd91abb7b62c6e8af4933197d7b7f84f67ee733b8df8"
+      fingerprint: "sha256:43176520b6d9d6e681d7c292c12eb1bc1e5ba467352ece88409ae9168daec4be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3302/c/3.yaml":
     pending:
-      fingerprint: "sha256:b91c3e1d49bc96a618b8d0bfa8f302604424f689a36fc55c0251d2a59d72c7a9"
+      fingerprint: "sha256:370c8e8d5f2857b1f036e9e0afbfd1d6781faf6d79f23154502920fdfbbca038"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17368,7 +19682,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3305.yaml":
     pending:
-      fingerprint: "sha256:d1bc78c2f5b756e0bcd8e7ecd73b833d931509810d99f093a27150307163193b"
+      fingerprint: "sha256:768ebb4baad9c2521a35b12e97840eb9edbfc47e1f87877bb384a05114d528fb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17380,7 +19694,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/b/1.yaml":
     pending:
-      fingerprint: "sha256:a308ab313ad8be86d47fb372a4b6e03b1f483928132a346b8f260f424c2d0faa"
+      fingerprint: "sha256:f5059d493ba9d68a14950ea55bde8e2b14fa174a9981251d0fbd9a6dd531d7c2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17470,13 +19784,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/b/5.yaml":
     pending:
-      fingerprint: "sha256:262e0900d69f2bccb69ecc9f33c5e919419c1884995e056369650bc90c42a0d4"
+      fingerprint: "sha256:a6a3912bf8fc0dadd8992828687d55db111299625e7ac8ad6bfc55a521d869ee"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3306/b/6.yaml":
     pending:
-      fingerprint: "sha256:4f53467cbecfdbc9900038f7843fe59da364984c59ab7c11be65bfb480f057ff"
+      fingerprint: "sha256:40ded95bc8ad8b3837e760a6b7f9608b0b7d7a6c63897466fe30ae65bc4187e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17500,7 +19814,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/c/1.yaml":
     pending:
-      fingerprint: "sha256:f202e9d45c38e8669e7b5214b6bba4b20bcf6049832b532e912cdba35119ae62"
+      fingerprint: "sha256:f5ffef63c7320ce83259ab721b8aa7f59c5f87bc2eb5bfd6bc82481a9a717e07"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17524,7 +19838,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/c/13.yaml":
     pending:
-      fingerprint: "sha256:3dc16958c5d7cb6a49a55eac469ca8f1670642884f395905e9e42ddfa3931a08"
+      fingerprint: "sha256:2aefc95dfb5403bc033078215059ee514d33aa566d95959ae41574bf6c109960"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17572,7 +19886,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/c/20.yaml":
     pending:
-      fingerprint: "sha256:7f1b403cf2e222c5051df803c093ddbed025793fe5e03ea95979bad97dec52b3"
+      fingerprint: "sha256:1a12f4786b100017b59d2c4c50c05f4e87863db5a02bf291785d605180638283"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17596,7 +19910,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/c/6.yaml":
     pending:
-      fingerprint: "sha256:67396ff69fc52800ed36087e48bbe8579f13883049ff546946d2e1b42080c62b"
+      fingerprint: "sha256:33dd14931251609269a41656de2429fee02a78f99b9ee8c4f02222798cb5e5cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17656,7 +19970,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3306/k.yaml":
     pending:
-      fingerprint: "sha256:0d75bd01a41dd9ff0794330f13ce28c45b8bc1bd42ed7ee1880b30c32ef2da09"
+      fingerprint: "sha256:49928b398d919d90ecfe938a6a15f012bbf4565879a61e69bce3087849753d94"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17680,7 +19994,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3311.yaml":
     pending:
-      fingerprint: "sha256:d5d07da98915864bde2b21a45158c3527e8b0efddafed6d50154c4e44889b586"
+      fingerprint: "sha256:d92c011070637fa51f7a59a0a31aef1d592071923072af3295e4838d3166df0d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17740,31 +20054,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3402/b.yaml":
     pending:
-      fingerprint: "sha256:8858cd850081a34b7effdcc87f5339104e08e51a7b5778aef6e52e581e4511de"
+      fingerprint: "sha256:5ae292e436fa9fc089ae66947cae2c4d3672e1fe853a11fd22f058482f338e7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/c.yaml":
     pending:
-      fingerprint: "sha256:9212e158ebe4f0aff447e80f025dc7c2b1764043a5af4efac5a5f484bdca692d"
+      fingerprint: "sha256:f8ade4eeee2204311781c63576bb0aac267beed47da82140d22f5f3a06304d24"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/d.yaml":
     pending:
-      fingerprint: "sha256:943824655f8afc25ea5f9c52d0a101a89bd63dc290bb5243a5f78d70055cee68"
+      fingerprint: "sha256:b716f39d9d5d54c5f11d608f3d8990842616153fb7e8aedc285afd15cfc9084e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/e.yaml":
     pending:
-      fingerprint: "sha256:3b8625577267196b07c00546e2ad7db0f598ee4b3987e6137c5fc08051f8bbad"
+      fingerprint: "sha256:8a076c85ceddcedf92773cb72159d6304ec9abd25f14f25bb42b985ff7601011"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/f.yaml":
     pending:
-      fingerprint: "sha256:946b1650e4d7ed2505d0cd9d398aaad9f06b023eae698dd8495b8634a604ff65"
+      fingerprint: "sha256:63a74f16b60e135a58847dd705b0ae155173b80a997cc5fbacd38d95c0026a7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17776,7 +20090,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3402/h.yaml":
     pending:
-      fingerprint: "sha256:3a2002f3b92c5526f5d42ea0efb181fae7feffbbba2941a603f07d7fe2bddf8f"
+      fingerprint: "sha256:1ac72666eb4830ad75397f0b0ba8215ff1f6d691fd37ae34ba974542dcb70166"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17788,19 +20102,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3402/j.yaml":
     pending:
-      fingerprint: "sha256:a148cf2e5afb0505a6f8e3b85d78730e0d4ca51686acb3518de0bec2800595b3"
+      fingerprint: "sha256:9a618efc20ee1284180ee334c80393d736df8ca18548693390e129a99743070d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/k.yaml":
     pending:
-      fingerprint: "sha256:a10d6e6d5b17bf0f25f5fda3b21d3205f6324026ada673601f17aba891b28093"
+      fingerprint: "sha256:60718e559f1d39d4fea982fadb29cab098b36e21db1c0bc4993382ce7b946f2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3402/l.yaml":
     pending:
-      fingerprint: "sha256:c7171c5968683b7af8279e82601d67125eae80686a2329d95659b64b9f290854"
+      fingerprint: "sha256:655e2acf84fe8deb22e90f40184072e22a7eeb34397906e2f10f5e53b4506b30"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17812,7 +20126,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3402/n.yaml":
     pending:
-      fingerprint: "sha256:62864e352b47a8aca8146e882c98e6dee7ff7c5e21d19898935cbae46e8a2a0e"
+      fingerprint: "sha256:595f350cde4ec7c2dc6ee9a6a9b4c78ac1e78fa65469949ae1ae2ea8989c424a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17842,7 +20156,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3402/s.yaml":
     pending:
-      fingerprint: "sha256:0739c2cd9afb3b3ec2ec62f69de6ee04286ade717f42ded9d92ba0c394bc5046"
+      fingerprint: "sha256:e5b2d615ccff65448e19b75e05924f5a1ee4d8b6f37816b62d328dd7fdc1af75"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17872,7 +20186,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3405/b.yaml":
     pending:
-      fingerprint: "sha256:562845ea3f6e388e482e0de7bcea1d311aed1608c9c3c3fad0f30bba04c4101b"
+      fingerprint: "sha256:cf59efd812fbfcb3cb6e1956de97ccf1681fdf6fe1650b614834138639d34eb5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17896,7 +20210,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3405/f.yaml":
     pending:
-      fingerprint: "sha256:cb710b6708cd4d899987c67523066136bee6e57217db5eb74f14b7ad2e538b73"
+      fingerprint: "sha256:579eccd9a6c38e7db79e0cf9a0cd8d9263d248256dd472a87827bb0aab950b97"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17914,7 +20228,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3406/c.yaml":
     pending:
-      fingerprint: "sha256:e566775b53b6c7c3708279ca8235bc42b5b8a0fbe21ecca11f4922da2abf7a23"
+      fingerprint: "sha256:144eb42ed174b2260048b1d402202dd91da80c167cb0e1fc8f190a3cc9ae9d30"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17926,7 +20240,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3406/e.yaml":
     pending:
-      fingerprint: "sha256:806c2a1ccab781e3c27c2b65414885ff47e68a39214e66744c47a8f034f2106a"
+      fingerprint: "sha256:8e475636c47251251fab33b8b31b660fbfe94d48e18d37d37fe500e523b77c6c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17956,7 +20270,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3502.yaml":
     pending:
-      fingerprint: "sha256:5f3f8011005ceb4ebe2046c04c6f47e23c7f7722671fe0bc12b42bc4938f25d8"
+      fingerprint: "sha256:3376a89866c5ab0a33b5c6c6d90969e107a384138f5d2f1755b32e176bbfa339"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17974,7 +20288,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3505.yaml":
     pending:
-      fingerprint: "sha256:30d35286f9bb7fa862c90f1261c4e1f7928748bfcead908f16509f9f03170a8e"
+      fingerprint: "sha256:b916ba7924f3e349c2a184151f35b561205fda9b9a7fd0b802169c4e4b3d6e5e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17986,19 +20300,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3507.yaml":
     pending:
-      fingerprint: "sha256:44f8e07d910f76615001084a30cbcb2fe1b6a9b1ad148d74847a5083a470ab9a"
+      fingerprint: "sha256:34641a1f4f96ebab443ae0bdbe2cc2634152c671f1a5e332159f039673b907fa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3508.yaml":
     pending:
-      fingerprint: "sha256:ac3fac31eb5eaf902bef5f208c270e7b32d137ca3c4353e8a30449d260b9a137"
+      fingerprint: "sha256:97fc59ba8069bcfec4148f83af5082a1edd381f16bfd5fda6606749f2e5538fe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3509.yaml":
     pending:
-      fingerprint: "sha256:89baedd107a3c8528099792f3006c7c5073a969686dd205d989a8ae82e6047c9"
+      fingerprint: "sha256:bf6d23d67a40499c253fc7bb37eddc557dbdfde94861c9bb7326670a0694d8d8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18010,7 +20324,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3511.yaml":
     pending:
-      fingerprint: "sha256:13fc8d7bfef84671ad64bb8a1af4706379eab3feea72de324f9f58015a445d80"
+      fingerprint: "sha256:b20d25889eac0051e091dbcf74e1e2fac68f37d0619ede21df592e6cc4e1f193"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18022,7 +20336,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/36B.yaml":
     pending:
-      fingerprint: "sha256:12ed7460b6de91cbe17f8a78011815a511648c0e97a714039164f28a8a72404c"
+      fingerprint: "sha256:6cb66a261134b1dd1c35a82373d74809695a2e4c0685b33b6757ad320c0653e7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18034,7 +20348,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/36B/b/3/A.yaml":
     pending:
-      fingerprint: "sha256:90a2e9c2a4ece55dd701bd9ee76b93902b4ce9d259c827181421c9b6cd2ee0f8"
+      fingerprint: "sha256:a12c4c4bf173e92ece78bb5a781acc0e7ea368e3a21f81b960fc0b9bf36fe038"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18070,7 +20384,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/45A/a.yaml":
     pending:
-      fingerprint: "sha256:a9c5c48014efdfe65eb032d73b212c5e180f2011576209a8091217387c176c82"
+      fingerprint: "sha256:e0ff3077dec4bdcb0d25be9f5cc6e45cf8719797df21abb833fc4690f0a3cb2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18082,7 +20396,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/45A/c.yaml":
     pending:
-      fingerprint: "sha256:00a2fd58155b3605bd063066ae07d91db125e9e566425e9eeba904ca1528d0fe"
+      fingerprint: "sha256:cde2e47844a542d56bc27ab64e4626836fea7d830ece2efa1669ec403518d98a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18106,7 +20420,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/55.yaml":
     pending:
-      fingerprint: "sha256:a18c7555beb7f4fe6bb577bae4db6bd606f469c39031c36df44df4133c291f51"
+      fingerprint: "sha256:6968eb4b212dc75e21b59d7226fc6fa436913957df14cd535c5e061bb5a68914"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18124,7 +20438,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/62.yaml":
     pending:
-      fingerprint: "sha256:af281de9c915dfcf6383340b5e72c1bd1c654b504baef1fe35fe413b2d0ecdc3"
+      fingerprint: "sha256:05f7546b5fc3817cfa051a7d400cbcad2c1ea2f687fbfa4de5088dabb6d2c95e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18148,7 +20462,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/64.yaml":
     pending:
-      fingerprint: "sha256:96002d2062aa354b2ff12fd2782f77df3f156f68afda76fdd0c0b2ca60ed1810"
+      fingerprint: "sha256:251904f44e39923c60bc78784794ebaabd6fb37f115d7b664fe502fb17d9a5d6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18166,7 +20480,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/68.yaml":
     pending:
-      fingerprint: "sha256:3a161a2e871f518149b1b6ed6370b7e0a2a1f028ef4dbbdc7d58b6ef6e9b5b60"
+      fingerprint: "sha256:909c09b491f717b429a0961c7d1225a5cc199e837265a1cb668f8ada32133a7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18184,13 +20498,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/85.yaml":
     pending:
-      fingerprint: "sha256:86f85f6b9438cfc28224a1c49d147a90a54bf8c77573e771f066975a7da22818"
+      fingerprint: "sha256:cdca8c323ca786230651c1490cd83515fbc500fce190042973dab4ae6b68855d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/86.yaml":
     pending:
-      fingerprint: "sha256:002eac4053eec298cd35d4ff67659bef06336f42cae5580f7a4177b80564f8dc"
+      fingerprint: "sha256:4a8a5c7607a9f7536024c3c2611fb3744515e8dee6957499c3e00dcf4e8edf30"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18214,7 +20528,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/931.yaml":
     pending:
-      fingerprint: "sha256:8b602dd15ece410b8b15b3af7036e588222ed2ed7aa0ce51c25387a2dd65f0b6"
+      fingerprint: "sha256:57d6a962a32f20f2651af6a2d68cdc62936dd6af0eafbc2077d6d8633257ea62"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18232,7 +20546,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1382/a/1.yaml":
     pending:
-      fingerprint: "sha256:0fb31304f88df2e23ea23b8257eff292f0774488997a4d9c5145adbc1cf115e3"
+      fingerprint: "sha256:67bd2da9522c2fa8c47263b63d39c7fbf1049de3c7a2343aba68ab794d1931d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18250,7 +20564,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1382/b.yaml":
     pending:
-      fingerprint: "sha256:b7026155e61936d5f0cbae728e2eff92440857835ae386973a2ce3a2602852cc"
+      fingerprint: "sha256:ea928592376d75c95aeee29603bd481c05b764dd5584bc4082eab2c89a11064a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18262,13 +20576,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1382a/b/2.yaml":
     pending:
-      fingerprint: "sha256:0923682ddcff1c982bff2a3f871427da9594aa6b5ec17fda97f657b377482cfd"
+      fingerprint: "sha256:2d16f2003624ba561d44f89d4c51dd6db101e378a3c48745e6dbddc4bc2d59dc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1382a/b/4.yaml":
     pending:
-      fingerprint: "sha256:e039ef046c12f0f9a6b7f6ac2c9cb52affad85d61c4dd85a0f58ac7905f85a4c"
+      fingerprint: "sha256:486f8bf47a38a3d6278b83731a139e73e0e5129bcdbc2b11442bd68228e7adac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18280,7 +20594,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1382c/a/1.yaml":
     pending:
-      fingerprint: "sha256:2fca5508f977303205f9fab200ae0637f8e53bb9cf0258d0746a5ea1d2725ad1"
+      fingerprint: "sha256:1bf79e8ef35370b89bfe9edd4bb5e151383ad069c127fb2e1743dbe188875ad3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18292,7 +20606,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1382f/a.yaml":
     pending:
-      fingerprint: "sha256:25eb2cf3263ed30fa655ddad84e9ea0359d7144d764f2cf66396782a982b723c"
+      fingerprint: "sha256:a2c6e4d560a816bf0cba5e16d57fc61e5586948198ef0d2c85ae6b804dbb81fb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18304,43 +20618,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1396a/a/10.yaml":
     pending:
-      fingerprint: "sha256:6db57340f8bee455be7e930e3c6192756f9b9ee129302efba3282c5de73730e7"
+      fingerprint: "sha256:f121e2a1bf1a15fa4fee9236648f4f53024eec5de608ce9a7c666881551eef4e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396a/e.yaml":
     pending:
-      fingerprint: "sha256:7fe412bb865abc2a3eee38d0c4b72e440fbd2bfdd9f6f41dd9c97a7e014a6ce7"
+      fingerprint: "sha256:2eadd3c451a8ae070907668e979ab0267dd0e440dedfbe8596cb791c4cc14132"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396a/e/14.yaml":
     pending:
-      fingerprint: "sha256:eccc611b95dd491972729cdfc3c86de559ae15dd517f11c9765fa5163da9cf57"
+      fingerprint: "sha256:4b7ea0f8c1defa6c515e771873d5900fe0199c2fcce56e833b38aacbc580c191"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396a/f.yaml":
     pending:
-      fingerprint: "sha256:63c010566817c0f614ffd431dce6343f2d3a450eec8da37b3e7d238e369b44bb"
+      fingerprint: "sha256:d9f5f5e37b7400f3123a786100f0005ee138452b22071bde49f4d2e0b17ced28"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396a/l.yaml":
     pending:
-      fingerprint: "sha256:49920764d17317fe96978e8e872a42e33a295788ba9a6881757dd1f967778646"
+      fingerprint: "sha256:5101b613ae836f441bdacc99c458bde476af10fedfa80a6dffcaf20442da76c3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396a/m.yaml":
     pending:
-      fingerprint: "sha256:b9643cd38a66873d1d02a6590188c65d509aa9361f39ebe552d23cf70b1f2025"
+      fingerprint: "sha256:c8b970583f451f34ce6665f58e3aab591c767e3a6c7c726c30810c862fcb41d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/1396b/f.yaml":
     pending:
-      fingerprint: "sha256:b72acb1101b555075f1fb52befd9223ea5a7a5063ac0fb97425662ff48a98776"
+      fingerprint: "sha256:759aaf66db280bd3559c5c2dcd9b223c97b9783e7d4bc72d0d15bfad5920f77a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18352,7 +20666,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1396d/a/i.yaml":
     pending:
-      fingerprint: "sha256:6343150a83f41e3968082e8350debc4ab07bdfa7c7e715a14950ce022f9fc164"
+      fingerprint: "sha256:55a20f7ecf6f5a1086f7e951dd52eee864925691db910acc8c0a77620432b539"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18364,7 +20678,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1396p/f.yaml":
     pending:
-      fingerprint: "sha256:f828bbc11dd461dd9b27e34666b0f1d417d36d7d4ca0b1773df68daf082fe05f"
+      fingerprint: "sha256:13fb873d6c8d3fb400455d2bcbf7299f10ab932bdb40852c3e801bca49f175ac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18382,7 +20696,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/18795.yaml":
     pending:
-      fingerprint: "sha256:700e015b8313136dfe3af36bca5cc0e1a594bc23e61989b6b6708db1c541c04f"
+      fingerprint: "sha256:4cc74f865ad6fb7528a665c75cc1f1cbe9bda95422391a1a6a9626c67b20db5f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18418,19 +20732,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/402/w.yaml":
     pending:
-      fingerprint: "sha256:c1b6095fb67c91e04bfaa2915f6fb4fe4ea0ebd7176e9d0eaae1b1da51b70264"
+      fingerprint: "sha256:b9092a2f4962291d97db067c947f25746ccc3e5628566d89c63ebc884968c61e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/416/l.yaml":
     pending:
-      fingerprint: "sha256:c0602781af4dfc3eb6b7b5d97b4588954e2d987e6a04c20a18fac5829191298a"
+      fingerprint: "sha256:7e816f6d233e067caf2c2b211c9ee1cbe04030f34a2d5e759e8d9a5a06428929"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426.yaml":
     pending:
-      fingerprint: "sha256:042d1e0d63b3dc7508e4b036da88909b608f45cb5153a0b96ce728ee6d2ca87c"
+      fingerprint: "sha256:303663e2e5a9e06d6c051ba543db53202ee204458f53622191843b67f9564860"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18454,7 +20768,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/426/b.yaml":
     pending:
-      fingerprint: "sha256:a93620d9d5298bc4bf6679e3422e562b99db7b2a34e21ca43ed06a4c27d1daf0"
+      fingerprint: "sha256:a687b786e3eaff0173456836ab80d5e82d055fc62d5227898c449bf832cad09f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18466,43 +20780,43 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/426/b/2.yaml":
     pending:
-      fingerprint: "sha256:0209fdc74f00bcdabb7fb629730a5722204ac673fb8423531fc526eefe4e11a4"
+      fingerprint: "sha256:b3b17157f7e73b645996cfc4b7a4f348ee6250f1543765ec15cd91151b422f7b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/c.yaml":
     pending:
-      fingerprint: "sha256:4f7e328081367dfdcaa0496c26eb2fbbe5f990da07584b266aef8a61a829ca05"
+      fingerprint: "sha256:25de27589677135cfb549ac178ce83ffcc130ab87e9872b50d7e760b0c4fcfa9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/d.yaml":
     pending:
-      fingerprint: "sha256:d8e354ac0af070d438f03cc944057a8a551861b584c5647316d0a2fa746dd293"
+      fingerprint: "sha256:61114f4cbfcedf2ff5cca54a36b160f3e57ca8543412098b7c31325bf286cf0e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/e.yaml":
     pending:
-      fingerprint: "sha256:0ece331f19a3f10262c2553fbe3340408e15c9c323f8783505747d97769989d7"
+      fingerprint: "sha256:445784563971a44f3eceea217d42970b093872da41cc6bd30fc7a938c27893b7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/f.yaml":
     pending:
-      fingerprint: "sha256:8840d3a9dca98a1d0634d29af111787075e91ca052c0b01397262f10c18abf90"
+      fingerprint: "sha256:c1c1eb9f16e32ccc2c22880adba96ebbdf448af9327ff9d6649d82ec900d0377"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/h.yaml":
     pending:
-      fingerprint: "sha256:9d2c452f9f6cca4e2ec8ac08bae8bc250d42daca7955e0079e2ed8be67f6c154"
+      fingerprint: "sha256:37ea6173a2c70aa7affc90d7b406d4111bee1280eb2fb990d4397b87d1eb63af"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/426/h/1.yaml":
     pending:
-      fingerprint: "sha256:aeaf2667a4feafe9f5389a7707909d99c393027003c89a14bfb6a3769e86ab0a"
+      fingerprint: "sha256:728d59a30474fc0585ca509dd3456b894e890c9c034fe7e84efb736d12550370"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18526,7 +20840,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/7/2014/c.yaml":
     pending:
-      fingerprint: "sha256:4cfd6b8a8bb6804750cd82c9b90771b2917cc30eb4d05dfb36520e7deb123435"
+      fingerprint: "sha256:966819b9be35ce33dfce7e57762fdc44b34d33686195a46ecb7a4acab2e12d87"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18550,7 +20864,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/7/2014/e/6/A.yaml":
     pending:
-      fingerprint: "sha256:03d8c60c650e843a1a03fe0ac673582e346b71a26e7b5a3684684fce352ae824"
+      fingerprint: "sha256:7b28484bc82e4b0aa69acfe8d98ea9e13ce562c7620cec01afe3279d9dbbcae8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18634,7 +20948,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/8/1641/b.yaml":
     pending:
-      fingerprint: "sha256:36535f72d0054a79b70b7124c186aa2a195e2a53afce4d7cc2a3a7c016d28d37"
+      fingerprint: "sha256:88474f12453834dd0969c56bac46508b50cb66d2cc27adcd817c566e0051c306"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Waiver-only: protected-base approvals for the strict-cutover bind (#911)

This PR changes **only** `known-validation-gaps.yaml`: **1,021 pending approvals** — 461 inserted (9 as new pending-only entries for branch-only ledger paths), 560 stale pending mints replaced. No active record touched; no expiry extended; every pending carries its branch entry's own owner/issue/expires so `pending → active` consumption equality holds on the whole record.

**Where the fingerprints come from.** Full re-execution census of all 3,099 #911-declared waivers at the exact round toolchain — encoder 0.2.1330 (axiom-encode#1190 merge `485cc984`), engine `05eac9d2`, corpus `01e00777`, release `us-rulespec-2026-07-22-current-la-status-fix` — via the same `_fingerprint_validation_waiver_modules` executor CI runs. Counts: 1,020 drift / 1,631 stale / 448 ok, zero errors. Pin-identity receipt with module-tree provenance: `TheAxiomFoundation/ops` → `strict-cutover/receipts/waiver-census-0722.pins.json` (+ the census jsonl beside it).

**Why fingerprints moved.** Same failure classes; the canonical messages embed corpus provision `file:line`, which the LA-status-fix re-cut shifted per scope.

**The 1,021st approval** (`us-co/statutes/39/39-22-627.yaml`, census-ok) exists only on the branch ledger: `protected_base_transition_issues` requires a base pending for ANY new-vs-base active waiver, drift or not.

**Review**: Sol adversarial gate — round 1 DO-NOT-SHIP (2 HIGH: the undocumented 1,021st approval; missing pin-identity receipt), both closed; round 2 **SHIP, no findings** (independently recomputed the release content sha, verified pins against live worktrees, verified fingerprint fidelity byte-for-byte, confirmed the transition-law necessity of the extra approval). Transcripts: ops → `strict-cutover/receipts/sol-gate-8{,b}.md`.

Downstream: #911 consumes these (1,020 re-fingerprints + 1 entry-addition) and deletes the 1,631 stale entries — its `protected_base_transition_issues` pre-flight against this ledger returns zero issues.

Coordination context: TheAxiomFoundation/.github#39 + the plan on #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
