### PR TITLE
Add Pennsylvania 2026 resident tax core

### DIFF
--- a/.axiom/encoding-manifests/us-pa/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-pa/policies/income_tax/resident_core_liability_pipeline.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml",
-      "sha256": "c2a7542a7a296dbe6f5a8ab6fec664999dde9db14f41b825d9e7874643925dfd"
+      "sha256": "e35f5f1c79484d26f06ff63e00ba230f4cefa5328a1febbafa4f8eb078e3be0f"
     },
     {
       "path": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
-      "sha256": "3a901c741d962305beee25ac90178e1ee901942e510dd20dae490e24cca703d1"
+      "sha256": "cb154737cd58ba6384a7ab173219c3cbeaebe353aa8efc0745fc6bc7cb2a8e4e"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-pa:policies/income_tax/resident_core_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T21:30:33.043002+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp55v6mqc9/sign-applied-files/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp55v6mqc9",
-  "generated_output_sha256": "3a901c741d962305beee25ac90178e1ee901942e510dd20dae490e24cca703d1",
+  "generated_at": "2026-07-23T21:42:18.886900+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_38f9ftb/sign-applied-files/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_38f9ftb",
+  "generated_output_sha256": "cb154737cd58ba6384a7ab173219c3cbeaebe353aa8efc0745fc6bc7cb2a8e4e",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,15 +34,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "0104b462924d54c0128cd83579d7b437938ba6bf85f4ffab284f5b4c736cacc2"
+    "value": "97571485488b32dcb0d4e19c04733a868bf2e3a1e528bcfa9cce77e6b12acf28"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-23T21:24:23.259983+00:00",
+    "generated_at": "2026-07-23T21:30:33.043002+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "920b84e56291f5103204cb243bb2602b9656e997cefa479ce40791cd886e55bb",
-    "prior_signature": "81c04f9a332019f595c51a8683efdc88516d76a465f59ebe1e2cde9bfedb8051",
+    "manifest_sha256": "834256ae01ef2f82bb2affeba6097206e58cbddc0c8ea478b4ee224a46fdaf12",
+    "prior_signature": "0104b462924d54c0128cd83579d7b437938ba6bf85f4ffab284f5b4c736cacc2",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-23T21:24:23.259983+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "920b84e56291f5103204cb243bb2602b9656e997cefa479ce40791cd886e55bb",
+      "prior_signature": "81c04f9a332019f595c51a8683efdc88516d76a465f59ebe1e2cde9bfedb8051",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/.axiom/encoding-manifests/us-pa/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-pa/policies/income_tax/resident_core_liability_pipeline.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml",
+      "sha256": "c2a7542a7a296dbe6f5a8ab6fec664999dde9db14f41b825d9e7874643925dfd"
+    },
+    {
+      "path": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+      "sha256": "3a901c741d962305beee25ac90178e1ee901942e510dd20dae490e24cca703d1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-pa:policies/income_tax/resident_core_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-23T21:30:33.043002+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp55v6mqc9/sign-applied-files/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp55v6mqc9",
+  "generated_output_sha256": "3a901c741d962305beee25ac90178e1ee901942e510dd20dae490e24cca703d1",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0104b462924d54c0128cd83579d7b437938ba6bf85f4ffab284f5b4c736cacc2"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-23T21:24:23.259983+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "920b84e56291f5103204cb243bb2602b9656e997cefa479ce40791cd886e55bb",
+    "prior_signature": "81c04f9a332019f595c51a8683efdc88516d76a465f59ebe1e2cde9bfedb8051",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -26643,6 +26643,15 @@
         ]
       }
     ],
+    "us-pa/statute/act-1971-2/article-3/section-301": [
+      {
+        "module": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-pa/statute/act-1971-2/article-3/section-302": [
       {
         "module": "us-pa/policies/income_tax/2026_rate_table.yaml",
@@ -26653,6 +26662,40 @@
       },
       {
         "module": "us-pa/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-pa/statute/act-1971-2/article-3/section-303": [
+      {
+        "module": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-pa/statute/act-1971-2/article-3/section-304": [
+      {
+        "module": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-pa/statute/act-1971-2/article-3/section-314": [
+      {
+        "module": "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1784
+ceiling: 1808
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -2054,6 +2054,78 @@ entries:
 - legal_id: us-pa:policies/income_tax/pilot_liability_pipeline#pa_pit_pilot_taxable_income
   source: manual
   since: '2026-07-16'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_claimant_treated_as_married_for_poverty_forgiveness
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_income_after_qualified_tuition_program_deduction
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_married_claimant_base_poverty_income_limit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_credit_limit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_tax_credit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_excess_upper_bound_by_band
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_amount
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate_by_band
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income_allowance_per_dependent
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income_limit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_contribution_is_positive
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction_per_beneficiary
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_before_annual_deductions
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_single_claimant_base_poverty_income_limit
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction
+  source: manual
+  since: '2026-07-23'
+- legal_id: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction_cap
+  source: manual
+  since: '2026-07-23'
 - legal_id: us-ri:policies/income_tax/pilot_liability_pipeline#ri_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-15'

--- a/us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -94,6 +94,24 @@
     us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction: '2500'
     us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income: '7500'
 
+- name: loss_in_one_income_class_does_not_offset_another_class
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: -5000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_before_annual_deductions: '10000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income: '10000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits: '307'
+
 - name: poverty_income_subtracts_each_statutory_exclusion
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:

--- a/us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-pa/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -1,0 +1,280 @@
+# Hand-calculated statutory fixtures for the source-certified TY2026 resident
+# core. These tests intentionally stop before the unresolved combination and
+# refundable-credit surface described in the module's deferred outputs.
+
+- name: positive_qualified_tuition_contribution_per_beneficiary_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 25000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 19000
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_contribution_is_positive: holds
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction_per_beneficiary: '19000'
+
+- name: eight_income_classes_and_uncapped_deductions
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 40000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 5000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: 1000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 2000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 300
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 400
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 500
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 800
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 1000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit:
+      - us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 2000
+        us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 19000
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_before_annual_deductions: '50000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction: '2000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction: '1000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income: '47000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits: '1442.9'
+
+- name: qualified_tuition_cap_is_per_beneficiary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 100000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit:
+      - us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 25000
+        us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 19000
+      - us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 5000
+        us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 19000
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction: '24000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_income_after_qualified_tuition_program_deduction: '76000'
+
+- name: deductions_cannot_reduce_taxable_income_below_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 3000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 4000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit:
+      - us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 2000
+        us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 19000
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_qualified_tuition_program_deduction: '2000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction: '1000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income: '0'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits: '0'
+
+- name: student_loan_interest_statutory_cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 4000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: &zero_qtp_relation
+      - us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualified_tuition_contribution_paid: 0
+        us-pa:policies/income_tax/resident_core_liability_pipeline#input.federal_section_2503_b_annual_gift_exclusion_amount: 0
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction: '2500'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_taxable_income: '7500'
+
+- name: poverty_income_subtracts_each_statutory_exclusion
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 17000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_periodic_sickness_and_disability_payments: 100
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_workers_compensation_and_similar_payments: 200
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_old_age_and_retirement_benefits: 300
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_public_assistance_and_unemployment_compensation: 400
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_actual_expense_reimbursements: 500
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_employer_or_union_benefit_program_payments: 600
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_combat_zone_compensation: 700
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income: '14200'
+
+- name: single_with_one_dependent_at_full_forgiveness_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: &resident_zero_inputs
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_profits: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_gains_from_property: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_rents_royalties_patents_and_copyrights: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_dividends: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_interest_and_similar_receipts: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_taxable_gambling_and_lottery_winnings: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_net_income_from_estates_and_trusts: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_student_loan_interest_paid: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_periodic_sickness_and_disability_payments: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_workers_compensation_and_similar_payments: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_old_age_and_retirement_benefits: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_public_assistance_and_unemployment_compensation: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_actual_expense_reimbursements: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_employer_or_union_benefit_program_payments: 0
+      us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_excluded_combat_zone_compensation: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 16000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 1
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income_limit: '16000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: 1
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_amount: '307'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness: '0'
+
+- name: married_joint_first_partial_forgiveness_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 13250
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: true
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_claimant_treated_as_married_for_poverty_forgiveness: holds
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income_limit: '13000'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 1
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: '0.9'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness: '30.7'
+
+- name: married_separate_apart_is_treated_as_unmarried
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 6750
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: true
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: true
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: true
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_claimant_treated_as_married_for_poverty_forgiveness: not_holds
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_income_limit: '6500'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 1
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: '0.9'
+
+- name: poverty_forgiveness_tenth_band_upper_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 8750
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 9
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: '0.1'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness: '276.3'
+
+- name: one_dollar_above_final_forgiveness_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 8751
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 10
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness: '307'
+
+- name: federal_dependent_cannot_be_poverty_claimant
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 10000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_total_money_and_property_received: 1000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_married: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_file_separate_returns: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_and_spouse_lived_apart_all_last_six_months: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_separated_under_written_agreement: false
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_claimant_is_federal_dependent: true
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_band: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_rate: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_poverty_forgiveness_amount: '0'
+
+- name: other_jurisdiction_credit_limited_by_pa_proportion
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 100000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_eligible_tax_imposed_by_one_other_jurisdiction: 2000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_income_taxed_by_pa_and_one_other_jurisdiction: 30000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits: '3070'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_credit_limit: '921'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_tax_credit: '921'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit: '2149'
+
+- name: other_jurisdiction_tax_paid_is_lower_than_pa_limit
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 100000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_eligible_tax_imposed_by_one_other_jurisdiction: 500
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_income_taxed_by_pa_and_one_other_jurisdiction: 30000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_credit_limit: '921'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_tax_credit: '500'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit: '2570'
+
+- name: zero_taxable_income_has_zero_other_jurisdiction_limit
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *resident_zero_inputs
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_compensation: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_qualifying_dependent_count: 0
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_eligible_tax_imposed_by_one_other_jurisdiction: 500
+    us-pa:policies/income_tax/resident_core_liability_pipeline#input.pa_pit_income_taxed_by_pa_and_one_other_jurisdiction: 30000
+    us-pa:policies/income_tax/resident_core_liability_pipeline#relation.pa_pit_qualified_tuition_beneficiary_of_tax_unit: *zero_qtp_relation
+  output:
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_credit_limit: '0'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_one_other_jurisdiction_tax_credit: '0'
+    us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit: '0'

--- a/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -11,24 +11,30 @@ module:
       - us-pa/statute/act-1971-2/article-3/section-314
   summary: |-
     Source-certified tax-year 2026 Pennsylvania full-year resident personal
-    income-tax core. The caller supplies separately classified raw amounts for
-    the eight classes in section 303, raw qualified-tuition contributions by
-    designated beneficiary, student-loan interest, raw poverty receipts and
-    statutory exclusions, claimant family facts, and raw facts for one eligible
-    other taxing jurisdiction. The module constructs Pennsylvania income,
-    applies the per-beneficiary qualified-tuition and student-loan-interest
-    deductions without allowing taxable income below zero, applies the 3.07%
-    resident rate, computes the complete section 304 poverty-forgiveness
-    schedule, and computes the section 314 credit and limitation for one other
-    jurisdiction.
+    income-tax core for one resident individual. The caller supplies
+    separately computed section 303 class totals, qualified-tuition
+    contributions by designated beneficiary, student-loan interest, aggregated
+    claimant/spouse poverty receipts and statutory exclusions, claimant family
+    facts, and raw facts for one eligible other taxing jurisdiction. The module
+    floors each income class separately so a loss in one class cannot offset
+    another, applies the per-beneficiary qualified-tuition and per-individual
+    student-loan-interest deductions without allowing taxable income below
+    zero, applies the 3.07% resident rate, computes the section 304
+    poverty-forgiveness schedule from the supplied household receipt
+    categories, and computes the section 314 credit and limitation for one
+    other jurisdiction.
 
     This is deliberately not a completed resident-liability program. The pinned
-    Article III corpus does not contain the operative TY2026 authority and
-    return mechanics for Pennsylvania's refundable earned-income and
-    child/dependent-care credits, and sections 304 and 314 do not establish
-    their ordering relative to each other. The module therefore exposes
-    separately calculated tax-after-forgiveness and tax-after-one-jurisdiction-
-    credit branches, but does not combine them or claim a final liability.
+    corpus does not establish the transaction-level computation needed to
+    construct all eight Pennsylvania class totals, contributor-by-beneficiary
+    and taxpayer/spouse joint-return mechanics, or the conditional inclusion of
+    spouse receipts in poverty income. It also lacks the operative TY2026
+    authority and return mechanics for Pennsylvania's refundable earned-income
+    and child/dependent-care credits, while sections 304 and 314 do not
+    establish their ordering relative to each other. The module therefore
+    exposes separately calculated tax-after-forgiveness and
+    tax-after-one-jurisdiction-credit branches for its bounded input surface,
+    but does not combine them or claim a final liability.
   deferred_outputs:
     - output: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_encoded_relief
       reason: |-
@@ -40,9 +46,12 @@ module:
         - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit
     - output: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_net_income_tax_liability
       reason: |-
-        Final TY2026 liability additionally requires the operative refundable
-        Pennsylvania earned-income and child/dependent-care credit authorities
-        and return ordering, which are absent from the pinned Article III
+        Final TY2026 liability additionally requires transaction-level
+        construction of each Pennsylvania income class, joint taxpayer/spouse
+        class and deduction mechanics, conditional spouse poverty-income
+        inclusion, the operative refundable Pennsylvania earned-income and
+        child/dependent-care credit authorities, and final return ordering.
+        Those surfaces are absent from, or not fully established by, the pinned
         corpus.
       source_values:
         - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits
@@ -262,18 +271,23 @@ rules:
             source:
               corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
               excerpt: "The classes of income referred to above are as follows"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-302
+              excerpt: "a tax upon each dollar of income received by that resident"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          pa_pit_compensation
-          + pa_pit_net_profits
-          + pa_pit_net_gains_from_property
-          + pa_pit_net_rents_royalties_patents_and_copyrights
-          + pa_pit_dividends
-          + pa_pit_taxable_interest_and_similar_receipts
-          + pa_pit_taxable_gambling_and_lottery_winnings
-          + pa_pit_net_income_from_estates_and_trusts
+          max(0, pa_pit_compensation)
+          + max(0, pa_pit_net_profits)
+          + max(0, pa_pit_net_gains_from_property)
+          + max(0, pa_pit_net_rents_royalties_patents_and_copyrights)
+          + max(0, pa_pit_dividends)
+          + max(0, pa_pit_taxable_interest_and_similar_receipts)
+          + max(0, pa_pit_taxable_gambling_and_lottery_winnings)
+          + max(0, pa_pit_net_income_from_estates_and_trusts)
 
   - name: pa_pit_qualified_tuition_program_deduction
     kind: derived
@@ -684,49 +698,49 @@ inputs:
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(1) taxable compensation for the full-year resident return.
+    description: Caller-computed section 303(a)(1) taxable compensation for the resident individual.
   - name: pa_pit_net_profits
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(2) net profits after the class-specific business costs and expenses.
+    description: Caller-computed section 303(a)(2) net profits after class-specific costs and expenses.
   - name: pa_pit_net_gains_from_property
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(3) net gains less net losses from dispositions.
+    description: Caller-computed section 303(a)(3) class total for net gains less net losses from dispositions.
   - name: pa_pit_net_rents_royalties_patents_and_copyrights
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(4) net gains or income from the listed property classes.
+    description: Caller-computed section 303(a)(4) class total for the listed property income.
   - name: pa_pit_dividends
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(5) taxable dividends.
+    description: Caller-computed section 303(a)(5) taxable-dividend class total.
   - name: pa_pit_taxable_interest_and_similar_receipts
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(6) taxable interest and includable insurance, annuity, MSA, or HSA receipts.
+    description: Caller-computed section 303(a)(6) taxable-interest and similar-receipts class total.
   - name: pa_pit_taxable_gambling_and_lottery_winnings
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(7) taxable gambling and lottery winnings.
+    description: Caller-computed section 303(a)(7) taxable gambling and lottery class total.
   - name: pa_pit_net_income_from_estates_and_trusts
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Raw section 303(a)(8) net gains or income through estates or trusts.
+    description: Caller-computed section 303(a)(8) estate-and-trust income class total.
   - name: pa_pit_qualified_tuition_contribution_paid
     entity: Person
     dtype: Money

--- a/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-pa/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -1,0 +1,837 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-pa/statute/act-1971-2/article-3/section-301
+      - us-pa/statute/act-1971-2/article-3/section-302
+      - us-pa/statute/act-1971-2/article-3/section-303
+      - us-pa/statute/act-1971-2/article-3/section-304
+      - us-pa/statute/act-1971-2/article-3/section-314
+  summary: |-
+    Source-certified tax-year 2026 Pennsylvania full-year resident personal
+    income-tax core. The caller supplies separately classified raw amounts for
+    the eight classes in section 303, raw qualified-tuition contributions by
+    designated beneficiary, student-loan interest, raw poverty receipts and
+    statutory exclusions, claimant family facts, and raw facts for one eligible
+    other taxing jurisdiction. The module constructs Pennsylvania income,
+    applies the per-beneficiary qualified-tuition and student-loan-interest
+    deductions without allowing taxable income below zero, applies the 3.07%
+    resident rate, computes the complete section 304 poverty-forgiveness
+    schedule, and computes the section 314 credit and limitation for one other
+    jurisdiction.
+
+    This is deliberately not a completed resident-liability program. The pinned
+    Article III corpus does not contain the operative TY2026 authority and
+    return mechanics for Pennsylvania's refundable earned-income and
+    child/dependent-care credits, and sections 304 and 314 do not establish
+    their ordering relative to each other. The module therefore exposes
+    separately calculated tax-after-forgiveness and tax-after-one-jurisdiction-
+    credit branches, but does not combine them or claim a final liability.
+  deferred_outputs:
+    - output: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_encoded_relief
+      reason: |-
+        Sections 304 and 314 establish the two reductions but the pinned corpus
+        does not establish their ordering relative to each other. Combining
+        them would invent a liability-ordering rule.
+      source_values:
+        - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness
+        - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit
+    - output: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_net_income_tax_liability
+      reason: |-
+        Final TY2026 liability additionally requires the operative refundable
+        Pennsylvania earned-income and child/dependent-care credit authorities
+        and return ordering, which are absent from the pinned Article III
+        corpus.
+      source_values:
+        - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_before_credits
+        - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_poverty_forgiveness
+        - us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_resident_income_tax_after_one_other_jurisdiction_credit
+
+imports:
+  - us-pa:policies/income_tax/2026_rate_table#personal_income_tax_rate
+
+rules:
+  - name: pa_pit_qualified_tuition_beneficiary_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: pa_pit_qualified_tuition_beneficiary_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+    source: Tax Reform Code section 303(a.7)(1), deduction limited per designated beneficiary
+
+  - name: pa_pit_student_loan_interest_deduction_cap
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.11)(1)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "exceed two thousand five hundred dollars ($2,500) per taxable year"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2500'
+
+  - name: pa_pit_single_claimant_base_poverty_income_limit
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)(1)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "six thousand five hundred dollars ($6,500) or less"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '6500'
+
+  - name: pa_pit_married_claimant_base_poverty_income_limit
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)(1)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "thirteen thousand dollars ($13,000) or less"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '13000'
+
+  - name: pa_pit_poverty_income_allowance_per_dependent
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)(1)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "an additional income allowance of nine thousand five hundred dollars ($9,500) for each dependent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '9500'
+
+  - name: pa_pit_poverty_excess_upper_bound_by_band
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: pa_pit_poverty_forgiveness_band
+    source: Tax Reform Code section 304(d)(2)(i)-(ix)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "two hundred fifty dollars ($250)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          1: 250
+          2: 500
+          3: 750
+          4: 1000
+          5: 1250
+          6: 1500
+          7: 1750
+          8: 2000
+          9: 2250
+
+  - name: pa_pit_poverty_forgiveness_rate_by_band
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: pa_pit_poverty_forgiveness_band
+    source: Tax Reform Code section 304(d)(1)-(2)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "Ninety per cent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 1
+          1: 0.9
+          2: 0.8
+          3: 0.7
+          4: 0.6
+          5: 0.5
+          6: 0.4
+          7: 0.3
+          8: 0.2
+          9: 0.1
+          10: 0
+
+  - name: pa_pit_qualified_tuition_contribution_is_positive
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Tax Reform Code section 303(a.7)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "An amount paid as a contribution into a qualified tuition program shall be deductible"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: pa_pit_qualified_tuition_contribution_paid > 0
+
+  - name: pa_pit_qualified_tuition_program_deduction_per_beneficiary
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.7)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "not to exceed the threshold for exclusion from gifts as provided in section 2503(b) ... per designated beneficiary"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, pa_pit_qualified_tuition_contribution_paid),
+            max(0, federal_section_2503_b_annual_gift_exclusion_amount)
+          )
+
+  - name: pa_pit_resident_income_before_annual_deductions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code sections 301(j), 302(a), and 303(a)(1)-(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "The classes of income referred to above are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          pa_pit_compensation
+          + pa_pit_net_profits
+          + pa_pit_net_gains_from_property
+          + pa_pit_net_rents_royalties_patents_and_copyrights
+          + pa_pit_dividends
+          + pa_pit_taxable_interest_and_similar_receipts
+          + pa_pit_taxable_gambling_and_lottery_winnings
+          + pa_pit_net_income_from_estates_and_trusts
+
+  - name: pa_pit_qualified_tuition_program_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.7)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "per designated beneficiary"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, pa_pit_resident_income_before_annual_deductions),
+            sum_where(
+              pa_pit_qualified_tuition_beneficiary_of_tax_unit,
+              pa_pit_qualified_tuition_program_deduction_per_beneficiary,
+              pa_pit_qualified_tuition_contribution_is_positive
+            )
+          )
+
+  - name: pa_pit_income_after_qualified_tuition_program_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.7)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "The deduction shall not result in taxable income being less than zero."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            pa_pit_resident_income_before_annual_deductions
+            - pa_pit_qualified_tuition_program_deduction
+          )
+
+  - name: pa_pit_student_loan_interest_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "exceed two thousand five hundred dollars ($2,500) per taxable year"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-pa:policies/income_tax/resident_core_liability_pipeline#pa_pit_student_loan_interest_deduction_cap
+              output: pa_pit_student_loan_interest_deduction_cap
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, pa_pit_student_loan_interest_paid),
+            min(
+              pa_pit_student_loan_interest_deduction_cap,
+              max(0, pa_pit_income_after_qualified_tuition_program_deduction)
+            )
+          )
+
+  - name: pa_pit_resident_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 303(a.7)(1) and (a.11)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-303
+              excerpt: "shall be deductible from taxable income on the annual personal income tax return"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            pa_pit_income_after_qualified_tuition_program_deduction
+            - pa_pit_student_loan_interest_deduction
+          )
+
+  - name: pa_pit_resident_income_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 302(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-302
+              excerpt: "every resident individual ... shall be subject to, and shall pay"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-pa:policies/income_tax/2026_rate_table#personal_income_tax_rate
+              output: personal_income_tax_rate
+              hash: sha256:e80c64e4db8f6b3d6a356ff2db84bb387696b2a79a7e780f92296675cc9d463b
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: pa_pit_resident_taxable_income * personal_income_tax_rate
+
+  - name: pa_pit_poverty_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 301(o.2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-301
+              excerpt: "all moneys or property ... received of whatever nature and from whatever source derived, but not including"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            pa_pit_total_money_and_property_received
+            - pa_pit_excluded_periodic_sickness_and_disability_payments
+            - pa_pit_excluded_workers_compensation_and_similar_payments
+            - pa_pit_excluded_old_age_and_retirement_benefits
+            - pa_pit_excluded_public_assistance_and_unemployment_compensation
+            - pa_pit_excluded_actual_expense_reimbursements
+            - pa_pit_excluded_employer_or_union_benefit_program_payments
+            - pa_pit_excluded_combat_zone_compensation
+          )
+
+  - name: pa_pit_claimant_treated_as_married_for_poverty_forgiveness
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Tax Reform Code section 304(d)(1)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "a claimant shall not be considered to be married if"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          pa_pit_claimant_is_married
+          and not (
+            pa_pit_claimant_and_spouse_file_separate_returns
+            and (
+              pa_pit_claimant_and_spouse_lived_apart_all_last_six_months
+              or pa_pit_claimant_is_separated_under_written_agreement
+            )
+          )
+
+  - name: pa_pit_poverty_income_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "with an additional income allowance of nine thousand five hundred dollars ($9,500) for each dependent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          (
+            if pa_pit_claimant_treated_as_married_for_poverty_forgiveness:
+              pa_pit_married_claimant_base_poverty_income_limit
+            else:
+              pa_pit_single_claimant_base_poverty_income_limit
+          )
+          + (
+            max(0, pa_pit_qualifying_dependent_count)
+            * pa_pit_poverty_income_allowance_per_dependent
+          )
+
+  - name: pa_pit_poverty_forgiveness_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Tax Reform Code section 304(d)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "If the poverty income of the claimant during an entire taxable year does not exceed the poverty income limitations"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if pa_pit_poverty_income <= pa_pit_poverty_income_limit: 0
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[1]: 1
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[2]: 2
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[3]: 3
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[4]: 4
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[5]: 5
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[6]: 6
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[7]: 7
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[8]: 8
+          else: if pa_pit_poverty_income <= pa_pit_poverty_income_limit + pa_pit_poverty_excess_upper_bound_by_band[9]: 9
+          else: 10
+
+  - name: pa_pit_poverty_forgiveness_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: Tax Reform Code section 304(d)(1)-(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "refund or forgiveness based on the per centage prescribed"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if pa_pit_claimant_is_federal_dependent:
+            pa_pit_poverty_forgiveness_rate_by_band[10]
+          else:
+            pa_pit_poverty_forgiveness_rate_by_band[pa_pit_poverty_forgiveness_band]
+
+  - name: pa_pit_poverty_forgiveness_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "refund or forgiveness of any moneys which have been paid over to (or would except for the provisions of this act be payable to)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          pa_pit_resident_income_tax_before_credits
+          * pa_pit_poverty_forgiveness_rate
+
+  - name: pa_pit_resident_income_tax_after_poverty_forgiveness
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 304(d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-304
+              excerpt: "refund or forgiveness based on the per centage prescribed"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            pa_pit_resident_income_tax_before_credits
+            - pa_pit_poverty_forgiveness_amount
+          )
+
+  - name: pa_pit_one_other_jurisdiction_credit_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 314(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-314
+              excerpt: "shall not exceed the proportion of the tax otherwise due under this article"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if pa_pit_resident_taxable_income > 0:
+            pa_pit_resident_income_tax_before_credits
+            * min(
+                max(0, pa_pit_income_taxed_by_pa_and_one_other_jurisdiction),
+                max(0, pa_pit_resident_taxable_income)
+              )
+            / pa_pit_resident_taxable_income
+          else:
+            0
+
+  - name: pa_pit_one_other_jurisdiction_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 314(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-314
+              excerpt: "allowed a credit against the tax otherwise due under this article for the amount of any income tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+            max(0, pa_pit_eligible_tax_imposed_by_one_other_jurisdiction),
+            pa_pit_one_other_jurisdiction_credit_limit
+          )
+
+  - name: pa_pit_resident_income_tax_after_one_other_jurisdiction_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Tax Reform Code section 314(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-pa/statute/act-1971-2/article-3/section-314
+              excerpt: "allowed a credit against the tax otherwise due under this article"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            pa_pit_resident_income_tax_before_credits
+            - pa_pit_one_other_jurisdiction_tax_credit
+          )
+
+inputs:
+  - name: pa_pit_compensation
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(1) taxable compensation for the full-year resident return.
+  - name: pa_pit_net_profits
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(2) net profits after the class-specific business costs and expenses.
+  - name: pa_pit_net_gains_from_property
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(3) net gains less net losses from dispositions.
+  - name: pa_pit_net_rents_royalties_patents_and_copyrights
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(4) net gains or income from the listed property classes.
+  - name: pa_pit_dividends
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(5) taxable dividends.
+  - name: pa_pit_taxable_interest_and_similar_receipts
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(6) taxable interest and includable insurance, annuity, MSA, or HSA receipts.
+  - name: pa_pit_taxable_gambling_and_lottery_winnings
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(7) taxable gambling and lottery winnings.
+  - name: pa_pit_net_income_from_estates_and_trusts
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 303(a)(8) net gains or income through estates or trusts.
+  - name: pa_pit_qualified_tuition_contribution_paid
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw amount paid to a qualified tuition program for this designated beneficiary.
+  - name: federal_section_2503_b_annual_gift_exclusion_amount
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal section 2503(b) annual gift-exclusion output for the tax year.
+  - name: pa_pit_student_loan_interest_paid
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw interest paid on the resident claimant's qualified student loan.
+  - name: pa_pit_total_money_and_property_received
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: All money and property received by the claimant and, when applicable, spouse for the poverty-income test.
+  - name: pa_pit_excluded_periodic_sickness_and_disability_payments
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(i) excluded receipts.
+  - name: pa_pit_excluded_workers_compensation_and_similar_payments
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(ii) excluded receipts.
+  - name: pa_pit_excluded_old_age_and_retirement_benefits
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(iii) excluded receipts.
+  - name: pa_pit_excluded_public_assistance_and_unemployment_compensation
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(iv) excluded receipts.
+  - name: pa_pit_excluded_actual_expense_reimbursements
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(v) excluded receipts.
+  - name: pa_pit_excluded_employer_or_union_benefit_program_payments
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(vi) excluded receipts.
+  - name: pa_pit_excluded_combat_zone_compensation
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw section 301(o.2)(vii) excluded receipts.
+  - name: pa_pit_claimant_is_married
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: Whether the claimant is married before the section 304(d)(1) separate-household exception.
+  - name: pa_pit_claimant_and_spouse_file_separate_returns
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: Whether the claimant and spouse file separate returns.
+  - name: pa_pit_claimant_and_spouse_lived_apart_all_last_six_months
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: Whether the claimant and spouse lived apart at all times in the final six months.
+  - name: pa_pit_claimant_is_separated_under_written_agreement
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: Whether the claimant is separated under a written separation agreement.
+  - name: pa_pit_qualifying_dependent_count
+    entity: TaxUnit
+    dtype: Count
+    period: Year
+    description: Number of claimant child dependents within sections 301(e.1) and 304(d)(1).
+  - name: pa_pit_claimant_is_federal_dependent
+    entity: TaxUnit
+    dtype: Bool
+    period: Year
+    description: Whether another taxpayer may claim the claimant under federal section 151, which prevents claimant status.
+  - name: pa_pit_eligible_tax_imposed_by_one_other_jurisdiction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw eligible income, wage, or earned/unearned-income tax imposed by one U.S. state, DC, Puerto Rico, territory, or possession.
+  - name: pa_pit_income_taxed_by_pa_and_one_other_jurisdiction
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw portion of Pennsylvania taxable income also subject to the eligible tax of that one jurisdiction.


### PR DESCRIPTION
## Summary

- adds a source-certified TY2026 Pennsylvania resident-individual tax core
- computes from eight separately supplied income classes through 529 and student-loan-interest deductions, 3.07% tax, poverty forgiveness, and one-other-jurisdiction credit
- floors each statutory income class independently and covers poverty bands, marital treatment, dependent allowance, and the resident-credit limit
- advances the unfiltered oracle-pending ratchet by exactly 24 PA outputs

## Truthful boundary

This is not combined-return or final net Pennsylvania liability. The pinned corpus does not establish the ordering between §304 forgiveness and §314 resident credit and does not contain operative refundable PA EITC/CDCC authority. The combined/final endpoint remains explicitly deferred.

## Review-fix cycle

Independent review found six source/scope/test issues; the branch fixed them, including per-class nonnegative treatment and a negative-class regression. Exact-content re-review at pre-rebase commit 46c62165748ded928397696a5d1a353655efa1ae returned no actionable findings. After Georgia and North Carolina merged, the branch was mechanically rebased to current head 1924f56d1286b76952e202d73e4b22ae5069d9a9; reviewed RuleSpec, test, and pending-ratchet hashes remained exact, and focused checks were rerun.

## Checks

- validate: pass
- proof-validate: 27 atoms
- companion fixtures: 16/16
- pinned-engine compile: 26 rules
- signed-manifest guard: pass
- reverse index: fresh on current main
- unfiltered oracle-pending ratchet: 1808/1808, zero stale/problems
- focused manifest/reverse-index tests: 9 passed
- full structural tests before review fixes: 55 passed
- git diff --check: pass