### PR TITLE
Pin corrected CMS corpus release

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-axiom_corpus_release = "us-rulespec-2026-07-22-current-la-status-fix"
-axiom_corpus_release_content_sha256 = "6bfd97b24cb63cb709fa52e9a5e6764c916dec95c5557447e11f47778ee4768f"
+axiom_corpus_release = "us-rulespec-2026-07-24-cms-435-correction-immutable-scopes"
+axiom_corpus_release_content_sha256 = "914c0daedad1eeee96691d7a245420e434b55c971199661f1df140e6ad99699e"
 validation_waiver_set_sha256 = "396e188da03b212c978b8b7bc222af6e5ee9fd26b32d942b64e92aaf73f8b748"

--- a/.axiom/workflow-toolchain.toml
+++ b/.axiom/workflow-toolchain.toml
@@ -1,9 +1,9 @@
 # Immutable checkout identities used by validation and generation workflows.
 # Signed corpus release and waiver evidence remain in toolchain.toml.
 [workflow_toolchain]
-axiom_encode_version = "0.2.1344"
+axiom_encode_version = "0.2.1345"
 axiom_compose_ref = "fabe0b3b3fd6e90d3e8f075516f9b668f524f711"
-axiom_encode_ref = "2b62dc2c1bdb60531887ac33e819741a651d898e"
+axiom_encode_ref = "8504a7e57534a81c2090211384d853a74988ab6c"
 axiom_rules_engine_ref = "05eac9d2f89dabe5c6673176260762cef3a58f47"
-axiom_corpus_ref = "01e00777cb05db84792c0de004b4fa24cfd453c3"
+axiom_corpus_ref = "cbf3d2492c8077ba454cd49df9676e8265c9b497"
 rulespec_us_ref = "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5"

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -176,11 +176,11 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         "workflow_toolchain"
     ]
     assert toolchain == {
-        "axiom_encode_version": "0.2.1344",
+        "axiom_encode_version": "0.2.1345",
         "axiom_compose_ref": "fabe0b3b3fd6e90d3e8f075516f9b668f524f711",
-        "axiom_encode_ref": "2b62dc2c1bdb60531887ac33e819741a651d898e",
+        "axiom_encode_ref": "8504a7e57534a81c2090211384d853a74988ab6c",
         "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
-        "axiom_corpus_ref": "01e00777cb05db84792c0de004b4fa24cfd453c3",
+        "axiom_corpus_ref": "cbf3d2492c8077ba454cd49df9676e8265c9b497",
         "rulespec_us_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",
     }
     release_toolchain = tomllib.loads((ROOT / ".axiom/toolchain.toml").read_text())[


### PR DESCRIPTION
## Summary

- pin the activated `us-rulespec-2026-07-24-cms-435-correction-immutable-scopes` release and signed content hash
- pin corpus merge `cbf3d249` and encoder `0.2.1345` / `8504a7e5`
- update the immutable-toolchain regression expectation

## Validation

- full RuleSpec suite: `88 passed`
- signed corpus object verified locally with the configured public key
- corpus production publication and activation succeeded

## Review cycle

Independent review pending. Do not merge until current-head CI is green and the public corpus mirror is available.