### PR TITLE
Encode Idaho 2026 resident income tax as bounded source holds

### DIFF
--- a/.axiom/encoding-manifests/us-id/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-id/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-id/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
+      "sha256": "ceddbbc788d2a3119c87f4b7b1ab785beeebb14d351510f4c7f134001d8e7ede"
+    },
+    {
+      "path": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+      "sha256": "816ef3cbe3c96b294a8b2db425fe924060caff05375eafd1718fc637884c6655"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-id:policies/income_tax/2026_full_year_resident_source_hold",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-25T00:17:23.866382+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbu26aqmz/sign-applied-files/us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpbu26aqmz",
+  "generated_output_sha256": "816ef3cbe3c96b294a8b2db425fe924060caff05375eafd1718fc637884c6655",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "dc2bb04eeea567db7b9cf300be5578567383cfcc19d5494171cb2a5f0ceb3a0c"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-25T00:10:27.009019+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "787aa9e6d695fbabfe6bb1bd26e90a0588811619c47329b0f0210b5b9c384978",
+    "prior_signature": "a62eef980217bfc2557d86376ecff4d5bd5389f66d9f465fb2b4a61a5dc64e24",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -18794,6 +18794,13 @@
     ],
     "us-id/statute/63-3022D": [
       {
+        "module": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-id/statutes/63-3022D.yaml",
         "via": [
           "module",
@@ -18803,6 +18810,13 @@
     ],
     "us-id/statute/63-3022E": [
       {
+        "module": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-id/statutes/63-3022E.yaml",
         "via": [
           "module",
@@ -18811,6 +18825,13 @@
       }
     ],
     "us-id/statute/63-3024": [
+      {
+        "module": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-id/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
@@ -18828,6 +18849,13 @@
     ],
     "us-id/statute/63-3024A": [
       {
+        "module": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-id/statutes/63-3024A.yaml",
         "via": [
           "module",
@@ -18836,6 +18864,13 @@
       }
     ],
     "us-id/statute/63-3025D": [
+      {
+        "module": "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-id/statutes/63-3025D.yaml",
         "via": [

--- a/us-id/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-id/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -1,0 +1,66 @@
+# The pinned Idaho statute recovery retains raw official HTML and official
+# citation paths, but the corpus provision layer has no substantive provision
+# bodies; the official income-tax regulations and annual-return forms are also
+# not ingested. These fixtures prove only the allowed federal boundary,
+# full-year-resident domain gate, typed source holds, and fail-closed Money
+# sentinels. No zero is a substantive Idaho tax result.
+
+- name: valid positive federal return is held through signed liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_adjusted_gross_income: 60000.0
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_is_full_year_idaho_resident_return: true
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_and_idaho_filing_units_are_aligned: true
+  output:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_federal_adjusted_gross_income_boundary: '60000'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_input_domain_is_valid: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_income_and_modification_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_deduction_and_exemption_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_indexed_schedule_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_surtax_surface_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_nonrefundable_credit_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_refundable_credit_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_complete_liability_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_state_income_after_modifications: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_taxable_income: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_tax_before_credits_including_indexed_schedule_and_surtaxes: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_tax_after_nonrefundable_credits: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_refundable_credits: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: negative federal adjusted gross income remains a valid raw boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_adjusted_gross_income: -5000.0
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_is_full_year_idaho_resident_return: true
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_and_idaho_filing_units_are_aligned: true
+  output:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_federal_adjusted_gross_income_boundary: '-5000'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_input_domain_is_valid: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_complete_liability_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_state_income_after_modifications: '0'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: part-year return is outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_adjusted_gross_income: 45000.0
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_is_full_year_idaho_resident_return: false
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_and_idaho_filing_units_are_aligned: true
+  output:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_federal_adjusted_gross_income_boundary: '45000'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_input_domain_is_valid: not_holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_complete_liability_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: misaligned filing units are outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_adjusted_gross_income: 1100000.0
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_is_full_year_idaho_resident_return: true
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#input.id_pit_2026_federal_and_idaho_filing_units_are_aligned: false
+  output:
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_federal_adjusted_gross_income_boundary: '1100000'
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_input_domain_is_valid: not_holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_complete_liability_source_hold_applies: holds
+    us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_net_income_tax_liability_before_payments: '0'

--- a/us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -1,0 +1,437 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-id/statute/63-3022D
+      - us-id/statute/63-3022E
+      - us-id/statute/63-3024
+      - us-id/statute/63-3024A
+      - us-id/statute/63-3025D
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-id/statute/63-3022D
+        - us-id/statute/63-3022E
+        - us-id/statute/63-3024
+        - us-id/statute/63-3024A
+        - us-id/statute/63-3025D
+      rationale: |-
+        The pinned official Idaho corpus snapshot identifies five Title 63
+        provisions relevant to deductions, ordinary tax, the grocery credit,
+        and an elderly or disabled household-member amount. The raw official
+        Legislature HTML is retained, but the corpus provision layer failed to
+        extract the substantive provisions: each section is represented only
+        by an empty parent plus site-navigation and search wrapper blocks. The
+        Idaho income-tax regulation and tax-form manifests are also not
+        ingested into that snapshot.
+
+        Consequently, the pinned corpus does not establish an executable
+        tax-year-2026 resident return. It does not pin the federal starting
+        point and complete addition/subtraction chain, the deduction and
+        exemption chain, the operative annual indexed section 63-3024
+        thresholds, complete surtax or specialty-tax applicability, complete
+        nonrefundable and refundable credit eligibility and ordering, or the
+        signed liability before payments.
+
+        This module accepts only an allowed federal-return output and raw
+        residency and filing-unit facts. It never accepts Idaho adjusted gross
+        income, modifications, taxable income, deductions, exemptions, rates,
+        thresholds, tax, surtax, credits, or liability. Typed source holds
+        remain active, and every public Idaho Money stage is a fail-closed zero
+        sentinel. Those sentinels are not legal claims that Idaho income,
+        credits, or tax are zero.
+  summary: |-
+    Tax-year-2026 Idaho full-year-resident individual-income-tax
+    source-readiness boundary. It preserves federal adjusted gross income as
+    an allowed federal-return output and accepts raw residency and filing-unit
+    alignment facts for the future executable return.
+
+    Idaho income after additions and subtractions, taxable income after
+    deductions and exemptions, tax including the annual indexed section
+    63-3024 schedule and any surtaxes, tax after nonrefundable credits,
+    refundable credits, and signed liability before payments all fail closed
+    while the pinned source gaps remain. The module is intentionally
+    incomplete and makes no annual liability or oracle-parity claim.
+
+    Withholding, estimated payments, extension payments, penalties, interest,
+    refunds of payments, local taxes, nonresident sourcing, part-year
+    allocation, estates, and trusts are outside scope.
+  deferred_outputs:
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_state_income_after_modifications
+      reason: |-
+        The pinned corpus does not contain a substantive, current Idaho
+        definition of the federal starting point or the complete operative
+        2026 additions and subtractions.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_income_and_modification_source_hold_applies
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_taxable_income
+      reason: |-
+        Idaho taxable income cannot be completed until the 2026 income,
+        modification, deduction, and exemption chains are source complete.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_income_and_modification_source_hold_applies
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_deduction_and_exemption_source_hold_applies
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_tax_before_credits_including_indexed_schedule_and_surtaxes
+      reason: |-
+        Tax before credits cannot be completed without source-complete taxable
+        income, the official 2026 section 63-3024 indexed thresholds, and a
+        closed surtax and specialty-tax surface.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_income_and_modification_source_hold_applies
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_deduction_and_exemption_source_hold_applies
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_indexed_schedule_source_hold_applies
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_surtax_surface_source_hold_applies
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_tax_after_nonrefundable_credits
+      reason: |-
+        Complete 2026 nonrefundable-credit eligibility, limitations,
+        carryforwards, and ordering are not pinned.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_nonrefundable_credit_source_hold_applies
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_refundable_credits
+      reason: |-
+        A cited grocery-credit section and household-member provision do not
+        establish a source-complete 2026 refundable-credit inventory or
+        ordering chain because their substantive bodies are absent from the
+        corpus provision layer.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_refundable_credit_source_hold_applies
+    - output: us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_net_income_tax_liability_before_payments
+      reason: |-
+        Signed annual resident liability cannot be completed until every
+        income, deduction, schedule, surtax, and credit source hold is cleared.
+      source_values:
+        - us-id:policies/income_tax/2026_full_year_resident_source_hold#id_pit_2026_complete_liability_source_hold_applies
+
+rules:
+  - name: id_pit_2026_federal_adjusted_gross_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Allowed federal adjusted gross income boundary; the Idaho starting-point rule remains source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: id_pit_2026_federal_adjusted_gross_income
+
+  - name: id_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Full-year Idaho resident individual return with an aligned federal filing unit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          id_pit_2026_is_full_year_idaho_resident_return
+          and id_pit_2026_federal_and_idaho_filing_units_are_aligned
+          and (
+            id_pit_2026_federal_adjusted_gross_income >= 0
+            or id_pit_2026_federal_adjusted_gross_income < 0
+          )
+
+  - name: id_pit_2026_income_and_modification_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing substantive official 2026 Idaho income-base, addition, and subtraction authority in the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_deduction_and_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete substantive official 2026 Idaho deduction and exemption chain in the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3022E
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_indexed_schedule_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing official tax-year-2026 Idaho section 63-3024 indexed threshold publication in the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_surtax_surface_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Idaho individual surtax and specialty-tax applicability is not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_nonrefundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Idaho nonrefundable-credit inventory, limitations, carryforwards, and ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3025D
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_refundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Idaho refundable-credit inventory, eligibility, and ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024A
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3025D
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: id_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined source hold for incomplete tax-year-2026 Idaho resident liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-id/statute/63-3024A
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          id_pit_2026_income_and_modification_source_hold_applies
+          or id_pit_2026_deduction_and_exemption_source_hold_applies
+          or id_pit_2026_indexed_schedule_source_hold_applies
+          or id_pit_2026_surtax_surface_source_hold_applies
+          or id_pit_2026_nonrefundable_credit_source_hold_applies
+          or id_pit_2026_refundable_credit_source_hold_applies
+
+  - name: id_pit_2026_state_income_after_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Idaho income-after-modifications sentinel while the complete 2026 income, addition, and subtraction chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: id_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Idaho taxable-income sentinel while the complete 2026 income, deduction, and exemption chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3022D
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3022E
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: id_pit_2026_tax_before_credits_including_indexed_schedule_and_surtaxes
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Idaho tax sentinel while taxable income, the annual indexed schedule, and the complete surtax surface are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: id_pit_2026_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Idaho tax-after-nonrefundable-credits sentinel while the complete credit surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3025D
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: id_pit_2026_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Idaho refundable-credit sentinel while the complete 2026 credit inventory and ordering are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024A
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3025D
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: id_pit_2026_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed Idaho resident income-tax liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-id/statute/63-3024A
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+inputs:
+  - name: id_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income from the aligned federal return; it is not a completed Idaho income amount.
+  - name: id_pit_2026_is_full_year_idaho_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is within this program's full-year Idaho resident scope.
+  - name: id_pit_2026_federal_and_idaho_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the federal and Idaho returns cover the same filing unit.


### PR DESCRIPTION
## Summary

- add a bounded 2026 full-year Idaho resident income-tax RuleSpec
- carry raw federal income through the statewide liability stages to signed net liability before payments
- fail closed with typed source holds where the retained official corpus does not establish an operative complete current-year chain
- add 4 companion cases, signed apply provenance, and the generated provision reverse-index entries

## Scope

State individual income tax only. Local taxes, nonresident/part-year allocation, payments, withholding, estimated tax, penalties, interest, and administrative collection are excluded.

## Validation

- independent review-fix cycle: CLEAN, no actionable findings
- signed `guard-generated`: pass
- pinned `axiom-encode validate --skip-reviewers`: pass
- pinned `proof-validate`: pass, 21 atoms
- pinned money-atom validation: pass, 0 missing of 0 obligations
- pinned companion test: pass, 4/4 cases
- reverse-index regeneration: clean
- `python -m pytest -q tests`: 59 passed
- `git diff --check`: pass

Validated with the repository-pinned legacy encoder 0.2.1200, rules engine `ffd8213271947b0189a9dd61a055c1e0e78908a0`, and retained union corpus `5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7`.

Exact reviewed head: `bd389ba4f2c95e4706d1213bdab6e99c59769480`.
Exact base: `9a88f94dcb253309f96371e4df2d877e39cdf436`.