### PR TITLE
Encode West Virginia TY2026 resident income-tax core

### DIFF
--- a/.axiom/encoding-manifests/us-wv/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-wv/policies/income_tax/resident_core_liability_pipeline.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml",
-      "sha256": "92cf3f1126727a4cb83682ab15a78040399e37a0b147137327abadbd43c57a66"
+      "sha256": "3ae8d9f86c7b4720566047a8b24d619cc5dafee4b998f3cc824b41e3fba7c58d"
     },
     {
       "path": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
-      "sha256": "acad94ea372d2618d7c5c4945e4c7d64496722fa3673fbbdb553740873c0cdc9"
+      "sha256": "f4e63a07352fa22468db3982732386800eef84bbd711da9f19b86334cf47eabd"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-wv:policies/income_tax/resident_core_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-24T00:24:14.391118+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfckx8mns/sign-applied-files/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfckx8mns",
-  "generated_output_sha256": "acad94ea372d2618d7c5c4945e4c7d64496722fa3673fbbdb553740873c0cdc9",
+  "generated_at": "2026-07-24T00:45:05.487975+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_xzazz0d/sign-applied-files/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp_xzazz0d",
+  "generated_output_sha256": "f4e63a07352fa22468db3982732386800eef84bbd711da9f19b86334cf47eabd",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "2f0aebda612ab7c83c6ad57169cd87bf84d696e4b88059cd1bf34a3466ad7d9e"
+    "value": "2932390e6624e77b22d7b71a09f6a25f521fb3966a00e427448e9468810f7f2c"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-24T00:24:14.391118+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "7471f220d5c8c4ad0450edc0d5f507037b9f3f3a9806538ad35d6862f3468bb7",
+    "prior_signature": "2f0aebda612ab7c83c6ad57169cd87bf84d696e4b88059cd1bf34a3466ad7d9e",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-wv/policies/income_tax/resident_core_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-wv/policies/income_tax/resident_core_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml",
+      "sha256": "92cf3f1126727a4cb83682ab15a78040399e37a0b147137327abadbd43c57a66"
+    },
+    {
+      "path": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+      "sha256": "acad94ea372d2618d7c5c4945e4c7d64496722fa3673fbbdb553740873c0cdc9"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-wv:policies/income_tax/resident_core_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-24T00:24:14.391118+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfckx8mns/sign-applied-files/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfckx8mns",
+  "generated_output_sha256": "acad94ea372d2618d7c5c4945e4c7d64496722fa3673fbbdb553740873c0cdc9",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "2f0aebda612ab7c83c6ad57169cd87bf84d696e4b88059cd1bf34a3466ad7d9e"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -32179,6 +32179,13 @@
     ],
     "us-wv/statute/11-21-10": [
       {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-wv/statutes/11-21-10.yaml",
         "via": [
           "module",
@@ -32186,7 +32193,131 @@
         ]
       }
     ],
+    "us-wv/statute/11-21-11": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12A": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12C": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12E": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12F": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12G": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12I": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12J": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12M": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12N": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-12O": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-13": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wv/statute/11-21-16": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-wv/statutes/11-21-16.yaml",
         "via": [
@@ -32204,6 +32335,15 @@
         ]
       }
     ],
+    "us-wv/statute/11-21-22B": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wv/statute/11-21-23": [
       {
         "module": "us-wv/statutes/11-21-23.yaml",
@@ -32213,9 +32353,25 @@
         ]
       }
     ],
+    "us-wv/statute/11-21-26": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-wv/statute/11-21-3": [
       {
         "module": "us-wv/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"
@@ -32240,6 +32396,22 @@
     "us-wv/statute/11-21-4J": [
       {
         "module": "us-wv/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-wv/statute/11-21-9": [
+      {
+        "module": "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 1857
+ceiling: 1888
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -2792,6 +2792,99 @@ entries:
 - legal_id: us-wv:policies/income_tax/pilot_liability_pipeline#wv_pit_pilot_top_bracket_rate
   source: manual
   since: '2026-07-21'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_autism_trust_subtraction_cap_joint
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_autism_trust_subtraction_cap_single_or_separate
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_child_and_dependent_care_credit_share
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_first_bracket_ceiling
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_first_bracket_rate
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_fourth_bracket_ceiling
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_fourth_bracket_rate
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_jumpstart_annual_subtraction_cap
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_additions
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_core_subtractions
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_personal_exemptions
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_special_subtractions
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_total_subtractions
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_retirement_subtraction_cap_per_person
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_schedule_scale
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_second_bracket_ceiling
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_second_bracket_rate
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_separate_first_bracket_ceiling
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_child_and_dependent_care_credit
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_third_bracket_ceiling
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_third_bracket_rate
+  source: bulk
+  since: '2026-07-23'
+- legal_id: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_top_bracket_rate
+  source: bulk
+  since: '2026-07-23'
 - legal_id: us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap
   source: bulk
   since: '2026-07-08'

--- a/us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -1,0 +1,367 @@
+# Hand-computed from the pinned West Virginia Code provisions identified by the
+# companion RuleSpec. Inputs omitted from a case take the rules-engine default
+# of zero or false; each case supplies every fact needed to enter or reject the
+# bounded full-year-resident profile.
+- name: general schedule first bracket from federal agi
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - &wv_common_hold_zero
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_income_is_separated_from_joint_federal_return: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_nonresident_spouse: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_msa_contributions_and_interest_potential_subtraction: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_prior_prepaid_tuition_carryforward: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_prior_autism_trust_carryforward: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_prior_able_carryforward: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_prior_jumpstart_carryforward: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_section_12d_pension_termination_adjustment: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_legacy_qoz_business_net_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_other_article_excluded_federal_agi: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_other_federally_protected_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_age_disability_or_surviving_spouse_modification_facts: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_fiduciary_adjustment: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_partner_or_s_corporation_modification_items: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_electing_pass_through_entity_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_adoption_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_business_or_severance_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_historic_rehabilitation_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_low_income_or_homestead_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_jumpstart_employer_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_military_or_sales_use_tax_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_employer_child_care_credit: false
+      - &wv_zero_direct_facts
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_non_west_virginia_state_obligation_interest: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_authority_interest_exempt_federally_not_state: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_interest_to_carry_state_exempt_obligations: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_section_128_tax_exempt_savings_interest: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_separately_taxed_federal_lump_sum_distribution: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_section_199_deduction: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_long_term_care_premiums_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_autism_trust_contributions_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_able_contributions_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_jumpstart_contributions_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_jumpstart_distributions_rolled_to_wv_able: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_college_savings_distributions_rolled_to_jumpstart: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_wv_gambling_winnings: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 12000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income: '12000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_personal_exemptions: '2000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '10000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '211'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability: '211'
+
+- name: low income exclusion at general threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 10000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '10000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+
+- name: low income exclusion just above general threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000.01
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 10000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '8000.01'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '168.800211'
+
+- name: low income exclusion at married separate threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 5000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 5000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '5000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_schedule_scale: '2'
+
+- name: low income exclusion just above married separate threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 5000.01
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 5000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '3000.01'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '63.300211'
+
+- name: broad joint modifications caps exemptions and care credit
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: *wv_common_hold_zero
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 200000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 2
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_non_west_virginia_state_obligation_interest: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_authority_interest_exempt_federally_not_state: 200
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21: 300
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_interest_to_carry_state_exempt_obligations: 400
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_section_128_tax_exempt_savings_interest: 500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_separately_taxed_federal_lump_sum_distribution: 600
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted: 700
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_section_199_deduction: 800
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted: 900
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted: 1000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 200
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 300
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 3000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 1500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 400
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 600
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 700
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 800
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_long_term_care_premiums_not_federally_deducted: 200
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi: 300
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_autism_trust_contributions_not_federally_deducted: 2500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_able_contributions_not_federally_deducted: 400
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_jumpstart_contributions_not_federally_deducted: 30000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted: 26000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_jumpstart_distributions_rolled_to_wv_able: 500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_college_savings_distributions_rolled_to_jumpstart: 600
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi: 900
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_wv_gambling_winnings: 700
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted: 800
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi: 900
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 1000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_additions: '5500'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_core_subtractions: '7100'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_special_subtractions: '56500'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_total_subtractions: '63600'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income: '141900'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_personal_exemptions: '4000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '137900'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '5518.32'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_child_and_dependent_care_credit: '500'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits: '5018.32'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability: '5018.32'
+
+- name: special dependent exemption replaces count
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 3
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_personal_exemptions: 500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '9500'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '200.45'
+
+- name: care credit is capped at tax
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 2200
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 100
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '200'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '4.22'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_child_and_dependent_care_credit: '4.22'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits: '0'
+
+- name: general top bracket through full chain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 102000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '100000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '3782.5'
+
+- name: married separate top bracket through full chain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 102000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '100000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_schedule_scale: '2'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '4181.25'
+
+- name: medical savings account facts hold tax outputs
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability: '0'
+
+- name: specialty credit facts hold tax outputs
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_child_and_dependent_care_credit: '0'
+
+- name: negative raw amount fails closed
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: -1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'

--- a/us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml
+++ b/us-wv/policies/income_tax/resident_core_liability_pipeline.test.yaml
@@ -29,17 +29,18 @@
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_jumpstart_employer_credit: false
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_military_or_sales_use_tax_credit: false
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_employer_child_care_credit: false
-      - &wv_zero_direct_facts
+      - &wv_zero_additions
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_non_west_virginia_state_obligation_interest: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_authority_interest_exempt_federally_not_state: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_interest_to_carry_state_exempt_obligations: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_section_128_tax_exempt_savings_interest: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_separately_taxed_federal_lump_sum_distribution: 0
-        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_section_199_deduction: 0
-        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted: 0
-        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 0
+      - &wv_zero_core_subtractions
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 0
@@ -49,6 +50,7 @@
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 0
+      - &wv_zero_education_subtractions
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_long_term_care_premiums_not_federally_deducted: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi: 0
@@ -58,6 +60,7 @@
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_jumpstart_distributions_rolled_to_wv_able: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_college_savings_distributions_rolled_to_jumpstart: 0
+      - &wv_zero_gambling_portable_subtractions
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_wv_gambling_winnings: 0
         us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted: 0
@@ -69,7 +72,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -85,7 +88,7 @@
 - name: low income exclusion at general threshold
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -93,7 +96,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 10000
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -106,7 +109,7 @@
 - name: low income exclusion just above general threshold
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000.01
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -114,7 +117,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 10000
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -126,7 +129,7 @@
 - name: low income exclusion at married separate threshold
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 5000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -134,7 +137,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 5000
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -146,7 +149,7 @@
 - name: low income exclusion just above married separate threshold
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 5000.01
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -154,7 +157,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 5000
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -180,11 +183,11 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_interest_to_carry_state_exempt_obligations: 400
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_section_128_tax_exempt_savings_interest: 500
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_separately_taxed_federal_lump_sum_distribution: 600
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted: 700
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_529_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 700
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_section_199_deduction: 800
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted: 900
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted: 1000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_able_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 900
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income: 1000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 100
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 200
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 300
@@ -227,7 +230,7 @@
 - name: special dependent exemption replaces count
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 10000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -235,7 +238,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 3
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -247,7 +250,7 @@
 - name: care credit is capped at tax
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 2200
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -255,7 +258,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 100
@@ -268,7 +271,7 @@
 - name: general top bracket through full chain
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 102000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -276,7 +279,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -284,10 +287,107 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '100000'
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '3782.5'
 
+- name: general schedule second bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *wv_common_hold_zero
+      - *wv_zero_additions
+      - *wv_zero_core_subtractions
+      - *wv_zero_education_subtractions
+      - *wv_zero_gambling_portable_subtractions
+      - &wv_standard_single_profile
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 27000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '25000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '632.5'
+
+- name: general schedule third bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 42000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '40000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '1106.5'
+
+- name: general schedule fourth bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 62000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '60000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '1950.5'
+
+- name: married separate first bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *wv_common_hold_zero
+      - *wv_zero_additions
+      - *wv_zero_core_subtractions
+      - *wv_zero_education_subtractions
+      - *wv_zero_gambling_portable_subtractions
+      - &wv_standard_mfs_profile
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: true
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 7000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '5000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '105.5'
+
+- name: married separate second bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_mfs_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 14500
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '12500'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '316.25'
+
+- name: married separate third bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_mfs_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 22000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '20000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '553.25'
+
+- name: married separate fourth bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_mfs_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 32000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_taxable_income: '30000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_schedule_tax: '975.25'
+
 - name: married separate top bracket through full chain
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 102000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -295,7 +395,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -308,7 +408,7 @@
 - name: medical savings account facts hold tax outputs
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -316,20 +416,21 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 100
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
   output:
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: holds
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '0'
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability: '0'
 
 - name: specialty credit facts hold tax outputs
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -337,7 +438,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -349,7 +450,7 @@
 - name: negative raw amount fails closed
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    <<: [*wv_common_hold_zero, *wv_zero_direct_facts]
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
@@ -357,7 +458,7 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
-    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: -1
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
     us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
@@ -365,3 +466,179 @@
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: not_holds
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
     us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+
+- name: part year return keeps public tax outputs unavailable
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 1
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_low_income_earned_income_exclusion: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability: '0'
+
+- name: conflicting filing statuses fail the domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: true
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 2
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+
+- name: nonjoint spouse retirement amount holds public tax outputs
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 100
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_input_domain_is_valid: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: not_holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_before_credits: '0'
+
+- name: retirement subtraction applies per person caps
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *wv_common_hold_zero
+      - *wv_zero_additions
+      - *wv_zero_education_subtractions
+      - *wv_zero_gambling_portable_subtractions
+      - &wv_standard_joint_profile
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_full_year_resident_return: true
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_joint: true
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_filing_status_is_married_separate: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_exemption_count: 2
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_is_dependent_with_zero_federal_exemption_amount: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_earned_income_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_obligation_interest: 0
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_has_other_state_income_tax_credit: false
+        us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_child_and_dependent_care_credit: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 3000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 3000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies: holds
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_core_subtractions: '4000'
+
+- name: autism trust subtraction uses single cap
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_long_term_care_premiums_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_autism_trust_contributions_not_federally_deducted: 1500
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_able_contributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_jumpstart_contributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_jumpstart_distributions_rolled_to_wv_able: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_college_savings_distributions_rolled_to_jumpstart: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_special_subtractions: '1000'
+
+- name: jumpstart current contribution and distribution caps
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 100000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_long_term_care_premiums_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_autism_trust_contributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_able_contributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_current_jumpstart_contributions_not_federally_deducted: 30000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted: 26000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_jumpstart_distributions_rolled_to_wv_able: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_college_savings_distributions_rolled_to_jumpstart: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_special_subtractions: '50000'
+
+- name: gambling loss modification is limited by winnings
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_core_subtractions, *wv_zero_education_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 50000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi: 900
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_wv_gambling_winnings: 700
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi: 0
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_special_subtractions: '700'
+
+- name: social security subtraction below single threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 40000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 10000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_core_subtractions: '10000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income: '30000'
+
+- name: social security subtraction above single threshold
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<: [*wv_common_hold_zero, *wv_zero_additions, *wv_zero_education_subtractions, *wv_zero_gambling_portable_subtractions, *wv_standard_single_profile]
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_federal_adjusted_gross_income: 60000
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_us_or_wv_authority_interest_and_dividends: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxpayer_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_joint_spouse_uniformed_services_retirement_income: 0
+    us-wv:policies/income_tax/resident_core_liability_pipeline#input.wv_pit_2026_taxable_social_security_benefits: 10000
+  output:
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_core_subtractions: '10000'
+    us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_profile_candidate_adjusted_gross_income: '50000'

--- a/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -82,7 +82,12 @@ module:
     the medical-savings-account surtax, the section 12(d) revenue-limited
     pension adjustment, legacy opportunity-zone entitlements, and every credit
     other than section 26. All unsigned held amounts must equal exactly zero,
-    and invalid negative category amounts fail closed.
+    and invalid negative category amounts fail closed. Every ungated
+    intermediate amount is marked private as a diagnostic; only outputs whose
+    names begin `wv_pit_2026_supported_profile_` expose tax amounts outside the
+    module, and those outputs return zero unless the supported profile holds.
+    Increasing-modification withdrawal inputs are expressly limited to amounts
+    not already included in federal adjusted gross income.
 
     The candidate is not represented as complete annual-return liability
     because specialty nonrefundable credits, the indexed low-income family
@@ -149,11 +154,11 @@ rules:
           and wv_pit_2026_interest_to_carry_state_exempt_obligations >= 0
           and wv_pit_2026_section_128_tax_exempt_savings_interest >= 0
           and wv_pit_2026_separately_taxed_federal_lump_sum_distribution >= 0
-          and wv_pit_2026_nonmedical_msa_withdrawals >= 0
-          and wv_pit_2026_nonqualified_529_withdrawals_previously_deducted >= 0
+          and wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income >= 0
+          and wv_pit_2026_nonqualified_529_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income >= 0
           and wv_pit_2026_federal_section_199_deduction >= 0
-          and wv_pit_2026_nonqualified_able_withdrawals_previously_deducted >= 0
-          and wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted >= 0
+          and wv_pit_2026_nonqualified_able_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income >= 0
+          and wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income >= 0
           and wv_pit_2026_us_obligation_interest >= 0
           and wv_pit_2026_us_or_wv_authority_interest_and_dividends >= 0
           and wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi >= 0
@@ -210,6 +215,9 @@ rules:
             kind: exception
             source: {corpus_citation_path: us-wv/statute/11-21-9, excerpt: "20 percent additional tax imposed on taxable withdrawals from a medical savings account"}
           - path: versions[0].formula
+            kind: condition
+            source: {corpus_citation_path: us-wv/statute/11-21-10, excerpt: "Taxable year must be full taxable year"}
+          - path: versions[0].formula
             kind: exception
             source: {corpus_citation_path: us-wv/statute/11-21-22B, excerpt: "Tax Commissioner shall develop and publish on an annual basis two indexed tax credit tables"}
     versions:
@@ -231,7 +239,7 @@ rules:
           and not wv_pit_2026_has_age_disability_or_surviving_spouse_modification_facts
           and not wv_pit_2026_has_fiduciary_adjustment
           and not wv_pit_2026_has_partner_or_s_corporation_modification_items
-          and wv_pit_2026_nonmedical_msa_withdrawals == 0
+          and wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income == 0
           and wv_pit_2026_msa_contributions_and_interest_potential_subtraction == 0
           and wv_pit_2026_prior_prepaid_tuition_carryforward == 0
           and wv_pit_2026_prior_autism_trust_carryforward == 0
@@ -259,6 +267,7 @@ rules:
     unit: USD
     source: W. Va. Code section 11-21-10
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -276,28 +285,34 @@ rules:
           - path: versions[0].formula
             kind: import
             import: {target: us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold, output: eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold, hash: sha256:8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-10, excerpt: "Except in the case of a taxable year closed by reason of the death of the taxpayer, no credit shall be allowed under this section in the case of a taxable year covering a period of less than twelve months"}
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          if wv_pit_2026_filing_status_is_married_separate:
-            if wv_pit_2026_federal_adjusted_gross_income
-              <= eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold:
-              min(
-                wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
-                separate_return_earned_income_exclusion_cap
-              )
+          if wv_pit_2026_is_full_year_resident_return:
+            if wv_pit_2026_filing_status_is_married_separate:
+              if wv_pit_2026_federal_adjusted_gross_income
+                <= eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold:
+                min(
+                  wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
+                  separate_return_earned_income_exclusion_cap
+                )
+              else:
+                0
             else:
-              0
+              if wv_pit_2026_federal_adjusted_gross_income
+                <= eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold:
+                min(
+                  wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
+                  annual_earned_income_exclusion_cap
+                )
+              else:
+                0
           else:
-            if wv_pit_2026_federal_adjusted_gross_income
-              <= eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold:
-              min(
-                wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
-                annual_earned_income_exclusion_cap
-              )
-            else:
-              0
+            0
 
   - name: wv_pit_2026_profile_candidate_additions
     kind: derived
@@ -307,6 +322,7 @@ rules:
     unit: USD
     source: W. Va. Code sections 11-21-12(b), 12(f), 12(g), 12(j), and 12(m)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -334,11 +350,11 @@ rules:
           + wv_pit_2026_interest_to_carry_state_exempt_obligations
           + wv_pit_2026_section_128_tax_exempt_savings_interest
           + wv_pit_2026_separately_taxed_federal_lump_sum_distribution
-          + wv_pit_2026_nonmedical_msa_withdrawals
-          + wv_pit_2026_nonqualified_529_withdrawals_previously_deducted
+          + wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income
+          + wv_pit_2026_nonqualified_529_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income
           + wv_pit_2026_federal_section_199_deduction
-          + wv_pit_2026_nonqualified_able_withdrawals_previously_deducted
-          + wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted
+          + wv_pit_2026_nonqualified_able_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income
+          + wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income
 
   - name: wv_pit_2026_retirement_subtraction_cap_per_person
     kind: parameter
@@ -366,6 +382,7 @@ rules:
     unit: USD
     source: W. Va. Code section 11-21-12(c)(1)-(8)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -385,7 +402,16 @@ rules:
             source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "retirement income from the uniformed services"}
           - path: versions[0].formula
             kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "For taxable years beginning on or after January 1, 2022, 100 percent of the social security benefits"}
+          - path: versions[0].formula
+            kind: condition
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "allowable only when the federal adjusted gross income of a married couple filing a joint return does not exceed $100,000, or $50,000 in the case of a single individual or a married individual filing a separate return"}
+          - path: versions[0].formula
+            kind: formula
             source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "For taxable years beginning on or after January 1, 2026, 100 percent of the social security benefits"}
+          - path: versions[0].formula
+            kind: condition
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "allowable only when the federal adjusted gross income of a married couple filing a joint return exceeds $100,000, or $50,000 in the case of a single individual or a married individual filing a separate return"}
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -463,6 +489,7 @@ rules:
     unit: USD
     source: W. Va. Code sections 11-21-10 and 11-21-12(a), (c), (e), (i), (j), (m), (n), and (o)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -486,6 +513,9 @@ rules:
           - path: versions[0].formula
             kind: formula
             source: {corpus_citation_path: us-wv/statute/11-21-12N, excerpt: "not to exceed the amount of West Virginia gaming and gambling winnings"}
+          - path: versions[0].formula
+            kind: definition
+            source: {corpus_citation_path: us-wv/statute/11-21-9, excerpt: "the modification the person would have been allowed to claim pursuant to §11-21-12n of this code for the taxable year had the federal income tax law not been amended"}
           - path: versions[0].formula
             kind: formula
             source: {corpus_citation_path: us-wv/statute/11-21-12O, excerpt: "For taxable years beginning on or after January 1, 2026"}
@@ -521,6 +551,7 @@ rules:
     unit: USD
     source: Sum of directly encoded Article 21 decreasing modifications
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -541,6 +572,7 @@ rules:
     unit: USD
     source: W. Va. Code section 11-21-12(a)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -562,6 +594,7 @@ rules:
     unit: USD
     source: W. Va. Code section 11-21-16(a) and (d)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -573,6 +606,9 @@ rules:
           - path: versions[0].formula
             kind: formula
             source: {corpus_citation_path: us-wv/statute/11-21-16, excerpt: "for each exemption for which he is entitled to a deduction for the taxable year for federal income tax purposes"}
+          - path: versions[0].formula
+            kind: definition
+            source: {corpus_citation_path: us-wv/statute/11-21-9, excerpt: "the exemption the person would have been allowed to claim for the taxable year had the federal income tax law not been amended to eliminate the personal exemption"}
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -591,6 +627,7 @@ rules:
     unit: USD
     source: W. Va. Code sections 11-21-11, 11-21-13, and 11-21-16
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -720,6 +757,7 @@ rules:
     unit: USD
     source: W. Va. Code section 11-21-4J(a)-(b)
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -858,11 +896,11 @@ inputs:
   - {name: wv_pit_2026_interest_to_carry_state_exempt_obligations, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally deducted interest incurred to purchase or carry obligations exempt under Article 21.}
   - {name: wv_pit_2026_section_128_tax_exempt_savings_interest, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Section 128 savings-certificate interest excluded from federal gross income.}
   - {name: wv_pit_2026_separately_taxed_federal_lump_sum_distribution, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Lump-sum distribution separately taxed federally under section 402(e) and excluded from federal adjusted gross income.}
-  - {name: wv_pit_2026_nonmedical_msa_withdrawals, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Medical-savings-account withdrawals used other than for medical expenses; any positive amount invokes the deferred cross-title surtax branch.}
-  - {name: wv_pit_2026_nonqualified_529_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified college-plan withdrawals previously deducted under section 12(a).}
+  - {name: wv_pit_2026_nonmedical_msa_withdrawals_not_in_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Medical-savings-account withdrawals used other than for medical expenses and not already included in federal adjusted gross income; any positive amount invokes the deferred cross-title surtax branch.}
+  - {name: wv_pit_2026_nonqualified_529_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified college-plan withdrawals previously deducted under section 12(a), limited to the amount not already included in federal adjusted gross income.}
   - {name: wv_pit_2026_federal_section_199_deduction, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Any section 199 deduction present under the federal-law conformity cutoff and not already added.}
-  - {name: wv_pit_2026_nonqualified_able_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified West Virginia ABLE withdrawals previously deducted under section 12(j).}
-  - {name: wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Jumpstart withdrawals previously deducted and not used for qualified expenses within the statutory period.}
+  - {name: wv_pit_2026_nonqualified_able_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified West Virginia ABLE withdrawals previously deducted under section 12(j), limited to the amount not already included in federal adjusted gross income.}
+  - {name: wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted_not_in_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Jumpstart withdrawals previously deducted and not used for qualified expenses within the statutory period, limited to the amount not already included in federal adjusted gross income.}
   - {name: wv_pit_2026_us_obligation_interest, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally included interest on obligations of the United States and its possessions.}
   - {name: wv_pit_2026_us_or_wv_authority_interest_and_dividends, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally included authority or instrumentality interest and dividends exempt from West Virginia tax.}
   - {name: wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: State or other-jurisdiction income-tax refunds included in federal adjusted gross income.}

--- a/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml
+++ b/us-wv/policies/income_tax/resident_core_liability_pipeline.yaml
@@ -1,0 +1,910 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-wv/statute/11-21-3
+      - us-wv/statute/11-21-4J
+      - us-wv/statute/11-21-9
+      - us-wv/statute/11-21-10
+      - us-wv/statute/11-21-11
+      - us-wv/statute/11-21-12
+      - us-wv/statute/11-21-12A
+      - us-wv/statute/11-21-12C
+      - us-wv/statute/11-21-12E
+      - us-wv/statute/11-21-12F
+      - us-wv/statute/11-21-12G
+      - us-wv/statute/11-21-12I
+      - us-wv/statute/11-21-12J
+      - us-wv/statute/11-21-12M
+      - us-wv/statute/11-21-12N
+      - us-wv/statute/11-21-12O
+      - us-wv/statute/11-21-13
+      - us-wv/statute/11-21-16
+      - us-wv/statute/11-21-22B
+      - us-wv/statute/11-21-26
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-wv/statute/chapter-11/article-21
+        - us-wv/statute/11-21-3
+        - us-wv/statute/11-21-4J
+        - us-wv/statute/11-21-9
+        - us-wv/statute/11-21-10
+        - us-wv/statute/11-21-11
+        - us-wv/statute/11-21-12
+        - us-wv/statute/11-21-12A
+        - us-wv/statute/11-21-12C
+        - us-wv/statute/11-21-12E
+        - us-wv/statute/11-21-12F
+        - us-wv/statute/11-21-12G
+        - us-wv/statute/11-21-12I
+        - us-wv/statute/11-21-12J
+        - us-wv/statute/11-21-12M
+        - us-wv/statute/11-21-12N
+        - us-wv/statute/11-21-12O
+        - us-wv/statute/11-21-13
+        - us-wv/statute/11-21-16
+        - us-wv/statute/11-21-22B
+        - us-wv/statute/11-21-26
+      rationale: |-
+        The pinned official West Virginia Code Article 21 package supplies the
+        resident adjusted-gross-income base, current additions and subtractions,
+        post-1986 no-deduction rule, personal exemptions, enacted tax-year-2026
+        schedules, and the child/dependent-care credit encoded here. The older
+        recovery records separately ground sections 10 and 16; the current
+        full-article record grounds the 2026 amendments and specialty
+        modifications.
+
+        The pinned corpus does not contain the 2026 annual return and
+        instructions, the Tax Commissioner's 2026 indexed low-income credit
+        tables, the 2026 federal poverty-guideline publication used by the
+        refundable property credits, or the cross-title medical-savings-account
+        provisions that define taxable withdrawals subject to the Article 21
+        surtax. Those stages are typed holds rather than caller-completed
+        amounts. No completed West Virginia adjusted gross income, taxable
+        income, exemption, credit, rate, surtax, or tax is accepted.
+  summary: |-
+    Tax-year-2026 West Virginia full-year resident individual-income-tax core
+    for aligned federal and state filing units. It begins with federal adjusted
+    gross income and raw category facts, computes the directly source-grounded
+    Article 21 additions, low-income earned-income exclusion, current-year
+    decreasing modifications, personal exemptions, taxable-income candidate,
+    and the enacted section 4J general or married-separate schedule.
+
+    Within the disclosed supported profile, the module also computes tax before
+    credits, the nonrefundable child/dependent-care credit, tax after
+    nonrefundable credits, and a net-liability candidate. The profile excludes
+    separate-state allocation from a joint federal return, nonresident-spouse
+    mechanics, per-person age/disability and surviving-spouse modifications,
+    prior-year state carryforwards, fiduciary and pass-through allocations,
+    the medical-savings-account surtax, the section 12(d) revenue-limited
+    pension adjustment, legacy opportunity-zone entitlements, and every credit
+    other than section 26. All unsigned held amounts must equal exactly zero,
+    and invalid negative category amounts fail closed.
+
+    The candidate is not represented as complete annual-return liability
+    because specialty nonrefundable credits, the indexed low-income family
+    credit, refundable homestead credits, and the medical-savings-account
+    surtax remain unresolved by the pinned annual sources.
+  deferred_outputs:
+    - output: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_medical_savings_account_surtax
+      reason: |-
+        Section 11-21-9(c) states the 20 percent rate, but the pinned corpus does
+        not contain sections 33-15-20 and 33-16-15 that determine which
+        withdrawals are taxable and which exceptions apply. The supported
+        profile therefore requires no medical-savings-account withdrawal.
+      source_values:
+        - us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies
+    - output: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_complete_tax_after_nonrefundable_credits
+      reason: |-
+        Article 21 contains adoption, business, historic-rehabilitation,
+        other-state, low-income, Jumpstart, military, sales/use-tax, and
+        employer child-care credits whose complete 2026 annual-return ordering
+        or cross-title inputs are not pinned. The candidate is valid only when
+        the supported-profile status holds.
+      source_values:
+        - us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_applies
+        - us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits
+    - output: us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_net_income_tax_liability
+      reason: |-
+        The final annual-return liability additionally requires the 2026
+        poverty-guideline and Tax Commissioner table inputs for low-income and
+        refundable homestead credits, plus all specialty credit ordering.
+      source_values:
+        - us-wv:policies/income_tax/resident_core_liability_pipeline#wv_pit_2026_supported_profile_candidate_net_income_tax_liability
+
+imports:
+  - us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap
+  - us-wv:statutes/11-21-10#separate_return_earned_income_exclusion_cap
+  - us-wv:statutes/11-21-10#eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold
+  - us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold
+  - us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption
+  - us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount
+
+rules:
+  - name: wv_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Fail-closed nonnegative domain for unsigned raw category inputs
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source: {corpus_citation_path: us-wv/statute/11-21-11, excerpt: "West Virginia taxable income of a resident individual"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          not (wv_pit_2026_filing_status_is_joint and wv_pit_2026_filing_status_is_married_separate)
+          and wv_pit_2026_federal_exemption_count >= 0
+          and wv_pit_2026_earned_income_in_federal_adjusted_gross_income >= 0
+          and wv_pit_2026_non_west_virginia_state_obligation_interest >= 0
+          and wv_pit_2026_federal_authority_interest_exempt_federally_not_state >= 0
+          and wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21 >= 0
+          and wv_pit_2026_interest_to_carry_state_exempt_obligations >= 0
+          and wv_pit_2026_section_128_tax_exempt_savings_interest >= 0
+          and wv_pit_2026_separately_taxed_federal_lump_sum_distribution >= 0
+          and wv_pit_2026_nonmedical_msa_withdrawals >= 0
+          and wv_pit_2026_nonqualified_529_withdrawals_previously_deducted >= 0
+          and wv_pit_2026_federal_section_199_deduction >= 0
+          and wv_pit_2026_nonqualified_able_withdrawals_previously_deducted >= 0
+          and wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted >= 0
+          and wv_pit_2026_us_obligation_interest >= 0
+          and wv_pit_2026_us_or_wv_authority_interest_and_dividends >= 0
+          and wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi >= 0
+          and wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income >= 0
+          and wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income >= 0
+          and wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income >= 0
+          and wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income >= 0
+          and wv_pit_2026_taxpayer_uniformed_services_retirement_income >= 0
+          and wv_pit_2026_joint_spouse_uniformed_services_retirement_income >= 0
+          and wv_pit_2026_taxable_social_security_benefits >= 0
+          and wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted >= 0
+          and wv_pit_2026_long_term_care_premiums_not_federally_deducted >= 0
+          and wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi >= 0
+          and wv_pit_2026_current_autism_trust_contributions_not_federally_deducted >= 0
+          and wv_pit_2026_current_able_contributions_not_federally_deducted >= 0
+          and wv_pit_2026_current_jumpstart_contributions_not_federally_deducted >= 0
+          and wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted >= 0
+          and wv_pit_2026_jumpstart_distributions_rolled_to_wv_able >= 0
+          and wv_pit_2026_college_savings_distributions_rolled_to_jumpstart >= 0
+          and wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi >= 0
+          and wv_pit_2026_wv_gambling_winnings >= 0
+          and wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted >= 0
+          and wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi >= 0
+          and wv_pit_2026_msa_contributions_and_interest_potential_subtraction >= 0
+          and wv_pit_2026_prior_prepaid_tuition_carryforward >= 0
+          and wv_pit_2026_prior_autism_trust_carryforward >= 0
+          and wv_pit_2026_prior_able_carryforward >= 0
+          and wv_pit_2026_prior_jumpstart_carryforward >= 0
+          and wv_pit_2026_section_12d_pension_termination_adjustment >= 0
+          and wv_pit_2026_legacy_qoz_business_net_income >= 0
+          and wv_pit_2026_other_article_excluded_federal_agi >= 0
+          and wv_pit_2026_other_federally_protected_income >= 0
+          and wv_pit_2026_federal_child_and_dependent_care_credit >= 0
+
+  - name: wv_pit_2026_supported_profile_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Status for the bounded full-year resident Article 21 core
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source: {corpus_citation_path: us-wv/statute/11-21-3, excerpt: "West Virginia taxable income of every individual"}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-11, excerpt: "Separate taxes may be determined on their separate West Virginia taxable incomes if they so elect"}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "the taxpayer’s share, as beneficiary of an estate or trust, of the West Virginia fiduciary adjustment"}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-9, excerpt: "20 percent additional tax imposed on taxable withdrawals from a medical savings account"}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-22B, excerpt: "Tax Commissioner shall develop and publish on an annual basis two indexed tax credit tables"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_input_domain_is_valid
+          and wv_pit_2026_is_full_year_resident_return
+          and not wv_pit_2026_state_income_is_separated_from_joint_federal_return
+          and not wv_pit_2026_has_nonresident_spouse
+          and (
+            wv_pit_2026_filing_status_is_joint
+            or (
+              wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income == 0
+              and wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income == 0
+              and wv_pit_2026_joint_spouse_uniformed_services_retirement_income == 0
+            )
+          )
+          and not wv_pit_2026_has_age_disability_or_surviving_spouse_modification_facts
+          and not wv_pit_2026_has_fiduciary_adjustment
+          and not wv_pit_2026_has_partner_or_s_corporation_modification_items
+          and wv_pit_2026_nonmedical_msa_withdrawals == 0
+          and wv_pit_2026_msa_contributions_and_interest_potential_subtraction == 0
+          and wv_pit_2026_prior_prepaid_tuition_carryforward == 0
+          and wv_pit_2026_prior_autism_trust_carryforward == 0
+          and wv_pit_2026_prior_able_carryforward == 0
+          and wv_pit_2026_prior_jumpstart_carryforward == 0
+          and wv_pit_2026_section_12d_pension_termination_adjustment == 0
+          and wv_pit_2026_legacy_qoz_business_net_income == 0
+          and wv_pit_2026_other_article_excluded_federal_agi == 0
+          and wv_pit_2026_other_federally_protected_income == 0
+          and not wv_pit_2026_has_electing_pass_through_entity_credit
+          and not wv_pit_2026_has_adoption_credit
+          and not wv_pit_2026_has_business_or_severance_credit
+          and not wv_pit_2026_has_historic_rehabilitation_credit
+          and not wv_pit_2026_has_other_state_income_tax_credit
+          and not wv_pit_2026_has_low_income_or_homestead_credit
+          and not wv_pit_2026_has_jumpstart_employer_credit
+          and not wv_pit_2026_has_military_or_sales_use_tax_credit
+          and not wv_pit_2026_has_employer_child_care_credit
+
+  - name: wv_pit_2026_low_income_earned_income_exclusion
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-10
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-10, excerpt: "there shall be allowed as a deduction from federal adjusted gross income the amount of his or her earned income included therein"}
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-10#annual_earned_income_exclusion_cap, output: annual_earned_income_exclusion_cap, hash: sha256:8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0}
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-10#separate_return_earned_income_exclusion_cap, output: separate_return_earned_income_exclusion_cap, hash: sha256:8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0}
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-10#eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold, output: eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold, hash: sha256:8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0}
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-10#eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold, output: eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold, hash: sha256:8f912827cd44372fae541e6b5ea803d1993b9059d939aefca8889b769be8acd0}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if wv_pit_2026_filing_status_is_married_separate:
+            if wv_pit_2026_federal_adjusted_gross_income
+              <= eligible_taxpayer_separate_return_federal_adjusted_gross_income_threshold:
+              min(
+                wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
+                separate_return_earned_income_exclusion_cap
+              )
+            else:
+              0
+          else:
+            if wv_pit_2026_federal_adjusted_gross_income
+              <= eligible_taxpayer_joint_or_unmarried_federal_adjusted_gross_income_threshold:
+              min(
+                wv_pit_2026_earned_income_in_federal_adjusted_gross_income,
+                annual_earned_income_exclusion_cap
+              )
+            else:
+              0
+
+  - name: wv_pit_2026_profile_candidate_additions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code sections 11-21-12(b), 12(f), 12(g), 12(j), and 12(m)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "There shall be added to federal adjusted gross income, unless already included therein"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12F, excerpt: "subsequently withdrawn from the prepaid tuition contract or other college savings plan"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12G, excerpt: "there shall be added to federal taxable income the amount deducted under Section 199"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12J, excerpt: "subsequently withdrawn from the account for purposes other than a qualified disability expense"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12M, excerpt: "subsequently withdrawn from said account and not used for qualified expenses"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_non_west_virginia_state_obligation_interest
+          + wv_pit_2026_federal_authority_interest_exempt_federally_not_state
+          + wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21
+          + wv_pit_2026_interest_to_carry_state_exempt_obligations
+          + wv_pit_2026_section_128_tax_exempt_savings_interest
+          + wv_pit_2026_separately_taxed_federal_lump_sum_distribution
+          + wv_pit_2026_nonmedical_msa_withdrawals
+          + wv_pit_2026_nonqualified_529_withdrawals_previously_deducted
+          + wv_pit_2026_federal_section_199_deduction
+          + wv_pit_2026_nonqualified_able_withdrawals_previously_deducted
+          + wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted
+
+  - name: wv_pit_2026_retirement_subtraction_cap_per_person
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(c)(5)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "the total modification under this paragraph shall not exceed $2,000 per person receiving retirement benefits"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2000'
+
+  - name: wv_pit_2026_profile_candidate_core_subtractions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(c)(1)-(8)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "There shall be subtracted from federal adjusted gross income to the extent included therein"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "The amount of any refund or credit for overpayment of income taxes imposed by this state, or any other taxing jurisdiction"}
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "the total modification under this paragraph shall not exceed $2,000 per person receiving retirement benefits"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "Retirement income received in the form of pensions and annuities after December 31, 1979, under any West Virginia police"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "retirement income from the uniformed services"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "For taxable years beginning on or after January 1, 2026, 100 percent of the social security benefits"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_us_obligation_interest
+          + wv_pit_2026_us_or_wv_authority_interest_and_dividends
+          + wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi
+          + min(wv_pit_2026_retirement_subtraction_cap_per_person, wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income)
+          + min(wv_pit_2026_retirement_subtraction_cap_per_person, wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income)
+          + wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income
+          + wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income
+          + wv_pit_2026_taxpayer_uniformed_services_retirement_income
+          + wv_pit_2026_joint_spouse_uniformed_services_retirement_income
+          + wv_pit_2026_taxable_social_security_benefits
+
+  - name: wv_pit_2026_autism_trust_subtraction_cap_single_or_separate
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(i)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12I, excerpt: "up to a maximum of $1,000 per year for individual filers and persons who are married but filing separately"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '1000'
+
+  - name: wv_pit_2026_autism_trust_subtraction_cap_joint
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(i)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12I, excerpt: "$2,000 per year for persons who are married and filing jointly"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '2000'
+
+  - name: wv_pit_2026_jumpstart_annual_subtraction_cap
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(m)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12M, excerpt: "may not exceed $25,000 in a single taxable year"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '25000'
+
+  - name: wv_pit_2026_profile_candidate_special_subtractions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code sections 11-21-10 and 11-21-12(a), (c), (e), (i), (j), (m), (n), and (o)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12A, excerpt: "any payment made under a prepaid tuition contract or other college savings plan"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12C, excerpt: "any payment during the taxable year for premiums for a long-term care insurance policy"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12E, excerpt: "active duty military pay received by a resident individual"}
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12I, excerpt: "up to a maximum of $1,000 per year for individual filers and persons who are married but filing separately, and $2,000 per year for persons who are married and filing jointly"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12J, excerpt: "any contributions to an account created pursuant to the West Virginia ABLE Act"}
+          - path: versions[0].formula
+            kind: amount
+            source: {corpus_citation_path: us-wv/statute/11-21-12M, excerpt: "may not exceed $25,000 in a single taxable year"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12N, excerpt: "not to exceed the amount of West Virginia gaming and gambling winnings"}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12O, excerpt: "For taxable years beginning on or after January 1, 2026"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_low_income_earned_income_exclusion
+          + wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted
+          + wv_pit_2026_long_term_care_premiums_not_federally_deducted
+          + wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi
+          + min(
+              if wv_pit_2026_filing_status_is_joint: wv_pit_2026_autism_trust_subtraction_cap_joint else: wv_pit_2026_autism_trust_subtraction_cap_single_or_separate,
+              wv_pit_2026_current_autism_trust_contributions_not_federally_deducted
+            )
+          + wv_pit_2026_current_able_contributions_not_federally_deducted
+          + min(wv_pit_2026_jumpstart_annual_subtraction_cap, wv_pit_2026_current_jumpstart_contributions_not_federally_deducted)
+          + min(wv_pit_2026_jumpstart_annual_subtraction_cap, wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted)
+          + wv_pit_2026_jumpstart_distributions_rolled_to_wv_able
+          + wv_pit_2026_college_savings_distributions_rolled_to_jumpstart
+          + min(
+              wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi,
+              wv_pit_2026_wv_gambling_winnings
+            )
+          + wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted
+          + wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi
+
+  - name: wv_pit_2026_profile_candidate_total_subtractions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Sum of directly encoded Article 21 decreasing modifications
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "Modifications reducing federal adjusted gross income"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_profile_candidate_core_subtractions
+          + wv_pit_2026_profile_candidate_special_subtractions
+
+  - name: wv_pit_2026_profile_candidate_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-12(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-12, excerpt: "federal adjusted gross income as defined in the laws of the United States for the taxable year with the modifications specified in this section"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          wv_pit_2026_federal_adjusted_gross_income
+          + wv_pit_2026_profile_candidate_additions
+          - wv_pit_2026_profile_candidate_total_subtractions
+
+  - name: wv_pit_2026_profile_candidate_personal_exemptions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-16(a) and (d)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-16#west_virginia_exemption_per_federal_exemption, output: west_virginia_exemption_per_federal_exemption, hash: sha256:990a10139d1bb1ed8e065cd9ecf683130449d68786402095af8a6fe3a059b336}
+          - path: versions[0].formula
+            kind: import
+            import: {target: us-wv:statutes/11-21-16#certain_dependent_single_exemption_amount, output: certain_dependent_single_exemption_amount, hash: sha256:990a10139d1bb1ed8e065cd9ecf683130449d68786402095af8a6fe3a059b336}
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-16, excerpt: "for each exemption for which he is entitled to a deduction for the taxable year for federal income tax purposes"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if wv_pit_2026_is_dependent_with_zero_federal_exemption_amount:
+            certain_dependent_single_exemption_amount
+          else:
+            west_virginia_exemption_per_federal_exemption
+              * wv_pit_2026_federal_exemption_count
+
+  - name: wv_pit_2026_profile_candidate_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code sections 11-21-11, 11-21-13, and 11-21-16
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-11, excerpt: "West Virginia adjusted gross income less his West Virginia personal exemptions"}
+          - path: versions[0].formula
+            kind: exception
+            source: {corpus_citation_path: us-wv/statute/11-21-13, excerpt: "no West Virginia deduction shall be allowed for taxable years beginning after December 31, 1986"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            wv_pit_2026_profile_candidate_adjusted_gross_income
+            - wv_pit_2026_profile_candidate_personal_exemptions
+          )
+
+  - name: wv_pit_2026_first_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-4J
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Not over $10,000 2.11% of the taxable income"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0211'}]
+
+  - name: wv_pit_2026_second_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-4J
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "$211 plus 2.81% of excess over $10,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0281'}]
+
+  - name: wv_pit_2026_third_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-4J
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "$632.50 plus 3.16% of excess over $25,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0316'}]
+
+  - name: wv_pit_2026_fourth_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-4J
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "$1,106.50 plus 4.22% of excess over $40,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0422'}]
+
+  - name: wv_pit_2026_top_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-4J
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: parameter, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Over $60,000 $1,950.50 plus 4.58% of excess over $60,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '0.0458'}]
+
+  - name: wv_pit_2026_first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(a)
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Not over $10,000 2.11% of the taxable income"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '10000'}]
+
+  - name: wv_pit_2026_second_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(a)
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Over $10,000 but not over $25,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '25000'}]
+
+  - name: wv_pit_2026_third_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(a)
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Over $25,000 but not over $40,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '40000'}]
+
+  - name: wv_pit_2026_fourth_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(a)
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Over $40,000 but not over $60,000"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '60000'}]
+
+  - name: wv_pit_2026_separate_first_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(b)
+    metadata: {private: true, proof: {atoms: [{path: 'versions[0].formula', kind: amount, source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Not over $5,000 2.11% of the taxable income"}}]}}
+    versions: [{effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '5000'}]
+
+  - name: wv_pit_2026_schedule_scale
+    kind: derived
+    entity: TaxUnit
+    dtype: Number
+    period: Year
+    source: W. Va. Code section 11-21-4J(a)-(b)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "Rate of tax on married individuals filing separate returns"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: "if wv_pit_2026_filing_status_is_married_separate: wv_pit_2026_first_bracket_ceiling / wv_pit_2026_separate_first_bracket_ceiling else: 1"
+
+  - name: wv_pit_2026_profile_candidate_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-4J(a)-(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-4J, excerpt: "shall be determined in accordance with the following table"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          (
+            wv_pit_2026_first_bracket_rate * min(wv_pit_2026_profile_candidate_taxable_income * wv_pit_2026_schedule_scale, wv_pit_2026_first_bracket_ceiling)
+            + wv_pit_2026_second_bracket_rate * min(max(0, wv_pit_2026_profile_candidate_taxable_income * wv_pit_2026_schedule_scale - wv_pit_2026_first_bracket_ceiling), wv_pit_2026_second_bracket_ceiling - wv_pit_2026_first_bracket_ceiling)
+            + wv_pit_2026_third_bracket_rate * min(max(0, wv_pit_2026_profile_candidate_taxable_income * wv_pit_2026_schedule_scale - wv_pit_2026_second_bracket_ceiling), wv_pit_2026_third_bracket_ceiling - wv_pit_2026_second_bracket_ceiling)
+            + wv_pit_2026_fourth_bracket_rate * min(max(0, wv_pit_2026_profile_candidate_taxable_income * wv_pit_2026_schedule_scale - wv_pit_2026_third_bracket_ceiling), wv_pit_2026_fourth_bracket_ceiling - wv_pit_2026_third_bracket_ceiling)
+            + wv_pit_2026_top_bracket_rate * max(0, wv_pit_2026_profile_candidate_taxable_income * wv_pit_2026_schedule_scale - wv_pit_2026_fourth_bracket_ceiling)
+          ) / wv_pit_2026_schedule_scale
+
+  - name: wv_pit_2026_supported_profile_candidate_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code sections 11-21-3 and 11-21-4J, no surtax facts
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-3, excerpt: "A tax determined in accordance with the rates hereinafter set forth in this article is hereby imposed"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: "if wv_pit_2026_supported_profile_applies: wv_pit_2026_profile_candidate_schedule_tax else: 0"
+
+  - name: wv_pit_2026_child_and_dependent_care_credit_share
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: W. Va. Code section 11-21-26
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-wv/statute/11-21-26, excerpt: "50 percent of the federal child and dependent care tax credit"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.50'
+
+  - name: wv_pit_2026_supported_profile_child_and_dependent_care_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: W. Va. Code section 11-21-26
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-26, excerpt: "allowed a nonrefundable credit against the tax imposed"}
+          - path: versions[0].formula
+            kind: parameter
+            source: {corpus_citation_path: us-wv/statute/11-21-26, excerpt: "50 percent of the federal child and dependent care tax credit"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if wv_pit_2026_supported_profile_applies:
+            min(
+              wv_pit_2026_supported_profile_candidate_tax_before_credits,
+              wv_pit_2026_child_and_dependent_care_credit_share
+                * wv_pit_2026_federal_child_and_dependent_care_credit
+            )
+          else:
+            0
+
+  - name: wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Supported-profile tax after the section 26 nonrefundable credit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-26, excerpt: "nonrefundable credit against the tax imposed"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          max(
+            0,
+            wv_pit_2026_supported_profile_candidate_tax_before_credits
+            - wv_pit_2026_supported_profile_child_and_dependent_care_credit
+          )
+
+  - name: wv_pit_2026_supported_profile_candidate_net_income_tax_liability
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Supported-profile candidate before payments, with refundable-credit branches held absent
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source: {corpus_citation_path: us-wv/statute/11-21-3, excerpt: "taxable year on the West Virginia taxable income of every individual"}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: wv_pit_2026_supported_profile_candidate_tax_after_nonrefundable_credits
+
+inputs:
+  - {name: wv_pit_2026_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federal adjusted gross income for the aligned full-year resident filing unit.}
+  - {name: wv_pit_2026_is_full_year_resident_return, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether the return covers a full taxable year for West Virginia full-year residents.}
+  - {name: wv_pit_2026_filing_status_is_joint, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether the filing unit uses a joint resident return.}
+  - {name: wv_pit_2026_filing_status_is_married_separate, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 4J(b) married-separate rates apply.}
+  - {name: wv_pit_2026_state_income_is_separated_from_joint_federal_return, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 11-21-12(f) requires separating a joint federal adjusted gross income; true is outside this raw-fact profile.}
+  - {name: wv_pit_2026_has_nonresident_spouse, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 11-21-11(b)(3) resident/nonresident spouse mechanics apply.}
+  - {name: wv_pit_2026_federal_exemption_count, entity: TaxUnit, dtype: Count, period: Year, description: Federal exemptions that would have been allowed absent the post-2017 federal personal-exemption elimination.}
+  - {name: wv_pit_2026_is_dependent_with_zero_federal_exemption_amount, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 11-21-16(d) substitutes the single $500 dependent exemption.}
+  - {name: wv_pit_2026_earned_income_in_federal_adjusted_gross_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Section 11-21-10 earned income included in federal adjusted gross income, excluding pensions annuities and inmate services.}
+  - {name: wv_pit_2026_non_west_virginia_state_obligation_interest, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Interest on non-West-Virginia state or political-subdivision obligations not already in federal adjusted gross income.}
+  - {name: wv_pit_2026_federal_authority_interest_exempt_federally_not_state, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federal authority or instrumentality interest or dividends exempt federally but not from West Virginia tax.}
+  - {name: wv_pit_2026_federal_agi_deduction_not_allowed_by_article_21, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federal adjusted-gross-income deduction specifically disallowed under Article 21.}
+  - {name: wv_pit_2026_interest_to_carry_state_exempt_obligations, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally deducted interest incurred to purchase or carry obligations exempt under Article 21.}
+  - {name: wv_pit_2026_section_128_tax_exempt_savings_interest, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Section 128 savings-certificate interest excluded from federal gross income.}
+  - {name: wv_pit_2026_separately_taxed_federal_lump_sum_distribution, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Lump-sum distribution separately taxed federally under section 402(e) and excluded from federal adjusted gross income.}
+  - {name: wv_pit_2026_nonmedical_msa_withdrawals, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Medical-savings-account withdrawals used other than for medical expenses; any positive amount invokes the deferred cross-title surtax branch.}
+  - {name: wv_pit_2026_nonqualified_529_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified college-plan withdrawals previously deducted under section 12(a).}
+  - {name: wv_pit_2026_federal_section_199_deduction, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Any section 199 deduction present under the federal-law conformity cutoff and not already added.}
+  - {name: wv_pit_2026_nonqualified_able_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Nonqualified West Virginia ABLE withdrawals previously deducted under section 12(j).}
+  - {name: wv_pit_2026_nonqualified_jumpstart_withdrawals_previously_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Jumpstart withdrawals previously deducted and not used for qualified expenses within the statutory period.}
+  - {name: wv_pit_2026_us_obligation_interest, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally included interest on obligations of the United States and its possessions.}
+  - {name: wv_pit_2026_us_or_wv_authority_interest_and_dividends, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federally included authority or instrumentality interest and dividends exempt from West Virginia tax.}
+  - {name: wv_pit_2026_state_or_local_income_tax_refunds_in_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: State or other-jurisdiction income-tax refunds included in federal adjusted gross income.}
+  - {name: wv_pit_2026_taxpayer_capped_public_or_federal_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Taxpayer retirement benefits subject to the combined $2,000 per-person section 12(c)(5) cap.}
+  - {name: wv_pit_2026_joint_spouse_capped_public_or_federal_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Joint-return spouse retirement benefits subject to the combined $2,000 per-person section 12(c)(5) cap.}
+  - {name: wv_pit_2026_taxpayer_fully_exempt_wv_public_safety_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Taxpayer section 12(c)(6) West Virginia public-safety retirement income included federally.}
+  - {name: wv_pit_2026_joint_spouse_fully_exempt_wv_public_safety_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Joint-return spouse section 12(c)(6) West Virginia public-safety retirement income included federally.}
+  - {name: wv_pit_2026_taxpayer_uniformed_services_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Taxpayer uniformed-services retirement income included in federal adjusted gross income.}
+  - {name: wv_pit_2026_joint_spouse_uniformed_services_retirement_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Joint-return spouse uniformed-services retirement income included in federal adjusted gross income.}
+  - {name: wv_pit_2026_taxable_social_security_benefits, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Social Security benefits included in federal adjusted gross income and fully subtracted for 2026.}
+  - {name: wv_pit_2026_current_prepaid_tuition_or_college_savings_payment_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Current qualifying section 12(a) payment not deducted federally.}
+  - {name: wv_pit_2026_long_term_care_premiums_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Qualifying long-term-care premiums paid in 2026 and not deducted federally.}
+  - {name: wv_pit_2026_qualifying_active_duty_military_pay_in_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Active-duty military pay satisfying section 12(e) and included in federal adjusted gross income.}
+  - {name: wv_pit_2026_current_autism_trust_contributions_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Current qualifying autism-trust contributions not deducted federally, before the statutory filing-unit cap.}
+  - {name: wv_pit_2026_current_able_contributions_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Current qualifying West Virginia ABLE contributions not deducted federally.}
+  - {name: wv_pit_2026_current_jumpstart_contributions_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Current Jumpstart contributions not deducted federally, before the $25,000 annual cap.}
+  - {name: wv_pit_2026_qualified_jumpstart_distributions_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Qualified Jumpstart distributions not deducted federally, before the $25,000 annual cap.}
+  - {name: wv_pit_2026_jumpstart_distributions_rolled_to_wv_able, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Jumpstart distributions deposited in a West Virginia ABLE account within 30 days and not federally deducted.}
+  - {name: wv_pit_2026_college_savings_distributions_rolled_to_jumpstart, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: College-savings distributions deposited in a Jumpstart account within 30 days and not federally deducted.}
+  - {name: wv_pit_2026_lawful_wv_gambling_losses_not_deducted_in_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Substantiated lawful West Virginia gambling losses not applied in federal adjusted gross income and excluding costs and expenses.}
+  - {name: wv_pit_2026_wv_gambling_winnings, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: West Virginia gambling winnings that cap the section 12(n) loss modification.}
+  - {name: wv_pit_2026_portable_benefit_plan_contributions_not_federally_deducted, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: 2026 taxpayer contributions to a qualifying voluntary portable benefits plan not deducted federally.}
+  - {name: wv_pit_2026_portable_benefit_plan_receipts_in_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: 2026 portable-benefit-plan contribution receipts included in federal adjusted gross income.}
+  - {name: wv_pit_2026_msa_contributions_and_interest_potential_subtraction, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Potential section 12(c)(11) medical-savings-account subtraction; positive amounts are held pending per-person computation.}
+  - {name: wv_pit_2026_prior_prepaid_tuition_carryforward, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Prior-year section 12(a) carryforward; positive amounts are outside the current-year raw-fact profile.}
+  - {name: wv_pit_2026_prior_autism_trust_carryforward, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Prior-year section 12(i) carryforward; positive amounts are outside the current-year raw-fact profile.}
+  - {name: wv_pit_2026_prior_able_carryforward, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Prior-year section 12(j) carryforward; positive amounts are outside the current-year raw-fact profile.}
+  - {name: wv_pit_2026_prior_jumpstart_carryforward, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Prior-year section 12(m) carryforward; positive amounts are outside the current-year raw-fact profile.}
+  - {name: wv_pit_2026_section_12d_pension_termination_adjustment, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Potential section 12(d) pension-plan-termination adjustment; positive amounts are held because the annual revenue-limit determination is absent.}
+  - {name: wv_pit_2026_legacy_qoz_business_net_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Potential legacy section 12(l) opportunity-zone income; positive amounts require entitlement history outside this profile.}
+  - {name: wv_pit_2026_other_article_excluded_federal_agi, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Potential unenumerated section 12(c)(3) exclusion; positive amounts are outside the explicitly enumerated profile.}
+  - {name: wv_pit_2026_other_federally_protected_income, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Potential unenumerated federally protected section 12(c)(12) income; positive amounts are outside the explicitly enumerated profile.}
+  - {name: wv_pit_2026_has_age_disability_or_surviving_spouse_modification_facts, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 12(c)(9)-(10) or 16(c) per-person age disability or surviving-spouse rules may apply.}
+  - {name: wv_pit_2026_has_fiduciary_adjustment, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 12(d) fiduciary allocation is required.}
+  - {name: wv_pit_2026_has_partner_or_s_corporation_modification_items, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether sections 12(e), 12(k), 17, or 17a require entity-level modification allocation.}
+  - {name: wv_pit_2026_has_electing_pass_through_entity_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether an owner credit under section 3a may apply.}
+  - {name: wv_pit_2026_has_adoption_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 10a adoption-credit facts or a carryover election may apply.}
+  - {name: wv_pit_2026_has_business_or_severance_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 8 business-and-occupation or related business credit facts may apply.}
+  - {name: wv_pit_2026_has_historic_rehabilitation_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 8a or 8g historic-rehabilitation credit facts or carryovers may apply.}
+  - {name: wv_pit_2026_has_other_state_income_tax_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 20 other-state income-tax credit facts may apply.}
+  - {name: wv_pit_2026_has_low_income_or_homestead_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether sections 21 through 23 low-income or refundable homestead credit facts may apply.}
+  - {name: wv_pit_2026_has_jumpstart_employer_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 25 employer matching-contribution credit facts may apply.}
+  - {name: wv_pit_2026_has_military_or_sales_use_tax_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether sections 42 or 43 cross-title credit facts may apply.}
+  - {name: wv_pit_2026_has_employer_child_care_credit, entity: TaxUnit, dtype: Judgment, period: Year, description: Whether section 97 employer child-care credit facts or carryovers may apply.}
+  - {name: wv_pit_2026_federal_child_and_dependent_care_credit, entity: TaxUnit, dtype: Money, period: Year, unit: USD, description: Federal section 21 child and dependent care credit allowed for tax year 2026.}


### PR DESCRIPTION
## Summary

- encode the TY2026 full-year resident federal-AGI-to-tax pipeline supported by the pinned West Virginia Article 21 corpus
- compute direct additions/subtractions, the low-income earned-income exclusion, personal exemptions, taxable income, enacted general/MFS schedules, and the §26 child/dependent-care credit
- fail closed outside the explicitly supported profile and retain honest typed holds for the MSA surtax, indexed low-income/property credits, specialty credits, ordering, and complete net liability
- add 31 minimal oracle-pending declarations and regenerate signed artifacts/reverse index

## Review cycle

Independent review found unsupported-profile intermediate exposure, incomplete SS/exemption/gambling/full-year proofs, withdrawal addback semantics, and missing boundary/branch tests. All findings were fixed. Exact reviewed content HEAD `7463912790a9f2b06bb642e683ca729a92795587` then received a no-actionable-findings review. A conflict-free rebase onto current main preserved the exact reviewed module and test hashes; the only later change is the mechanical, authoritative 31-entry oracle-pending ratchet update.

Reviewed hashes:

- module: `f4e63a07352fa22468db3982732386800eef84bbd711da9f19b86334cf47eabd`
- tests: `3ae8d9f86c7b4720566047a8b24d619cc5dafee4b998f3cc824b41e3fba7c58d`

## Checks

- proof validation — 66 atoms passed
- companion tests — 29/29 passed
- compile — 48 rules
- signed generated-file guard against current main
- reverse index — 4,019 provisions / 4,757 edges / 4,441 modules
- oracle pending — 1,888 declared and applied, 0 stale, 0 problems
- repository tests before the hash-preserving rebase — 55 passed
- `git diff --check`

The complete annual-return liability remains intentionally held where the pinned official sources do not yet supply the required TY2026 indexed parameters or cross-title mechanics.