### PR TITLE
Advance corpus pin through California 2026 sources

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "4c12ebf0675ceda3891d7646df7dcb236a02e2af"
+axiom_corpus_ref = "527a5be2ca97f19301c2e8964d305548cadefa03"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Scope

Advances the pinned `axiom-corpus` commit from `4c12ebf0675ceda3891d7646df7dcb236a02e2af` to `527a5be2ca97f19301c2e8964d305548cadefa03`. The new pin includes the independently reviewed and fully green Maine TY2026 rate/surcharge source package (corpus PR #489) and California TY2026 estimated-tax source package (corpus PR #490).

No encoder, rules-engine, canonical-target, module, test, index, waiver, or oracle setting changes.

## Verification

- target is exact current `axiom-corpus` main merge commit
- old pin is an ancestor of the new pin
- Maine merge is the first-parent ancestor of the California merge
- one-file / one-line semantic diff
- `git diff --check`: pass

## Review cycle

Independent semantic review of commit `244662b18b24aff8af80ecc12620e84546d50751`: **CLEAN**, no actionable findings. It verified the exact ancestry chain and that all non-corpus toolchain fields are unchanged.

The branch was then merged cleanly with rulespec main `ca2d424fcb85ce8c3a8f4706113331710f114460`; exact PR head is `0b476d9f624551af9c0e48b4defd4414248eafb0`. The PR remains draft pending a lightweight exact-head review and full CI.
