### PR TITLE
Add end-to-end state income-tax contract and New Hampshire program

### DIFF
--- a/.axiom/encoding-manifests/programs/us-nh/income-tax/fy-2026.json
+++ b/.axiom/encoding-manifests/programs/us-nh/income-tax/fy-2026.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "programs/us-nh/income-tax/fy-2026.yaml",
+      "sha256": "1ac582eee14d680622033b63bd3d576afd983caebd30e46e971640927548e266"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:programs/us-nh/income-tax/fy-2026",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-23T20:29:57.250398+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpd3_0hhpr/sign-applied-files/programs/us-nh/income-tax/fy-2026.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpd3_0hhpr",
+  "generated_output_sha256": "1ac582eee14d680622033b63bd3d576afd983caebd30e46e971640927548e266",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "5a76fca5f97b1719a845854b3ebb27c596e4ff49b3144a514f3d04bafa388dbd"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-nh/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nh/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-nh/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "59b971bc5a9892e83a7a78f0a7bb21aa01d794abef19c078d3d3eccc7e6f9f6b"
+      "sha256": "67f515cba9c9d2a40f1f3a1cb5ec4c1b1516d24f8966feb32f1e492bd88cb8f7"
     },
     {
       "path": "us-nh/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "8c689d1f40bbc0fe1b02e2331a7554673c87b3e6017ba2b59c3e1501b644f71f"
+      "sha256": "52c6cb9636b49f4bd2a306113771a49f0902dbc1600ad227ab48eb1aba4f5eee"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-pinned-3869",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,10 +21,10 @@
   "citation": "us-nh:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-21T15:45:46.878508+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa/sign-applied-files/us-nh/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpefs2kdqa",
-  "generated_output_sha256": "8c689d1f40bbc0fe1b02e2331a7554673c87b3e6017ba2b59c3e1501b644f71f",
+  "generated_at": "2026-07-23T20:41:53.661805+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp7ohsrknv/sign-applied-files/us-nh/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp7ohsrknv",
+  "generated_output_sha256": "52c6cb9636b49f4bd2a306113771a49f0902dbc1600ad227ab48eb1aba4f5eee",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,22 +34,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "98f9207fd3b13fadc58ae1ac52cb76266bcdab0ef02c1edb441a811cbb0de374"
+    "value": "4fe149e57f6e8a9e4b16c102438eab59c49109fc4c57884474bc0356ff930d37"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-21T15:44:47.907641+00:00",
+    "generated_at": "2026-07-21T15:45:46.878508+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "9eec2054266989ac3e14a450397dbb17aacdb9691c8254e7007170728a88f45b",
-    "prior_signature": "3405812719f10e61ea8b050d57720513a8e0b57a428d4272563b0e87d34af191",
+    "manifest_sha256": "1bc04355bede960f4f1d443a056161b8f2e9495b7d4ffb0277073693e99b4f74",
+    "prior_signature": "98f9207fd3b13fadc58ae1ac52cb76266bcdab0ef02c1edb441a811cbb0de374",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-16T16:01:06.954630+00:00",
+      "generated_at": "2026-07-21T15:44:47.907641+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "00bb33ee5b4ee5c103423c1a693dc0cb474a68072752d2c18f902e8fd11188a9",
-      "prior_signature": "c85acc5ae54c53a3237cbb826bed0817968415460b2159ff678b47d7271c1b66",
+      "manifest_sha256": "9eec2054266989ac3e14a450397dbb17aacdb9691c8254e7007170728a88f45b",
+      "prior_signature": "3405812719f10e61ea8b050d57720513a8e0b57a428d4272563b0e87d34af191",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-16T16:01:06.954630+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "00bb33ee5b4ee5c103423c1a693dc0cb474a68072752d2c18f902e8fd11188a9",
+        "prior_signature": "c85acc5ae54c53a3237cbb826bed0817968415460b2159ff678b47d7271c1b66",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/bulk/PROGRESS-us-state-income-tax-e2e.md
+++ b/bulk/PROGRESS-us-state-income-tax-e2e.md
@@ -1,0 +1,118 @@
+# US resident state income-tax end-to-end campaign
+
+Mission: extend the 44 jurisdiction-level individual-income-tax schedule
+pipelines into source-grounded tax-year 2026 resident-liability programs. The
+program boundary begins with federal return outputs and raw taxpayer facts and
+ends with state income tax after refundable and nonrefundable credits, before
+payments.
+
+The earlier 44-jurisdiction campaign remains useful schedule coverage, but its
+completed-return inputs (for example, completed state taxable income or a
+caller-supplied state credit) are not an end-to-end boundary.
+
+## Liability contract
+
+Every completed jurisdiction program with an imposed individual income tax
+must expose these semantic stages, using jurisdiction-prefixed RuleSpec output
+names:
+
+1. state income or adjusted gross income after state additions and
+   subtractions;
+2. state taxable income after the encoded deduction and exemption rules;
+3. tax before credits, including ordinary schedules and applicable surtaxes;
+4. tax after nonrefundable credits, floored at zero unless the controlling
+   authority provides a different ordering rule; and
+5. net state income-tax liability after refundable credits and before
+   withholding, estimated payments, extensions, penalties, interest, and
+   refunds of payments.
+
+The final stage may be negative when refundable credits exceed pre-credit tax.
+Each program manifest must expose the final output without listing it under
+`acknowledged_incomplete`.
+
+A jurisdiction whose individual income tax has been repealed or does not exist
+must not invent zero-dollar state-income or state-taxable-income concepts. Its
+program instead exposes the applicable liability stages and must prove from
+current authority that no resident individual income tax is imposed throughout
+the program period. The source and eval gates still apply, including a
+positive-control oracle probe when an oracle retains a disabled legacy model.
+
+### Allowed caller inputs
+
+- federal return outputs whose federal computation is outside the state
+  program, such as federal adjusted gross income, federal taxable income,
+  federal itemized deductions, and federal credit amounts when state law
+  explicitly uses them;
+- filing status, ages, disability or blindness facts, dependent and qualifying
+  child facts, residency facts fixed to the full-year-resident program scope,
+  and other raw eligibility facts;
+- raw income, loss, expense, contribution, and transaction facts needed by a
+  state-specific addition, subtraction, deduction, exemption, surtax, or
+  credit.
+
+### Prohibited completion shortcuts
+
+A program is not end to end if it requires a caller to supply:
+
+- completed state adjusted gross income or state taxable income;
+- a completed state deduction, exemption, surtax, or credit amount;
+- a state tax rate, bracket, threshold, phaseout, or indexed parameter; or
+- tax before or after credits.
+
+An explicitly named federal output remains allowed even when a state form
+copies that amount onto a state line. State parameters must come from encoded
+official authority, including the operative tax-year inflation adjustment.
+
+## Scope
+
+Included: full-year resident individual returns; state additions and
+subtractions; standard/itemized deductions; exemptions; ordinary income-tax
+schedules; state surtaxes; and refundable and nonrefundable state income-tax
+credits.
+
+Excluded unless required to determine state liability: withholding, estimated
+payments, extension payments, filing and collection administration, penalties,
+interest, local income taxes, nonresident sourcing/allocation, part-year
+allocation, and corporate or pass-through-entity-level taxes.
+
+## Completion gates
+
+A jurisdiction is complete only when all of the following are true:
+
+1. operative TY2026 official sources are present in the pinned corpus;
+2. the RuleSpec program satisfies the input and output contract above;
+3. focused tests cover every material stage, filing-status path, threshold
+   boundary, credit ordering rule, and refundable-credit sign behavior;
+4. a PolicyEngine, TAXSIM, official example, or independently calculated eval
+   suite is recorded, with source/oracle differences dispositioned rather than
+   hidden; a repealed/no-tax surface may instead carry a typed oracle exclusion
+   backed by a positive pre-repeal activation control and post-repeal zero
+   probes;
+5. strict source, proof, compile, and repository validation pass against the
+   pinned toolchain; and
+6. the mandatory independent review/fix cycle ends with no actionable finding.
+
+Missing TY2026 authority is a typed source hold. It is never permission to use
+a projected parameter as law or to mark a partial program complete.
+
+## Progress
+
+| Jurisdiction | State | Notes |
+| --- | --- | --- |
+| NH | complete | RSA Chapter 77 was repealed effective 2025-01-01, so state-income and taxable-income stages are legally inapplicable. The TY2026 program has no taxpayer inputs and returns zero at each applicable liability stage. `axiom-oracles` records the typed `oracle_models_repealed_law` exclusion and a positive 2024 interest/dividend activation control followed by exact-zero 2025/2026 probes. |
+| Remaining 43 | audit/implementation | Schedule pilots exist; upstream state base construction and/or credit surfaces remain to be encoded. |
+
+The first nonzero implementation lanes are selected by source readiness rather
+than alphabetical order:
+
+| Lane | Jurisdictions | Readiness |
+| --- | --- | --- |
+| Source-rich first wave | GA, NC, PA, MO, LA, DE, IA, WV, OK | Core statutes and the operative 2026 rate regime are present; ingest or verify the final-return instructions and credit schedules as each state starts. |
+| Source-rich follow-on | RI, MT, ND, NJ, HI, OR, SC, WI | Broad governing chapters are present, but the return chain or credit surface is larger. |
+| Partial-source buildout | AL, AR, AZ, CA, CT, DC, IL, IN, KS, KY, MA, MD, ME, MI, MN, MS, NE, NM, NY, OH, UT, VA | Important rate modules exist; additional statutes, forms, instructions, or indexed parameters are needed before completion. |
+| Explicit 2026 publication hold | CO, ID, VT, WA | A revenue-triggered rate/refund determination or official 2026 indexed parameter remains unpublished or absent from the pinned official corpus. |
+
+These lanes are planning order, not reduced scope. A source-rich state remains
+incomplete until specialty income, deductions, exemptions, surtaxes, and all
+applicable refundable and nonrefundable income-tax credits satisfy the
+completion gates.

--- a/programs/us-nh/income-tax/fy-2026.yaml
+++ b/programs/us-nh/income-tax/fy-2026.yaml
@@ -1,0 +1,14 @@
+# New Hampshire resident individual income tax -- TY 2026
+#
+# RSA Chapter 77 was repealed effective January 1, 2025. The complete resident
+# program therefore has no taxpayer inputs and returns zero at every liability
+# stage; it does not model the repeal as an active zero-rate tax.
+program: us-nh/income-tax
+period: 2026-01
+outputs:
+  - nh_pit_resident_income_tax_before_credits
+  - nh_pit_resident_income_tax_after_nonrefundable_credits
+  - nh_pit_resident_net_income_tax_liability
+scope:
+  state:
+    - policies/income_tax/pilot_liability_pipeline

--- a/us-nh/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nh/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,7 +1,9 @@
 # RSA Chapter 77 was repealed effective January 1, 2025, so the 2026 legal
-# result is no imposed tax rather than an active zero-percent schedule. All six
-# final outputs exactly match PolicyEngine's
-# nh_income_tax_before_refundable_credits for the standard wage grid.
+# result is no imposed tax rather than an active zero-percent schedule. These
+# input-free fixtures verify that the repeal result has no taxpayer-fact
+# boundary. The independent axiom-oracles repeal probe uses large positive
+# interest and dividend income as a 2024 activation control and verifies exact
+# zero before-refundable and final liability in 2025 and 2026.
 - name: single_30000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -9,6 +11,9 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_income_tax_before_credits: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_income_tax_after_nonrefundable_credits: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'
 - name: single_60000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -16,6 +21,7 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'
 - name: single_150000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -23,6 +29,7 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'
 - name: married_60000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -30,6 +37,7 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'
 - name: married_120000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -37,6 +45,7 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'
 - name: married_300000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input: {}
@@ -44,3 +53,6 @@
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_chapter_77_repealed: true
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_tax_imposed: false
     us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_pilot_income_tax_liability: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_income_tax_before_credits: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_income_tax_after_nonrefundable_credits: '0'
+    us-nh:policies/income_tax/pilot_liability_pipeline#nh_pit_resident_net_income_tax_liability: '0'

--- a/us-nh/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nh/policies/income_tax/pilot_liability_pipeline.yaml
@@ -15,15 +15,20 @@ module:
         the 2026 legal result as the absence of an imposed Chapter 77 tax. It
         does not represent repeal as an operative zero-percent rate schedule.
   summary: |-
-    New Hampshire RSA Chapter 77 repeal-result pipeline for tax year 2026. It
-    records that the chapter is repealed, derives that no Chapter 77 income tax
-    is imposed, and returns zero liability as the repeal's legal consequence.
-    This matches PolicyEngine 4.18.9 /
-    PolicyEngine-US 1.752.2 `nh_income_tax_before_refundable_credits` on the
-    standard six-case childless age-40 wage grid. PolicyEngine's legacy
-    `nh_taxable_income` machinery remains present but its `in_effect` parameter
-    is false at 2026; this module intentionally models the legal repeal rather
-    than that obsolete tax base or a fictional active zero-rate schedule.
+    Complete New Hampshire resident income-tax pipeline for tax year 2026. It
+    records that RSA Chapter 77 is repealed, derives that no Chapter 77 income
+    tax is imposed, and returns zero before credits, after nonrefundable
+    credits, and after refundable credits as the repeal's legal consequence.
+    Because no individual income tax is imposed, no taxpayer income, deduction,
+    exemption, or credit input can change the result.
+    PolicyEngine's legacy `nh_taxable_income` machinery remains present but its
+    `in_effect` parameter is false at 2026; this module intentionally models
+    the legal repeal rather than that obsolete tax base or a fictional active
+    zero-rate schedule. The current `axiom-oracles`
+    `scripts/probe_us_nh_repealed_income_tax.py` exclusion probe supplies large
+    positive interest and dividend income, establishes positive 2024 liability
+    as an activation control, and verifies exact-zero before-refundable and
+    final liability in 2025 and 2026.
 rules:
   - name: nh_pit_pilot_chapter_77_repealed
     kind: derived
@@ -71,6 +76,63 @@ rules:
     period: Year
     unit: USD
     source: RSA Title V, Chapter 77 repeal-result liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nh/statute/chapter-77
+              excerpt: "[Repealed by 2021, 91:189, II, eff. Jan. 1, 2025.]"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+
+  - name: nh_pit_resident_income_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: RSA Title V, no Chapter 77 resident income tax after repeal
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nh/statute/chapter-77
+              excerpt: "Entire Chapter was repealed"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+
+  - name: nh_pit_resident_income_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: RSA Title V, no Chapter 77 resident income tax or credit ordering after repeal
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nh/statute/chapter-77
+              excerpt: "Chapter 77 Repealed – Entire Chapter was repealed"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+
+  - name: nh_pit_resident_net_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: RSA Title V, final resident income-tax liability after Chapter 77 repeal and before payments
     metadata:
       proof:
         atoms:


### PR DESCRIPTION
## Summary

- define the TY2026 full-year resident state income-tax end-to-end contract and completion gates
- document source-ready lanes and explicit 2026 publication holds across the 44-jurisdiction campaign
- expose New Hampshire pre-credit, post-nonrefundable-credit, and final net liability as a complete no-tax program after RSA Chapter 77 repeal
- record the no-tax exception for legally inapplicable AGI/taxable-income stages and the existing axiom-oracles positive-control repeal probe

## Validation

- axiom-encode validate --skip-reviewers: pass
- axiom-encode proof-validate: pass (7 atoms)
- axiom-encode test: 6/6 cases pass
- guard-generated: pass
- oracle-coverage-pending: 1784 declared / 1784 applied / 0 stale / 0 problems
- program artifact build: 33/33 programs compile, including us-nh/income-tax
- git diff --check: pass

## Review-fix cycle

Independent review found two actionable issues: the contract initially lacked a no-tax exception for inapplicable income-base stages, and the completion claim did not point to a durable non-vacuous oracle evaluation. Both were fixed. The re-review confirmed the contract exception and the axiom-oracles positive 2024 interest/dividend activation control plus exact-zero 2025/2026 probe; no actionable findings remain.

## Scope

Full-year resident state individual income tax only. Payments, filing administration, local taxes, nonresident allocation, and corporate/pass-through-entity-level taxes remain excluded unless required to determine state liability.