### PR TITLE
Pin encoder 0.2.1373 on hard cut

### DIFF
--- a/.axiom/workflow-toolchain.toml
+++ b/.axiom/workflow-toolchain.toml
@@ -1,9 +1,9 @@
 # Immutable checkout identities used by validation and generation workflows.
 # Signed corpus release and waiver evidence remain in toolchain.toml.
 [workflow_toolchain]
-axiom_encode_version = "0.2.1372"
+axiom_encode_version = "0.2.1373"
 axiom_compose_ref = "fabe0b3b3fd6e90d3e8f075516f9b668f524f711"
-axiom_encode_ref = "5ceb5c5400065bd92a07a82b71ba85fd501ef4fb"
+axiom_encode_ref = "caebbda1a190181ef8184ed7aaffedb3789202a3"
 axiom_rules_engine_ref = "05eac9d2f89dabe5c6673176260762cef3a58f47"
 axiom_corpus_ref = "0fd35bfbda98836c406ec539a492c4e661c6695d"
 rulespec_us_ref = "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5"

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -176,9 +176,9 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
         "workflow_toolchain"
     ]
     assert toolchain == {
-        "axiom_encode_version": "0.2.1372",
+        "axiom_encode_version": "0.2.1373",
         "axiom_compose_ref": "fabe0b3b3fd6e90d3e8f075516f9b668f524f711",
-        "axiom_encode_ref": "5ceb5c5400065bd92a07a82b71ba85fd501ef4fb",
+        "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
         "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
         "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
         "rulespec_us_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",


### PR DESCRIPTION
## Summary
- pin `axiom-encode` 0.2.1373 at reviewed merge `caebbda1a190181ef8184ed7aaffedb3789202a3`
- refresh the immutable workflow-toolchain freeze fixture
- unblock hosted proof validation for the remaining Florida legal clauses and Georgia CAPS OCR footnotes

## Scope
This changes only the immutable encoder version/ref and its exact test fixture. No RuleSpec policy content is edited.

## Checks
- `uv run pytest -q tests/test_legacy_rulespec_freeze.py` (`21 passed`)
- `uv run pytest -q` (`92 passed`)
- `git diff --check`

Encoder source PR: TheAxiomFoundation/axiom-encode#1269
