### PR TITLE
Encode Massachusetts 2026 estimated-tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ma/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ma/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ma/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "4eca6dd3c7ebac1bb4ec426a59c7fdb75dfe0f6afc3050b54d002b171059174d"
+      "sha256": "691067a07b022744ca6f8821fe942285b13eddc3760262ca99f74d962a9a1db2"
     },
     {
       "path": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "f683d427226cda946fe41f9cd262a87677c3c84edb096c96d5c66c8872b5f5f1"
+      "sha256": "1c96452744b23e0bde1b40baf4b611b2c869f5cf422337d85467be2cdf46392c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "d6cf9cb0f65c9af094d23b591268fe7be7bc9f80",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/_axiom-worktrees/statetax-liability-20260706/axiom-encode-pin",
-    "version": "0.2.1160",
-    "version_commit": "d6cf9cb0f65c9af094d23b591268fe7be7bc9f80"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1160",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ma:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-06T17:33:07.802519+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpwwk_rukg/sign-applied-files/us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpwwk_rukg",
-  "generated_output_sha256": "f683d427226cda946fe41f9cd262a87677c3c84edb096c96d5c66c8872b5f5f1",
+  "generated_at": "2026-07-23T15:37:03.034627+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpd3kqfhfq/sign-applied-files/us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpd3kqfhfq",
+  "generated_output_sha256": "1c96452744b23e0bde1b40baf4b611b2c869f5cf422337d85467be2cdf46392c",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,7 +33,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "9368f071b53e9d1d1397bf9293dd5457ded6ee1a38f7bb5cd5721c631aac2a81"
+    "value": "7c5bd63d2c4cb1cabb69d3fb6165df071bcbfdda055fb14811df57cc926375c3"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-06T17:33:07.802519+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "312de19c39ca0020b31213827ed60653184e5daca41e8670829723c6a4924024",
+    "prior_signature": "9368f071b53e9d1d1397bf9293dd5457ded6ee1a38f7bb5cd5721c631aac2a81",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18847,6 +18847,24 @@
         ]
       }
     ],
+    "us-ma/form/individual-income-tax/2026/1-es/document-1": [
+      {
+        "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation": [
+      {
+        "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/guidance/dta/policy-online/snap-cola/2025-10-01": [
       {
         "module": "us-ma/policies/dta/snap-cola/2025-10-01/shelter-deductions.yaml",
@@ -20840,13 +20858,6 @@
     ],
     "us-ma/statute/62/3": [
       {
-        "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-ma/statutes/62/3.yaml",
         "via": [
           "module",
@@ -20856,14 +20867,16 @@
     ],
     "us-ma/statute/62/4": [
       {
-        "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
+        "module": "us-ma/statutes/62/4.yaml",
         "via": [
           "module",
           "proof_atom"
         ]
-      },
+      }
+    ],
+    "us-ma/statute/62/4/block-2": [
       {
-        "module": "us-ma/statutes/62/4.yaml",
+        "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -13170,12 +13170,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ma/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:caa362d34ec667700697f2d495b3ffcb0b9a193cf2d1fd0cfe65ca523efb508a"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/360/010/block-1.yaml":
     pending:
       fingerprint: "sha256:056e6a38c8ce8e6ab297894cefbb66cadb223e705929162e1b4b57c15bedbc88"

--- a/us-ma/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ma/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,133 +1,105 @@
-# Fixtures are hand-computed at the 2026 tax year (encode#1060 convention:
-# the expected values are the author's own shown arithmetic, not an oracle
-# read-back). Massachusetts Part B liability = 0.05 * (Part B AGI - personal
-# exemption - min(FICA, 2000)) + 0.04 * max(0, Part B taxable - 1,107,750).
-# Personal exemption: single/separate 4,400; joint 8,800; head of household
-# 6,800 (2026 amounts equal the section 3(b) statutory caps). FICA deduction is
-# supplied and capped at 2,000 per employee.
-- name: single_60k_flat_five_percent
-  # 60000 - 4400 - 2000 = 53600 taxable; 53600 * 0.05 = 2680.00; no surtax.
+# Hand-computed tax-year-2026 Form 1-ES fixtures. The supplied amount is the
+# completed taxable 5%-income amount on worksheet line 1 after deductions and
+# exemptions; worksheet lines 2a through 2c are zero. Expected values are
+# arithmetic fixtures, not oracle read-back or final-return liability.
+- name: negative_completed_income_floors_to_zero
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 60000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: false
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: -100
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_personal_exemption: 4400
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 53600
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_tax: 2680
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_surtax: 0
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 2680
-- name: single_30k_flat_five_percent
-  # 30000 - 4400 - 2000 = 23600; 23600 * 0.05 = 1180.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: 0
+
+- name: zero_completed_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 30000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: false
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 0
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 23600
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 1180
-- name: single_150k_flat_five_percent
-  # 150000 - 4400 - 2000 = 143600; 143600 * 0.05 = 7180.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: 0
+
+- name: one_dollar_uses_five_percent_rate
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 150000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: false
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 1
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 143600
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 7180
-- name: joint_60k_flat_five_percent
-  # 60000 - 8800 (joint exemption) - 2000 = 49200; 49200 * 0.05 = 2460.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 1
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: '0.05'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: '0.05'
+
+- name: ordinary_income_below_surtax_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 60000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: true
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 100000
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_personal_exemption: 8800
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 49200
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 2460
-- name: joint_120k_flat_five_percent
-  # 120000 - 8800 - 2000 = 109200; 109200 * 0.05 = 5460.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 100000
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: 5000
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: 5000
+
+- name: one_cent_below_surtax_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 120000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: true
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 1107749.99
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 109200
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 5460
-- name: joint_300k_flat_five_percent
-  # 300000 - 8800 - 2000 = 289200; 289200 * 0.05 = 14460.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: '1107749.99'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: '55387.4995'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: '55387.4995'
+
+- name: exactly_at_surtax_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 300000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: true
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 1107750
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 289200
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 14460
-- name: single_1_2m_triggers_four_percent_surtax
-  # 1200000 - 4400 - 2000 = 1193600 taxable; base 1193600 * 0.05 = 59680;
-  # surtax (1193600 - 1107750) * 0.04 = 85850 * 0.04 = 3434; total 63114.00.
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 1107750
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: '55387.5'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 0
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: '55387.5'
+
+- name: one_cent_above_surtax_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_part_b_adjusted_gross_income: 1200000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_fica_deduction: 2000
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_indexed_surtax_threshold: 1107750
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_part_b_rate: 0.05
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_supplied_surtax_rate: 0.04
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_joint: false
-    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_filing_status_head_of_household: false
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 1107750.01
   output:
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_part_b_taxable_income: 1193600
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_tax: 59680
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_surtax: 3434
-    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_income_tax_liability: 63114
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: '1107750.01'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: '55387.5005'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: '0.0004'
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: '55387.5009'
+
+- name: one_point_two_million_includes_surtax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ma:policies/income_tax/pilot_liability_pipeline#input.ma_pit_pilot_completed_five_percent_taxable_income: 1200000
+  output:
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_five_percent_taxable_income: 1200000
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_base_estimated_tax: 60000
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_surtax: 3690
+    us-ma:policies/income_tax/pilot_liability_pipeline#ma_pit_pilot_estimated_tax: 63690

--- a/us-ma/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ma/policies/income_tax/pilot_liability_pipeline.yaml
@@ -1,180 +1,204 @@
 format: rulespec/v1
-imports:
-  - us-ma:statutes/62/3#single_or_separate_personal_exemption_cap
-  - us-ma:statutes/62/3#head_of_household_personal_exemption_cap
-  - us-ma:statutes/62/3#joint_return_personal_exemption_cap
 module:
   proof_validation:
     required: true
   source_verification:
     corpus_citation_paths:
-      - us-ma/statute/62/3
-      - us-ma/statute/62/4
+      - us-ma/form/individual-income-tax/2026/1-es/document-1
+      - us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+      - us-ma/statute/62/4/block-2
     upstream_source_check:
-      status: composed_from_grounded_modules
+      status: official_parameter_source
       checked_paths:
-        - us-ma/statute/62/3
-        - us-ma/statute/62/4
+        - us-ma/form/individual-income-tax/2026/1-es/document-1
+        - us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+        - us-ma/statute/62/4/block-2
       rationale: |-
-        The section 3(b) personal-exemption cap amounts for single/separate,
-        head of household, and joint filers are imported from the already-
-        grounded MGL c.62 section 3 module; the section 3 personal exemptions
-        have equalled their statutory caps since 2004, so those caps are the
-        operative 2026 amounts, and the section 3 filing-status/medical-expense
-        mechanics that determine them in the general case are not re-derived
-        here. The operative flat Part B rate (5 per cent) and the section 4(d)
-        additional-tax rate (4 per cent) are declared caller-supplied inputs
-        (ma_pit_pilot_supplied_part_b_rate, ma_pit_pilot_supplied_surtax_rate)
-        rather than imported, because the section 4 encoding carries them inside
-        rate schedules with baseline-tax-growth and one-million-dollar-threshold
-        mechanics that a flat-rate application would strand; Massachusetts has in
-        fact taxed Part B income at the 5 per cent section 4(b) statutory floor
-        since tax year 2020 and applies the 4 per cent section 4(d) additional
-        tax, and those encoded floor and additional rates are the cited authority
-        for the supplied values. The section 4(d) 2026 indexed surtax threshold
-        is likewise a supplied input (ma_pit_pilot_supplied_indexed_surtax_
-        threshold), because the indexed amount is published by the Department of
-        Revenue rather than stated in the statute; the operative 2026 value is
-        1,107,750 dollars, indexing the section 4(d) one-million-dollar base by
-        the Code section 1(f) cost-of-living adjustment. The 2026 Part B
-        liability equals the 5 per cent rate on Part B taxable income plus the
-        4 per cent additional tax on Part B taxable income above the supplied
-        indexed threshold.
+        Massachusetts Department of Revenue Form 1-ES is the current official
+        tax-year-2026 parameter source for this estimated-tax slice. Its
+        worksheet applies 5 per cent to completed taxable 5%-income on line 1,
+        applies 4 per cent to taxable income above the $1,107,750 surtax
+        threshold on line 3, and adds those amounts on line 4. The Department's
+        separate surtax guidance confirms the 2026 threshold and requires the
+        surtax base to sum only positive Part A, Part B, and Part C taxable
+        income amounts. MGL c.62 section 4 supplies the underlying 5-per-cent
+        floor, 4-per-cent additional-tax rate, positive-Part boundary, and
+        annual threshold-indexing authority.
+
+        The caller supplies Form 1-ES line 1's completed taxable 5%-income
+        amount after all upstream deductions and exemptions. This module
+        models the worksheet slice in which lines 2a through 2c are zero, so
+        line 1 is also the entire surtax base. It does not determine taxable
+        income or compose a final return.
   summary: |-
-    Composed Massachusetts Part B individual income-tax liability pipeline for
-    the oracle slice at the 2026 tax year. It exposes a TaxUnit-level path from
-    a supplied Part B adjusted gross income (a completed-return, AGI-level
-    input) into the MGL c.62 section 4(b)/(d) liability so an end-to-end
-    comparison against PolicyEngine (ma_income_tax) and TAXSIM (siitax) does not
-    require the caller to supply the section 4 rate-schedule or section 3
-    exemption stage boundaries. It wires: the section 3(b) personal exemption
-    selected by supplied filing status, the supplied section 3(b)(a)(2)
-    FICA/employment-tax deduction (capped at 2,000 dollars per employee), Part B
-    taxable income after those subtractions, the 5 per cent Part B rate on Part
-    B taxable income, and the 4 per cent section 4(d) additional tax on Part B
-    taxable income above the supplied 2026 indexed one-million-dollar threshold.
-    It deliberately excludes Part A (interest, dividends, short-term and long-term
-    capital gains) and Part C (qualified small business stock) income, which are
-    charged at separate section 4(a)/(c) rates and are zero for the ordinary
-    wage earner this slice models, and it excludes section 6 credits (EITC,
-    limited-income credit), no-tax-status, deductions beyond the FICA
-    deduction, and the dependent/age-65/blindness additional exemptions, all of
-    which are supplied as zero for this slice. Filing status, Part B AGI, and
-    the FICA deduction are supplied inputs; PolicyEngine and TAXSIM both apply
-    the same 5 per cent flat rate and equal exemptions across 2024-2026, so this
-    2026 pipeline is directly comparable to TAXSIM's latest (2024) law year for
-    the flat-rate cases.
+    Massachusetts 2026 Form 1-ES estimated-tax schedule for the narrow
+    completed-5%-income slice. The module floors the supplied line-1 taxable
+    amount at zero, applies the form's 5-per-cent rate, and adds 4 per cent of
+    the amount above the official $1,107,750 surtax threshold.
+
+    This is not final-return liability. It excludes 8.5%- and 12%-rate income,
+    separately entered long-term capital gains, cross-Part deductions upstream
+    of completed taxable income, credits, withholding, prior-year
+    overpayments, the $400 estimated-payment requirement, installments,
+    residency and allocation rules, and every final Form 1 or Form 1-NR/PY
+    step. It is bounded to tax year 2026 and makes no PolicyEngine or TAXSIM
+    parity claim.
 rules:
-  - name: ma_pit_pilot_personal_exemption
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
+  - name: ma_pit_pilot_five_percent_rate
+    kind: parameter
+    dtype: Rate
     period: Year
-    unit: USD
-    source: MGL c.62 s.3(b), personal exemption selected by supplied filing status (2026 amounts equal the statutory caps)
+    source: 2026 Form 1-ES line 1, rate on completed taxable 5%-income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
+            kind: parameter
             source:
-              corpus_citation_path: us-ma/statute/62/3
-              excerpt: "a personal exemption of"
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+              excerpt: "1 x .05"
           - path: versions[0].formula
-            kind: import
-            import:
-              target: us-ma:statutes/62/3#single_or_separate_personal_exemption_cap
-              output: single_or_separate_personal_exemption_cap
-              hash: sha256:339de2008275feebafc70700ca627f994e21e23a1b7f369c541a7994b05e229f
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-ma:statutes/62/3#head_of_household_personal_exemption_cap
-              output: head_of_household_personal_exemption_cap
-              hash: sha256:339de2008275feebafc70700ca627f994e21e23a1b7f369c541a7994b05e229f
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-ma:statutes/62/3#joint_return_personal_exemption_cap
-              output: joint_return_personal_exemption_cap
-              hash: sha256:339de2008275feebafc70700ca627f994e21e23a1b7f369c541a7994b05e229f
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          if ma_pit_pilot_filing_status_joint: joint_return_personal_exemption_cap else: (if ma_pit_pilot_filing_status_head_of_household: head_of_household_personal_exemption_cap else: single_or_separate_personal_exemption_cap)
-  - name: ma_pit_pilot_part_b_taxable_income
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: MGL c.62 s.3(a)-(b), Part B taxable income after the personal exemption and the FICA/employment deduction
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
+            kind: parameter
             source:
-              corpus_citation_path: us-ma/statute/62/3
-              excerpt: "Part B adjusted gross income less the deductions and exemptions"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ma_pit_pilot_part_b_adjusted_gross_income - ma_pit_pilot_personal_exemption - ma_pit_pilot_supplied_fica_deduction)
-  - name: ma_pit_pilot_base_tax
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: MGL c.62 s.4(b), supplied operative 5 per cent Part B rate on Part B taxable income
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ma/statute/62/4
+              corpus_citation_path: us-ma/statute/62/4/block-2
               excerpt: "Part B taxable income shall be taxed at a rate of not less than 5 per cent."
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          ma_pit_pilot_part_b_taxable_income * ma_pit_pilot_supplied_part_b_rate
-  - name: ma_pit_pilot_surtax
+        effective_to: '2026-12-31'
+        formula: '0.05'
+
+  - name: ma_pit_pilot_surtax_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: 2026 Form 1-ES line 3 and DOR guidance, additional surtax rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+              excerpt: "You must multiply the difference by 4%"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+              excerpt: "plus an additional 4 per cent."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.04'
+
+  - name: ma_pit_pilot_surtax_threshold
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: DOR 4% surtax guidance, tax-year-2026 indexed threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+              excerpt: "Tax year 2026 is $1,107,750"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1107750'
+
+  - name: ma_pit_pilot_five_percent_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: MGL c.62 s.4(d), supplied 4 per cent additional tax on Part B taxable income above the supplied indexed threshold
+    source: Completed Form 1-ES line-1 taxable 5%-income, floored at the positive-Part boundary
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ma/statute/62/4
-              excerpt: "the portion of such taxable income exceeding $1,000,000 shall be taxed at the rates specified in subsections (a) to (c), inclusive, plus an additional 4 per cent"
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+              excerpt: "Taxable 5% income* (after deductions and exemptions)"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+              excerpt: "any Part that is negative is treated as 0"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, ma_pit_pilot_part_b_taxable_income - ma_pit_pilot_supplied_indexed_surtax_threshold) * ma_pit_pilot_supplied_surtax_rate
-  - name: ma_pit_pilot_income_tax_liability
+          max(0, ma_pit_pilot_completed_five_percent_taxable_income)
+
+  - name: ma_pit_pilot_base_estimated_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: MGL c.62 s.4(b), (d), Part B liability before section 6 credits
+    source: 2026 Form 1-ES line 1, 5 per cent of completed taxable 5%-income
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ma/statute/62/4
-              excerpt: "Part B taxable income shall be taxed"
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+              excerpt: "1 x .05"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, ma_pit_pilot_base_tax + ma_pit_pilot_surtax)
+          ma_pit_pilot_five_percent_taxable_income * ma_pit_pilot_five_percent_rate
+
+  - name: ma_pit_pilot_estimated_surtax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 DOR guidance and Form 1-ES line 3, 4 per cent above the indexed threshold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+              excerpt: "you subtract the amount of the surtax threshold for that year"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+              excerpt: "You must multiply the difference by 4%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, ma_pit_pilot_five_percent_taxable_income - ma_pit_pilot_surtax_threshold) * ma_pit_pilot_surtax_rate
+
+  - name: ma_pit_pilot_estimated_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 2026 Form 1-ES line 4 for the line-1-only estimated-tax slice
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+              excerpt: "Total tax. Add column B of lines 1 through 3"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ma_pit_pilot_base_estimated_tax + ma_pit_pilot_estimated_surtax


### PR DESCRIPTION
## Scope

Replace the stale Massachusetts caller-supplied rate/threshold and final-liability pilot with a narrow, official-source TY2026 Form 1-ES schedule:

- caller supplies completed worksheet line-1 taxable 5%-income after deductions and exemptions
- negative input is floored at zero
- base estimated tax is 5% of that amount
- estimated surtax is 4% above the official $1,107,750 threshold
- total is base plus surtax

The module explicitly assumes worksheet lines 2a through 2c are zero. It is **not** final-return liability and makes no PolicyEngine or TAXSIM parity claim. It excludes all other rate classes, upstream taxable-income construction, credits, withholding, overpayments, payment thresholds/installments, residency/allocation, and final Form 1/Form 1-NR/PY steps.

Corpus-pin PR #1011 is merged, so the body-bearing Form 1-ES and DOR guidance citations are now on `main`. This supersedes auto-closed stacked PR #1012; its base branch was deleted when #1011 merged. The semantic head is unchanged.

## Generated changes

- signed apply manifest refreshed for exactly the module and companion test
- stale module validation waiver removed
- provision-to-rules reverse index regenerated
- no toolchain or oracle-coverage-pending change in this semantic commit

## Checks

- pinned `axiom-encode` 0.2.1200 validate: pass
- companion tests: 8/8 pass, including one cent below/at/above threshold
- signed generated-file guard: pass
- reverse index check: pass (3947 provisions, 4666 edges, 4433 modules)
- repository pytest: 55 passed
- `git diff --check`: pass

## Review cycle

Independent read-only review: **CLEAN** on exact unchanged head `a48d10209d58d4b1ad8b842a294a7dcd8d299a1f`; no fixes required.