### PR TITLE
Add North Carolina 2026 resident tax core

### DIFF
--- a/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml",
-      "sha256": "3330a7d6f0bb66620b489ecf7a3c8cdcde371d6359e57f025899f772f760ef1b"
+      "sha256": "510e38412cff911193c95faa3589ccbc52933ea27ba5afc292932ae3e486c2da"
     },
     {
       "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
-      "sha256": "a675929db438eb1648838ae5047d912bb4fa8f17e3037d4c06ea17530aed73a9"
+      "sha256": "1cca7a1553f80cd647f8e964337afcf36c70d5938aecf9086a214f4d93bf7cc6"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-nc:policies/income_tax/resident_core_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T20:58:16.358719+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf51_6rv6/sign-applied-files/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf51_6rv6",
-  "generated_output_sha256": "a675929db438eb1648838ae5047d912bb4fa8f17e3037d4c06ea17530aed73a9",
+  "generated_at": "2026-07-23T21:10:53.476297+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjbnea399/sign-applied-files/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjbnea399",
+  "generated_output_sha256": "1cca7a1553f80cd647f8e964337afcf36c70d5938aecf9086a214f4d93bf7cc6",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,16 +34,34 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c9658ecffd59dc46ccc1fc5061f7b99536c9192869d0f4009c5c6377a9376ca0"
+    "value": "2f3d258f99dd3b5246c4c42e70e47b4b122f33fd8a66a5035e78d0bf987f88c7"
   },
   "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-23T20:58:01.740874+00:00",
+    "backend": "deterministic",
+    "generated_at": "2026-07-23T21:09:05.617645+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "3d391ee793bf779c4eefda7bf8dfeabbf10475fd6a11d2c4121db74db3c47606",
-    "prior_signature": "5c5659749ea23a6327d077c356054dd527c13130ccf1f11d23e85dec049d7c10",
-    "run_id": null,
-    "tool": "axiom-encode sign-applied-files"
+    "manifest_sha256": "f06a18b7964b47167ed1a0e19d17e54ebd2a09e9fe84ba15789fa2c2099d563b",
+    "prior_signature": "8f0a5dba4bb5321c81cc590310d9bbda5a884558308d58f60d5ae11b63b05417",
+    "run_id": "deterministic-repair",
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-23T20:58:16.358719+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "1f3f8ed1b053b5ef705052414cad5723a4c9f404e77f4dda436a8bef83b96bc3",
+      "prior_signature": "c9658ecffd59dc46ccc1fc5061f7b99536c9192869d0f4009c5c6377a9376ca0",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-23T20:58:01.740874+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "3d391ee793bf779c4eefda7bf8dfeabbf10475fd6a11d2c4121db74db3c47606",
+        "prior_signature": "5c5659749ea23a6327d077c356054dd527c13130ccf1f11d23e85dec049d7c10",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode repair-test-input-assignments"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml",
-      "sha256": "510e38412cff911193c95faa3589ccbc52933ea27ba5afc292932ae3e486c2da"
+      "sha256": "96d71b65aa72d610443c1cfdc38facd3cf3583735e2d4595fa2689dbf6fc5815"
     },
     {
       "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
-      "sha256": "1cca7a1553f80cd647f8e964337afcf36c70d5938aecf9086a214f4d93bf7cc6"
+      "sha256": "8be2982fa78201f49f853d21493dd7ef85d49a776660b2fb614f07be4818a4df"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-nc:policies/income_tax/resident_core_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T21:10:53.476297+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjbnea399/sign-applied-files/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjbnea399",
-  "generated_output_sha256": "1cca7a1553f80cd647f8e964337afcf36c70d5938aecf9086a214f4d93bf7cc6",
+  "generated_at": "2026-07-23T21:20:23.775019+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp1kr6llo_/sign-applied-files/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp1kr6llo_",
+  "generated_output_sha256": "8be2982fa78201f49f853d21493dd7ef85d49a776660b2fb614f07be4818a4df",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,30 +34,48 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2f3d258f99dd3b5246c4c42e70e47b4b122f33fd8a66a5035e78d0bf987f88c7"
+    "value": "ec448dc2906b9e9a65bb055b03bda66109e83e78599a53a6cf259c9be8a0b0e5"
   },
   "supersedes": {
     "backend": "deterministic",
-    "generated_at": "2026-07-23T21:09:05.617645+00:00",
+    "generated_at": "2026-07-23T21:18:34.767088+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "f06a18b7964b47167ed1a0e19d17e54ebd2a09e9fe84ba15789fa2c2099d563b",
-    "prior_signature": "8f0a5dba4bb5321c81cc590310d9bbda5a884558308d58f60d5ae11b63b05417",
+    "manifest_sha256": "e659a4e293fd0bd5f49aae45e4d1bb3a31e430442f4228511f488365b2478471",
+    "prior_signature": "7cd8356da93326c0023bff2a00cdc66f97f45a29d2f9e2fc647ea193d4bcf130",
     "run_id": "deterministic-repair",
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-23T20:58:16.358719+00:00",
+      "generated_at": "2026-07-23T21:10:53.476297+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "1f3f8ed1b053b5ef705052414cad5723a4c9f404e77f4dda436a8bef83b96bc3",
-      "prior_signature": "c9658ecffd59dc46ccc1fc5061f7b99536c9192869d0f4009c5c6377a9376ca0",
+      "manifest_sha256": "45e20a8e121f1cd5915c78f6c52c792d8d100b39ea7a60497596b96726c5f53d",
+      "prior_signature": "2f3d258f99dd3b5246c4c42e70e47b4b122f33fd8a66a5035e78d0bf987f88c7",
       "run_id": null,
       "supersedes": {
-        "backend": "manual",
-        "generated_at": "2026-07-23T20:58:01.740874+00:00",
+        "backend": "deterministic",
+        "generated_at": "2026-07-23T21:09:05.617645+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "3d391ee793bf779c4eefda7bf8dfeabbf10475fd6a11d2c4121db74db3c47606",
-        "prior_signature": "5c5659749ea23a6327d077c356054dd527c13130ccf1f11d23e85dec049d7c10",
-        "run_id": null,
-        "tool": "axiom-encode sign-applied-files"
+        "manifest_sha256": "f06a18b7964b47167ed1a0e19d17e54ebd2a09e9fe84ba15789fa2c2099d563b",
+        "prior_signature": "8f0a5dba4bb5321c81cc590310d9bbda5a884558308d58f60d5ae11b63b05417",
+        "run_id": "deterministic-repair",
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-23T20:58:16.358719+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "1f3f8ed1b053b5ef705052414cad5723a4c9f404e77f4dda436a8bef83b96bc3",
+          "prior_signature": "c9658ecffd59dc46ccc1fc5061f7b99536c9192869d0f4009c5c6377a9376ca0",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-23T20:58:01.740874+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "3d391ee793bf779c4eefda7bf8dfeabbf10475fd6a11d2c4121db74db3c47606",
+            "prior_signature": "5c5659749ea23a6327d077c356054dd527c13130ccf1f11d23e85dec049d7c10",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
+        "tool": "axiom-encode repair-test-input-assignments"
       },
       "tool": "axiom-encode sign-applied-files"
     },

--- a/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nc/policies/income_tax/resident_core_liability_pipeline.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml",
+      "sha256": "3330a7d6f0bb66620b489ecf7a3c8cdcde371d6359e57f025899f772f760ef1b"
+    },
+    {
+      "path": "us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
+      "sha256": "a675929db438eb1648838ae5047d912bb4fa8f17e3037d4c06ea17530aed73a9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-nc:policies/income_tax/resident_core_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-23T20:58:16.358719+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf51_6rv6/sign-applied-files/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpf51_6rv6",
+  "generated_output_sha256": "a675929db438eb1648838ae5047d912bb4fa8f17e3037d4c06ea17530aed73a9",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c9658ecffd59dc46ccc1fc5061f7b99536c9192869d0f4009c5c6377a9376ca0"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-23T20:58:01.740874+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "3d391ee793bf779c4eefda7bf8dfeabbf10475fd6a11d2c4121db74db3c47606",
+    "prior_signature": "5c5659749ea23a6327d077c356054dd527c13130ccf1f11d23e85dec049d7c10",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -25933,6 +25933,15 @@
         ]
       }
     ],
+    "us-nc/statute/105/105-153.5": [
+      {
+        "module": "us-nc/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-nc/statute/105/105-153.5/a": [
       {
         "module": "us-nc/statutes/105/105-153.5/a.yaml",

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -1,22 +1,30 @@
-# Integrated source-supported resident-core fixture. Every local fact is
-# explicit so proof-required evaluation cannot pass through implicit defaults.
 - name: joint resident itemized child and modification path
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 100000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: true
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 5000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 18000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 7000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 1000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 2
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 2000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
-    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 3000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
@@ -26,7 +34,8 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
-    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement: 4000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 4000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 6000
@@ -44,6 +53,8 @@
   output:
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_filing_status_index: 2
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 25500
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_eligible_charitable_contributions: '5000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_mortgage_and_property_tax_deduction: '20000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '26000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '26000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_band: 3
@@ -51,26 +62,36 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction: '3000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_additions: '5000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_other_deductions: '10000'
-    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_taxable_income: '66000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '66000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_tax_base: '66000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits: '2633.4'
-
 - name: zero resident core
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: -1000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
-    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
@@ -80,7 +101,8 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
-    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
@@ -97,10 +119,380 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
   output:
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_eligible_charitable_contributions: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_mortgage_and_property_tax_deduction: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_additions: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_other_deductions: '0'
-    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_taxable_income: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '-1000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_tax_base: '0'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits: '0'
+- name: single child threshold exact
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 20000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_filing_status_index: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 12750
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_band: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_per_child: 3000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '4250'
+- name: single child threshold just over
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 20000.01
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_band: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_per_child: 2500
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '4750.01'
+- name: head of household child deduction phased out
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 105001
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_filing_status_index: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 19125
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_band: 6
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_per_child: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '85876'
+- name: married separate combined cap proration
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 100000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 15000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 10000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 40000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0.4
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_mortgage_and_property_tax_deduction: '8000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '8000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '92000'
+- name: credit backed donation excluded from itemized deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 100000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 30000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 5000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_eligible_charitable_contributions: '25000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '25000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '25000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '75000'
+- name: mortgage and property amount exactly at cap
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 50000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 15000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 5000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_mortgage_and_property_tax_deduction: '20000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '20000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '20000'
+- name: all 2026 modification branches nonzero
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 50000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 1
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_additions: '11'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_other_deductions: '17'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '37244'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits: '1486.0356'

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -10,7 +10,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 5000
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 18000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 7000
@@ -77,7 +77,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
@@ -144,7 +144,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
@@ -202,7 +202,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
@@ -259,7 +259,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
@@ -321,7 +321,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
@@ -366,7 +366,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 100000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 30000
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 5000
     ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
     : 0
@@ -414,6 +414,121 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '25000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '25000'
     us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '75000'
+- name: limited credit-backed section 170 deduction preserves unrelated charitable
+    deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 50000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 7000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
+    : 2000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_eligible_charitable_contributions: '5000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '5000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '5000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '45000'
+- name: married separate combined amount below cap uses actual spouse deductions
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 50000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_married_separately: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 6000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 4000
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    : 18000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_mfs_cap_allocation_share: 0.1
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement
+    : 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_mortgage_and_property_tax_deduction: '10000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '10000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '10000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_modified_income_before_tax_base: '40000'
 - name: mortgage and property amount exactly at cap
   period:
     period_kind: tax_year
@@ -426,7 +541,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 5000
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
@@ -479,7 +594,7 @@
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 1
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
-    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_credit_backed_qualified_real_property_donation
+    ? us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     : 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
     us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -1,0 +1,106 @@
+# Integrated source-supported resident-core fixture. Every local fact is
+# explicit so proof-required evaluation cannot pass through implicit defaults.
+- name: joint resident itemized child and modification path
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 100000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: true
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 5000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 18000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 7000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 1000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 2
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 2000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 3000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement: 4000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 6000
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_filing_status_index: 2
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 25500
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '26000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '26000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_band: 3
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction_per_child: 1500
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction: '3000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_additions: '5000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_other_deductions: '10000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_taxable_income: '66000'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits: '2633.4'
+
+- name: zero resident core
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_adjusted_gross_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_joint_or_surviving_spouse: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_filing_status_head_of_household: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_for_federal_standard_deduction: false
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_charitable_contributions: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_qualified_residence_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_real_estate_property_taxes: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_medical_and_dental_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_claim_of_right_repayment_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_child_tax_credit_qualifying_children: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_other_state_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_s_corporation_built_in_gains_reduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_and_expensing_addback: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_net_operating_loss_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_nonqualified_education_withdrawal: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_deferred_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_opportunity_fund_step_up_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_income_allocated_expenses: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_excess_federal_nol_carryforward_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_loss_addition: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_obligation_interest: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_exempt_obligation_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxable_social_security_and_railroad_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_income_tax_refunds: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_bailey_retirement_benefits: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_uniformed_services_retirement: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_eligible_tribal_income: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_north_carolina_basis_excess: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_accelerated_depreciation_recovery: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_federal_credit_disallowed_business_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_employee_retention_credit_disallowed_expense: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_personal_education_student_account_deposit: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_disaster_relief_payment: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_economic_incentive_and_recovery_grants: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_state_net_operating_loss: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_previously_taxed_opportunity_fund_gain: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#input.nc_pit_2026_taxed_pass_through_income_deduction: 0
+  output:
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_standard_deduction: 0
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_itemized_deduction: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_deduction_amount: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_child_deduction: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_additions: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_statutory_other_deductions: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_taxable_income: '0'
+    us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits: '0'

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -27,8 +27,8 @@ module:
     It starts with federal adjusted gross income, adds and subtracts separately
     supplied amounts classified under the current section 105-153.5 branches,
     selects the larger supported standard or itemized deduction, computes the
-    current child deduction, floors North Carolina taxable income at zero, and
-    applies the section 105-153.7 rate.
+    current child deduction, preserves signed North Carolina taxable income,
+    and applies the section 105-153.7 rate to its nonnegative tax base.
 
     The result is tax before credits, not final liability. Current 2026 final
     forms and complete credit authority are absent from the pinned corpus, so
@@ -440,14 +440,77 @@ rules:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          max(0, nc_pit_2026_charitable_contributions)
-          + min(
+          nc_pit_2026_eligible_charitable_contributions
+          + nc_pit_2026_mortgage_and_property_tax_deduction
+          + max(0, nc_pit_2026_medical_and_dental_expenses)
+          + max(0, nc_pit_2026_claim_of_right_repayment_deduction)
+
+  - name: nc_pit_2026_eligible_charitable_contributions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a)(2)a, charitable contributions excluding credit-backed qualified real-property donations
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "A qualified donation that is the basis for an allocated credit under G.S. 105-153.11 is not eligible for a deduction under this subdivision."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            nc_pit_2026_charitable_contributions
+            - nc_pit_2026_credit_backed_qualified_real_property_donation
+          )
+
+  - name: nc_pit_2026_mortgage_and_property_tax_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a)(2)b, combined spousal cap and married-separate allocation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: ordering
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "For spouses filing as married filing separately or married filing jointly, the total mortgage interest and real estate taxes claimed by both spouses combined may not exceed twenty thousand dollars ($20,000)."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "these deductions must be prorated based on the percentage paid by each spouse"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nc_pit_2026_filing_status_married_separately:
+            if nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+              <= nc_pit_2026_mortgage_and_property_tax_cap:
+              max(
+                0,
+                nc_pit_2026_qualified_residence_interest
+                + nc_pit_2026_real_estate_property_taxes
+              )
+            else:
+              nc_pit_2026_mortgage_and_property_tax_cap
+              * nc_pit_2026_mfs_cap_allocation_share
+          else:
+            min(
               nc_pit_2026_mortgage_and_property_tax_cap,
               max(0, nc_pit_2026_qualified_residence_interest)
               + max(0, nc_pit_2026_real_estate_property_taxes)
             )
-          + max(0, nc_pit_2026_medical_and_dental_expenses)
-          + max(0, nc_pit_2026_claim_of_right_repayment_deduction)
 
   - name: nc_pit_2026_deduction_amount
     kind: derived
@@ -632,13 +695,13 @@ rules:
           + max(0, nc_pit_2026_previously_taxed_opportunity_fund_gain)
           + max(0, nc_pit_2026_taxed_pass_through_income_deduction)
 
-  - name: nc_pit_2026_taxable_income
+  - name: nc_pit_2026_modified_income_before_tax_base
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: N.C. Gen. Stat. 105-153.5, modified federal adjusted gross income less allowed deductions
+    source: N.C. Gen. Stat. 105-153.5, signed modified federal adjusted gross income less allowed deductions
     metadata:
       proof:
         atoms:
@@ -651,14 +714,32 @@ rules:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          max(
-            0,
-            nc_pit_2026_federal_adjusted_gross_income
-            + nc_pit_2026_statutory_additions
-            - nc_pit_2026_statutory_other_deductions
-            - nc_pit_2026_deduction_amount
-            - nc_pit_2026_child_deduction
-          )
+          nc_pit_2026_federal_adjusted_gross_income
+          + nc_pit_2026_statutory_additions
+          - nc_pit_2026_statutory_other_deductions
+          - nc_pit_2026_deduction_amount
+          - nc_pit_2026_child_deduction
+
+  - name: nc_pit_2026_tax_base
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Nonnegative base used to apply the section 105-153.7 rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "In calculating North Carolina taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, nc_pit_2026_modified_income_before_tax_base)
 
   - name: nc_pit_2026_income_tax_before_credits
     kind: derived
@@ -680,7 +761,7 @@ rules:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          nc_pit_2026_taxable_income * individual_income_tax_rate
+          nc_pit_2026_tax_base * individual_income_tax_rate
 
 inputs:
   - name: nc_pit_2026_federal_adjusted_gross_income
@@ -699,6 +780,11 @@ inputs:
     dtype: Judgment
     period: Year
     description: True only for head-of-household status; otherwise the narrow single or married-separate schedule applies.
+  - name: nc_pit_2026_filing_status_married_separately
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for married-separate status; used for the combined spousal itemized-deduction cap.
   - name: nc_pit_2026_eligible_for_federal_standard_deduction
     entity: TaxUnit
     dtype: Judgment
@@ -710,6 +796,12 @@ inputs:
     period: Year
     unit: USD
     description: Charitable contributions allowed under Code section 170 for the taxable year.
+  - name: nc_pit_2026_credit_backed_qualified_real_property_donation
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Qualified real-property donation that is the basis for an allocated section 105-153.11 credit and is therefore excluded from the deduction.
   - name: nc_pit_2026_qualified_residence_interest
     entity: TaxUnit
     dtype: Money
@@ -722,6 +814,17 @@ inputs:
     period: Year
     unit: USD
     description: Real-estate property taxes allowed under Code section 164.
+  - name: nc_pit_2026_mfs_combined_mortgage_interest_and_property_taxes
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Combined qualified residence interest and real-estate taxes claimed by both spouses on married-separate returns.
+  - name: nc_pit_2026_mfs_cap_allocation_share
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    description: Married-separate share of the combined cap based on percentage paid, or income share for joint obligations paid from joint accounts.
   - name: nc_pit_2026_medical_and_dental_expenses
     entity: TaxUnit
     dtype: Money

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -451,7 +451,7 @@ rules:
     dtype: Money
     period: Year
     unit: USD
-    source: N.C. Gen. Stat. 105-153.5(a)(2)a, charitable contributions excluding credit-backed qualified real-property donations
+    source: N.C. Gen. Stat. 105-153.5(a)(2)a, charitable contributions excluding the section 170 deduction attributable to a credit-backed qualified real-property donation
     metadata:
       proof:
         atoms:
@@ -467,7 +467,7 @@ rules:
           max(
             0,
             nc_pit_2026_charitable_contributions
-            - nc_pit_2026_credit_backed_qualified_real_property_donation
+            - nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
           )
 
   - name: nc_pit_2026_mortgage_and_property_tax_deduction
@@ -796,12 +796,12 @@ inputs:
     period: Year
     unit: USD
     description: Charitable contributions allowed under Code section 170 for the taxable year.
-  - name: nc_pit_2026_credit_backed_qualified_real_property_donation
+  - name: nc_pit_2026_section_170_deduction_attributable_to_credit_backed_donation
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Qualified real-property donation that is the basis for an allocated section 105-153.11 credit and is therefore excluded from the deduction.
+    description: Current-year federal section 170 deduction amount attributable to a qualified real-property donation that is the basis for an allocated section 105-153.11 credit; this deduction amount, rather than the donation's value, is excluded from the North Carolina charitable deduction.
   - name: nc_pit_2026_qualified_residence_interest
     entity: TaxUnit
     dtype: Money

--- a/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -1,0 +1,909 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-nc/statute/105/105-153.5
+    upstream_source_check:
+      status: composed_from_supplied_current_authority
+      checked_paths:
+        - us-nc/statute/105/105-153.5
+        - us-nc/statute/105/105-153.7
+      rationale: |-
+        The pinned official North Carolina statute supplies the tax-year-2026
+        adjusted-gross-income modifications, deduction amounts, child-deduction
+        table, and 3.99-percent rate. This module composes the resident core
+        calculation from federal adjusted gross income and separately supplied
+        statutory facts. It does not silently reuse a completed North Carolina
+        taxable-income boundary.
+
+        The pinned corpus does not contain a current tax-year-2026 final D-400,
+        D-401, D-400TC, or the complete current authority for every individual
+        credit. Its section 105-153.9 provision is expressly the version for
+        taxable years before 2023. The final liability-before-payments output is
+        therefore deferred. No refundable-credit or final-return claim is made.
+  summary: |-
+    North Carolina tax-year-2026 full-year resident core income-tax calculation.
+    It starts with federal adjusted gross income, adds and subtracts separately
+    supplied amounts classified under the current section 105-153.5 branches,
+    selects the larger supported standard or itemized deduction, computes the
+    current child deduction, floors North Carolina taxable income at zero, and
+    applies the section 105-153.7 rate.
+
+    The result is tax before credits, not final liability. Current 2026 final
+    forms and complete credit authority are absent from the pinned corpus, so
+    credits, payments, nonresident allocation, and final-return rounding remain
+    outside this source-supported core.
+  deferred_outputs:
+    - output: us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_resident_income_tax_before_payments
+      reason: |-
+        A complete tax-year-2026 final-return source package is not published in
+        or ingested into the pinned corpus. In particular, the available
+        section 105-153.9 provision is the pre-2023 version and NCDOR currently
+        publishes only the 2026 estimated-tax worksheet, not the 2026 D-400,
+        D-401, and D-400TC final-return materials.
+      source_values:
+        - us-nc:policies/income_tax/resident_core_liability_pipeline#nc_pit_2026_income_tax_before_credits
+imports:
+  - us-nc:statutes/105/105-153/7#individual_income_tax_rate
+rules:
+  - name: nc_pit_2026_narrow_status_index
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal index for the single or married-separate statutory row
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "based on the taxpayer's filing status"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0'}
+
+  - name: nc_pit_2026_head_status_index
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal index for the head-of-household statutory row
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "based on the taxpayer's filing status"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '1'}
+
+  - name: nc_pit_2026_joint_status_index
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal index for the joint or surviving-spouse statutory row
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "based on the taxpayer's filing status"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2'}
+
+  - name: nc_pit_2026_child_band_zero
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal first child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0'}
+
+  - name: nc_pit_2026_child_band_one
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal second child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '1'}
+
+  - name: nc_pit_2026_child_band_two
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal third child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2'}
+
+  - name: nc_pit_2026_child_band_three
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal fourth child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '3'}
+
+  - name: nc_pit_2026_child_band_four
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal fifth child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4'}
+
+  - name: nc_pit_2026_child_band_five
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal sixth child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '5'}
+
+  - name: nc_pit_2026_child_band_six
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: Internal fully phased-out child-deduction band index
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-nc/statute/105/105-153.5, excerpt: "The amount of the deduction is equal to the amount listed in the table below based on the taxpayer's adjusted gross income"}
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '6'}
+
+  - name: nc_pit_2026_standard_deduction_by_status
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: nc_pit_2026_filing_status_index
+    source: N.C. Gen. Stat. 105-153.5(a)(1), 2022-and-later standard deductions
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "Married, filing jointly/surviving spouse $25,500 Head of Household 19,125 Single 12,750 Married, filing separately 12,750"
+              table:
+                header: Filing Status Standard Deduction
+                row_key: filing_status
+                column_key: standard_deduction
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 12750
+          1: 19125
+          2: 25500
+
+  - name: nc_pit_2026_mortgage_and_property_tax_cap
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a)(2)b
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "The amount allowed under this sub-subdivision may not exceed twenty thousand dollars ($20,000)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '20000'
+
+  - name: nc_pit_2026_child_joint_upper_agi
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: nc_pit_2026_child_deduction_band
+    source: N.C. Gen. Stat. 105-153.5(a1), joint child-deduction AGI bands
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: married_joint_or_surviving_spouse
+                column_key: upper_agi
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 40000
+          1: 60000
+          2: 80000
+          3: 100000
+          4: 120000
+          5: 140000
+
+  - name: nc_pit_2026_child_head_upper_agi
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: nc_pit_2026_child_deduction_band
+    source: N.C. Gen. Stat. 105-153.5(a1), head-of-household child-deduction AGI bands
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: head_of_household
+                column_key: upper_agi
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 30000
+          1: 45000
+          2: 60000
+          3: 75000
+          4: 90000
+          5: 105000
+
+  - name: nc_pit_2026_child_narrow_upper_agi
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: nc_pit_2026_child_deduction_band
+    source: N.C. Gen. Stat. 105-153.5(a1), single and married-separate child-deduction AGI bands
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: single_or_married_separate
+                column_key: upper_agi
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 20000
+          1: 30000
+          2: 40000
+          3: 50000
+          4: 60000
+          5: 70000
+
+  - name: nc_pit_2026_child_deduction_by_band
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: nc_pit_2026_child_deduction_band
+    source: N.C. Gen. Stat. 105-153.5(a1), child deduction per qualifying child
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: agi_band
+                column_key: deduction_amount
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 3000
+          1: 2500
+          2: 2000
+          3: 1500
+          4: 1000
+          5: 500
+          6: 0
+
+  - name: nc_pit_2026_filing_status_index
+    kind: derived
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    source: Filing-status selector for section 105-153.5(a)(1)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "based on the taxpayer's filing status"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nc_pit_2026_filing_status_joint_or_surviving_spouse:
+            nc_pit_2026_joint_status_index
+          else: if nc_pit_2026_filing_status_head_of_household:
+            nc_pit_2026_head_status_index
+          else:
+            nc_pit_2026_narrow_status_index
+
+  - name: nc_pit_2026_standard_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a)(1), 2022-and-later standard deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "The standard deduction amount is zero"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if not nc_pit_2026_eligible_for_federal_standard_deduction:
+            0
+          else:
+            nc_pit_2026_standard_deduction_by_status[nc_pit_2026_filing_status_index]
+
+  - name: nc_pit_2026_itemized_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a)(2), supported North Carolina itemized deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "An amount equal to the sum of the items listed in this subdivision."
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "The amount allowed under this sub-subdivision may not exceed twenty thousand dollars ($20,000)."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, nc_pit_2026_charitable_contributions)
+          + min(
+              nc_pit_2026_mortgage_and_property_tax_cap,
+              max(0, nc_pit_2026_qualified_residence_interest)
+              + max(0, nc_pit_2026_real_estate_property_taxes)
+            )
+          + max(0, nc_pit_2026_medical_and_dental_expenses)
+          + max(0, nc_pit_2026_claim_of_right_repayment_deduction)
+
+  - name: nc_pit_2026_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a), taxpayer may deduct the standard or itemized amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "a taxpayer may deduct from adjusted gross income either the standard deduction amount provided in subdivision (1) of this subsection or the itemized deduction amount provided in subdivision (2)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(nc_pit_2026_standard_deduction, nc_pit_2026_itemized_deduction)
+
+  - name: nc_pit_2026_child_deduction_per_child
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a1), current child-deduction table
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "A taxpayer who is allowed a federal child tax credit under section 24 of the Code for the taxable year is allowed a deduction under this subsection for each qualifying child"
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: filing_status_and_agi
+                column_key: deduction_amount
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          nc_pit_2026_child_deduction_by_band[nc_pit_2026_child_deduction_band]
+
+  - name: nc_pit_2026_child_deduction_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    source: N.C. Gen. Stat. 105-153.5(a1), filing-status and AGI band
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              table:
+                header: Filing Status AGI Deduction Amount
+                row_key: filing_status_and_agi
+                column_key: deduction_amount
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if nc_pit_2026_filing_status_joint_or_surviving_spouse:
+            if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_zero]: nc_pit_2026_child_band_zero
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_one]: nc_pit_2026_child_band_one
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_two]: nc_pit_2026_child_band_two
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_three]: nc_pit_2026_child_band_three
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_four]: nc_pit_2026_child_band_four
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_joint_upper_agi[nc_pit_2026_child_band_five]: nc_pit_2026_child_band_five
+            else: nc_pit_2026_child_band_six
+          else: if nc_pit_2026_filing_status_head_of_household:
+            if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_zero]: nc_pit_2026_child_band_zero
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_one]: nc_pit_2026_child_band_one
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_two]: nc_pit_2026_child_band_two
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_three]: nc_pit_2026_child_band_three
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_four]: nc_pit_2026_child_band_four
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_head_upper_agi[nc_pit_2026_child_band_five]: nc_pit_2026_child_band_five
+            else: nc_pit_2026_child_band_six
+          else:
+            if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_zero]: nc_pit_2026_child_band_zero
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_one]: nc_pit_2026_child_band_one
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_two]: nc_pit_2026_child_band_two
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_three]: nc_pit_2026_child_band_three
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_four]: nc_pit_2026_child_band_four
+            else: if nc_pit_2026_federal_adjusted_gross_income <= nc_pit_2026_child_narrow_upper_agi[nc_pit_2026_child_band_five]: nc_pit_2026_child_band_five
+            else: nc_pit_2026_child_band_six
+
+  - name: nc_pit_2026_child_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(a1), per-child deduction for federal section 24 qualifying children
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "allowed a deduction under this subsection for each qualifying child for whom the taxpayer is allowed the federal tax credit"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, nc_pit_2026_federal_child_tax_credit_qualifying_children)
+          * nc_pit_2026_child_deduction_per_child
+
+  - name: nc_pit_2026_statutory_additions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(c), (c2), and (c3), tax-year-2026 additions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "In calculating North Carolina taxable income, a taxpayer must add to the taxpayer's adjusted gross income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, nc_pit_2026_other_state_obligation_interest)
+          + max(0, nc_pit_2026_s_corporation_built_in_gains_reduction)
+          + max(0, nc_pit_2026_federal_basis_excess)
+          + max(0, nc_pit_2026_accelerated_depreciation_and_expensing_addback)
+          + max(0, nc_pit_2026_federal_net_operating_loss_deduction)
+          + max(0, nc_pit_2026_nonqualified_education_withdrawal)
+          + max(0, nc_pit_2026_opportunity_fund_deferred_gain)
+          + max(0, nc_pit_2026_opportunity_fund_step_up_gain)
+          + max(0, nc_pit_2026_exempt_income_allocated_expenses)
+          + max(0, nc_pit_2026_excess_federal_nol_carryforward_deduction)
+          + max(0, nc_pit_2026_taxed_pass_through_loss_addition)
+
+  - name: nc_pit_2026_statutory_other_deductions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5(b), (c2), and (c3), tax-year-2026 deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "In calculating North Carolina taxable income, a taxpayer may deduct from the taxpayer's adjusted gross income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(0, nc_pit_2026_eligible_obligation_interest)
+          + max(0, nc_pit_2026_exempt_obligation_gain)
+          + max(0, nc_pit_2026_taxable_social_security_and_railroad_retirement)
+          + max(0, nc_pit_2026_income_tax_refunds)
+          + max(0, nc_pit_2026_bailey_retirement_benefits)
+          + max(0, nc_pit_2026_eligible_uniformed_services_retirement)
+          + max(0, nc_pit_2026_eligible_tribal_income)
+          + max(0, nc_pit_2026_north_carolina_basis_excess)
+          + max(0, nc_pit_2026_accelerated_depreciation_recovery)
+          + max(0, nc_pit_2026_federal_credit_disallowed_business_expense)
+          + max(0, nc_pit_2026_employee_retention_credit_disallowed_expense)
+          + max(0, nc_pit_2026_personal_education_student_account_deposit)
+          + max(0, nc_pit_2026_disaster_relief_payment)
+          + max(0, nc_pit_2026_economic_incentive_and_recovery_grants)
+          + max(0, nc_pit_2026_state_net_operating_loss)
+          + max(0, nc_pit_2026_previously_taxed_opportunity_fund_gain)
+          + max(0, nc_pit_2026_taxed_pass_through_income_deduction)
+
+  - name: nc_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.5, modified federal adjusted gross income less allowed deductions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-nc/statute/105/105-153.5
+              excerpt: "In calculating North Carolina taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            nc_pit_2026_federal_adjusted_gross_income
+            + nc_pit_2026_statutory_additions
+            - nc_pit_2026_statutory_other_deductions
+            - nc_pit_2026_deduction_amount
+            - nc_pit_2026_child_deduction
+          )
+
+  - name: nc_pit_2026_income_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: N.C. Gen. Stat. 105-153.7(a), 3.99 percent of North Carolina taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
+              output: individual_income_tax_rate
+              hash: sha256:c0306fd55fd67ea700a1abdc65cdbfa473c781522aa15e9f4d2b4fecc2277e0d
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          nc_pit_2026_taxable_income * individual_income_tax_rate
+
+inputs:
+  - name: nc_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income for the resident tax unit.
+  - name: nc_pit_2026_filing_status_joint_or_surviving_spouse
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for married-joint or surviving-spouse status.
+  - name: nc_pit_2026_filing_status_head_of_household
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: True only for head-of-household status; otherwise the narrow single or married-separate schedule applies.
+  - name: nc_pit_2026_eligible_for_federal_standard_deduction
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Eligibility for a federal standard deduction under Code section 63.
+  - name: nc_pit_2026_charitable_contributions
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Charitable contributions allowed under Code section 170 for the taxable year.
+  - name: nc_pit_2026_qualified_residence_interest
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Qualified residence interest allowed under Code section 163(h).
+  - name: nc_pit_2026_real_estate_property_taxes
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Real-estate property taxes allowed under Code section 164.
+  - name: nc_pit_2026_medical_and_dental_expenses
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Medical and dental expense deduction allowed under Code section 213.
+  - name: nc_pit_2026_claim_of_right_repayment_deduction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Claim-of-right repayment deduction computed under section 105-153.5(a)(2)d.
+  - name: nc_pit_2026_federal_child_tax_credit_qualifying_children
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    description: Children for whom the taxpayer is allowed the federal section 24 child tax credit.
+  - name: nc_pit_2026_other_state_obligation_interest
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Interest on obligations of other states included by section 105-153.5(c)(1).
+  - name: nc_pit_2026_s_corporation_built_in_gains_reduction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Section 105-153.5(c)(2) S-corporation built-in-gains reduction.
+  - name: nc_pit_2026_federal_basis_excess
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal-over-State basis difference required by section 105-153.5(c)(3).
+  - name: nc_pit_2026_accelerated_depreciation_and_expensing_addback
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Current section 105-153.6 accelerated-depreciation and expensing add-back.
+  - name: nc_pit_2026_federal_net_operating_loss_deduction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal NOL deduction required to be added under section 105-153.5(c)(6).
+  - name: nc_pit_2026_nonqualified_education_withdrawal
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Previously deducted nonqualified education withdrawal under section 105-153.5(c)(7).
+  - name: nc_pit_2026_opportunity_fund_deferred_gain
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Opportunity-fund deferred gain add-back under section 105-153.5(c2)(5).
+  - name: nc_pit_2026_opportunity_fund_step_up_gain
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Opportunity-fund basis step-up gain add-back under section 105-153.5(c2)(7).
+  - name: nc_pit_2026_exempt_income_allocated_expenses
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Expenses allocable to exempt income under section 105-153.5(c2)(20).
+  - name: nc_pit_2026_excess_federal_nol_carryforward_deduction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Excess federal NOL carryforward deduction under section 105-153.5(c2)(13).
+  - name: nc_pit_2026_taxed_pass_through_loss_addition
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Taxed S-corporation or partnership loss addition under section 105-153.5(c3).
+  - name: nc_pit_2026_eligible_obligation_interest
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible obligation interest deduction under section 105-153.5(b)(1).
+  - name: nc_pit_2026_exempt_obligation_gain
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible pre-July-1995 obligation gain under section 105-153.5(b)(2).
+  - name: nc_pit_2026_taxable_social_security_and_railroad_retirement
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Taxable Social Security and Railroad Retirement benefits under section 105-153.5(b)(3).
+  - name: nc_pit_2026_income_tax_refunds
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: State, local, and foreign income-tax refunds included in federal AGI.
+  - name: nc_pit_2026_bailey_retirement_benefits
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Court-order-exempt government retirement benefits under section 105-153.5(b)(5).
+  - name: nc_pit_2026_eligible_uniformed_services_retirement
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible uniformed-services retirement or survivor-plan payments under section 105-153.5(b)(5a).
+  - name: nc_pit_2026_eligible_tribal_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible tribal income under section 105-153.5(b)(6).
+  - name: nc_pit_2026_north_carolina_basis_excess
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: State-over-federal basis difference under section 105-153.5(b)(7).
+  - name: nc_pit_2026_accelerated_depreciation_recovery
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Current section 105-153.6 depreciation or expensing recovery deduction.
+  - name: nc_pit_2026_federal_credit_disallowed_business_expense
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Business expense disallowed because of a federal credit under section 105-153.5(b)(11).
+  - name: nc_pit_2026_employee_retention_credit_disallowed_expense
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Expense disallowed because of the federal employee-retention credit.
+  - name: nc_pit_2026_personal_education_student_account_deposit
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible personal education student account deposit.
+  - name: nc_pit_2026_disaster_relief_payment
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible State disaster-relief payment.
+  - name: nc_pit_2026_economic_incentive_and_recovery_grants
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Eligible economic-incentive and recovery-grant amounts.
+  - name: nc_pit_2026_state_net_operating_loss
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: State net operating loss allowed under section 105-153.5A.
+  - name: nc_pit_2026_previously_taxed_opportunity_fund_gain
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Opportunity-fund gain previously included in North Carolina taxable income.
+  - name: nc_pit_2026_taxed_pass_through_income_deduction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Taxed S-corporation or partnership income deduction under section 105-153.5(c3).


### PR DESCRIPTION
## Summary

- adds a source-certified TY2026 full-year-resident North Carolina tax core
- computes from federal AGI through current additions, deductions, child deduction, nonnegative tax base, and the 3.99% tax before credits
- covers all filing-status branches, modification branches, mortgage/property cap allocation, and the 2025-2026 charitable-deduction exclusion

## Truthful boundary

This is not final North Carolina liability before payments. NCDOR has not published TY2026 D-400, D-401, or D-400TC final-return materials, and the pinned corpus version of §105-153.9 is the obsolete pre-2023 credit text. Credits and final-return ordering remain explicitly deferred.

## Review-fix cycle

The independent cycle found and fixed signed-income flooring, MFS cap handling, the current charitable-deduction exclusion, incomplete boundary/status coverage, deduction-attribution semantics for credit-backed property, and an untested MFS under-cap branch. Same-reviewer exact-content re-review at a77355c9b4349c93e0a144b81f3ef2ebcbe1be82 returned no actionable findings. After Georgia merged, the branch was mechanically rebased to current head c294a83ec0bb4fe259e7e5757997ac4be6aecf08; the reviewed RuleSpec and test hashes remained exact, and focused checks were rerun.

## Checks

- validate: pass
- proof-validate: 32 atoms / 6 money obligations / 0 missing
- companion fixtures: 11/11
- pinned-engine compile: 34 rules
- PolicyEngine classification: 60 unsupported, 0 unmapped
- signed-manifest guard: pass
- reverse index: fresh on current main
- unfiltered oracle-pending ratchet: 1784/1784, zero stale/problems
- focused repository tests: 12 passed
- git diff --check: pass