### PR TITLE
Pin activated SNAP CMS PIT corpus union

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-axiom_corpus_release = "us-rulespec-2026-07-24-cms-435-correction-immutable-scopes"
-axiom_corpus_release_content_sha256 = "914c0daedad1eeee96691d7a245420e434b55c971199661f1df140e6ad99699e"
+axiom_corpus_release = "us-rulespec-2026-07-24-snap-cms-pit-union"
+axiom_corpus_release_content_sha256 = "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544"
 validation_waiver_set_sha256 = "396e188da03b212c978b8b7bc222af6e5ee9fd26b32d942b64e92aaf73f8b748"

--- a/.axiom/workflow-toolchain.toml
+++ b/.axiom/workflow-toolchain.toml
@@ -1,9 +1,9 @@
 # Immutable checkout identities used by validation and generation workflows.
 # Signed corpus release and waiver evidence remain in toolchain.toml.
 [workflow_toolchain]
-axiom_encode_version = "0.2.1345"
+axiom_encode_version = "0.2.1347"
 axiom_compose_ref = "fabe0b3b3fd6e90d3e8f075516f9b668f524f711"
-axiom_encode_ref = "8504a7e57534a81c2090211384d853a74988ab6c"
+axiom_encode_ref = "9e82ccec28180cee18740b7cb3805a9678509479"
 axiom_rules_engine_ref = "05eac9d2f89dabe5c6673176260762cef3a58f47"
-axiom_corpus_ref = "cbf3d2492c8077ba454cd49df9676e8265c9b497"
+axiom_corpus_ref = "0fd35bfbda98836c406ec539a492c4e661c6695d"
 rulespec_us_ref = "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5"

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -176,11 +176,11 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         "workflow_toolchain"
     ]
     assert toolchain == {
-        "axiom_encode_version": "0.2.1345",
+        "axiom_encode_version": "0.2.1347",
         "axiom_compose_ref": "fabe0b3b3fd6e90d3e8f075516f9b668f524f711",
-        "axiom_encode_ref": "8504a7e57534a81c2090211384d853a74988ab6c",
+        "axiom_encode_ref": "9e82ccec28180cee18740b7cb3805a9678509479",
         "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
-        "axiom_corpus_ref": "cbf3d2492c8077ba454cd49df9676e8265c9b497",
+        "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
         "rulespec_us_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",
     }
     release_toolchain = tomllib.loads((ROOT / ".axiom/toolchain.toml").read_text())[


### PR DESCRIPTION
## Summary
- pin the activated `us-rulespec-2026-07-24-snap-cms-pit-union` corpus release
- record its signed content SHA and exact corpus provenance commit
- advance the encoder workflow pins to the merged signed-apply gate fix while preserving all other protected toolchain refs

## Release evidence
- publication: https://github.com/TheAxiomFoundation/axiom-corpus/actions/runs/30083674689 (successful retry)
- activation preview: https://github.com/TheAxiomFoundation/axiom-corpus/actions/runs/30088383594
- activation production: https://github.com/TheAxiomFoundation/axiom-corpus/actions/runs/30088517491
- public mirror: pending protected `release-mirror` approval (run 30088951583)

## Validation
- `git diff --check`
- `uv run pytest -q tests/test_legacy_rulespec_freeze.py` (21 passed in independent review)
- `uv run pytest -q` (88 passed; one existing unmanifested-module warning)

## Review cycle
Independent review completed before push with no actionable findings. The reviewer independently recomputed the content hash, verified the Ed25519 signature and activation, checked release provenance and all protected refs, and reran the freeze suite.