### PR TITLE
Pin reviewed hard-cut workflow anchor

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -75,7 +75,7 @@ jobs:
 
   validate:
     needs: [legacy-rulespec-freeze, workflow-toolchain]
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@0bfa8b1b6b8f4397109c81e4f8dbe351267996dd
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@19673fb6314ce511bbde59b9a9451cbc18c8c201
     secrets: inherit
     with:
       axiom-encode-ref: ${{ needs.workflow-toolchain.outputs.axiom_encode_ref }}

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -113,7 +113,7 @@ def test_required_workflow_runs_freeze_before_validation() -> None:
 
     assert "legacy-rulespec-freeze:" in workflow
     assert "needs: [legacy-rulespec-freeze, workflow-toolchain]" in workflow
-    assert "0bfa8b1b6b8f4397109c81e4f8dbe351267996dd" in workflow
+    assert "19673fb6314ce511bbde59b9a9451cbc18c8c201" in workflow
     assert (
         "retired-schema-bootstrap-sha256: >-\n"
         "        ${{ ((github.event_name == 'pull_request'"


### PR DESCRIPTION
## Summary
- pin the reviewed central RuleSpec workflow merge `19673fb6314ce511bbde59b9a9451cbc18c8c201`
- refresh the exact legacy-freeze assertion
- authorize PR #911 from reviewed hard-cut anchor `b7cea0e625460f5170d6b4835283994dece963d8`

## Scope
This changes only the immutable shared-workflow reference and its exact test fixture. It does not alter RuleSpec content, waiver data, or encoder outputs.

The shared workflow advances the reviewed anchor without broadening any event, repository, PR, topology, ancestry, allowed-path, hash, or merge-tree constraint.

## Checks
- `uv run pytest -q tests/test_legacy_rulespec_freeze.py` (`21 passed`)
- `uv run pytest -q` (`92 passed`)
- `git diff --check`

Central workflow source: TheAxiomFoundation/.github#65
