### PR TITLE
Encode Alaska 2026 resident individual income tax

### DIFF
--- a/.axiom/encoding-manifests/us-ak/policies/income_tax/2026_resident_zero_liability.json
+++ b/.axiom/encoding-manifests/us-ak/policies/income_tax/2026_resident_zero_liability.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ak/policies/income_tax/2026_resident_zero_liability.test.yaml",
+      "sha256": "e6d57d933dfe6a484387456da71ffbd516043c85fb58674e25355222e8682c73"
+    },
+    {
+      "path": "us-ak/policies/income_tax/2026_resident_zero_liability.yaml",
+      "sha256": "2a89c1c1f2b18373367098d0d054217fe6923f931dab683634edb065303d8cda"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ak:policies/income_tax/2026_resident_zero_liability",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-24T16:31:28.972580+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp6j_6vzax/sign-applied-files/us-ak/policies/income_tax/2026_resident_zero_liability.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp6j_6vzax",
+  "generated_output_sha256": "2a89c1c1f2b18373367098d0d054217fe6923f931dab683634edb065303d8cda",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0a5530e31e387b2c6d5c47bb5697e810e209e6103f0afefb5990597a9be4f558"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -86,6 +86,33 @@
         ]
       }
     ],
+    "us-ak/statute/43/20/11": [
+      {
+        "module": "us-ak/policies/income_tax/2026_resident_zero_liability.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ak/statute/43/20/12": [
+      {
+        "module": "us-ak/policies/income_tax/2026_resident_zero_liability.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ak/statute/43/20/13": [
+      {
+        "module": "us-ak/policies/income_tax/2026_resident_zero_liability.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-al/manual/dhr/poe/chapter-01-household-concept/103": [
       {
         "module": "us-al/policies/dhr/poe/chapter-01-household-concept/103.yaml",

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "ec575c79ec789e56213e6519db3c32b94af5b08a"
+axiom_corpus_ref = "59a3ae382487307cc79351a46ff72bbca1ed2518"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "59a3ae382487307cc79351a46ff72bbca1ed2518"
+axiom_corpus_ref = "ccd225f063d58da49bfc1dab39b0bd18dfca3d45"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/us-ak/policies/income_tax/2026_resident_zero_liability.test.yaml
+++ b/us-ak/policies/income_tax/2026_resident_zero_liability.test.yaml
@@ -1,0 +1,104 @@
+- name: resident_without_credit_inputs_has_proven_precredit_zero_and_held_signed_outputs
+  period: &tax_year_2026
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    <<: &zero_credit_resident_inputs
+      us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: true
+      us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: 0
+      us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: 0
+      us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: 0
+      us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: 0
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_chapter_tax_applies_to_individual: false
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_corporate_tax_boundary_preserved: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_credit_return_surface_applies: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_deduction_and_exemption_stage_applies: false
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_surtax_stage_applies: false
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_alaska_adjusted_gross_income: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_deductions_and_exemptions: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_taxable_income: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_tax_before_credits: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_nonrefundable_credits: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_tax_after_nonrefundable_credits: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_refundable_credit_source_hold_applies: holds
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_refundable_credits: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_complete_liability_source_hold_applies: holds
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: resident_zero_credit_candidates_are_zero_at_person_scope
+  period: *tax_year_2026
+  input:
+    <<: *zero_credit_resident_inputs
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_cap: 100
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_rate: 0.16
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_supported_resident_credit_profile_applies: holds
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '0'
+
+- name: political_credit_candidate_combines_categories_and_caps_at_one_hundred
+  period: *tax_year_2026
+  input:
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: 70
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: 35
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: 20
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: 0
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_statutory_candidate: '100'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '100'
+
+- name: federal_dependent_care_credit_flows_raw_at_sixteen_percent_but_public_amount_is_held
+  period: *tax_year_2026
+  input:
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: 0
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: 0
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: 0
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: 600
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_statutory_candidate: '96'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '96'
+
+- name: resident_with_both_credit_candidates_combines_person_level_candidates
+  period: *tax_year_2026
+  input:
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: 40
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: 0
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: 10
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: 500
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_statutory_candidate: '50'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_statutory_candidate: '80'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '130'
+
+- name: negative_raw_amounts_are_clamped_before_statutory_candidate_math
+  period: *tax_year_2026
+  input:
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: true
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: -50
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: -25
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: -10
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: -100
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '0'
+
+- name: nonresident_or_part_year_profile_is_outside_credit_domain
+  period: *tax_year_2026
+  input:
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_is_full_year_alaska_resident_return: false
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_candidate_campaign_contributions: 100
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_ballot_measure_contributions: 100
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_qualifying_political_nonprofit_dues: 100
+    us-ak:policies/income_tax/2026_resident_zero_liability#input.ak_pit_2026_federal_household_and_dependent_care_credit_claimed: 1000
+  output:
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_supported_resident_credit_profile_applies: not_holds
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_political_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_dependent_care_credit_statutory_candidate: '0'
+    us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_combined_refundable_credit_statutory_candidate: '0'

--- a/us-ak/policies/income_tax/2026_resident_zero_liability.yaml
+++ b/us-ak/policies/income_tax/2026_resident_zero_liability.yaml
@@ -1,0 +1,559 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ak/statute/43/20/11
+      - us-ak/statute/43/20/12
+      - us-ak/statute/43/20/13
+    upstream_source_check:
+      status: current_controlling_authority_with_downstream_holds
+      checked_paths:
+        - us-ak/statute/43/20/11
+        - us-ak/statute/43/20/12
+        - us-ak/statute/43/20/13
+      rationale: |-
+        The Alaska Legislature's current official Title 43 establishes the
+        relevant tax-year-2026 legal surface. Section 43.20.011 imposes the
+        chapter tax on corporations. Section 43.20.012(a)(1) expressly makes
+        that tax inapplicable to an individual, while subsection (b) permits
+        an individual return for the credits in section 43.20.013.
+
+        Section 43.20.013 provides a resident political-contribution credit
+        capped at $100 and a resident household-and-dependent-care credit
+        equal to 16 percent of the corresponding federal credit claimed. It
+        directs the commissioner to pay allowed credits as refunds, but also
+        states that payment may not be made without an appropriation.
+
+        The current statute therefore proves no individual income-tax base,
+        deduction, exemption, surtax, or pre-credit liability, and it proves
+        the statutory candidate arithmetic for the two resident credits. The
+        pinned source set does not prove a tax-year-2026 appropriation or
+        current claim mechanics. Public refundable-credit and signed
+        net-liability outputs consequently remain deferred behind typed holds.
+  summary: |-
+    Alaska tax-year-2026 full-year-resident individual-income-tax pipeline.
+    Title 43 imposes the chapter tax on corporations and expressly excludes an
+    individual, so Alaska adjusted gross income, deductions and exemptions,
+    taxable income, tax, surtax, nonrefundable credits, and tax after
+    nonrefundable credits are zero. These pre-credit zeros reflect the legal
+    absence of an individual income tax, not a fictional zero-percent bracket
+    or a zero-income assumption.
+
+    Alaska nevertheless provides two resident credits payable as refunds:
+    a political-contribution credit capped at $100 and 16 percent of the
+    federal household-and-dependent-care credit claimed. Private outputs
+    calculate only those statutory candidates from raw factual and federal
+    inputs. Because the pinned source set does not establish a tax-year-2026
+    appropriation or current claim mechanics, public refundable-credit and
+    signed net-liability outputs return fail-closed zero sentinels while typed
+    source holds remain active. Those sentinels are not substantive zero
+    claims.
+
+    Corporate and other entity taxes, Permanent Fund Dividend eligibility or
+    taxation, payments, withholding, filing administration, local taxes,
+    nonresident allocation, and part-year allocation are outside scope.
+  deferred_outputs:
+    - output: us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_refundable_credits
+      reason: |-
+        Section 43.20.013 establishes statutory resident credit candidates and
+        refund treatment, but the pinned source set does not establish a
+        tax-year-2026 appropriation or current claim mechanics.
+      source_values:
+        - us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_refundable_credit_source_hold_applies
+    - output: us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_net_income_tax_liability_before_payments
+      reason: |-
+        Signed net liability cannot be completed until the refundable-credit
+        hold is cleared and the amount payable for tax year 2026 is established.
+      source_values:
+        - us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_complete_liability_source_hold_applies
+rules:
+  - name: ak_pit_2026_political_credit_cap
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.013(a)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A resident individual is entitled to a tax credit not to exceed $100"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 100
+
+  - name: ak_pit_2026_dependent_care_credit_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Alaska Stat. § 43.20.013(b)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A resident individual is entitled to a tax credit equal to 16 percent"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0.16
+
+  - name: ak_pit_2026_chapter_tax_applies_to_individual
+    kind: derived
+    dtype: Boolean
+    period: Year
+    source: Alaska Stat. § 43.20.012(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: false
+
+  - name: ak_pit_2026_corporate_tax_boundary_preserved
+    kind: derived
+    dtype: Boolean
+    period: Year
+    source: Alaska Stat. § 43.20.011(e)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/11
+              excerpt: "There is imposed for each taxable year upon the entire taxable income of every corporation"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ak_pit_2026_credit_return_surface_applies
+    kind: derived
+    dtype: Boolean
+    period: Year
+    source: Alaska Stat. § 43.20.012(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "An individual may file a return under this chapter in order to receive a tax credit under AS 43.20.013."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ak_pit_2026_supported_resident_credit_profile_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: Alaska Stat. § 43.20.013(a)-(b), resident-individual credit scope
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A resident individual is entitled to a tax credit"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ak_pit_2026_is_full_year_alaska_resident_return
+
+  - name: ak_pit_2026_deduction_and_exemption_stage_applies
+    kind: derived
+    dtype: Boolean
+    period: Year
+    source: Alaska Stat. § 43.20.012(a)(1), chapter tax inapplicable to individuals
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: false
+
+  - name: ak_pit_2026_surtax_stage_applies
+    kind: derived
+    dtype: Boolean
+    period: Year
+    source: Alaska Stat. § 43.20.012(a)(1), chapter tax inapplicable to individuals
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: false
+
+  - name: ak_pit_2026_alaska_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.012(a)(1), no individual income-tax base
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_deductions_and_exemptions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.012(a)(1), no individual deduction or exemption stage
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.012(a)(1), no individual taxable-income stage
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. §§ 43.20.011(e), 43.20.012(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/11
+              excerpt: "There is imposed for each taxable year upon the entire taxable income of every corporation"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. §§ 43.20.012(b), 43.20.013(c), resident credits are paid as refunds
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "The commissioner shall pay the amount of a tax credit allowed by this section"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A credit under this section shall be paid in the manner provided in AS 43.20.030(e) for the payment of refunds"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. §§ 43.20.012(a)(1), 43.20.013(c)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A credit under this section shall be paid in the manner provided in AS 43.20.030(e) for the payment of refunds"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_political_credit_statutory_candidate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.013(a)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A resident individual is entitled to a tax credit not to exceed $100"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "a contribution made in a calendar year to a person or organization for use exclusively"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "dues paid in a calendar year to a nonprofit organization organized primarily for the purpose of influencing elections in Alaska"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ak_pit_2026_supported_resident_credit_profile_applies:
+            min(
+              ak_pit_2026_political_credit_cap,
+              max(0, ak_pit_2026_qualifying_candidate_campaign_contributions)
+              + max(0, ak_pit_2026_qualifying_ballot_measure_contributions)
+              + max(0, ak_pit_2026_qualifying_political_nonprofit_dues)
+            )
+          else: 0
+
+  - name: ak_pit_2026_dependent_care_credit_statutory_candidate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.013(b)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "A resident individual is entitled to a tax credit equal to 16 percent"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "the tax credit claimed by the individual on the federal income tax return of the individual for household and dependent care services necessary for gainful employment"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ak_pit_2026_supported_resident_credit_profile_applies:
+            ak_pit_2026_dependent_care_credit_rate
+            * max(0, ak_pit_2026_federal_household_and_dependent_care_credit_claimed)
+          else: 0
+
+  - name: ak_pit_2026_combined_refundable_credit_statutory_candidate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Alaska Stat. § 43.20.013(a)-(c), statutory candidate before appropriation and claim mechanics
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "The commissioner shall pay the amount of a tax credit allowed by this section"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ak_pit_2026_political_credit_statutory_candidate
+          + ak_pit_2026_dependent_care_credit_statutory_candidate
+
+  - name: ak_pit_2026_refundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Alaska Stat. § 43.20.013(c), payment requires appropriation; 2026 appropriation and current claim mechanics not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "payment may not be made without an appropriation for that purpose."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ak_pit_2026_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed sentinel pending tax-year-2026 appropriation and current claim mechanics
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "payment may not be made without an appropriation for that purpose."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: ak_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Alaska Stat. § 43.20.013(c), signed liability awaits payable refundable-credit amount
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "payment may not be made without an appropriation for that purpose."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ak_pit_2026_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed sentinel pending refundable-credit amount and signed-liability completion
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/12
+              excerpt: "The tax imposed by this chapter does not apply to (1) an individual"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ak/statute/43/20/13
+              excerpt: "payment may not be made without an appropriation for that purpose."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+inputs:
+  - name: ak_pit_2026_is_full_year_alaska_resident_return
+    entity: Person
+    dtype: Bool
+    period: Year
+    description: True only for a full-year Alaska resident individual return.
+  - name: ak_pit_2026_qualifying_candidate_campaign_contributions
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Calendar-year contributions satisfying Alaska Stat. § 43.20.013(a)(1)(A).
+  - name: ak_pit_2026_qualifying_ballot_measure_contributions
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Calendar-year contributions satisfying Alaska Stat. § 43.20.013(a)(1)(B).
+  - name: ak_pit_2026_qualifying_political_nonprofit_dues
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Calendar-year dues satisfying Alaska Stat. § 43.20.013(a)(2).
+  - name: ak_pit_2026_federal_household_and_dependent_care_credit_claimed
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Raw household-and-dependent-care credit claimed on the aligned federal income-tax return.


### PR DESCRIPTION
## Summary
- encode Alaska TY2026 full-year-resident individual income-tax stages from adjusted gross income through signed liability before payments
- preserve source-backed pre-credit zeros while calculating private person-level statutory credit candidates
- hold public refundable-credit and signed-liability outputs pending TY2026 appropriation and current claim mechanics
- pin the exact merged Alaska corpus authority and add signed RuleSpec provenance

## Independent review cycle
- initial review found the corpus toolchain pin predated Alaska authority
- fixed by pinning exact merged corpus `ccd225f063d58da49bfc1dab39b0bd18dfca3d45`
- refreshed onto exact post-green main `3e8bb244fe56341fb32c0f02e92c5fb8824daa51`; independent re-review of exact head `19dacd3bf9a5adc4487ebbaa8ed631b84978ce79` found no actionable findings

## Checks
- deterministic validate: pass
- proof validation: 28 atoms, money-atom gate pass
- companion tests: 7 passed
- generated-file signature guard: pass
- reverse index check: pass
- repository tests: 67 passed under CI Python 3.13
- exact oracle coverage: 21/21 known_not_comparable, tax-scoped
- `git diff --check`