### PR TITLE
Drain stale Hawaii PIT oracle-pending declaration

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1785
+ceiling: 1784
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -111,9 +111,6 @@ entries:
   source: manual
   since: '2026-07-22'
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_schedule_c_rate
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_smaller_net_capital_gain
   source: manual
   since: '2026-07-22'
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_taxable_income


### PR DESCRIPTION
## Scope

Drains the one genuinely stale state-PIT declaration from the repository oracle-pending ledger:

- removes `us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_smaller_net_capital_gain`, which no longer exists;
- lowers the ledger ceiling from 1,785 to 1,784;
- preserves every other entry and all entry metadata byte-for-byte.

The current Hawaii replacement, `hi_pit_pilot_taxable_income_reduced_by_capital_gain`, remains live, tested, and pending classification. No RuleSpec, fixture, manifest, source, oracle registry, index, or toolchain file changes.

## Validation

- pinned encoder 0.2.1200 and unfiltered oracle coverage (the authoritative ledger mode)
- pending ratchet: 1,784 declared / 1,784 applied / 0 stale / 0 problems
- PIT coverage: 511 outputs across 44 module files
  - 273 pending classification
  - 238 known-not-comparable
  - 0 unmapped
- live Hawaii replacement retained with 9 test-output assertions
- semantic base/head assertion: exactly one removed ID, no additions or common-entry metadata changes
- YAML sorted, unique, and count equals ceiling
- repository-layout tests: 9 passed
- generated-file guard and `git diff --check`: pass

## Review cycle

An independent audit first identified that `--program tax` is not authoritative for these pilot paths because they currently infer as program `unknown`; the unfiltered report was used instead. It found exactly one real stale declaration, not the misleading filtered count.

The minimal exact head `f67610c23b4c5cb20de65c6a40f3b2ef9d60952f` then received an independent review: **CLEAN**, with no actionable findings.

This PR remains draft until exact-head CI is fully green.
