### PR TITLE
Pin corrected legacy validation workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@799195b2ca85c8106fcee001ead074fa99e2feef # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@e3952e1e4d664f66a5386863a70131d89982d1a0 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- pin repository checks to the reviewed and merged reusable legacy validation workflow
- preserve the existing legacy RuleSpec toolchain unchanged relative to current `main`
- make changed-file oracle coverage install only the exact `axiom-oracles` dependency pinned by the reviewed encoder SHA

## Safety
- reusable workflow merge: `e3952e1e4d664f66a5386863a70131d89982d1a0`
- `.axiom/toolchain.toml` unchanged relative to current base (SHA-256 `9cd80657afca4b38958c813daf4f503e87929b07b6691cf32a37a7ea693513e2`)
- full RuleSpec migration draft #911 is not modified

## Checks
- `ruby` YAML safe parse of `.github/workflows/repository-checks.yml`
- referenced reusable workflow exists at the pinned merge SHA
- `git diff --check`
- pre-serialization `python3.12 -m pytest -q -c /dev/null` (67 passed; existing unmanifested-module warning)
- post-Nevada rebase `python3.12 -m pytest -q -c /dev/null tools/tests/test_manifest_provenance.py` (8 passed)
- Nevada exact-merge postmerge workflows all green before rebase: Repository Checks `30110838064`, Source staleness `30110837737`, program-artifacts `30110837844`

## Review cycle
- initial independent review of base `a6cafce98b8bca0a482a28c874c73146221f746f` through head `2d2da92545ac069d210a58d83f6f5405fd6a2ca0`: CLEAN
- serialized behind Nevada #1059 and rebased after its merge/postmerge gates succeeded
- fresh independent review of current base `62f05afb4810e0ff0c9400f9901eb000583c66ef` through head `4a69940733b53c3e33702bb8d547d71ab7d03d9e`: CLEAN
- reviewer reconfirmed sole immutable SHA diff, exact production merge ancestry, compatible `validate-roots: auto` contract, byte-identical current-base toolchain, and no actionable findings