### PR TITLE
Encode Minnesota 2026 income-tax schedules

### DIFF
--- a/.axiom/encoding-manifests/us-mn/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-mn/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "8df6dfe0d5bce1db166bf9bbdefc4fa5de3b9962283413c99c2529d90ea22a2c"
+      "sha256": "818b56fd3478b618326de3641fea896d16f25d4dfcf4fe65907775e6ddbdf362"
     },
     {
       "path": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "e83bd457ca4dc2831f679f22bf707d6dcd8724795dd7529e62a24321937a0507"
+      "sha256": "897851e2f8fc945272e1e8b4bc40dbb2e72a88a756ebd22005c8c9f40ff10f4c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1196",
-    "version_commit": "3f80b174580e14160fd4221fb96e6da8adc2d14a"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1196",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-mn:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T06:33:47.691474+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq/sign-applied-files/us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp933u94lq",
-  "generated_output_sha256": "e83bd457ca4dc2831f679f22bf707d6dcd8724795dd7529e62a24321937a0507",
+  "generated_at": "2026-07-23T15:40:18.669759+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphy5wvtf1/sign-applied-files/us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmphy5wvtf1",
+  "generated_output_sha256": "897851e2f8fc945272e1e8b4bc40dbb2e72a88a756ebd22005c8c9f40ff10f4c",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "311be8d8bafacdb9c258451eae5b9c2a6846936cc1d0216d564a8891d2dfdd96"
+    "value": "ed8fddf75875998a43179cf4c1e79c298da4fc0ce54fd32de31d15bd1ac2d264"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-09T06:33:47.691474+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6c592748b5782fc13e28e1c4fe49418daea6d4a42699acc9004c4e68660a10e6",
+    "prior_signature": "311be8d8bafacdb9c258451eae5b9c2a6846936cc1d0216d564a8891d2dfdd96",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -21169,6 +21169,42 @@
         ]
       }
     ],
+    "us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household": [
+      {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse": [
+      {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate": [
+      {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single": [
+      {
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-mn/manual/dhs/combined-manual/current/page-944": [
       {
         "module": "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
@@ -21189,12 +21225,6 @@
     ],
     "us-mn/statute/290.0121": [
       {
-        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module"
-        ]
-      },
-      {
         "module": "us-mn/statutes/290/0121.yaml",
         "via": [
           "module",
@@ -21203,13 +21233,6 @@
       }
     ],
     "us-mn/statute/290.0123": [
-      {
-        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-mn/statutes/290/0123.yaml",
         "via": [
@@ -21220,14 +21243,25 @@
     ],
     "us-mn/statute/290.06": [
       {
+        "module": "us-mn/statutes/290/06.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-mn/statute/290.06/block-12": [
+      {
         "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"
         ]
-      },
+      }
+    ],
+    "us-mn/statute/290.06/block-13": [
       {
-        "module": "us-mn/statutes/290/06.yaml",
+        "module": "us-mn/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -13944,12 +13944,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-mn/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:e71b0de04947fdc750303f74101ce7cd0585cabae6c5f407b55bfda3ae58dd35"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-mn/statutes/290/0121.yaml":
     pending:
       fingerprint: "sha256:757312db07924c40384f1c506855c059c0680a4ff89c92a9f3280943bbd97e6b"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1741
+ceiling: 1759
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -791,15 +791,69 @@ entries:
 - legal_id: us-mi:statutes/206/272#total_earned_income_tax_credit_allowed
   source: bulk
   since: '2026-07-08'
-- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability
-  source: bulk
-  since: '2026-07-09'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_head_threshold_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_head_threshold_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_head_threshold_4
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_joint_threshold_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_joint_threshold_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_joint_threshold_4
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_rate_1
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_rate_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_rate_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_rate_4
+  source: manual
+  since: '2026-07-23'
 - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax
   source: bulk
   since: '2026-07-09'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_separate_threshold_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_separate_threshold_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_separate_threshold_4
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_single_threshold_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_single_threshold_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_single_threshold_4
+  source: manual
+  since: '2026-07-23'
 - legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income
   source: bulk
   since: '2026-07-09'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_2
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_3
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_4
+  source: manual
+  since: '2026-07-23'
 - legal_id: us-mn:statutes/290/0121#all_other_filers_phaseout_step_amount
   source: bulk
   since: '2026-07-08'

--- a/us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-mn/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,106 +1,418 @@
-# Fixtures are hand-computed at the 2026 tax year (expected values are the
-# author's shown arithmetic from the supplied schedule, which axiom-encode test
-# proves equal the engine output to full decimal precision, not an oracle
-# read-back). Minnesota section 290.06 subd. 2c graduated tax; the top married case adds the section 290.091 alternative minimum tax as a negative supplied credit.
-- name: single_30000
-  # taxable 14750; schedule 0 + 0.0535*max(0,14750-0) = 789.125; less credit 0 -> liability 789.125.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Hand-computed fixtures for the official 2026 continuous schedules. Each
+# threshold is exercised immediately below, exactly at, and immediately above
+# the boundary. These fixtures do not assert final-return liability or oracle
+# parity; section 290.06 subdivision 2c(d)'s low-income tax tables are outside
+# this module.
+- name: negative_income_floors_to_zero_single
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 30000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 0
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 0
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0535
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: -1
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '14750'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '789.125'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '789.125'
-- name: single_60000
-  # taxable 44750; schedule 1782.085 + 0.068*max(0,44750-33310) = 2560.005; less credit 0 -> liability 2560.005.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '0'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_2: 33310
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_3: 109430
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_threshold_4: 203150
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '0'
+
+- name: single_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 60000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 33310
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 1782.085
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.068
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '44750'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2560.005'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '2560.005'
-- name: single_150000
-  # taxable 134750; schedule 6956.885 + 0.0785*max(0,134750-109410) = 8946.075; less credit 0 -> liability 8946.075.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '0'
+- name: single_below_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 150000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 15250
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 109410
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 6956.885
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0785
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 33309
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '134750'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '8946.075'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '8946.075'
-- name: married_60000
-  # taxable 29450; schedule 0 + 0.0535*max(0,29450-0) = 1575.575; less credit 0 -> liability 1575.575.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1782.0315'
+- name: single_at_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 60000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 30550
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 0
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 0
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0535
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 33310
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '29450'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1575.575'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '1575.575'
-- name: married_120000
-  # taxable 89450; schedule 2605.45 + 0.068*max(0,89450-48700) = 5376.45; less credit 0 -> liability 5376.45.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1782.085'
+- name: single_above_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 120000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 30550
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 48700
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 2605.45
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.068
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 33311
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '89450'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '5376.45'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '5376.45'
-- name: married_300000
-  # taxable 271119.5; schedule 12449.81 + 0.0785*max(0,271119.5-193470) = 18545.29575; less credit -182.58 -> liability 18727.87575.
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1782.153'
+- name: single_below_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_adjusted_gross_income: 300000
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_standard_deduction: 28880.5
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_floor: 193470
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_bracket_base: 12449.81
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_marginal_rate: 0.0785
-    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_supplied_nonrefundable_credit: -182.58
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 109429
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
   output:
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_taxable_income: '271119.5'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '18545.29575'
-    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_income_tax_liability: '18727.87575'
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6958.177'
+- name: single_at_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 109430
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6958.245'
+- name: single_above_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 109431
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6958.3235'
+- name: single_below_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 203149
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '14315.1865'
+- name: single_at_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 203150
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '14315.265'
+- name: single_above_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 203151
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '14315.3635'
+- name: single_top_band
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 213150
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '15300.265'
+
+- name: joint_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '0'
+- name: joint_below_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 48699
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2605.3965'
+- name: joint_at_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 48700
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2605.45'
+- name: joint_above_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 48701
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2605.518'
+- name: joint_below_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 193479
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '12450.422'
+- name: joint_at_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 193480
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '12450.49'
+- name: joint_above_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 193481
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '12450.5685'
+- name: joint_below_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 337929
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '23789.7365'
+- name: joint_at_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 337930
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '23789.815'
+- name: joint_above_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 337931
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '23789.9135'
+- name: joint_top_band
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 347930
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '24774.815'
+
+- name: separate_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '0'
+- name: separate_below_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 24349
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1302.6715'
+- name: separate_at_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 24350
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1302.725'
+- name: separate_above_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 24351
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '1302.793'
+- name: separate_below_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 96739
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6225.177'
+- name: separate_at_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 96740
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6225.245'
+- name: separate_above_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 96741
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '6225.3235'
+- name: separate_below_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 168964
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '11894.829'
+- name: separate_at_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 168965
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '11894.9075'
+- name: separate_above_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 168966
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '11895.006'
+- name: separate_top_band
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 178965
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: true
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: false
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '12879.9075'
+
+- name: head_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 0
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '0'
+- name: head_below_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 41009
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2193.9815'
+- name: head_at_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 41010
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2194.035'
+- name: head_above_second_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 41011
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '2194.103'
+- name: head_below_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 164799
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '10611.687'
+- name: head_at_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 164800
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '10611.755'
+- name: head_above_third_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 164801
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '10611.8335'
+- name: head_below_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 270059
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '18874.5865'
+- name: head_at_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 270060
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '18874.665'
+- name: head_above_fourth_threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 270061
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '18874.7635'
+- name: head_top_band
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_state_taxable_income: 280060
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_joint_or_surviving_spouse: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_separate: false
+    us-mn:policies/income_tax/pilot_liability_pipeline#input.mn_pit_pilot_filing_status_head_of_household: true
+  output:
+    us-mn:policies/income_tax/pilot_liability_pipeline#mn_pit_pilot_schedule_tax: '19859.665'

--- a/us-mn/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-mn/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,124 +4,486 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
-      - us-mn/statute/290.06
-      - us-mn/statute/290.0123
-      - us-mn/statute/290.0121
+      - us-mn/statute/290.06/block-12
+      - us-mn/statute/290.06/block-13
+      - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse
+      - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate
+      - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single
+      - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: official_parameter_source
       checked_paths:
-        - us-mn/statute/290.06
-        - us-mn/statute/290.0123
-        - us-mn/statute/290.0121
+        - us-mn/statute/290.06/block-12
+        - us-mn/statute/290.06/block-13
+        - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse
+        - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate
+        - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single
+        - us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household
       rationale: |-
-        This pipeline computes the Minnesota section 290.06 subdivision 2c
-        individual income-tax liability for the ordinary resident wage-earner
-        slice: the graduated tax on Minnesota taxable income (Minnesota adjusted
-        gross income less the section 290.0123 standard deduction and the section
-        290.0121 exemptions). The encoded 290.06 module carries the statutory
-        subdivision 2c schedule — 5.35, 6.8, 7.85, and 9.85 per cent — but
-        subdivision 2d requires the Commissioner to adjust the bracket dollar
-        amounts each year for inflation under section 270C.22, so the operative
-        2026 bracket boundaries are indexed values PolicyEngine projects (33,310 /
-        109,410 / 203,130 single; 48,700 / 193,470 / 337,900 joint). Because the
-        six-case grid crosses several brackets, each case supplies the cumulative
-        tax at its bracket floor, that floor, and the bracket marginal rate, so the
-        schedule reproduces the graduated tax as the supplied cumulative base plus
-        the supplied marginal rate on taxable income above the floor. To reach a
-        liability comparable to PolicyEngine mn_income_tax to the cent, the amounts
-        this pipeline needs are declared caller-supplied inputs: the section
-        290.0123 standard deduction plus the section 290.0121 exemptions (indexed,
-        and phased out at higher income so the supplied subtraction shrinks in the
-        top married case), the per-case bracket floor, the cumulative base tax at
-        that floor, and the bracket marginal rate. The supplied credit carries the
-        section 290.091 alternative minimum tax as a NEGATIVE credit in the one
-        case where it binds (the 300,000-dollar married filer, whose 6.75-per-cent
-        alternative minimum tax exceeds the regular subdivision-2c tax by 182.58
-        dollars); every other case has a zero supplied credit. The pipeline adds no
-        numeric literals of its own; it wires the graduated-tax mechanics only. The
-        section 290.0123 deduction, section 290.0121 exemption, and section 290.091
-        alternative-minimum-tax provisions are supplied here pending their own
-        executable encodings, mirroring the California pilot's supplied standard
-        deduction.
+        Minnesota Statutes section 290.06, subdivision 2c supplies the four
+        individual filing-status schedules and the 5.35, 6.8, 7.85, and 9.85
+        percent rates. Subdivision 2d requires the Commissioner of Revenue to
+        adjust the bracket dollar amounts annually without changing those
+        rates. The Department's official 2026 inflation-adjusted-amounts
+        guidance supplies all three operative thresholds for joint or
+        surviving-spouse, married-separate, single, and head-of-household
+        returns.
+
+        This module therefore accepts completed-return Minnesota taxable net
+        income and three mutually exclusive filing-status classifications as
+        caller boundaries. When all three classifications are false, the
+        single schedule applies. It does not reconstruct Minnesota taxable
+        income, deductions, exemptions, residency allocation, alternative
+        minimum tax, tax-table rounding for income below the Commissioner's
+        prescribed amount, surtaxes, or credits. It fails closed outside tax
+        year 2026.
   summary: |-
-    Composed Minnesota individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Minnesota adjusted gross income into the section 290.06 subdivision 2c
-    graduated tax on Minnesota taxable income, so an end-to-end comparison against
-    PolicyEngine (mn_income_tax_before_refundable_credits) and TAXSIM (siitax)
-    does not require the caller to supply the subdivision-2c bracket application.
-    It wires: Minnesota taxable income (Minnesota AGI less the supplied section
-    290.0123 standard deduction and section 290.0121 exemptions); the graduated
-    tax as the supplied cumulative base tax at the case's bracket floor plus the
-    supplied marginal rate on taxable income above that floor, which reproduces the
-    statutory 5.35/6.8/7.85/9.85-per-cent schedule for filers above the floor; and
-    that tax less the supplied credit — zero except for the top married filer,
-    where the supplied credit is the negative section 290.091 alternative minimum
-    tax addition that binds above the regular tax — floored at zero. It
-    deliberately models only the ordinary resident wage earner and excludes the
-    working-family and other refundable credits, all zero for the childless
-    wage-earner grid. Minnesota AGI, filing status, the deduction/exemption
-    subtraction, the bracket floor, base, and marginal rate, and the credit are
-    supplied inputs; the Commissioner indexes the brackets and the
-    deduction/exemption each year, so this 2026 pipeline is compared against
-    PolicyEngine at 2026 and against TAXSIM's latest 2024 law year with the
-    indexation vintage dispositioned.
+    Minnesota 2026 individual graduated income-tax schedule under section
+    290.06, subdivisions 2c and 2d. From completed-return Minnesota taxable
+    net income, the module selects and applies the official joint or surviving-
+    spouse, married-separate, single, or head-of-household schedule. It is a
+    narrow continuous rate-schedule computation, not final Minnesota income-tax
+    liability. The statutory tax-table method for taxable net income below the
+    Commissioner's prescribed amount and every downstream tax, allocation,
+    surtax, and credit remain outside this target. PolicyEngine parity is not
+    claimed; the official 2026 guidance and focused boundary fixtures are the
+    acceptance standard.
 rules:
+  - name: mn_pit_pilot_rate_1
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Minnesota Statutes 290.06 subd. 2c, first individual rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "5.35 percent"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0535'}
+
+  - name: mn_pit_pilot_rate_2
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Minnesota Statutes 290.06 subd. 2c, second individual rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "6.8 percent"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.068'}
+
+  - name: mn_pit_pilot_rate_3
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Minnesota Statutes 290.06 subd. 2c, third individual rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "7.85 percent"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0785'}
+
+  - name: mn_pit_pilot_rate_4
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Minnesota Statutes 290.06 subd. 2c, fourth individual rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "9.85 percent"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0985'}
+
+  - name: mn_pit_pilot_joint_threshold_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 joint second-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse
+              excerpt: "2nd Bracket Threshold 2019 $48,700"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '48700'}
+
+  - name: mn_pit_pilot_joint_threshold_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 joint third-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse
+              excerpt: "3rd Bracket Threshold 2019 $193,480"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '193480'}
+
+  - name: mn_pit_pilot_joint_threshold_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 joint fourth-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-joint-or-surviving-spouse
+              excerpt: "4th Bracket Threshold 2019 $337,930"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '337930'}
+
+  - name: mn_pit_pilot_separate_threshold_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 married-separate second-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate
+              excerpt: "2nd Bracket Threshold 2019 $24,350"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '24350'}
+
+  - name: mn_pit_pilot_separate_threshold_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 married-separate third-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate
+              excerpt: "3rd Bracket Threshold 2019 $96,740"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '96740'}
+
+  - name: mn_pit_pilot_separate_threshold_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 married-separate fourth-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/married-separate
+              excerpt: "4th Bracket Threshold 2019 $168,965"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '168965'}
+
+  - name: mn_pit_pilot_single_threshold_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 single second-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single
+              excerpt: "2nd Bracket Threshold 2019 $33,310"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '33310'}
+
+  - name: mn_pit_pilot_single_threshold_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 single third-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single
+              excerpt: "3rd Bracket Threshold 2019 $109,430"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '109430'}
+
+  - name: mn_pit_pilot_single_threshold_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 single fourth-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/single
+              excerpt: "4th Bracket Threshold 2019 $203,150"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '203150'}
+
+  - name: mn_pit_pilot_head_threshold_2
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 head-of-household second-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household
+              excerpt: "2nd Bracket Threshold 2019 $41,010"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '41010'}
+
+  - name: mn_pit_pilot_head_threshold_3
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 head-of-household third-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household
+              excerpt: "3rd Bracket Threshold 2019 $164,800"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '164800'}
+
+  - name: mn_pit_pilot_head_threshold_4
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Department of Revenue official 2026 head-of-household fourth-bracket threshold
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-mn/guidance/department-of-revenue/inflation-adjusted-amounts/2026/income-tax-brackets/head-of-household
+              excerpt: "4th Bracket Threshold 2019 $270,060"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '270060'}
+
   - name: mn_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 290.06 and 290.0123/290.0121, Minnesota taxable income after the supplied standard deduction and exemptions
+    source: Minnesota Statutes 290.06 subd. 2c, completed-return taxable net income
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-mn/statute/290.0123
-              excerpt: "standard deduction"
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "taxable net income"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, mn_pit_pilot_state_taxable_income)
+
+  - name: mn_pit_pilot_threshold_2
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Statutes 290.06 subds. 2c-2d and official 2026 filing-status thresholds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-13
+              excerpt: "annually adjust the minimum and maximum dollar amounts for each rate bracket"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          max(0, mn_pit_pilot_adjusted_gross_income - mn_pit_pilot_supplied_standard_deduction)
+          if mn_pit_pilot_filing_status_joint_or_surviving_spouse:
+            mn_pit_pilot_joint_threshold_2
+          else: if mn_pit_pilot_filing_status_separate:
+            mn_pit_pilot_separate_threshold_2
+          else: if mn_pit_pilot_filing_status_head_of_household:
+            mn_pit_pilot_head_threshold_2
+          else:
+            mn_pit_pilot_single_threshold_2
+
+  - name: mn_pit_pilot_threshold_3
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Statutes 290.06 subds. 2c-2d and official 2026 filing-status thresholds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-13
+              excerpt: "rate bracket for married filing separate must be one-half"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if mn_pit_pilot_filing_status_joint_or_surviving_spouse:
+            mn_pit_pilot_joint_threshold_3
+          else: if mn_pit_pilot_filing_status_separate:
+            mn_pit_pilot_separate_threshold_3
+          else: if mn_pit_pilot_filing_status_head_of_household:
+            mn_pit_pilot_head_threshold_3
+          else:
+            mn_pit_pilot_single_threshold_3
+
+  - name: mn_pit_pilot_threshold_4
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Minnesota Statutes 290.06 subds. 2c-2d and official 2026 filing-status thresholds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mn/statute/290.06/block-13
+              excerpt: "rate brackets as adjusted must be rounded to the nearest $10 amount"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if mn_pit_pilot_filing_status_joint_or_surviving_spouse:
+            mn_pit_pilot_joint_threshold_4
+          else: if mn_pit_pilot_filing_status_separate:
+            mn_pit_pilot_separate_threshold_4
+          else: if mn_pit_pilot_filing_status_head_of_household:
+            mn_pit_pilot_head_threshold_4
+          else:
+            mn_pit_pilot_single_threshold_4
+
   - name: mn_pit_pilot_schedule_tax
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 290.06 subd. 2c, graduated tax as the supplied cumulative base at the bracket floor plus the supplied marginal rate above it
+    source: Minnesota Statutes 290.06 subds. 2c-2d, official 2026 continuous graduated schedule
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-mn/statute/290.06
-              excerpt: "income tax rate schedules for individuals"
+              corpus_citation_path: us-mn/statute/290.06/block-12
+              excerpt: "computed by applying to their taxable net income the following schedule of rates"
     versions:
       - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
         formula: |-
-          mn_pit_pilot_supplied_bracket_base
-          + mn_pit_pilot_supplied_marginal_rate * max(0, mn_pit_pilot_taxable_income - mn_pit_pilot_supplied_bracket_floor)
-  - name: mn_pit_pilot_income_tax_liability
-    kind: derived
+          mn_pit_pilot_rate_1 * min(mn_pit_pilot_taxable_income, mn_pit_pilot_threshold_2)
+          + mn_pit_pilot_rate_2 * min(max(0, mn_pit_pilot_taxable_income - mn_pit_pilot_threshold_2), mn_pit_pilot_threshold_3 - mn_pit_pilot_threshold_2)
+          + mn_pit_pilot_rate_3 * min(max(0, mn_pit_pilot_taxable_income - mn_pit_pilot_threshold_3), mn_pit_pilot_threshold_4 - mn_pit_pilot_threshold_3)
+          + mn_pit_pilot_rate_4 * max(0, mn_pit_pilot_taxable_income - mn_pit_pilot_threshold_4)
+
+inputs:
+  - name: mn_pit_pilot_state_taxable_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 290.06 subd. 2c graduated tax less the supplied credit (negative = the 290.091 alternative minimum tax addition), floored at zero
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-mn/statute/290.06
-              excerpt: "the tax imposed by this section"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, mn_pit_pilot_schedule_tax - mn_pit_pilot_supplied_nonrefundable_credit)
+    description: Completed-return Minnesota taxable net income supplied by the caller.
+  - name: mn_pit_pilot_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a joint return or surviving-spouse filing status.
+  - name: mn_pit_pilot_filing_status_separate
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a married-separate return.
+  - name: mn_pit_pilot_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for a head-of-household filing status; all false selects single.


### PR DESCRIPTION
## Scope

Replace the stale Minnesota caller-supplied bracket-floor/base/rate pilot with the complete official tax-year-2026 continuous graduated schedule:

- caller supplies completed-return Minnesota taxable net income
- three mutually exclusive filing-status classifications select joint/surviving-spouse, married-separate, or head-of-household; all false selects single
- official thresholds for all four filing statuses
- statutory rates of 5.35%, 6.8%, 7.85%, and 9.85%
- TY2026-only versions

This computes only the continuous section 290.06 schedule. It is not final Minnesota income-tax liability and makes no PolicyEngine parity claim. It excludes taxable-income construction, the Commissioner's low-income tax-table method, residency allocation, AMT, surtaxes, credits, and downstream return mechanics.

## Generated/registry changes

- signed apply manifest refreshed for exactly module + companion test
- stale module validation waiver removed
- reverse index regenerated
- retired final-liability oracle-pending output removed
- schedule/taxable outputs retained and 19 new private schedule parameters/selectors declared; ceiling increases by the exact net +18
- no toolchain change

## Checks

- pinned encoder validate: pass
- companion fixtures: 45/45 pass
- full repository pytest: 55 passed
- focused repository tests: 18 passed
- signed generated guard: pass
- reverse index current (3950 provisions, 4668 edges, 4433 modules)
- `git diff --check`: pass
- global pending-ratchet has one inherited unrelated Hawaii stale declaration and zero Minnesota problems

## Review cycle

Independent review-fix-re-review of semantic commit `0fab73e354e4af92a28b627bc63c1136fe666c80`: **CLEAN**. After merging current `main`, a lightweight independent integrity review found **CLEAN** on exact head `601374d78611fb1f8e8f6e28fa55721040dbd718`; all six blobs are byte-identical and no unrelated changes exist.