### PR TITLE
Correct 42 CFR 435.558 reverification source citation

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/558.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/558.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us/regulations/42-cfr/435/558.test.yaml",
-      "sha256": "1b6126384fe2dba6656b2f5b7450eab5f6c7f119e9ce394e8ad6937abf3836b2"
+      "sha256": "77020cd490cdc3b45de2ecba23ff110b6c6baa38c7528c7ae6e97e63c69589db"
     },
     {
       "path": "us/regulations/42-cfr/435/558.yaml",
-      "sha256": "21df6e278201328e209b831d7780a8e60f6e44c552cacab2c9fcf76f12c70b90"
+      "sha256": "3b14f02e3a3373bea5ec6be23d718b26aa24b4295b6932d66b4b1488e9e68395"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3869d66d",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,11 +21,12 @@
   "citation": "us:regulations/42-cfr/435/558",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-20T17:29:04.458438+00:00",
-  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/558.yaml",
-  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
-  "generated_output_sha256": "21df6e278201328e209b831d7780a8e60f6e44c552cacab2c9fcf76f12c70b90",
+  "generated_at": "2026-07-24T07:48:31.984175+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp89_1_v5e/sign-applied-files/us/regulations/42-cfr/435/558.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp89_1_v5e",
+  "generated_output_sha256": "3b14f02e3a3373bea5ec6be23d718b26aa24b4295b6932d66b4b1488e9e68395",
   "generation_prompt_sha256": null,
+  "manual_exception": "repair",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -33,43 +34,61 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "fae7734df74b98def78a496060695cdbdabec76eb0db898b5d266d21367f4a3b"
+    "value": "2d735254e04068e535f878432a6bb27c112c673855e779085962b13992976143"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-20T17:25:29.322748+00:00",
+    "generated_at": "2026-07-24T07:46:37.535839+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "16ad40cc21f6aa930eebb54754f386381a9df823d1df790e77cfc002a58590dc",
-    "prior_signature": "6e9498f6c2100d11ad743fbb9dac1b77cead3f8ff2b5cc2af56ee01bb8b7c11d",
+    "manifest_sha256": "9aa851a1d374ee5ca9a1b4b4254c773758ba6c9f023b3e4daba1a84d5d9b5ef0",
+    "prior_signature": "b974313e556381548872f23eee3224c89eda18e29b1c6d04856a7a305097acd1",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-20T17:24:35.383287+00:00",
+      "generated_at": "2026-07-20T17:29:04.458438+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "8b47bb321f12154a49204a8ac8ed6d7d1993d7fbaf421e486a6fde9607d62251",
-      "prior_signature": "359142a71558669010b894a420e41c694d7d830a9b2a690d5eb6912c8f843fea",
+      "manifest_sha256": "af3d48d09c2bab6d0b5f06e4b56299b92c3010c16ddce9ae4f60602b1e2bbfcc",
+      "prior_signature": "fae7734df74b98def78a496060695cdbdabec76eb0db898b5d266d21367f4a3b",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-20T17:22:55.117589+00:00",
+        "generated_at": "2026-07-20T17:25:29.322748+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "bd7395ca71230686b8c1d805971b8202633eae26b2284a3b7e481928f30b37e8",
-        "prior_signature": "2394c4cd55ceff268260a2401ceb3bdb240630cb78644a3c24d8a8e02139efaf",
+        "manifest_sha256": "16ad40cc21f6aa930eebb54754f386381a9df823d1df790e77cfc002a58590dc",
+        "prior_signature": "6e9498f6c2100d11ad743fbb9dac1b77cead3f8ff2b5cc2af56ee01bb8b7c11d",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-20T17:21:52.083292+00:00",
+          "generated_at": "2026-07-20T17:24:35.383287+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "5d6d80ef1e655113b1711d9b7b09459568b1287426c248aa187605a475ba50c8",
-          "prior_signature": "5955b25e1cd410d20bef133dd72ddeeedad4a9bfb1450aa19253174c62eef19b",
+          "manifest_sha256": "8b47bb321f12154a49204a8ac8ed6d7d1993d7fbaf421e486a6fde9607d62251",
+          "prior_signature": "359142a71558669010b894a420e41c694d7d830a9b2a690d5eb6912c8f843fea",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-20T17:18:52.865525+00:00",
+            "generated_at": "2026-07-20T17:22:55.117589+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "e81d965558ee0280e3b1a715c51b3aff371d8af9aa7d8e4ecd5880d024a99fe0",
-            "prior_signature": "706332965468665f502093b5d4e608310105b9ee4f3cd6f14429e197bacc1811",
+            "manifest_sha256": "bd7395ca71230686b8c1d805971b8202633eae26b2284a3b7e481928f30b37e8",
+            "prior_signature": "2394c4cd55ceff268260a2401ceb3bdb240630cb78644a3c24d8a8e02139efaf",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-20T17:21:52.083292+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "5d6d80ef1e655113b1711d9b7b09459568b1287426c248aa187605a475ba50c8",
+              "prior_signature": "5955b25e1cd410d20bef133dd72ddeeedad4a9bfb1450aa19253174c62eef19b",
+              "run_id": null,
+              "supersedes": {
+                "backend": "manual",
+                "generated_at": "2026-07-20T17:18:52.865525+00:00",
+                "generation_prompt_sha256": null,
+                "manifest_sha256": "e81d965558ee0280e3b1a715c51b3aff371d8af9aa7d8e4ecd5880d024a99fe0",
+                "prior_signature": "706332965468665f502093b5d4e608310105b9ee4f3cd6f14429e197bacc1811",
+                "run_id": null,
+                "tool": "axiom-encode sign-applied-files"
+              },
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35018,6 +35018,13 @@
           "module",
           "proof_atom"
         ]
+      },
+      {
+        "module": "us/regulations/42-cfr/435/558.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
       }
     ],
     "us/regulation/42/435/558": [

--- a/us/regulations/42-cfr/435/558.test.yaml
+++ b/us/regulations/42-cfr/435/558.test.yaml
@@ -69,7 +69,7 @@
   output:
     us:regulations/42-cfr/435/558#state_must_reconsider_magi_eligibility_after_reconsideration_period_submission: holds
     us:regulations/42-cfr/435/558#agency_must_not_restrict_reapplication_after_noncompliance_denial_or_disenrollment: holds
-- name: medically_frail_status_reverification_due_after_twelve_months
+- name: section_435_557_medically_frail_status_reverification_due_after_twelve_months
   period: 2026-06
   input:
     us:regulations/42-cfr/435/558#input.individual_has_medically_frail_or_special_medical_needs_status: true
@@ -78,7 +78,7 @@
   output:
     us:regulations/42-cfr/435/558#medically_frail_status_reverification_interval_months: 12
     us:regulations/42-cfr/435/558#agency_must_reverify_medically_frail_or_special_medical_needs_status: holds
-- name: medically_frail_status_reverification_not_due_before_twelve_months
+- name: section_435_557_medically_frail_status_reverification_not_due_before_twelve_months
   period: 2026-06
   input:
     us:regulations/42-cfr/435/558#input.individual_has_medically_frail_or_special_medical_needs_status: true

--- a/us/regulations/42-cfr/435/558.yaml
+++ b/us/regulations/42-cfr/435/558.yaml
@@ -5,7 +5,9 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/regulation/42/435/558
+    corpus_citation_paths:
+      - us/regulation/42/435/557
+      - us/regulation/42/435/558
   summary: |-
     If a State is unable to verify that an applicable individual has met, is deemed to have met, or is not subject to the community engagement requirement, the State must provide a notice of noncompliance, allow 30 calendar days after receipt for a satisfactory showing, continue Medicaid until ineligibility is determined, take specified steps if no satisfactory showing is made, impose no reapplication restriction, and reconsider MAGI eligibility when information is submitted during the reconsideration period.
 rules:
@@ -49,14 +51,14 @@ rules:
     kind: parameter
     dtype: Count
     unit: month
-    source: 42 CFR 435.558
+    source: 42 CFR 435.557(f)(1)(iii)
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: amount
             source:
-              corpus_citation_path: us/regulation/42/435/558
+              corpus_citation_path: us/regulation/42/435/557
               excerpt: "the agency must reverify this status at least every 12 months"
     versions:
       - effective_from: '0001-01-01'
@@ -487,14 +489,14 @@ rules:
     entity: Person
     dtype: Judgment
     period: Month
-    source: 42 CFR 435.558
+    source: 42 CFR 435.557(f)(1)(iii)
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: predicate
             source:
-              corpus_citation_path: us/regulation/42/435/558
+              corpus_citation_path: us/regulation/42/435/557
               excerpt: "the agency must reverify this status at least every 12 months"
           - path: versions[0].formula
             kind: import


### PR DESCRIPTION
## Problem

The Oregon corpus/toolchain merge activated the corrected CMS community-engagement corpus. That correction properly removes a contaminated §435.557 passage from the §435.558 source text, exposing a repository-wide numeric-grounding failure on the existing 12-month medical-frailty reverification rule. The mandate is in 42 CFR 435.557(f)(1)(iii), not §435.558.

## Fix

- Preserve the two existing published `us:regulations/42-cfr/435/558#...` legal IDs to avoid an unnecessary identity/API break.
- Declare both §435.557 and §435.558 as module source paths.
- Correct both rule-level authorities and proof citations for the reverification interval/requirement to §435.557(f)(1)(iii).
- Rename the two companion case labels to make the corrected section explicit.
- Refresh the signed full spec/test manifest and generated reverse index.

No formula, input, output, effective date, or expected value changes.

## Independent review-fix cycle

Independent review of exact head `ba1191a63995a42d4951d2bb22560e45bfa174a0` found no actionable issues. The reviewer confirmed against exact corpus ref `4c174389403f7fda19a1ce959410a22e1026c8d8` that corrected §435.557 contains the 12-month mandate, corrected §435.558 does not, and preserving the established legal IDs is preferable to relocating already-published outputs.

## Checks

- strict validator against exact corpus: pass
- compile: 25 rules
- companion: 20/20
- proof: 37 atoms, no issues
- numeric grounding: no issues
- signed generated-file guard: pass
- reverse index: current (4124 provisions / 4880 edges / 4448 modules)
- focused layout/manifest/reverse-index tests: 10 passed
- diff check: pass