### PR TITLE
Retire stale PIT validation waivers and re-attest New York

### DIFF
--- a/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
@@ -3,6 +3,10 @@
     {
       "path": "us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml",
       "sha256": "4b5bf3902cf6c14912d2f843049c2409c4d153f0f21878e47c7332697911fa5f"
+    },
+    {
+      "path": "us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c"
     }
   ],
   "axiom_encode_git": {
@@ -17,12 +21,11 @@
   "citation": "us-ny:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T10:58:56.863637+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa9ls3ejf/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpa9ls3ejf",
+  "generated_at": "2026-07-23T17:41:05.957431+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpka3i977a/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpka3i977a",
   "generated_output_sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c",
   "generation_prompt_sha256": null,
-  "manual_exception": "fixtures",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -30,22 +33,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2bec9ce33d3223ea90c330321d2c3d85f8d66b39a3fc4143498d1e7298804e6c"
+    "value": "6a686c0ae9b2ae76cd86530feea4ae5b491ccf2e60cf155c91ed9d0e79b333fb"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T09:21:07.368809+00:00",
+    "generated_at": "2026-07-22T10:58:56.863637+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "8343167e4b6a1e2718298a3bed909d94b3e2059da68a3ac8a4569e3081978640",
-    "prior_signature": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a",
+    "manifest_sha256": "4343b0910ca19633331bd53916443f22e650204619a1630cb47cf62a0e2723fe",
+    "prior_signature": "2bec9ce33d3223ea90c330321d2c3d85f8d66b39a3fc4143498d1e7298804e6c",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-06T17:33:07.803431+00:00",
+      "generated_at": "2026-07-22T09:21:07.368809+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
-      "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+      "manifest_sha256": "8343167e4b6a1e2718298a3bed909d94b3e2059da68a3ac8a4569e3081978640",
+      "prior_signature": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-06T17:33:07.803431+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
+        "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -8064,12 +8064,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-al/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:460932504f00aac2b12a7e5b954ffd8bc974006f6e8930671a3fea58ef1e5d67"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-al/regulations/660-4/1/01/block-1.yaml":
     pending:
       fingerprint: "sha256:a4c62ea708f74f3896bab3962af1abd5b5cbd9a349c2429ecb3157f8c7928355"
@@ -8355,12 +8349,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-az/policies/des/faa6/utility-allowance-current-amount.yaml":
     pending:
       fingerprint: "sha256:f8cd084084d9629b2fb9852e06878166a81ad257a992192af21d54703eabedc8"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us-az/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:4f60a295158605be9a6f0a631ad31615119920f97189f7ecd7e20dcb897a7091"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11982,12 +11970,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ct/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:7c3eb88e74ea63fd57319a4f0f9d5b25b83821dcc4f1b8af84530b40e8b2ea85"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ct/statutes/12-700.yaml":
     pending:
       fingerprint: "sha256:015228f885475fa0717750055ffeb8d72d9db861bc93908e81e188cb0bdb998e"
@@ -12051,12 +12033,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-de/policies/cms/delaware-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:d707ba54aaef0866b54ac0f8407928bbfdd5ab0ae6024166bc22436d9ea84615"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us-de/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:fa3965880ad932e2db93cafb5a29ef42f9933f1e87c40a2c7bbd2c2feeae0f99"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16494,12 +16470,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ne/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:ae3f3c0b43d8f24dcaa20799cf5a680eea5b7fa74ba201fd044f211a938ca461"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ne/statutes/77/77-2715/03.yaml":
     pending:
       fingerprint: "sha256:6d25293faa50d61b8409ff4f91f1a1c88b12861587db188106e820a17426dde2"
@@ -16749,12 +16719,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-oh/policies/cms/ohio-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:e64deee2d3240cca314ab4a3929d8dfd8ef15b54effba673ff0c3a9718a41745"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us-oh/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:51834b7517a7c7314c023029881a88d7d9bc12a0bc70a36c320eb853b45ec25e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17631,12 +17595,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-va/policies/cms/virginia-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:b93f9902e529a540cc02893d431e376561725f3f39a2ea1fb357990462d1a516"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -4146,12 +4146,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ny/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:3d812a02cedc20a5fee110a59660c251a77cdee3692e1bae2d1bf77b6435121c"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml":
     active:
       fingerprint: "sha256:881eda4279377e626a7c2af7051aead8e4b785c286d65eaa3ae2c599bc155e1d"


### PR DESCRIPTION
## Scope

Closes the remaining administrative validation-waiver debt for the 2026 state individual-income-tax campaign.

- Removes exactly eight historical pending-waiver entries whose current pinned validation is clean: Alabama, Arizona, Connecticut, Delaware, Nebraska, New York, Ohio, and Virginia.
- Re-attests New York's unchanged module and companion test in the canonical signed manifest before removing its waiver.
- Makes no RuleSpec, formula, source, fixture, oracle, reverse-index, or toolchain changes.

California, Maine, and Idaho waiver removals are already present on the base branch and remain preserved.

## Validation

- pinned encoder 0.2.1200
- pinned engine `ffd8213271947b0189a9dd61a055c1e0e78908a0`
- pinned corpus `527a5be2ca97f19301c2e8964d305548cadefa03`
- all eight affected state modules validate
- New York proof validation: 47 atoms, 30 monetary obligations, zero missing
- New York companion fixtures: 58/58
- signed generated-file guard: pass
- manifest/layout tests: 12/12
- YAML/JSON parsing and `git diff --check`: pass

## Review cycle

The seven non-New-York waivers were independently audited as safe removal candidates. New York was separately re-attested and validated before its waiver removal. The combined administrative head was independently reviewed CLEAN.

After merging current main, a fresh exact-head review of `99b07700658d3fce279693e4225e715d967f248b` confirmed exact patch identity, unchanged implementation blobs, preservation of the merged California/Maine/Idaho state, and no actionable findings.

This PR remains draft until exact-head CI is fully green.
