### PR TITLE
Encode Kentucky 2026 individual income-tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ky/policies/income_tax/pilot_liability_pipeline.json
@@ -2,29 +2,29 @@
   "applied_files": [
     {
       "path": "us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "50ce99e1753363c797db37aa5afb43d1eb96e531d3443d4cdb4949c27ff27ab7"
+      "sha256": "f7e38cefec3d8e84890b0c80ca04f81fa9fd7c1a8034cc853bbbcac48e478f49"
     },
     {
       "path": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "16e9ba07230f511f1cb0a748c637dff9d3f9728cf21799dc6734fffe6e795eb6"
+      "sha256": "924ba0bc2e8492ce1646a2fd3a9a9385aa48a12e250c2b1e939b0b1e2c867cbe"
     }
   ],
   "axiom_encode_git": {
-    "commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1195",
-    "version_commit": "177867c18d73e9d0e33ada9616d23bc1c36cbac0"
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1195",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ky:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-09T02:19:05.429181+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0/sign-applied-files/us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpe08mg1f0",
-  "generated_output_sha256": "3c32bb1cc691b92f9f41a2ac45f2a37547af094b8b033b8ace42578c17047160",
+  "generated_at": "2026-07-23T15:50:03.169732+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf1nc21a4/sign-applied-files/us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf1nc21a4",
+  "generated_output_sha256": "924ba0bc2e8492ce1646a2fd3a9a9385aa48a12e250c2b1e939b0b1e2c867cbe",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ced371768f390ecf7e1276e4516042fa49c7218981bfd89a3aad4314455992f2"
+    "value": "03c60da68debc1324e4c4a9721bda54ce531a93bd44ad67cecf4ad31c95a48d4"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-09T02:19:05.429181+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "87f69a048816822abf0af12c36a38c136879f55d26998b2b41d29fa8a33f71ad",
+    "prior_signature": "ced371768f390ecf7e1276e4516042fa49c7218981bfd89a3aad4314455992f2",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18745,13 +18745,6 @@
     ],
     "us-ky/statute/11/141.020": [
       {
-        "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
-      {
         "module": "us-ky/statutes/11/141/020.yaml",
         "via": [
           "module",
@@ -18777,7 +18770,7 @@
         ]
       }
     ],
-    "us-ky/statute/11/141.081": [
+    "us-ky/statute/krs/141.020/document-1": [
       {
         "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -13092,12 +13092,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ky/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:c5479efb88dbe2fdcc7e6820e5fb4ce99abf9844fe57d894a2cb5e37dbde09ba"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ky/statutes/11/141/020.yaml":
     pending:
       fingerprint: "sha256:a54f7cb7579c44f914fa7d62605a24617604ad1bb1f555a26ea58d60485b9fc1"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -464,15 +464,15 @@ entries:
 - legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_upper_rate
   source: manual
   since: '2026-07-21'
-- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_2026_rate
   source: manual
-  since: '2026-07-09'
-- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax
+  since: '2026-07-23'
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits
   source: manual
-  since: '2026-07-09'
-- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income
+  since: '2026-07-23'
+- legal_id: us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income
   source: manual
-  since: '2026-07-09'
+  since: '2026-07-23'
 - legal_id: us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits
   source: bulk
   since: '2026-07-08'

--- a/us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ky/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,114 +1,113 @@
-# Fixtures are hand-computed at the 2026 tax year (the author's own shown
-# arithmetic from the supplied schedule, which axiom-encode test proves equal the
-# engine output to full decimal precision, not an oracle read-back). Kentucky
-# liability = the section 141.020 flat tax (3.5 per cent) on Kentucky taxable
-# income (Kentucky AGI - the supplied section 141.081 standard deduction of
-# 3,344.11 at 2026) less the supplied nonrefundable exemption credit (zero; the
-# family-size tax credit is zero above its income ceiling). Kentucky has no zero
-# bracket, so the supplied no-tax threshold is zero and the whole taxable income
-# is taxed at the excess rate 0.035. The supplied standard deduction is calibrated
-# to PolicyEngine ky_taxable_income. Every case matches PolicyEngine
-# ky_income_tax_before_refundable_credits within a hundredth of a cent.
-- name: single_30000
-  # taxable 30000-3344.11 = 26655.89. Schedule 0.035*26655.89 = 932.95615.
+# Hand-computed tax-year-2026 fixtures for the narrow KRS 141.020 schedule.
+# The caller supplies completed Kentucky net income; the module floors it at
+# zero and multiplies by 0.035 before credits. The $3,360 amount published in
+# Form 740-ES is estimate-only and is intentionally not an input or boundary.
+- name: negative_net_income_floors_to_zero
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 30000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: -100
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '26655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '932.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '932.95615'
-- name: single_60000
-  # taxable 56655.89. Schedule 0.035*56655.89 = 1982.95615.
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: 0
+
+- name: zero_net_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 60000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 0
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '56655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '1982.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '1982.95615'
-- name: single_150000
-  # taxable 146655.89. Schedule 0.035*146655.89 = 5132.95615.
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: 0
+
+- name: one_cent_net_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 150000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 0.01
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '146655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '5132.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '5132.95615'
-- name: married_60000
-  # Married filing jointly, spouse income 0. taxable 56655.89. Schedule
-  # 0.035*56655.89 = 1982.95615 (Kentucky has no joint brackets; flat rate).
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: '0.01'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '0.00035'
+
+- name: one_dollar_net_income
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 60000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 1
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '56655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '1982.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '1982.95615'
-- name: married_120000
-  # taxable 116655.89. Schedule 0.035*116655.89 = 4082.95615.
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 1
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '0.035'
+
+- name: one_hundred_dollars
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 120000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 100
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '116655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '4082.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '4082.95615'
-- name: married_300000
-  # taxable 296655.89. Schedule 0.035*296655.89 = 10382.95615.
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 100
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '3.5'
+
+- name: estimate_only_amount_is_not_a_schedule_threshold
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_adjusted_gross_income: 300000
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_personal_exemption: 3344.11
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_no_tax_threshold: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_first_bracket_rate: 0
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_excess_rate: 0.035
-    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_exemption_credit: 0
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 3360
   output:
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_taxable_income: '296655.89'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_schedule_tax: '10382.95615'
-    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_liability: '10382.95615'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 3360
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '117.6'
+
+- name: one_cent_above_estimate_only_amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 3360.01
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: '3360.01'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '117.60035'
+
+- name: ten_thousand_dollars
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 10000
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 10000
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: 350
+
+- name: fractional_net_income_preserves_exact_arithmetic
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 12345.67
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: '12345.67'
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: '432.09845'
+
+- name: one_hundred_thousand_dollars
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ky:policies/income_tax/pilot_liability_pipeline#input.ky_pit_pilot_supplied_net_income: 100000
+  output:
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_net_income: 100000
+    us-ky:policies/income_tax/pilot_liability_pipeline#ky_pit_pilot_income_tax_before_credits: 3500

--- a/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-ky/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,108 +3,102 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-ky/statute/11/141.020
-      - us-ky/statute/11/141.081
+    corpus_citation_path: us-ky/statute/krs/141.020/document-1
     upstream_source_check:
       status: composed_from_supplied_current_authority
       checked_paths:
-        - us-ky/statute/11/141.020
-        - us-ky/statute/11/141.081
+        - us-ky/statute/krs/141.020/document-1
       rationale: |-
-        This pipeline computes the Kentucky section 141.020 individual
-        income-tax liability for the ordinary resident wage-earner slice: the
-        flat tax on Kentucky taxable income (Kentucky adjusted gross income less
-        the section 141.081 standard deduction). The encoded 141.020 levy carries
-        the statutory single-rate structure, but KRS 141.020(2)(d) steps the rate
-        down by legislation when the budget-reserve conditions are met (from 5 per
-        cent to 4 per cent to 3.5 per cent) and section 141.081 indexes the
-        standard deduction each year, so the operative 2026 rate (3.5 per cent)
-        and standard deduction ($3,344) are the current values PolicyEngine
-        applies. To reach a liability comparable to PolicyEngine ky_income_tax to
-        the cent, every amount this pipeline needs is a declared caller-supplied
-        input: the 3.5-per-cent rate and the section 141.081 standard deduction
-        supplied as the AGI-to-taxable-income subtraction. Kentucky has no
-        per-exemption tax credit for these cases (the family-size tax credit is
-        zero above its income ceiling), so the supplied nonrefundable exemption
-        credit is zero, and Kentucky imposes the flat rate from the first dollar
-        of taxable income, so the supplied no-tax threshold is zero. The pipeline
-        adds no numeric literals of its own; it wires the flat-rate mechanics only.
+        KRS 141.020 is the controlling codified authority for the individual
+        income-tax levy and the tax-year-2026 rate. Subsection (1) directs that
+        the applicable rate be applied to net income before allowable credits,
+        and subsection (2)(f) supplies the 3.5 percent rate for taxable years
+        beginning on or after January 1, 2026.
+
+        This narrow module therefore accepts completed Kentucky net income as
+        its only caller-supplied boundary, floors that amount at zero, and
+        applies the statutory rate before credits. It does not construct net
+        income, deductions, or credits. In particular, the $3,360 amount in
+        Kentucky's 2026 Form 740-ES instructions belongs to an estimated-tax
+        worksheet and is not encoded as a final-return deduction or liability
+        parameter here. All executable versions fail closed after tax year
+        2026.
   summary: |-
-    Composed Kentucky individual income-tax liability pipeline for the oracle
-    slice at the 2026 tax year. It exposes a TaxUnit-level path from a supplied
-    Kentucky adjusted gross income into the section 141.020 flat tax on Kentucky
-    taxable income, so an end-to-end comparison against PolicyEngine
-    (ky_income_tax_before_refundable_credits) and TAXSIM (siitax) does not require
-    the caller to supply the 141.020 rate application. It wires: Kentucky taxable
-    income (Kentucky AGI less the supplied section 141.081 standard deduction);
-    the tax as the supplied 3.5-per-cent rate on all Kentucky taxable income (the
-    supplied no-tax threshold is zero, Kentucky having no zero bracket); and that
-    tax less the supplied nonrefundable exemption credit (zero; the family-size
-    tax credit is zero above its income ceiling), floored at zero. It deliberately
-    models only the ordinary resident wage earner and excludes the family-size
-    and other nonrefundable credits, all zero for the childless wage grid.
-    Kentucky AGI, filing status, the no-tax threshold, the rate, the standard
-    deduction, and the exemption credit are supplied inputs; the rate steps by
-    legislation and the standard deduction is indexed, so this 2026 pipeline is
-    compared against PolicyEngine at 2026 and against TAXSIM's latest 2024 law
-    year with the 2024-to-2026 rate-step and deduction vintage dispositioned.
+    Kentucky tax-year-2026 individual income-tax schedule before credits under
+    KRS 141.020. The caller supplies completed Kentucky net income at the
+    TaxUnit level. The module floors that amount at zero and applies the
+    statute's 3.5 percent rate. Upstream net-income construction, deductions,
+    credits, nonresident allocation, and final-return liability are outside
+    this narrow schedule.
 rules:
-  - name: ky_pit_pilot_taxable_income
+  - name: ky_pit_pilot_2026_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: KRS 141.020(2)(f), tax-year-2026 individual income-tax rate
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "the tax shall be three and one-half percent (3.5%) of net income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.035'
+
+  - name: ky_pit_pilot_net_income
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 141.081, Kentucky taxable income after the supplied standard deduction
+    source: Supplied completed Kentucky net income under KRS 141.020(1), floored at zero
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ky/statute/11/141.081
-              excerpt: "optional standard deduction"
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "upon his or her entire net income as defined in this chapter"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ky_pit_pilot_adjusted_gross_income - ky_pit_pilot_supplied_personal_exemption)
-  - name: ky_pit_pilot_schedule_tax
+        effective_to: '2026-12-31'
+        formula: max(0, ky_pit_pilot_supplied_net_income)
+
+  - name: ky_pit_pilot_income_tax_before_credits
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 141.020, flat tax as the supplied rate on Kentucky taxable income above the supplied no-tax threshold
+    source: KRS 141.020(1) and (2)(f), 3.5 percent of Kentucky net income before allowable credits
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ky/statute/11/141.020
-              excerpt: "A tax at the rate provided in this subsection is hereby imposed"
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "applying the rates in subsection (2) of this section to net income and subtracting allowable tax credits"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "the tax shall be three and one-half percent (3.5%) of net income"
     versions:
       - effective_from: '2026-01-01'
-        formula: |-
-          ky_pit_pilot_supplied_first_bracket_rate * min(ky_pit_pilot_taxable_income, ky_pit_pilot_supplied_no_tax_threshold)
-          + ky_pit_pilot_supplied_excess_rate * max(0, ky_pit_pilot_taxable_income - ky_pit_pilot_supplied_no_tax_threshold)
-  - name: ky_pit_pilot_income_tax_liability
-    kind: derived
+        effective_to: '2026-12-31'
+        formula: ky_pit_pilot_net_income * ky_pit_pilot_2026_rate
+
+inputs:
+  - name: ky_pit_pilot_supplied_net_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: 141.020 flat tax less the supplied nonrefundable exemption credit, floored at zero
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-ky/statute/11/141.020
-              excerpt: "the tax imposed by this section"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          max(0, ky_pit_pilot_schedule_tax - ky_pit_pilot_supplied_exemption_credit)
+    description: Completed Kentucky net income supplied by the caller as an upstream boundary.


### PR DESCRIPTION
## Scope

Encodes the narrow Kentucky TY2026 pre-credit income-tax schedule from completed Kentucky net income: floor at zero and apply the statutory 3.5% rate. The $3,360 worksheet amount remains explicitly estimate-only and is not treated as a tax threshold. This module does not claim final-liability or PolicyEngine parity.

## Sources

Uses the body-bearing Kentucky corpus provision for KRS 141.020, pinned through corpus commit `4c12ebf0675ceda3891d7646df7dcb236a02e2af`.

## Validation

- pinned `axiom-encode` 0.2.1200 validation: pass
- exact rules engine `ffd8213271947b0189a9dd61a055c1e0e78908a0`
- proof validation: 4 atoms
- fixtures: 10/10
- signed generated-file guard: pass
- reverse-index check: pass
- full repository tests: 55 passed
- Kentucky-scoped oracle-pending ratchet: clean; global check retains an unrelated inherited Hawaii stale-ID finding

## Review cycle

- independent semantic review of commit `bab3b14319c7f83c4031b5e1b927f0cc6e07d951`: CLEAN
- current-main merge preserved all six reviewed file blobs byte-for-byte and introduced no toolchain diff
- exact-head post-merge review is in progress; this PR remains draft until that review and CI are clean
