### PR TITLE
Pin current RuleSpec validation anchor

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -75,7 +75,7 @@ jobs:
 
   validate:
     needs: [legacy-rulespec-freeze, workflow-toolchain]
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@19673fb6314ce511bbde59b9a9451cbc18c8c201
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@862f56d18ffb9d56d6f327e718ce1a8c5ba1010d
     secrets: inherit
     with:
       axiom-encode-ref: ${{ needs.workflow-toolchain.outputs.axiom_encode_ref }}

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -113,7 +113,7 @@ def test_required_workflow_runs_freeze_before_validation() -> None:
 
     assert "legacy-rulespec-freeze:" in workflow
     assert "needs: [legacy-rulespec-freeze, workflow-toolchain]" in workflow
-    assert "19673fb6314ce511bbde59b9a9451cbc18c8c201" in workflow
+    assert "862f56d18ffb9d56d6f327e718ce1a8c5ba1010d" in workflow
     assert (
         "retired-schema-bootstrap-sha256: >-\n"
         "        ${{ ((github.event_name == 'pull_request'"


### PR DESCRIPTION
## Summary
- pin repository validation to shared workflow merge 862f56d18ffb9d56d6f327e718ce1a8c5ba1010d
- keep the legacy freeze assertion aligned with the immutable workflow reference
- authorize the reviewed hard-cut ancestry at ae6998b49ef446ceae3e8d833375170affa32d2b without changing the waiver digest

## Validation
- `uv run pytest -q tests/test_legacy_rulespec_freeze.py` (21 passed)
- `uv run pytest -q` (92 passed)
- `git diff --check`