### PR TITLE
Pin corpus for Minnesota and Massachusetts 2026 tax sources

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "dfa47fb05bd1d3abbadf0ff17ce4a04bdd5c8085"
+axiom_corpus_ref = "343a7856221ae7af1086e5d91e0b9c55482068dc"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "343a7856221ae7af1086e5d91e0b9c55482068dc"
+axiom_corpus_ref = "4c12ebf0675ceda3891d7646df7dcb236a02e2af"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Scope

Pin `axiom-corpus` to merged commit `4c12ebf0675ceda3891d7646df7dcb236a02e2af`, making these official tax-year-2026 sources available to RuleSpec validation:

- Minnesota Department of Revenue four-filing-status income-tax bracket guidance
- Massachusetts Form 1-ES estimated-tax worksheet and separate DOR 4% surtax guidance

This PR changes only `.axiom/toolchain.toml`. It does not change RuleSpec semantics. Follow-up PRs will replace Minnesota's stale caller-supplied bracket inputs with the official schedule and add Massachusetts' narrow estimated-tax/source schedule.

## Checks

- pinned commit exists
- previous corpus pin is an ancestor of the new pin
- Minnesota merge commit is an ancestor of the new pin
- new pin contains the signed Minnesota and Massachusetts scope artifacts
- TOML parses and records the exact merged corpus commit
- `git diff --check`
- full repository validation is delegated to the required toolchain-pin CI matrix

## Review cycle

The original Minnesota-only head was independently CLEAN-reviewed. The pin was then advanced after Massachusetts merged; a fresh exact-head review is pending, as required for this substantive post-review change.