### PR TITLE
Add Georgia 2026 resident household tax core

### DIFF
--- a/.axiom/encoding-manifests/us-ga/policies/income_tax/2026_resident_household_core.json
+++ b/.axiom/encoding-manifests/us-ga/policies/income_tax/2026_resident_household_core.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ga/policies/income_tax/2026_resident_household_core.test.yaml",
-      "sha256": "f23ea35f0432fdf3c445d8119183c8edbc043c41ee7d2cb2dbdbbb93a241b93c"
+      "sha256": "b7784539dbe811a69bcf04110bbddca6f7edc7fbeb3b13d8292c0aadbc449380"
     },
     {
       "path": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
-      "sha256": "91a2d4e80ed8e929848c5696b5634d83554e46a06db085a422fec20145506bb5"
+      "sha256": "25f3d47f8203c869f30ddbd24814ff36a44780e6c1ee5b011d7ebaa7e099d75d"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ga:policies/income_tax/2026_resident_household_core",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T20:58:23.253002+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpe4q1z9io/sign-applied-files/us-ga/policies/income_tax/2026_resident_household_core.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpe4q1z9io",
-  "generated_output_sha256": "91a2d4e80ed8e929848c5696b5634d83554e46a06db085a422fec20145506bb5",
+  "generated_at": "2026-07-23T21:14:53.295892+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjvoplnbi/sign-applied-files/us-ga/policies/income_tax/2026_resident_household_core.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjvoplnbi",
+  "generated_output_sha256": "25f3d47f8203c869f30ddbd24814ff36a44780e6c1ee5b011d7ebaa7e099d75d",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0c6343974d0bdc7178c2a492d3240f5d13ec6a076f1d78e42a00ad87bf8b8089"
+    "value": "5d3b71694eb2c3c5772fcd9a210b5c39b6cd1e66c5fdd6f1009309d81a0031b8"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-23T20:58:23.253002+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "7df929060fdd7a695fe14ecde93e3818cd3b9debc74c1d32b3823515f2eb0aa1",
+    "prior_signature": "0c6343974d0bdc7178c2a492d3240f5d13ec6a076f1d78e42a00ad87bf8b8089",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-ga/policies/income_tax/2026_resident_household_core.json
+++ b/.axiom/encoding-manifests/us-ga/policies/income_tax/2026_resident_household_core.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ga/policies/income_tax/2026_resident_household_core.test.yaml",
+      "sha256": "f23ea35f0432fdf3c445d8119183c8edbc043c41ee7d2cb2dbdbbb93a241b93c"
+    },
+    {
+      "path": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+      "sha256": "91a2d4e80ed8e929848c5696b5634d83554e46a06db085a422fec20145506bb5"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ga:policies/income_tax/2026_resident_household_core",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-23T20:58:23.253002+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpe4q1z9io/sign-applied-files/us-ga/policies/income_tax/2026_resident_household_core.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpe4q1z9io",
+  "generated_output_sha256": "91a2d4e80ed8e929848c5696b5634d83554e46a06db085a422fec20145506bb5",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0c6343974d0bdc7178c2a492d3240f5d13ec6a076f1d78e42a00ad87bf8b8089"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17596,6 +17596,13 @@
     ],
     "us-ga/form/it-511/2025/document-1": [
       {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ga/statutes/48/48-7A-3.yaml",
         "via": [
           "module",
@@ -17959,6 +17966,13 @@
       }
     ],
     "us-ga/statute/session-laws/2025/hb136/document-1": [
+      {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7-29/10.yaml",
         "via": [

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -17856,6 +17856,13 @@
     ],
     "us-ga/statute/48/48-7-20": [
       {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ga/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -17864,6 +17871,12 @@
       }
     ],
     "us-ga/statute/48/48-7-26": [
+      {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7-26.yaml",
         "via": [
@@ -17874,6 +17887,13 @@
     ],
     "us-ga/statute/48/48-7-27": [
       {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ga/statutes/48/48-7-27.yaml",
         "via": [
           "module",
@@ -17883,6 +17903,13 @@
     ],
     "us-ga/statute/48/48-7-29.10": [
       {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ga/statutes/48/48-7-29/10.yaml",
         "via": [
           "module",
@@ -17891,6 +17918,13 @@
       }
     ],
     "us-ga/statute/48/48-7A-3": [
+      {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7A-3.yaml",
         "via": [
@@ -17934,6 +17968,13 @@
       }
     ],
     "us-ga/statute/session-laws/2026/hb463/document-1": [
+      {
+        "module": "us-ga/policies/income_tax/2026_resident_household_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ga/statutes/48/48-7-20.yaml",
         "via": [

--- a/us-ga/policies/income_tax/2026_resident_household_core.test.yaml
+++ b/us-ga/policies/income_tax/2026_resident_household_core.test.yaml
@@ -15,6 +15,8 @@
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
@@ -48,6 +50,8 @@
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 2
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 2
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
@@ -77,6 +81,8 @@
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
@@ -92,9 +98,11 @@
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '199.6'
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_allowed: holds
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 4
-    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '5'
-    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '5'
-    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '194.6'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_exemption_units: 1
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_age_units: 1
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '10'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '10'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '189.6'
 
 - name: completed_adjustments_itemization_and_nol_are_applied
   period: *ty2026
@@ -107,6 +115,8 @@
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: true
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 25000
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 1
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 1
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 10000
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
@@ -138,6 +148,8 @@
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
@@ -151,16 +163,191 @@
   output:
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '1000'
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '49.9'
-    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '10'
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_child_and_dependent_care_credit: '49.9'
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_household_core_nonrefundable_credits: '49.9'
     us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '0'
 
-- name: lowest_low_income_credit_band
+- name: federal_agi_5999_is_band_zero
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 5999
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 0
+
+- name: federal_agi_6000_is_band_one
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 6000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 1
+
+- name: federal_agi_7999_is_band_one
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 7999
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 1
+
+- name: federal_agi_8000_is_band_two
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 8000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 2
+
+- name: federal_agi_9999_is_band_two
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 9999
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 2
+
+- name: federal_agi_10000_is_band_three
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 10000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 3
+
+- name: federal_agi_14999_is_band_three
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 14999
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 3
+
+- name: federal_agi_15000_is_band_four
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 15000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 4
+
+- name: federal_agi_19999_is_band_four
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 19999
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 4
+
+- name: federal_agi_20000_is_outside_schedule
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 20000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: -1
+
+- name: federal_agi_controls_band_when_georgia_agi_differs
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 5999
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 25000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_adjusted_gross_income: '30999'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 0
+
+- name: low_income_units_include_self_spouse_and_age_but_exclude_unborn
   period: *ty2026
   input:
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 5000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 3
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 3
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 1
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: true
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_caller_classified_dependents_amount: '15000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_exemption_units: 4
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_age_units: 2
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '156'
+
+- name: married_separate_uses_standard_deduction_and_joint_equivalent_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 16000
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
     us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 30
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 0
   output:
-    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 0
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_standard_deduction: 15000
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '1000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '30'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '30'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '19.9'
+
+- name: claimed_as_another_dependent_disqualifies_low_income_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_allowed: not_holds
+
+- name: food_stamp_allotment_disqualifies_low_income_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_allowed: not_holds
+
+- name: incarceration_disqualifies_low_income_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: true
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_allowed: not_holds
+
+- name: untimely_claim_waives_low_income_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 19000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_unborn_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: false
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '10'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '0'

--- a/us-ga/policies/income_tax/2026_resident_household_core.test.yaml
+++ b/us-ga/policies/income_tax/2026_resident_household_core.test.yaml
@@ -1,0 +1,166 @@
+# Hand-computed tax-year-2026 fixtures. This module intentionally stops before
+# unencoded other-state, eligible-itemizer, IND-CR, Schedule 2, and refundable
+# Schedule 2B credits.
+- name: single_standard_deduction_no_credits
+  period: &ty2026
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 50000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 0
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_adjusted_gross_income: '50000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_standard_deduction: 15000
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '35000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '1746.5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: -1
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '0'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '0'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_child_and_dependent_care_credit: '0'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_household_core_nonrefundable_credits: '0'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '1746.5'
+
+- name: joint_with_two_dependents_and_child_care_credit
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 80000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 2
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 1200
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_standard_deduction: 30000
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_caller_classified_dependents_amount: '10000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '40000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '1996'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_child_and_dependent_care_credit: '600'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '1396'
+
+- name: age_65_low_income_credit_reduces_positive_tax
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 19000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 0
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '4000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '199.6'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_allowed: holds
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 4
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_before_cap: '5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '194.6'
+
+- name: completed_adjustments_itemization_and_nol_are_applied
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 100000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 5000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 10000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 25000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 1
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 10000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 1000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_adjusted_gross_income: '95000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_deduction: '25000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_caller_classified_dependents_amount: '5000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_before_nol: '65000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '55000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '2744.5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_child_and_dependent_care_credit: '500'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '2244.5'
+
+- name: credits_cannot_reduce_household_core_below_zero
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 16000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_joint: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_filing_status_married_separate: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_itemizes: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_itemized_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_georgia_dependent_count: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_nol_deduction: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_received_food_stamp_allotment: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_incarcerated_or_confined: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_married_separate_when_joint_return_could_be_filed: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_joint_equivalent_low_income_credit: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_taxpayer_age_65_or_older: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_spouse_age_65_or_older: false
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_low_income_credit_claim_filed_timely: true
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_child_and_dependent_care_credit: 1000
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_taxable_net_income: '1000'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_before_credits: '49.9'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit: '5'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_child_and_dependent_care_credit: '49.9'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_household_core_nonrefundable_credits: '49.9'
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_income_tax_after_household_core_credits: '0'
+
+- name: lowest_low_income_credit_band
+  period: *ty2026
+  input:
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_federal_adjusted_gross_income: 5000
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_additions: 0
+    us-ga:policies/income_tax/2026_resident_household_core#input.ga_2026_resident_completed_georgia_subtractions: 0
+  output:
+    us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_low_income_credit_band: 0

--- a/us-ga/policies/income_tax/2026_resident_household_core.yaml
+++ b/us-ga/policies/income_tax/2026_resident_household_core.yaml
@@ -9,16 +9,20 @@ module:
       - us-ga/statute/48/48-7-27
       - us-ga/statute/48/48-7-29.10
       - us-ga/statute/48/48-7A-3
+      - us-ga/statute/session-laws/2025/hb136/document-1
       - us-ga/statute/session-laws/2026/hb463/document-1
+      - us-ga/form/it-511/2025/document-1
     upstream_source_check:
-      status: composed_from_supplied_current_authority
+      status: checked_higher_authority
       checked_paths:
         - us-ga/statute/48/48-7-20
         - us-ga/statute/48/48-7-26
         - us-ga/statute/48/48-7-27
         - us-ga/statute/48/48-7-29.10
         - us-ga/statute/48/48-7A-3
+        - us-ga/statute/session-laws/2025/hb136/document-1
         - us-ga/statute/session-laws/2026/hb463/document-1
+        - us-ga/form/it-511/2025/document-1
       rationale: |-
         The cited current Georgia authorities supply the 2026 individual rate,
         standard deductions, dependent-exemption amount, low-income credit,
@@ -29,6 +33,14 @@ module:
         boundaries. Those boundaries avoid inventing the many cross-referenced
         adjustment, itemization, NOL, and dependent-definition rules that the
         encoded section 48-7-27 and 48-7-26 modules truthfully defer.
+
+        The unchanged low-income-credit statute and latest official IT-511
+        worksheet establish that its schedule uses federal adjusted gross
+        income and separate credit units for self, spouse on a joint return,
+        natural or legally adopted children other than unborn dependents, and
+        taxpayer/spouse age 65 status. These units are distinct from the
+        caller-classified Georgia dependent count used for the income-tax
+        exemption deduction.
 
         Georgia DOR has not published the tax-year-2026 Form 500 and IT-511
         annual-return package in the pinned official corpus. The latest official
@@ -45,7 +57,8 @@ module:
     deduction is supplied; subtracts the enacted $5,000 amount for each
     caller-classified Georgia dependent and a completed Georgia NOL deduction;
     applies the enacted 4.99 percent rate; and subtracts the section 48-7A-3
-    low-income credit and section 48-7-29.10 child/dependent-care credit without
+    low-income credit based on federal AGI and its separate exemption/age
+    units, and the section 48-7-29.10 child/dependent-care credit, without
     taking the result below zero.
 
     The result is not complete annual liability. Other-state, eligible-itemizer,
@@ -315,23 +328,24 @@ rules:
     entity: TaxUnit
     dtype: Integer
     period: Year
-    source: O.C.G.A. § 48-7A-3(b), adjusted-gross-income band
+    source: O.C.G.A. § 48-7A-3(b) and 2025 IT-511 worksheet, federal-adjusted-gross-income band
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ga/statute/48/48-7A-3
+              corpus_citation_path: us-ga/form/it-511/2025/document-1
+              excerpt: "Credit Table: Federal Adjusted Gross Income Credit"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          if ga_2026_resident_adjusted_gross_income < agi_band_0_upper_bound: 0
-          else: if ga_2026_resident_adjusted_gross_income >= agi_band_1_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_1_upper_bound: 1
-          else: if ga_2026_resident_adjusted_gross_income >= agi_band_2_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_2_upper_bound: 2
-          else: if ga_2026_resident_adjusted_gross_income >= agi_band_3_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_3_upper_bound: 3
-          else: if ga_2026_resident_adjusted_gross_income >= agi_band_4_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_4_upper_bound: ga_2026_resident_low_income_last_band_index
+          if ga_2026_resident_federal_adjusted_gross_income < agi_band_0_upper_bound: 0
+          else: if ga_2026_resident_federal_adjusted_gross_income >= agi_band_1_lower_bound and ga_2026_resident_federal_adjusted_gross_income <= agi_band_1_upper_bound: 1
+          else: if ga_2026_resident_federal_adjusted_gross_income >= agi_band_2_lower_bound and ga_2026_resident_federal_adjusted_gross_income <= agi_band_2_upper_bound: 2
+          else: if ga_2026_resident_federal_adjusted_gross_income >= agi_band_3_lower_bound and ga_2026_resident_federal_adjusted_gross_income <= agi_band_3_upper_bound: 3
+          else: if ga_2026_resident_federal_adjusted_gross_income >= agi_band_4_lower_bound and ga_2026_resident_federal_adjusted_gross_income <= agi_band_4_upper_bound: ga_2026_resident_low_income_last_band_index
           else: -1
 
   - name: ga_2026_resident_low_income_last_band_index
@@ -355,6 +369,68 @@ rules:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: '4'
+
+  - name: ga_2026_resident_low_income_exemption_units
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 2025 IT-511 Low Income Credit Worksheet line 2, self, spouse, and natural or legally adopted children excluding unborn dependents
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/form/it-511/2025/document-1
+              excerpt: "Exemptions are self, spouse and natural or legally adopted children"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/form/it-511/2025/document-1
+              excerpt: "dependents do not include those unborn with a detectable heartbeat"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "A husband and wife filing a joint return shall each be deemed a dependent for purposes of such joint return"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          1
+          + (if ga_2026_resident_filing_status_joint: 1 else: 0)
+          + max(
+              0,
+              ga_2026_resident_low_income_natural_or_legally_adopted_child_count_including_unborn
+              - max(0, ga_2026_resident_low_income_unborn_dependent_count)
+            )
+
+  - name: ga_2026_resident_low_income_age_units
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: O.C.G.A. § 48-7A-3(b) and 2025 IT-511 Low Income Credit Worksheet line 3, taxpayer and spouse age-65 units
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              excerpt: "Each taxpayer 65 years of age or over may claim double the tax credit."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/form/it-511/2025/document-1
+              excerpt: "Enter 1 if you or your spouse is 65 or older; enter 2 if you and your spouse are 65 or older"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          (if ga_2026_resident_taxpayer_age_65_or_older: 1 else: 0)
+          + (if ga_2026_resident_spouse_age_65_or_older: 1 else: 0)
 
   - name: ga_2026_resident_low_income_credit_before_cap
     kind: derived
@@ -390,9 +466,8 @@ rules:
             else:
               credit_amount_per_dependent[ga_2026_resident_low_income_credit_band]
               * (
-                max(0, ga_2026_resident_georgia_dependent_count)
-                + (if ga_2026_resident_taxpayer_age_65_or_older: 1 else: 0)
-                + (if ga_2026_resident_spouse_age_65_or_older: 1 else: 0)
+                ga_2026_resident_low_income_exemption_units
+                + ga_2026_resident_low_income_age_units
               )
           else:
             0
@@ -433,7 +508,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: O.C.G.A. § 48-7-29.10(a)-(b), 50 percent of federal credit capped by Georgia tax
+    source: O.C.G.A. § 48-7-29.10(a)-(b), as amended by 2025 HB 136, 50 percent of federal credit capped by Georgia tax
     metadata:
       proof:
         atoms:
@@ -446,7 +521,7 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              corpus_citation_path: us-ga/statute/session-laws/2025/hb136/document-1
               excerpt: "50 percent of the amount of the credit provided for in Section 21 of the Internal Revenue Code"
           - path: versions[0].formula
             kind: exception

--- a/us-ga/policies/income_tax/2026_resident_household_core.yaml
+++ b/us-ga/policies/income_tax/2026_resident_household_core.yaml
@@ -1,0 +1,526 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ga/statute/48/48-7-20
+      - us-ga/statute/48/48-7-26
+      - us-ga/statute/48/48-7-27
+      - us-ga/statute/48/48-7-29.10
+      - us-ga/statute/48/48-7A-3
+      - us-ga/statute/session-laws/2026/hb463/document-1
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-ga/statute/48/48-7-20
+        - us-ga/statute/48/48-7-26
+        - us-ga/statute/48/48-7-27
+        - us-ga/statute/48/48-7-29.10
+        - us-ga/statute/48/48-7A-3
+        - us-ga/statute/session-laws/2026/hb463/document-1
+      rationale: |-
+        The cited current Georgia authorities supply the 2026 individual rate,
+        standard deductions, dependent-exemption amount, low-income credit,
+        and child/dependent-care credit. This composition starts with federal
+        adjusted gross income but preserves completed Georgia Schedule 1
+        additions and subtractions, completed Georgia itemized deductions, the
+        Georgia NOL deduction, and Georgia-dependent classification as caller
+        boundaries. Those boundaries avoid inventing the many cross-referenced
+        adjustment, itemization, NOL, and dependent-definition rules that the
+        encoded section 48-7-27 and 48-7-26 modules truthfully defer.
+
+        Georgia DOR has not published the tax-year-2026 Form 500 and IT-511
+        annual-return package in the pinned official corpus. The latest official
+        package is tax year 2025, whose Form 500 separately orders the
+        other-state tax credit, eligible-itemizer credit, IND-CR credits,
+        Schedule 2 credits, and Schedule 2B refundable credits. This module
+        therefore stops before those unencoded surfaces and does not label its
+        terminal amount final liability.
+  summary: |-
+    Georgia tax-year-2026 resident household-core income tax. The pipeline
+    starts from federal adjusted gross income; applies caller-supplied completed
+    Georgia additions and subtractions; selects the enacted $30,000 joint or
+    $15,000 other-filer standard deduction unless a completed Georgia itemized
+    deduction is supplied; subtracts the enacted $5,000 amount for each
+    caller-classified Georgia dependent and a completed Georgia NOL deduction;
+    applies the enacted 4.99 percent rate; and subtracts the section 48-7A-3
+    low-income credit and section 48-7-29.10 child/dependent-care credit without
+    taking the result below zero.
+
+    The result is not complete annual liability. Other-state, eligible-itemizer,
+    IND-CR, Schedule 2, and refundable Schedule 2B credits remain outside this
+    source-certified core pending the official 2026 Form 500/IT-511 package and
+    separate encoding of their eligibility and amount surfaces. The pipeline is
+    limited to full-year resident individual returns and tax year 2026.
+  deferred_outputs:
+    - output: us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_final_income_tax_before_payments
+      reason: |-
+        A truthful final-before-payments output requires the tax-year-2026 Form
+        500 and IT-511 ordering plus all applicable other-state,
+        eligible-itemizer, IND-CR, Schedule 2, and refundable Schedule 2B credit
+        computations. The pinned official corpus contains only the 2025 annual
+        return package, so the 2026 final surface cannot yet be certified.
+imports:
+  - us-ga:statutes/48/48-7-20#individual_income_tax_rate
+  - us-ga:statutes/48/48-7-26#dependent_exemption_amount
+  - us-ga:statutes/48/48-7-27#single_or_head_of_household_standard_deduction
+  - us-ga:statutes/48/48-7-27#married_separate_standard_deduction
+  - us-ga:statutes/48/48-7-27#married_joint_standard_deduction
+  - us-ga:statutes/48/48-7-29/10#child_and_dependent_care_credit_percentage
+  - us-ga:statutes/48/48-7A-3#agi_band_0_upper_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_1_lower_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_1_upper_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_2_lower_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_2_upper_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_3_lower_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_3_upper_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_4_lower_bound
+  - us-ga:statutes/48/48-7A-3#agi_band_4_upper_bound
+  - us-ga:statutes/48/48-7A-3#credit_amount_per_dependent
+rules:
+  - name: ga_2026_resident_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-27(a), federal adjusted gross income after completed Georgia additions and subtractions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Georgia taxable net income of an individual shall be the taxpayer's federal adjusted gross income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ga_2026_resident_federal_adjusted_gross_income
+          + ga_2026_resident_completed_georgia_additions
+          - ga_2026_resident_completed_georgia_subtractions
+
+  - name: ga_2026_resident_standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-27(a)(1)(B), 2026 standard deduction selected by filing status
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-27#single_or_head_of_household_standard_deduction
+              output: single_or_head_of_household_standard_deduction
+              hash: sha256:f9e733b5499754ed829bc6c7610eee597d0ae55ba7dbb1fbdec257859737038e
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-27#married_separate_standard_deduction
+              output: married_separate_standard_deduction
+              hash: sha256:f9e733b5499754ed829bc6c7610eee597d0ae55ba7dbb1fbdec257859737038e
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-27#married_joint_standard_deduction
+              output: married_joint_standard_deduction
+              hash: sha256:f9e733b5499754ed829bc6c7610eee597d0ae55ba7dbb1fbdec257859737038e
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "then a standard deduction as provided for in the following subparagraphs"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ga_2026_resident_filing_status_joint:
+            married_joint_standard_deduction
+          else:
+            if ga_2026_resident_filing_status_married_separate:
+              married_separate_standard_deduction
+            else:
+              single_or_head_of_household_standard_deduction
+
+  - name: ga_2026_resident_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-27(a)(1), completed Georgia itemized deduction or statutory standard deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "At the taxpayer's election, federal itemized deductions"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:policies/income_tax/2026_resident_household_core#ga_2026_resident_standard_deduction
+              output: ga_2026_resident_standard_deduction
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ga_2026_resident_itemizes:
+            max(0, ga_2026_resident_completed_georgia_itemized_deduction)
+          else:
+            ga_2026_resident_standard_deduction
+
+  - name: ga_2026_resident_caller_classified_dependents_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-26(b), 2026 dependent exemption amount times caller-classified Georgia dependents
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-26#dependent_exemption_amount
+              output: dependent_exemption_amount
+              hash: sha256:1a4ca8c47965b220316d028b9b07f90658e089d4e92492e945402338dad9a0f7
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
+              excerpt: "$5,000.00 for each dependent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          dependent_exemption_amount * max(0, ga_2026_resident_georgia_dependent_count)
+
+  - name: ga_2026_resident_income_before_nol
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-27(a), Georgia adjusted gross income less deductions and exemptions before completed Georgia NOL
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "less the sum of the amounts allowed the taxpayer as deductions and exemptions"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0,
+            ga_2026_resident_adjusted_gross_income
+            - ga_2026_resident_deduction
+            - ga_2026_resident_caller_classified_dependents_amount
+          )
+
+  - name: ga_2026_resident_taxable_net_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-27(a), income before NOL less completed Georgia NOL deduction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-27
+              excerpt: "Georgia taxable net income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0,
+            ga_2026_resident_income_before_nol
+            - max(0, ga_2026_resident_completed_georgia_nol_deduction)
+          )
+
+  - name: ga_2026_resident_income_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-20(a.1), 2026 tax on Georgia taxable net income before credits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-20#individual_income_tax_rate
+              output: individual_income_tax_rate
+              hash: sha256:3b14bace271098396b2e7f91054f8f5453fdd291c7ba60a776f47b1f55d5fd02
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-20
+              excerpt: "computed at the rate of 5.39 percent"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/session-laws/2026/hb463/document-1
+              excerpt: "4.99 percent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ga_2026_resident_taxable_net_income * individual_income_tax_rate
+
+  - name: ga_2026_resident_low_income_credit_allowed
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: O.C.G.A. § 48-7A-3(a), resident low-income-credit eligibility boundary
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          not ga_2026_resident_taxpayer_claimed_or_eligible_as_another_dependent
+          and not ga_2026_resident_received_food_stamp_allotment
+          and not ga_2026_resident_incarcerated_or_confined
+
+  - name: ga_2026_resident_low_income_credit_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: O.C.G.A. § 48-7A-3(b), adjusted-gross-income band
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ga_2026_resident_adjusted_gross_income < agi_band_0_upper_bound: 0
+          else: if ga_2026_resident_adjusted_gross_income >= agi_band_1_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_1_upper_bound: 1
+          else: if ga_2026_resident_adjusted_gross_income >= agi_band_2_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_2_upper_bound: 2
+          else: if ga_2026_resident_adjusted_gross_income >= agi_band_3_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_3_upper_bound: 3
+          else: if ga_2026_resident_adjusted_gross_income >= agi_band_4_lower_bound and ga_2026_resident_adjusted_gross_income <= agi_band_4_upper_bound: ga_2026_resident_low_income_last_band_index
+          else: -1
+
+  - name: ga_2026_resident_low_income_last_band_index
+    kind: parameter
+    dtype: Integer
+    period: Year
+    source: O.C.G.A. § 48-7A-3(b), zero-based index of the fifth and final low-income-credit schedule band
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              table:
+                header: "TAX CREDIT SCHEDULE Adjusted Gross Income Tax Credit"
+                row: "15,000.00 but not more than 19,999.00"
+                column: "fifth schedule row"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '4'
+
+  - name: ga_2026_resident_low_income_credit_before_cap
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7A-3(b), low-income schedule amount before liability cap
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7A-3#credit_amount_per_dependent
+              output: credit_amount_per_dependent
+              hash: sha256:be1408488645d51211fa5d43dcae6bed04b38abb8a1b9b40733f381ca4dff5b2
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+              table:
+                header: "TAX CREDIT SCHEDULE Adjusted Gross Income Tax Credit"
+                row_key: "ga_2026_resident_low_income_credit_band"
+                column_key: "tax_credit"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ga_2026_resident_low_income_credit_allowed and ga_2026_resident_low_income_credit_band >= 0:
+            if ga_2026_resident_married_separate_when_joint_return_could_be_filed:
+              max(0, ga_2026_resident_completed_joint_equivalent_low_income_credit)
+            else:
+              credit_amount_per_dependent[ga_2026_resident_low_income_credit_band]
+              * (
+                max(0, ga_2026_resident_georgia_dependent_count)
+                + (if ga_2026_resident_taxpayer_age_65_or_older: 1 else: 0)
+                + (if ga_2026_resident_spouse_age_65_or_older: 1 else: 0)
+              )
+          else:
+            0
+
+  - name: ga_2026_resident_low_income_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7A-3(c)-(d), timely low-income credit capped by tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ga_2026_resident_low_income_credit_claim_filed_timely:
+            min(
+              max(0, ga_2026_resident_income_tax_before_credits),
+              max(0, ga_2026_resident_low_income_credit_before_cap)
+            )
+          else:
+            0
+
+  - name: ga_2026_resident_child_and_dependent_care_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. § 48-7-29.10(a)-(b), 50 percent of federal credit capped by Georgia tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-ga:statutes/48/48-7-29/10#child_and_dependent_care_credit_percentage
+              output: child_and_dependent_care_credit_percentage
+              hash: sha256:4ac284f36e8cc5bcd4b905b01ce889bbd93f2fa09cf21dcacbb57581d9eb2c85
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "50 percent of the amount of the credit provided for in Section 21 of the Internal Revenue Code"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "In no event shall the total amount of the tax credit under this Code section for a taxable year exceed the taxpayer's income tax liability."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, ga_2026_resident_income_tax_before_credits),
+            child_and_dependent_care_credit_percentage
+            * max(0, ga_2026_resident_federal_child_and_dependent_care_credit)
+          )
+
+  - name: ga_2026_resident_household_core_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. §§ 48-7A-3 and 48-7-29.10, household-core credits limited to tax
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, ga_2026_resident_income_tax_before_credits),
+            ga_2026_resident_low_income_credit
+            + ga_2026_resident_child_and_dependent_care_credit
+          )
+
+  - name: ga_2026_resident_income_tax_after_household_core_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: O.C.G.A. §§ 48-7-20, 48-7A-3, and 48-7-29.10, tax after encoded household-core nonrefundable credits and before all other credits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-20
+              excerpt: "A tax is imposed upon every resident of this state with respect to the Georgia taxable net income of the taxpayer"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7A-3
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ga/statute/48/48-7-29.10
+              excerpt: "In no event shall the total amount of the tax credit under this Code section for a taxable year exceed the taxpayer's income tax liability."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            ga_2026_resident_income_tax_before_credits
+            - ga_2026_resident_household_core_nonrefundable_credits
+          )


### PR DESCRIPTION
## Summary

- adds a source-certified TY2026 full-year-resident Georgia household tax core
- computes from federal AGI through Georgia adjustments, deduction choice, dependent exemption, 4.99% tax, low-income credit, and child/dependent-care credit
- aligns with the merged state PIT end-to-end contract while explicitly deferring the unpublished specialty-credit surface

## Truthful boundary

This is not final Georgia liability before payments. The official TY2026 Form 500/IT-511 package is not published or present in the pinned corpus. Other-state, eligible-itemizer, IND-CR, Schedule 2, and Schedule 2B credits remain declared deferred outputs.

## Review-fix cycle

Independent review found and the branch fixed: use of Georgia instead of federal AGI for low-income bands; missing self/spouse/age units and unborn-dependent exclusion; stale proof for the 50% care credit; and insufficient boundary/status/disqualifier fixtures. Exact-head re-review at f1c93416583230e5dd1936c7df56a2c026c9753a returned no actionable findings.

## Checks

- validate: pass
- proof-validate: 35 atoms
- companion fixtures: 22/22
- pinned-engine compile: 74 rules
- signed-manifest guard: pass
- reverse index: fresh
- oracle-pending ratchet: 1784/1784, zero stale/problems
- focused repository tests: 9 passed
- git diff --check: pass