### PR TITLE
Pin legacy validation workflow with Alaska and Tennessee oracle coverage

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@e3952e1e4d664f66a5386863a70131d89982d1a0 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@93857601473e1a607688c884b32a5e70ed28480b # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- pin the RuleSpec repository checks caller to the exact merged shared workflow that includes Alaska oracle coverage
- preserve the legacy RuleSpec toolchain pin unchanged
- keep the reusable-workflow reference immutable

## Dependency chain
- shared workflow merge: `93857601473e1a607688c884b32a5e70ed28480b`
- default oracle-coverage encoder: `f8eb0658401b23f10fc90c3d3a9e2619d1378455`
- shared-workflow post-merge run `30115173993`: success

## Independent review cycle
- exact base: `0909ece0b844c45bdc97a21ec8676b841371001c`
- exact reviewed head: `97573090b6fa38ed3164cc4376669f69815d4674`
- result: clean, no actionable findings

## Checks
- repository layout: 9 passed
- target reusable workflow exists at the pinned commit
- legacy `.axiom/toolchain.toml` byte-identical to base
- `git diff --check`