### PR TITLE
fix: pin union corpus after Illinois merge

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "65b9a98a271cda7d4fc109a62fb45b376738416b"
+axiom_corpus_ref = "5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- advance only `axiom_corpus_ref` from the Illinois-only merge revision to current union corpus `5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7`
- restore source coverage required by existing Alaska, South Dakota, and Tennessee modules while preserving Illinois sources byte-identically
- leave encoder, rules engine, and canonical-target pins unchanged

## Why

Illinois PR #1074 pinned corpus revision `65b9a98a...`, which contains the Illinois evidence but is not a descendant of the earlier state-tax corpus line and therefore omitted sources still referenced by AK/SD/TN. The replacement revision is an exact descendant of both prior-good corpus `710a3263...` and Illinois corpus merge `65b9a98a...`.

## Validation

- pinned legacy validation: AK, IL, SD, TN — PASS (CI mode)
- exact corpus audit: all declared citation paths and excerpts present for AK/IL/SD/TN
- compile/proof/money: PASS; 97 proof atoms; 0 missing money atoms across 5 obligations
- companion tests: 44 PASS
- reverse-index check and secure apply-key guard: PASS
- Python 3.13 full repository suite: 67 PASS
- independent no-edit review of exact `4cd4ef7b...e9fef7ec`: CLEAN

The diff is exactly one line in `.axiom/toolchain.toml`.