### PR TITLE
Pin encoder 0.2.1369 on canonical hard cut

### DIFF
--- a/.axiom/workflow-toolchain.toml
+++ b/.axiom/workflow-toolchain.toml
@@ -1,9 +1,9 @@
 # Immutable checkout identities used by validation and generation workflows.
 # Signed corpus release and waiver evidence remain in toolchain.toml.
 [workflow_toolchain]
-axiom_encode_version = "0.2.1347"
+axiom_encode_version = "0.2.1369"
 axiom_compose_ref = "fabe0b3b3fd6e90d3e8f075516f9b668f524f711"
-axiom_encode_ref = "9e82ccec28180cee18740b7cb3805a9678509479"
+axiom_encode_ref = "7ed95111e0c19f4cb58c42fc036e3aa5fc3eb73d"
 axiom_rules_engine_ref = "05eac9d2f89dabe5c6673176260762cef3a58f47"
 axiom_corpus_ref = "0fd35bfbda98836c406ec539a492c4e661c6695d"
 rulespec_us_ref = "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5"

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -176,9 +176,9 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         "workflow_toolchain"
     ]
     assert toolchain == {
-        "axiom_encode_version": "0.2.1347",
+        "axiom_encode_version": "0.2.1369",
         "axiom_compose_ref": "fabe0b3b3fd6e90d3e8f075516f9b668f524f711",
-        "axiom_encode_ref": "9e82ccec28180cee18740b7cb3805a9678509479",
+        "axiom_encode_ref": "7ed95111e0c19f4cb58c42fc036e3aa5fc3eb73d",
         "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
         "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
         "rulespec_us_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",


### PR DESCRIPTION
## Summary

- pin the canonical hard-cut validation workflow to `axiom-encode` `0.2.1369`
- use immutable encoder merge commit `7ed95111e0c19f4cb58c42fc036e3aa5fc3eb73d` from TheAxiomFoundation/axiom-encode#1263
- update the hard-cut immutable-toolchain regression fixture to the same version and SHA
- leave corpus, engine, compose, RuleSpec, waiver, workflow, and generated-content state unchanged

## Why

Encoder 0.2.1369 hardens proof grounding for evidence slices while preserving legal-marker positives. The hard-cut branch needs this release to validate the Louisiana proof cases before the shared waiver bootstrap can be advanced.

## Checks

- `git diff --check`
- parsed `.axiom/workflow-toolchain.toml` with Python `tomllib`
- verified the encoder merge SHA is on encoder `main` and both package version declarations are `0.2.1369`
- `python -m pytest -q tests/test_legacy_rulespec_freeze.py` (`21 passed`)
- `python -m pytest -q` (`92 passed`, one pre-existing unmanifested-module warning)

## Review cycle

Independent review found the stale immutable-toolchain fixture on the first head. The fixture was fixed and the complete diff was reviewed again at exact head `ec6d4430`; no actionable findings remain. Merge remains gated on the fresh program-artifacts build for that head.