### PR TITLE
Refresh evidence module shas for the seven e2e-re-encoded pilots

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -707,7 +707,7 @@
     },
     "us-ca/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:b156021da63599575025a5a768fb7d484ba833b5f8808703914de84a7903a476",
-      "module_sha256": "sha256:d97c3fad12a574c8fb93f35fbe709c8320009beb4ad55163357d1b8f9ab09747",
+      "module_sha256": "sha256:0ae43c1f1879e7c1c124dac07c6a301e62c510c05606f67a7f301f39729d451b",
       "passed": false
     },
     "us-ca/regulations/cdss/eas/49/49-035.yaml": {
@@ -6177,7 +6177,7 @@
     },
     "us-id/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:6ca089b2f0ced2adb339b6684dc655e50d478bd82d52c84e07339b4972cde5fc",
-      "module_sha256": "sha256:b095e006bc308f1d8e54b77ba5841c587af1afad1673798c83195594b6943104",
+      "module_sha256": "sha256:884daa010cfc3020d2040677f160e547a07323f4efcbd114b00de5204bc62b48",
       "passed": false
     },
     "us-id/regulations/idapa/16/03/04/page-1.yaml": {
@@ -6507,7 +6507,7 @@
     },
     "us-ky/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:c5479efb88dbe2fdcc7e6820e5fb4ce99abf9844fe57d894a2cb5e37dbde09ba",
-      "module_sha256": "sha256:16e9ba07230f511f1cb0a748c637dff9d3f9728cf21799dc6734fffe6e795eb6",
+      "module_sha256": "sha256:924ba0bc2e8492ce1646a2fd3a9a9385aa48a12e250c2b1e939b0b1e2c867cbe",
       "passed": false
     },
     "us-ky/statutes/11/141/020.yaml": {
@@ -6572,7 +6572,7 @@
     },
     "us-ma/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:caa362d34ec667700697f2d495b3ffcb0b9a193cf2d1fd0cfe65ca523efb508a",
-      "module_sha256": "sha256:f683d427226cda946fe41f9cd262a87677c3c84edb096c96d5c66c8872b5f5f1",
+      "module_sha256": "sha256:1c96452744b23e0bde1b40baf4b611b2c869f5cf422337d85467be2cdf46392c",
       "passed": false
     },
     "us-ma/regulations/106-cmr/360/010/block-1.yaml": {
@@ -7317,7 +7317,7 @@
     },
     "us-md/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:1b4d7acca34a3c9d03c1b8b2deac31011054bea42b7e3a36ec423926ecc3d314",
-      "module_sha256": "sha256:235db8b137605756252b2bce718b962c182ad95609840fe314b34d9ac12d8d8f",
+      "module_sha256": "sha256:22515bfc361b9abb013e4f53fb5d3a63d53a272abcd0e0df0f5a38a7acdc389e",
       "passed": false
     },
     "us-md/statutes/gtg/10-105.yaml": {
@@ -7337,7 +7337,7 @@
     },
     "us-me/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:fd34302a6cf7596cba8149ef9c8dff4983049781dfc933bb89f56c60a55c1192",
-      "module_sha256": "sha256:30ffb72137918aa65f2b4abf5581bdbba97439cc7b4f39426fb8c373895085b9",
+      "module_sha256": "sha256:f9b6dc2499f7ce2630bb5142f37f74a536d330b7a680760dd3ac70de40b3caf3",
       "passed": false
     },
     "us-me/regulations/dhhs/ofi/chapter-331/tanf-rule-125a/maximum-benefit-and-standard-of-need.yaml": {
@@ -7452,7 +7452,7 @@
     },
     "us-mn/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:e71b0de04947fdc750303f74101ce7cd0585cabae6c5f407b55bfda3ae58dd35",
-      "module_sha256": "sha256:e83bd457ca4dc2831f679f22bf707d6dcd8724795dd7529e62a24321937a0507",
+      "module_sha256": "sha256:897851e2f8fc945272e1e8b4bc40dbb2e72a88a756ebd22005c8c9f40ff10f4c",
       "passed": false
     },
     "us-mn/statutes/290/0121.yaml": {


### PR DESCRIPTION
Evidence-file-only. Main's overnight e2e merges re-encoded seven pilots, staling their approvals-evidence module shas; this refreshes them to main's current bytes (fingerprints untouched — the #911 branch keeps its strict-track pilot versions). Precedes the pendings-restore PR per the bridge's protected-base evidence check. Bind window: .github#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)