### PR TITLE
Pin reviewed hard-cut bootstrap workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -75,7 +75,7 @@ jobs:
 
   validate:
     needs: [legacy-rulespec-freeze, workflow-toolchain]
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@63f0cf25c862b822bc895f2dda72826ec02faa4e
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@0bfa8b1b6b8f4397109c81e4f8dbe351267996dd
     secrets: inherit
     with:
       axiom-encode-ref: ${{ needs.workflow-toolchain.outputs.axiom_encode_ref }}
@@ -93,7 +93,7 @@ jobs:
       retired-schema-bootstrap-sha256: >-
         ${{ ((github.event_name == 'pull_request' && github.event.pull_request.number == 911) || (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Merge pull request #911 from '))) && '396f4cd3e3e305999d7c0039740e31282c996d4024306f77be902e719294b658' || '' }}
       validation-waiver-bootstrap-sha256: >-
-        ${{ ((github.event_name == 'pull_request' && github.event.pull_request.number == 911) || (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Merge pull request #911 from '))) && 'bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3' || '' }}
+        ${{ ((github.event_name == 'pull_request' && github.event.pull_request.number == 911) || (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Merge pull request #911 from '))) && '396e188da03b212c978b8b7bc222af6e5ee9fd26b32d942b64e92aaf73f8b748' || '' }}
       guard-programs-root: false
 
   drift-alarm:

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -113,7 +113,7 @@ def test_required_workflow_runs_freeze_before_validation() -> None:
 
     assert "legacy-rulespec-freeze:" in workflow
     assert "needs: [legacy-rulespec-freeze, workflow-toolchain]" in workflow
-    assert "63f0cf25c862b822bc895f2dda72826ec02faa4e" in workflow
+    assert "0bfa8b1b6b8f4397109c81e4f8dbe351267996dd" in workflow
     assert (
         "retired-schema-bootstrap-sha256: >-\n"
         "        ${{ ((github.event_name == 'pull_request'"
@@ -123,7 +123,7 @@ def test_required_workflow_runs_freeze_before_validation() -> None:
         "validation-waiver-bootstrap-sha256: >-\n"
         "        ${{ ((github.event_name == 'pull_request'"
     ) in workflow
-    assert "bedeb89a4d0cfce60d9a83a705fa3e15826685e636d71381192e70c2e5cfb1e3" in workflow
+    assert "396e188da03b212c978b8b7bc222af6e5ee9fd26b32d942b64e92aaf73f8b748" in workflow
     assert '[ "${{ github.event.pull_request.number }}" != "911" ]' in workflow
     guard_expression = (
         "${{ !((github.event_name == 'pull_request' && "


### PR DESCRIPTION
## Summary

- pin the RuleSpec repository checks to central workflow merge `0bfa8b1b6b8f4397109c81e4f8dbe351267996dd`
- pass the reviewed hard-cut waiver SHA-256 `396e188da03b212c978b8b7bc222af6e5ee9fd26b32d942b64e92aaf73f8b748`
- update the immutable freeze assertions to the same values

## Scope

This PR changes only `.github/workflows/repository-checks.yml` and its freeze test. It does not change RuleSpec content, generated artifacts, toolchain pins, waiver content, retired-schema bootstrap identity, or event/topology conditions.

The pinned central workflow authorizes reviewed anchor `b4ded205d888390f20109a5bce9738c85246c0b0` and preserves the existing repository, PR-number, ancestry, topology, merge-tree, and allowed-path checks.

## Checks

- `git diff --check`
- verified the pinned central commit contains the exact hard-cut anchor and waiver hash
- verified `e51ffc4e` descends from the anchor and has no post-anchor paths outside the two explicitly permitted files
- `python -m pytest -q tests/test_legacy_rulespec_freeze.py` (`21 passed`)
- `python -m pytest -q` (`92 passed`, one pre-existing unmanifested-module warning)
- central bootstrap authorization regression passed

## Review cycle

Independent review completed at exact head `e51ffc4e5ac05866b7e8566789ea5ecb5b4ca449` with no actionable findings. Hosted repository checks intentionally run only when the hard-cut PR targets `main`; PR #911 is the required post-merge hosted gate.