### PR TITLE
Approve isolated replacement waiver fingerprints

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -4012,7 +4012,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:b4cc1c781dea7d3ca96043fcc8165edc6bc95b2d99fcaa6b9170f59ff2b4664d"
+      fingerprint: "sha256:d9375b14930a8362f5db779f54d5843eeb2570792add02fd87207d93a58ad3cf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4023,7 +4023,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:5737f1cc0ad920873b546935588a901f07525621937a03a4e3384cea7746f0fd"
+      fingerprint: "sha256:dfc981e7244f26f9a085bf6e4e08ed7b6c385595ae33c4bf71ce5f03f1bc1b32"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4034,7 +4034,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:9740986efc6338f0c392f57ba7b42efddebbc56de5e06a00d1aa243f9bf01b88"
+      fingerprint: "sha256:93aacbe77f4ff7d5c938dfe9a12abd154ada8c48849e104fce0adadef0af6b73"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4085,7 +4085,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:3ba88a6fc0e863ec29951ed7b45ce32dd6288120250a28841f79ca90befcf3fb"
+      fingerprint: "sha256:71dd37b615ca9531fbd2263ccf31dbba37305f639aa3655ca3ee43e43f8b4a18"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4130,7 +4130,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:528f257d99fcc879fd43a6067f13f5f75db0f08f138a833b4fed76f20a52b246"
+      fingerprint: "sha256:c6fbe453ef93dfda542a6bb0437d6adf5e10af8aa56e7ea7a305793a5a9c28a6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4342,6 +4342,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/151.yaml":
     active:
       fingerprint: "sha256:2a898e8691b13d46969b2d5288ad9d045edab79c3ad7fde76891cc7e395d4890"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c46ad79f1cd1d390caa77601d5ad7a4b832b1eb6c5a58b882fb266454bb91fbf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4679,7 +4684,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:0523216af81c35fbf8838b2f315ef061be8c5aa95eb9c88c3c7fd6b45b15971a"
+      fingerprint: "sha256:7f078800c5069efb4bc4fb09eb353825dbdc3d8485d3e2eedfb5adde2265189d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4714,7 +4719,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:c5bb260f4ac8e67b6c66b62a0887d303354ead1595064bd94d86c56e58079900"
+      fingerprint: "sha256:418faaa21ecc85196c7248ede2b45c903846b3283956e3083be2300d44a8e049"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4758,7 +4763,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:0ed2ce23ff264219b2367888cbe13620e17c22e6c70a731007e3e81af440d827"
+      fingerprint: "sha256:ee917e7c4e61911abffd9f57bc8b7a3c0a59fefdf3e092c09ae6ccea65f4bd09"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4874,7 +4879,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:963d7d0b3970c12cdbb2cf0d76a7111b7f8431719bc4e89d86d7df1381accd90"
+      fingerprint: "sha256:7afa9bd42436a651ce0bfab0b8409e3ddb67163c8a9148438d59e8e7a9efa970"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5278,7 +5283,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:046ba887409f8eab32d39bbb08389543c45a424fe3a66e2b4950c44069066da4"
+      fingerprint: "sha256:827c074f88e81f61abf02d7fe3ec6040836c1dc1f38190d03cb0cd94f234c686"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5335,7 +5340,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:5aa7dc34b0ce13fe3474118169aad8ce8575fed0ed71283f73067e8aa72634ee"
+      fingerprint: "sha256:545d6b6403580a2ab94667f2d5854e98f0aafd8cb98c48562799a6a5fe88e6a5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5374,7 +5379,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:e98166db92d71b2ca72d880555052ceac756aeb1853501f6ce23ba464e667afd"
+      fingerprint: "sha256:75a89306a1f3adf53cba6ced84dbb1544fe8077957deeb207af8b0af711b3a70"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5998,15 +6003,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:95599ecfe1053130f5178e24ab412c5d9a76da6c4943969b06a60197a2c006ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml":
     active:
       fingerprint: "sha256:a0426cb3ae5be118065e5a7cae8740b1bfceffcaa36af3e05d6c7f8a15d088bc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e07ea599c08ff108181a502ec5c29843445e4731512b992ead4be7a459d45536"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml":
     active:
       fingerprint: "sha256:b945e06453572a6a7cd56979a7a35df5fcd36c3877013c09ae022f4079444357"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:840bcbb9f5fae93869f1337c7a25224ddfc5aa11997c0d8d62e143a2804c4ccc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6046,6 +6066,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1fb6bc10ce849113aac100031af50ab4d2402a4e4aac04a64cbe531bc9c83501"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-340-deductions/page-22.yaml":
     active:
       fingerprint: "sha256:15a064d0bf5632817390d84e0b4a52b6abb2bc426d2fac1bef51520c1c4595bf"
@@ -6061,6 +6086,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml":
     active:
       fingerprint: "sha256:a788e2a2ed25f01571117ddc13bf8858d0e0b09c1a90510f44773c10eed4be21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7b6aef13d7d22b60ee668a49c69cc56890be2635b60bb6c7df65e6b01a86a06a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6127,6 +6157,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml":
     active:
       fingerprint: "sha256:ee1e6a743452892647a9719a4b8e9ddafaafdb95b2fb1e5c1144dc39a6e83998"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2ddc29000eec5c43e1b4a856f40271e120233ec041cfe880cd51f85e1f807716"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6280,9 +6315,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c31134f866ebc0f449307decfe7ffa19ddf9be74e4dffbf068c5c18d16d10065"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml":
     active:
       fingerprint: "sha256:5c6ccec3728481617c138d8f6300207cb52edae4c3d52a4204e10c80b2b159f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:874550359cb45dfeca692f9dee535b8fdb09d90bd1f7302cc00034a22a9b8aac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6313,6 +6358,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml":
     active:
       fingerprint: "sha256:6f6909aabfb3b2e12eab7b9a355bd9a0f3a05282c9adb75b0e209f9cd7ae385e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2771fc3dc86de455bb8421a565e007efec2f764e1bbbd5fc0de1744e5876e954"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6407,7 +6457,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:36c1bbd2adf9e793e3ca3f025a02f1b7a1df94dfff9ebb2cf966bbdf87a7f887"
+      fingerprint: "sha256:a9c25b06c4705a1eaf3a85b0252514d7edd8b3f7708c57ef8b238945a41b955a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6418,7 +6468,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:f96e56414c70f8c49c87b49d1707826dd5442cd577c9ac467b96f382ac813ae8"
+      fingerprint: "sha256:cea24e9a1a7645daf26ceb37e1036a85eceebf811e7a0d309d00255d3cf9a1ce"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6429,7 +6479,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:33446dc2051e3cab5e31882db17e1bdbec48b87b585dc8e1cdb6114a635f4e4b"
+      fingerprint: "sha256:b7a69436fc2161c2947b3aebe804992c4ce7e463a6c17fd2b2d0f8f86fdd7b76"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6440,7 +6490,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:ff2bdbcf21676688527e8063003c8d61d13776d087073d3f2e85ca8ff2c09c8f"
+      fingerprint: "sha256:988847e32cca202fa902b17c81ac23591b53be14664b2b5f670dc065f23ea070"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6451,7 +6501,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:65999eda50199d35e743749e9061a4ed8dc79dc54283d093139ccebea8427cb5"
+      fingerprint: "sha256:c885d942450e3d53f178b41238eb5ea879d13298dc923b10c347d86026522979"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6493,6 +6543,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-sc/policies/dss/snap-policy-manual/page-125.yaml":
     active:
       fingerprint: "sha256:71bc3c7ba4f295e64974e6f1c47d837a275bf9f398090a9b15cce7c88c5f7751"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b135dc74bc279292cdd7ab5ca577e934d1f841037027cd3a629ee2660153ac24"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6625,6 +6680,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-sc/policies/dss/snap-policy-manual/page-314.yaml":
     active:
       fingerprint: "sha256:fc77e1795e70b8b4b6649b3ea1c33476d3151e879d6c83ccec8ed23ce40048f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8627243507046dfbdf2e2e48a0c4e0a465d0117d2e971a787e7e556c78059757"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7138,6 +7198,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5b203210fa46184bf3eb0ff59d1efccd1d3cceb8fc56e736e7df2e191515ff27"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-tn/regulations/1240-01/14/09/block-1.yaml":
     active:
       fingerprint: "sha256:c1dbccc62213d4a54a2b4721aa7358c38f19f9de7c5ddbab6ec06caa0f2cd219"
@@ -7288,6 +7353,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:76377c19ffa1080e3c713c852c1cad450270075648d3d2330c28b18fe8505032"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-9.yaml":
     active:
       fingerprint: "sha256:f10e257306c897d6ff3dcf844c91a06c04bbe874b9c4dc58ef354f5fb82c83db"
@@ -7357,6 +7427,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml":
     active:
       fingerprint: "sha256:cdd0a1317e78e07b991e999b3b2a826b9079fb0fac8ff5a497416a7b627a7af3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b3cd4b767cf8783bd362333b2ba7dfd8878bbee370859660086e1daf546b02bf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7444,6 +7519,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e94778664870df9506ac2618c7a4e3ea7d3cc623a8b06f78f2246e6e516b52ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/decal/caps/appendix-c-payment-zones.yaml":
     active:
       fingerprint: "sha256:56d1760be5b422a9028e4043f619cb919b00371b0a717e0f6496f9dd8ed9a21a"
@@ -7453,6 +7533,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml":
     active:
       fingerprint: "sha256:ab8818ddadeede78a363551b8c77c35eccbe24c70a0ad8e165af69e1be42a2f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9d380849295103fa48e2f03f75326a6628ff485f57bd489210f3241083591450"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7498,6 +7583,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c933127697b98f68792b9883a7b5695f1baa188f2f4417333947bf4af1ff8c4f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml":
     active:
       fingerprint: "sha256:cd8b7e4c4044ce01019c5418ee6e33f35510c06f918ce9742b14876e812e8268"
@@ -7539,6 +7629,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3680f94624d40bbb0a3af77d6b7d5090051eefca1b7b71447919c74a00887e69"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml":
     active:
       fingerprint: "sha256:2342e46a0edf6cd01b90efb435402ec062e88cc5766a086507d9f9c3602379fc"
@@ -7563,6 +7658,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a0baa03196157ee7dd3f5d26c7fe88711386c8c7bea84675c866409895862dcf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mi/policies/mdhhs/bridges/bem/660.yaml":
     active:
       fingerprint: "sha256:3c0148f0c07a846addb454ce8666aa960c8f9c97d2f377f63b5ca872da4cf581"
@@ -7575,6 +7675,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d359d4061373dc352fef16f5fecf873081087d1f8cef9ee01ef2cfc7972c2375"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml":
     active:
       fingerprint: "sha256:5efdafca8e8769c4047ab48268510c2ab648ca8c5c67662308712ee8bd4bcadd"
@@ -7582,7 +7687,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:ded2d44fef7a4e9d7f7597fc8ec24b6f46e29a23925c4ae02b626ec7d312c5fe"
+      fingerprint: "sha256:2b9424a2f22c7f940955b7653f3522e980d3305e69947ec9f17904d3356237b4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8324,7 +8429,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/gross-income-test.yaml":
     pending:
-      fingerprint: "sha256:c2c52639afb4ef74b5313b65bec2ed1287ff730d3566e98323a8091ec3ea5673"
+      fingerprint: "sha256:62cc80cab619d9dd90a1ea5d22567ea29a9ba2a10ac66e6db284f597307273e3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8390,7 +8495,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/statutes/43-1023.yaml":
     pending:
-      fingerprint: "sha256:4381a9d0648e8d20df0c89f055de9f89a4a34c6f4253a0fc1bbb4c02aa44f7e2"
+      fingerprint: "sha256:542bcee01e5f8ae2fdf0901600d223fe1202dd4ea5bd6bb0111d1564329b3f87"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8432,13 +8537,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml":
     pending:
-      fingerprint: "sha256:aef37b20677d59b800f61c0797b2485c36f654adfbddd1059c9bc76c2f0727f4"
+      fingerprint: "sha256:22f5a0697b6f8e874a9d00f004fbca2b30b6d7d5f4cb75a05f91fc51e6db2079"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/monthly-aid-payment.yaml":
     pending:
-      fingerprint: "sha256:6734dfc183b5b25ed364bad9d2df4da2332211f07d17c8c56e311d2c9f125d7e"
+      fingerprint: "sha256:b664307194e918f742cd969c0b1f4d3eb09239a26e754abdb204e6a5caf1211b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8630,7 +8735,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.130.yaml":
     pending:
-      fingerprint: "sha256:cd5b5c56cbed725a888e9cc4f0e09e4a10429764ce5a5ebda02dce37cc85f99f"
+      fingerprint: "sha256:91f6c3068dab2eb6df55ff43b9e2c4749f5fd66067071a59f1ce49ce797b33d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8834,7 +8939,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.206.yaml":
     pending:
-      fingerprint: "sha256:7398c867e9117ea114c5b462915f7ed7e0eb48c135a6bc7aae8c7877c1109464"
+      fingerprint: "sha256:5f766951776f604566abdefa2c6078fc4092b8d81be1f26688b9ab5453f694f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9260,7 +9365,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.405.2.yaml":
     pending:
-      fingerprint: "sha256:f1585b9890fdd3c83a7194d2386ce27102ea3cbf971ad9bae0a9fb08d70fc61d"
+      fingerprint: "sha256:7b57e5ad540a814c7b1e66b545298a5426d3a98520bec8a9c557e3148ae76fc0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9920,7 +10025,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.41.yaml":
     pending:
-      fingerprint: "sha256:677f3b77e7c97aafeec4c416adf4d083f17efd8b9257ccc026344835cc83e67c"
+      fingerprint: "sha256:3ab758faa8009c4034a74e55b07ab151e1ed1022308baec5e5345c649668bf5d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9950,7 +10055,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.801.7.yaml":
     pending:
-      fingerprint: "sha256:b27d97b6cf7bceaa848c4b6794d9fa88d5a98604d4ee3ad95df1b5f28167b30c"
+      fingerprint: "sha256:50abcad15eb187ae66f278c33827c56df22ba1f968156cffb5b73131208edcf2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10040,7 +10145,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.2.yaml":
     pending:
-      fingerprint: "sha256:4a168740dcef2013f6a20619a965212294a4f61c88f60071b090fe9919310763"
+      fingerprint: "sha256:6b46dadf3034a8f2ee2cd385a667eba9bfe0b8d9a5dd4a6a518519ee0cfa51e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10052,13 +10157,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.4.yaml":
     pending:
-      fingerprint: "sha256:9083d94abeb67aad62d156ffd7e1cffb2bd78001c962f775b7d3f906fa543463"
+      fingerprint: "sha256:7d1bf3e42008bedf1a170d5a3a6b50b682654b4e6b074adb6f2c81e616414071"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.803.41.yaml":
     pending:
-      fingerprint: "sha256:addd1f1d0e91965cf68189e73455943b6dc53b5e33a7fe4dd2293475209fa809"
+      fingerprint: "sha256:ae61402e831ad6dff426ccf03339dcf8598fae75af49a9519d778a61f209b084"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10112,7 +10217,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.804.1.yaml":
     pending:
-      fingerprint: "sha256:03396ef0426aab59c8c6cfb0101e3379b2f76afe45531c6309490e4a2f0595ab"
+      fingerprint: "sha256:87d5731d85ec94c2a6b3a0a776a6bb0d5d4232f5bdd3b329aa57d11e025ec4b3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10202,7 +10307,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.903.31.yaml":
     pending:
-      fingerprint: "sha256:df005b01c50dfb5442ee72256993bc2f193bedfd67ebdd059582beb99bb53ff6"
+      fingerprint: "sha256:0fcbd5cb8f797fbfae08b7b2015715af7f33667bb3d12e89b2ab5d8bb1c9d8f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10256,7 +10361,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml":
     pending:
-      fingerprint: "sha256:eccac935993a72fe7b83a828a35ba4e0e5ff88081ea3e054896bf3ba8d7d3509"
+      fingerprint: "sha256:a5fdb8551898e0d7713be4865a5e15d9b0d488a45c1f48c854c1ab756c002e05"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10304,7 +10409,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.61.yaml":
     pending:
-      fingerprint: "sha256:9b2e347cb8ac4965d4c74befc1a999a713b42c305ee74c6319a68e80578b1278"
+      fingerprint: "sha256:a22112a39f80a82ffed9f9691e2500dfbc7aa1464d83c2810d0de6b1f80f39be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10322,7 +10427,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.64.yaml":
     pending:
-      fingerprint: "sha256:5b278ba3575d30737c45ac494e363483ea8ef224e8349365052ecc080088364b"
+      fingerprint: "sha256:877a29f4326eca73f5eca3a0ab92522135263abd99a58d9d7c5253c4d976fe63"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10352,19 +10457,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.69.yaml":
     pending:
-      fingerprint: "sha256:42193a1cfe465f85c2c3bfe12ba35269468612b3b1fe5f5a60a7758e69e869a4"
+      fingerprint: "sha256:5da22f2008ff1c639867fe1d81c5963a66a99c1ecd5d9a6269f9835c9c763c57"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.71.yaml":
     pending:
-      fingerprint: "sha256:ab489e93df13ce6fddba5b4a6f004b5bdd159552a42ac9b26abd2cc13f35ae1f"
+      fingerprint: "sha256:da9efa8d552feca0cbf1952cfe3fe491c54bf6d19ac566ffbf410354e03fcf8e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.72.yaml":
     pending:
-      fingerprint: "sha256:39bad003fd38bb407555dc80abff41a6af0622387ded383ed0abb794c0e3b0bb"
+      fingerprint: "sha256:7dc60397a488ca544c730699462a0b4d07282500a0a4db882f92b4e7ba425ed6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10376,13 +10481,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.741.yaml":
     pending:
-      fingerprint: "sha256:35f2f6bcb4129fdc214a13c876b1d2adac94d9779daa94f47151179fc51c343c"
+      fingerprint: "sha256:584c9ba0f8c826747c221ba3ec97e66bdfa60074db8bd0df700c8be27eead02c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.742.yaml":
     pending:
-      fingerprint: "sha256:7f0ac09ec4690ae0a1bd5f070db28835026ec6c50adebb2124fec5ebe1aaa92d"
+      fingerprint: "sha256:8f5ca45ebc9f85dfa1d9b37922c271c81d6bd6cb5ddea2820535cfef45593075"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10394,13 +10499,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.76.yaml":
     pending:
-      fingerprint: "sha256:13a69b88a7b31159a05d496c5424c52a10fe280d88c4a91d78029628fd7ed929"
+      fingerprint: "sha256:ebba75f4cb5219af83b6a4bc81a11deb5ef7ae134cfca75686c7c21ac00b832b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.77.yaml":
     pending:
-      fingerprint: "sha256:d8c813a43a189fd61e46ac474b4c712c4268e7def370fb26ba1acc637bd0783e"
+      fingerprint: "sha256:94434d42a37407c2a0d3b21b91a8bdee56bd79b0093985b7e9fcfacc836073e2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10424,7 +10529,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.784.yaml":
     pending:
-      fingerprint: "sha256:4f469f8ec58f97135288ab049ded9a333fae941531c06d0c215148ca6bc866ca"
+      fingerprint: "sha256:45f2eff3e6525fcfc0824a6138313c80d2a7c25257878cc8abf4df79852a24e9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10442,7 +10547,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.520.79.yaml":
     pending:
-      fingerprint: "sha256:9e3b8387e12252d5cdfc47e70d803bc54a20103efbaf5afc6512264f76b556fc"
+      fingerprint: "sha256:74338a182fcc205d7bdac5f4258fc3c3859788e65125665d16e6ac84d2ec5d5b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10454,7 +10559,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.530.yaml":
     pending:
-      fingerprint: "sha256:7b495c22546442023ae34c400478ad739ac22c2299ee9edd0784927d5d59c687"
+      fingerprint: "sha256:ca80ed65103a412a5b493f7a2a5a1778149a435f7b2ceab836c2c884dbfb0624"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10466,19 +10571,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.532.yaml":
     pending:
-      fingerprint: "sha256:3b4a7226c87b7e4b2e5a3ff2d13adc35ba6846c365f3ba81d485f76b16df449e"
+      fingerprint: "sha256:770c6a9d1ea3cc2215dd423ca5e53db2d486eaa43cd92ad7912e91afa4573cb2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.533.yaml":
     pending:
-      fingerprint: "sha256:8319f37fc9d9b24c2bb7d1e673f2b8da8a44baeafbc85f83e7f201d27603bff6"
+      fingerprint: "sha256:738a19abce2fb318dc525dd32b74533d5aaa4d45f13ab16526c8ee923822e051"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.534.yaml":
     pending:
-      fingerprint: "sha256:b6bf9b6bc921848200adbcc24b72167ac9751059dd5ce637db10ba18ab6403b4"
+      fingerprint: "sha256:3ead4061c5763ef2dac6ac0b325e2b8df5c734ef1e6da186f802df5a2c716363"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10508,7 +10613,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.541.3.yaml":
     pending:
-      fingerprint: "sha256:0d50075b9c8abdd3ae2c5b5d94e3316eb0816d9a6832db06530a582d9b26a3fa"
+      fingerprint: "sha256:2b27b990fb68a304c6ab397e29c91fdec32275080903da67e865328d22263a0f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10532,7 +10637,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.544.yaml":
     pending:
-      fingerprint: "sha256:0df41c986cc3f992b0875e3dfe813f8e519ceb01c4599dd78e0237f0cc663b52"
+      fingerprint: "sha256:825f332a52a10cdfd5eefaff242ecf0690be7a9abc0ffcc8ab07a2f2b3968199"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10544,7 +10649,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.546.yaml":
     pending:
-      fingerprint: "sha256:60e550323ca37ef10b6fa828c8e0bb959ffa03a2e244583ebb296b09dc823254"
+      fingerprint: "sha256:144a1e6f661ded8b30cfc4e218eaf520c75d7624ce9e41fe34ce47054bed80d9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10556,25 +10661,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.548.yaml":
     pending:
-      fingerprint: "sha256:9e3a06a2b3c9acdc06116587da9459205ca07373913cdf7e8259d835bf8b0569"
+      fingerprint: "sha256:4533d6266d2bdff3fb59e2d130eed57d756f2aee7ed9bbefcd9ee092f5474212"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.549.yaml":
     pending:
-      fingerprint: "sha256:f6a8b4349dc012c3d84319f6d83637b7ccc4ff1936be38bf9a054c1882639fc7"
+      fingerprint: "sha256:3231657b504073914980374036debdbd4cfe7cc0d9abcb5d276c3b611ca443f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.550.yaml":
     pending:
-      fingerprint: "sha256:b6c07c24b1d786c71fc2bc627c26366af81bde9e421b251b53b31649b2194fd6"
+      fingerprint: "sha256:001c92780909bd7316936ec0163a5e74aafecde196415617504875890a204ee1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.551.yaml":
     pending:
-      fingerprint: "sha256:e89d8b1801ff6ce90a20acd5fb818be9b6ec9123a937e026df7ae7bf308d0e6d"
+      fingerprint: "sha256:4fd1f16135e284952675a0dbc565a7054957416b00ec80f777e1f2b068131389"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10586,7 +10691,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.553.yaml":
     pending:
-      fingerprint: "sha256:fd4a7bc58afd02b479b089b4e00cb73c9d92056e6e9a28d9b1bb6293f3dcf8ae"
+      fingerprint: "sha256:0cc26cc5c24f1dcf1b7edd905ca7e024e1d4bfd30eeab02620cc8b0ad5e45663"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10604,7 +10709,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.11.yaml":
     pending:
-      fingerprint: "sha256:e9c3434fecafff55a364e35541f95324066299f7b8001e8149edd32042fbae7f"
+      fingerprint: "sha256:960752bcdebf8166e94b29f56cdcf508851265c84d6c1540a7c56a7c159b7c40"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10622,19 +10727,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.14.yaml":
     pending:
-      fingerprint: "sha256:c157a2cc1c8fb354eb1664d646352061d7a8e20367526e44769102283c5976d6"
+      fingerprint: "sha256:5e0d485b41e666defe63e2f8c9b6422f0fea754bc102b900ba6390abea72bc68"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.15.yaml":
     pending:
-      fingerprint: "sha256:5e754f4200eb7fb670e0bfe7a2c92d4eec679f0467e00289c2469d5b1be717ed"
+      fingerprint: "sha256:d18256d653fa9a16012bbaf5533c2ecb4aabb88b688fdfad9f023d5dec9ff39e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.16.yaml":
     pending:
-      fingerprint: "sha256:36183d434956049b03444907151673e68336ca5f2340a2e92fcf8644339c290d"
+      fingerprint: "sha256:702b48e915196bcc288036d1e744992fbe7841f10031e4abf5de0f2fdf9b775a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10646,7 +10751,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.18.yaml":
     pending:
-      fingerprint: "sha256:913c9debed544875583b38b11699efa1c23b0bc3f1fce01fe2b6fff4bf4d5e91"
+      fingerprint: "sha256:31ad1314eb5e224eb94de3e059ab29d05c0f907efaf03207ab7d556960e3f02e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10664,7 +10769,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.570.43.yaml":
     pending:
-      fingerprint: "sha256:e373632fde93e914b9435b032b591dded8bc121d1e894616b8fd05b14a947446"
+      fingerprint: "sha256:83ae092d4dd23f29da29d288505ded3b672d5223bceb18c3a1ffcab79525162e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10694,13 +10799,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.582.yaml":
     pending:
-      fingerprint: "sha256:a25a8e7cc14f5901c114e4bbe74dfdda505da88f453ba72e7052a2f9b7ecbb45"
+      fingerprint: "sha256:e981376b24ff900cbbd3045a6e79520e289748e76a9f82e8918084bbeb098bc4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.583.yaml":
     pending:
-      fingerprint: "sha256:2f74df0a04f06391b38fad393e49eecc24ae482a1935efe070710dcb2df4dc31"
+      fingerprint: "sha256:9ec8a41e0695a3d220fdb741ea8ac109eaff9ba37e877b62cd2536da61cc8177"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10712,7 +10817,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.585.yaml":
     pending:
-      fingerprint: "sha256:e5eb3e728a1ad686b999c73911bc2115a4516604835ca8927484df316ae42b56"
+      fingerprint: "sha256:3fff79fde9dd72fead6f9ec88d3ec75a489bbf89eddf7ebccb988955b969bb40"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10724,7 +10829,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-5/3.587.1.yaml":
     pending:
-      fingerprint: "sha256:5c7e214a8611df3e62223bda0cf095413072a78505197a4be4e292e02ef784f8"
+      fingerprint: "sha256:b4768a46d8defa0ea778ad7deafc9eff7e4cdcbe5c708a371da49450859ab39c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10796,7 +10901,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-105.5.yaml":
     pending:
-      fingerprint: "sha256:5fc56ff6379d7cb9ea22c92376e0d285782a50ee050fd36dcb14e9990500399a"
+      fingerprint: "sha256:85e27de39283c9c0f249a00cc4393fb79a8be24fba355ae8c26fffa4e59098be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10856,7 +10961,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-1-113.yaml":
     pending:
-      fingerprint: "sha256:d7e9781f56f59a60cc0a88c1c1ada50501411a2e7d0d1374bbe67b54ca076c91"
+      fingerprint: "sha256:90f8a79bc9d376bfa7621d0469c24d401876d037383cb467557e9510dae752d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10988,7 +11093,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/3/l.yaml":
     pending:
-      fingerprint: "sha256:e7103db7a94fc82a8432a8318bf274f5311296c00af1db69432a4b5204ab336d"
+      fingerprint: "sha256:480a3710bccc9deb5f374ccfce8c57127527c7e0820d06f2b08632452d37ea83"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11096,7 +11201,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-2003.yaml":
     pending:
-      fingerprint: "sha256:cd87598c64296f22a9dc2e7f44eb9e962355db9318259bc6d87b3bee7c744fce"
+      fingerprint: "sha256:0a4911baa1c3bcfadad713fe1c91db2f7f92078c25dc48d1da5cfbc03051181f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11108,7 +11213,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-547.yaml":
     pending:
-      fingerprint: "sha256:a306a5d7463a2de62061e3f981c0d4fe83b3b6444dc81c554416696670ca3e60"
+      fingerprint: "sha256:ed76868c2e844517b6ec40fd77923c85a557e65453eb38d6248d776aec2709ad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11132,7 +11237,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-103.5.yaml":
     pending:
-      fingerprint: "sha256:d552fcbff4e77769c0a2e24099d28d8c670e0b474256fd92403a12fef3524cc1"
+      fingerprint: "sha256:00ea594d08c388542a84aa884fb2001897feca049f7fcadd5bca421c613d978a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11144,7 +11249,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-104.yaml":
     pending:
-      fingerprint: "sha256:e63410f47f8f059324cf6baf832faf60bd1c9ca86a46a7dce741409589344676"
+      fingerprint: "sha256:103cd52256644050c73776dc440893783fc1284f77f3503aca0fba81702739a9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11156,7 +11261,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-105.4.yaml":
     pending:
-      fingerprint: "sha256:230d9507e197f3a5f43413e09fef95963e8b57a01f33826a17e58c5de8a9c487"
+      fingerprint: "sha256:7c359e7c695acb9604e2c95bdb6e06ab2e25580021203a086e71a081c977b8c7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11192,7 +11297,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-112.yaml":
     pending:
-      fingerprint: "sha256:488c650289ea1e38e02c885ce4b84b3930a4804f06c9000a824d7f2c8f67169a"
+      fingerprint: "sha256:6a4d17375ed52a065b5809807613b7b67667b3a2aa38e10a3df6365e3da9fc72"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11300,13 +11405,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-204.yaml":
     pending:
-      fingerprint: "sha256:c010c765a07a980439774ae266cfa17cd0337d01f17d8a6289454629c478d12e"
+      fingerprint: "sha256:041990f4f05b7375ea524b3b7d89e641a3d3511c7252d92ecad4eec94cdad7b1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-205.yaml":
     pending:
-      fingerprint: "sha256:107b629ada3924b5f733770c1892689e14174f5221c9c19afdc3fef4daa3d205"
+      fingerprint: "sha256:a55a2ae3f53aaf474fbbdfce9928bba811de4c8942236ef0cff7eab6736f018d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11372,13 +11477,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-704.yaml":
     pending:
-      fingerprint: "sha256:b819d2d3052e9c7a20495c08f390216cfdd63466f70197f8bdea23ae19b98383"
+      fingerprint: "sha256:18a218f461428a4d1d7510f5a37977440f1a073408ceefe729208e568a18d41d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-705.yaml":
     pending:
-      fingerprint: "sha256:58f6b7f014a001a3e9f6f4536f74a90e6331e909fe48c09f030b8391be8974c5"
+      fingerprint: "sha256:2932b8b41fc5788e2f9ebdf244fc7e8ea7d9bbd19ed2b2b20730a0799482e136"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11414,7 +11519,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-711.5.yaml":
     pending:
-      fingerprint: "sha256:f30acdcb53aeeabedd52bb7a50858725d145b3b0e5fcec73a30058f27fa5f62d"
+      fingerprint: "sha256:425ba81b4879415ac88c714259cc1edd51648174bf3984470d2339d3563b10ca"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11450,7 +11555,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-715.yaml":
     pending:
-      fingerprint: "sha256:45f31b8ef28fe3742ee61ffe1b41acf832739a934b5a7f7e8b29e6cade3017e3"
+      fingerprint: "sha256:faf15fa93948ba828869f230bc864a7bef130334424dd01a6813ed6a8495efa4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11468,13 +11573,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-718.yaml":
     pending:
-      fingerprint: "sha256:91b578cc8ac45bbc83eba20fadf1e28a18edcf6e46dd4a8b4c3b17077e7816aa"
+      fingerprint: "sha256:df39453408117097fb3d720fc4b153192a95fa2b7727fe0c8691f1d95d0f0edd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-719.yaml":
     pending:
-      fingerprint: "sha256:57b9b5af794b49f9445849f8f9f9dace710f31b33532f9a99b5ded40b9bb2a50"
+      fingerprint: "sha256:2be9dbf06cfd4cd9f7ea9fbbaae4bda91a3d6dd4bff9ee693bdcf7b033138a3a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11552,7 +11657,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-26-734.yaml":
     pending:
-      fingerprint: "sha256:d3298c58e3e79314c199aa5c253a04337b05f50349acab5d5714a4977dd6b79a"
+      fingerprint: "sha256:4290200eff4a38619c9969bf750d0b9147ec28b22dd6f136b39c13a8a926a666"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11612,7 +11717,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-104.yaml":
     pending:
-      fingerprint: "sha256:fb1ea712e1d882a025cd60a5757dbda5a70aa1546d4bc63ac32990bb068ee36f"
+      fingerprint: "sha256:918373277a4f9f77db3409123a836a4d46ba014c547639460041866062b03646"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11642,7 +11747,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-27-110.yaml":
     pending:
-      fingerprint: "sha256:412f70be881c7641540dd656d51d89b67c999313b79e515283390fb1665f1bdc"
+      fingerprint: "sha256:e18a4ec8f760222bf6f5f43a6c8008e9609da1108df65b9d998e2bf85f747f4e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11768,31 +11873,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-104.yaml":
     pending:
-      fingerprint: "sha256:c6f9009e568c2cec43f32cc3ff285024cd88fe856ef3e47482045f75e80a33be"
+      fingerprint: "sha256:074b7b631e8a1d6abf9c636ee05a80486b8aa8f2c744b024f941a2788b51330d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-105.yaml":
     pending:
-      fingerprint: "sha256:03cd57c025a1e71902ea573f7b81784fd8d319e7e6c9e5c161ef50e1ef660c1f"
+      fingerprint: "sha256:fce9b3a4a28d536342b36766f5aacde7f3d73b6328d9e5a8e5fec51ce9cc5046"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-106.yaml":
     pending:
-      fingerprint: "sha256:05cca45a62426951d66be40e4baa277e500de2ee2b72eb42287a0c779ba9afbb"
+      fingerprint: "sha256:e9b9c2dd130e47faf074c888a0e5284184ac9bb0a4adb4afdd8fa8ccd47dd8c8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-107.8.yaml":
     pending:
-      fingerprint: "sha256:3ed1406cdcb7a242e36e0110cef8a3617a231bebb38b22a185f2c33459899932"
+      fingerprint: "sha256:c1205366e51d04d40e3532efe723f92dd6f681f7dae679ef5b02f23023ba92cb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-107.yaml":
     pending:
-      fingerprint: "sha256:e91841850990c3477bba14e0ac95c5b16c9feb8d12234d760cf056d174dda222"
+      fingerprint: "sha256:3eb15b74fe44d3a849371a7285196c7e08f0394c9cd841f3891cecd2a052b21c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11804,7 +11909,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-109.3.yaml":
     pending:
-      fingerprint: "sha256:5909e953e49cc33d2d225eda00cb93ec1865393c49557b915968b9eb0cb70491"
+      fingerprint: "sha256:0ad8df785e00533d54116d047af0a7902b6ea3eb5bd85d3665e3a4e4f95c5e63"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11846,7 +11951,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-115.yaml":
     pending:
-      fingerprint: "sha256:22564419cd5fb981885da7f37f55c046bc03ae0e653b8fd1a327f6552bbe2330"
+      fingerprint: "sha256:6cdacc5669b27163917c8618f28403e34d69ead6f65d18276cc8ec85e9b62ff6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11882,7 +11987,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-3-206.yaml":
     pending:
-      fingerprint: "sha256:b0fc40493932d9da7facd169d420e4520263db1d2c386e1b8043738f1b641558"
+      fingerprint: "sha256:35421e664a82f96114d0d1f31ae383423683d45e841b03b629101633f0f891dc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11924,7 +12029,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-31-104.5.yaml":
     pending:
-      fingerprint: "sha256:39ff504d54c993770ca2150f9cdaaab0de9eecf579c4c0e9392cbe1f69c48fa2"
+      fingerprint: "sha256:e12490200535e6d4be9b28c849f34179bd0023f37f63e47f1d98826694ba1611"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12008,19 +12113,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ct/statutes/17b-104.yaml":
     pending:
-      fingerprint: "sha256:ea505c3d133e8cd6a78715e3867b2bbca0eb968efb9533d3a8ddea48bcc1d40e"
+      fingerprint: "sha256:49f4ea201b3867c2b2d24551d69c3ebdaed2d02bc0378442982904e08a46e8c5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-112.yaml":
     pending:
-      fingerprint: "sha256:cb9870255de3acae32e12ebcb16354898e03558768c3ee0aae2fd236b8eb93cb"
+      fingerprint: "sha256:2ddd17796f0d1532cbabbdcb8377dd513699ae2bb28ad5396d1cf92b0563934b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-600.yaml":
     pending:
-      fingerprint: "sha256:fd9df09da5a525bbeabdbbc3be51ef706f52b919fb74dec08b2853f6ee8c529f"
+      fingerprint: "sha256:9aa431dbbc84c58c70e5e14b068eff087e3968ac74aaa53c2d25bbdb3607249b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12080,31 +12185,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-de/statutes/30/1108.yaml":
     pending:
-      fingerprint: "sha256:9bda110ae1909ee26c7a7e27caa668d470080e355143b26881557940d188ba69"
+      fingerprint: "sha256:761d5e2f18227146d81c06d4de55e4f47cae8a4e89451459b05b48c0975d122a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1109.yaml":
     pending:
-      fingerprint: "sha256:2eeb3069a444ba4f5f9fbc419a3ed221f7c91a1509d438e99308d2c0e8920e05"
+      fingerprint: "sha256:431518ff5ab4f95cc4f7a27d1e0b1850adb67a63e2faf76666a12229abee48d6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1110.yaml":
     pending:
-      fingerprint: "sha256:831ac985b9aea213778c9efb08ac9995daa1e55fb4edf32d8421ee7062321314"
+      fingerprint: "sha256:31a7c04ebaf13f227635218dbd493a0bf985e5eec9af1999d49f746d5bdd6811"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1114.yaml":
     pending:
-      fingerprint: "sha256:17334a4bd47add3ee7aa8b4dfe5e624b03b00494e3ee89e8cd158db8ea951b6f"
+      fingerprint: "sha256:4db2c58135bebad41f47f9beb944bf47d86db8a1e5de98a0a0e5c15b6261f67c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-de/statutes/30/1117.yaml":
     pending:
-      fingerprint: "sha256:678102165d27aa1a310d58aba8052124beffa0cd8801ba9b9740e3495fc999b0"
+      fingerprint: "sha256:6d427e9ecded2dc602254fee8afc05745e5b9459fa3237ce3e4da0881e4f3af2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12638,7 +12743,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-hi/regulations/har/17/680/17-680-12.yaml":
     pending:
-      fingerprint: "sha256:51fee9c9ecdf8dc73aaee122128fecd7bb80ba8a6b5f4033eee69341e519c515"
+      fingerprint: "sha256:30df6025e52afff121ee0701db1d665c879e99705cf230fbaacc0ac4fc2d234c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12818,31 +12923,31 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/statutes/63-3022D.yaml":
     pending:
-      fingerprint: "sha256:2c3b62f0bf8c017be858b6a26a2050681189294c4c5a5b5a9091c32faabff655"
+      fingerprint: "sha256:5a0b3babd845e371b817089005d5f23abb31cc98a189ec4ce7c5ce661cf1a6cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3022E.yaml":
     pending:
-      fingerprint: "sha256:3835131cbd00b851374b2319e9854d80fe594935be5e5f99c2974f22b7d00965"
+      fingerprint: "sha256:bf972cb8563ea35d9db4560abaf56913fe1df4a5dc0578f68a8c8620b8e42eed"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3024.yaml":
     pending:
-      fingerprint: "sha256:ed677c90d81b54723a03daec6bb1f1a25117705a38b3be699f57c39903219ea4"
+      fingerprint: "sha256:ca9683f4cdd253b1aff76f70c85c35b34425ce2710e3ec8ed43b1cfe5d932822"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3024A.yaml":
     pending:
-      fingerprint: "sha256:493748717208e04c3f35440af30c888899b10ab08e7785ce369cc2be1d6ac83b"
+      fingerprint: "sha256:353f17baab59363920c29851390ec45e95653cdb5cad64bc8d802fecdb2bc2ce"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3025D.yaml":
     pending:
-      fingerprint: "sha256:d01c9b04d54ab7dd0fe1082fe8b636b82f5eee7305ad4c355b210d78d693714b"
+      fingerprint: "sha256:a261dbfe21ac3b3f6a5ca3f369870f2c10220aff936e75a78fbe979f4130e746"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13064,7 +13169,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/statutes/6-3-3-9.yaml":
     pending:
-      fingerprint: "sha256:7c000b7da63cd2acf8b8aca7adcad364eb1d2f91e3e60468333792def2ab80ec"
+      fingerprint: "sha256:98161a69813d294d4b4edce626abc6f1f117ecfe6c27d9caac70b4374064db23"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13106,13 +13211,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ky/statutes/11/141/067.yaml":
     pending:
-      fingerprint: "sha256:f8e8a156ef6a7ec43e5baf6dbc20e26d321f3ad1d9409f621c72836d4c3758ba"
+      fingerprint: "sha256:355f37ba3912f8cd034b897f363d7aa15a9657765b1b1c7987e493d16d2f8049"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ky/statutes/11/141/069.yaml":
     pending:
-      fingerprint: "sha256:d1ed31f094c6f3562fea02f7b53ab08cd68812a5a2b8d5ec36764b3ea6b9d756"
+      fingerprint: "sha256:136c2bc1e44f4c73dbedbad65c9d23b3557d942c3729e156ac6e173282eb916b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13148,7 +13253,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/policies/cms/massachusetts-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:45dcfe16cc7aa38d38246ac3e40e42b7894a69d3ef92c570deb306ea2caa5b77"
+      fingerprint: "sha256:107cc1a620ad112089f2e93b84e6ec431f10c7d3110f2bca63470fa60fb94d4c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13472,7 +13577,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/regulations/106-cmr/365/030/block-1.yaml":
     pending:
-      fingerprint: "sha256:b014bb86f592abc95ff96f0385f4c0cc1fed28507bc188e0a024d50b212e59c4"
+      fingerprint: "sha256:cc08c57b05be7fa8754b6d04595ee1ba75e4eb189251b2e96e3c0f0e719bfa7e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13790,7 +13895,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.yaml":
     pending:
-      fingerprint: "sha256:a962fe058b7f622c30e975a5a79d2ee5ca6b2883fb1533a0d24d7fd2b43a0ffc"
+      fingerprint: "sha256:9dbd467c895e84c469c85985f7602f61e3a56cdc1bff578cb6613e735e6b1cfd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13808,13 +13913,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-md/statutes/gtg/10-105.yaml":
     pending:
-      fingerprint: "sha256:8ea8b5880f49e328d55d31535e78549abc390adee11b9cd9fcb6dabb9c915f48"
+      fingerprint: "sha256:fe0d9a470f332dff456635ce24e099b5ea0ae1bb8a633e6e1a5a4e63bdaf7bfa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-md/statutes/gtg/10-211.yaml":
     pending:
-      fingerprint: "sha256:a1cced0f66ef9de8ec2f8ab1dab4a9a19c6a3cab4b6b7fc945649952cf7a2ca3"
+      fingerprint: "sha256:aaa6935cfb25b712480e561603d424b0ef53b0bfcfd224b30025288ddddf729f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13838,7 +13943,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-me/statutes/36/5111.yaml":
     pending:
-      fingerprint: "sha256:b8f07e6522c3a0512b634831da0c76206ef7ffc1f7673b800a4dfecad8bd89ec"
+      fingerprint: "sha256:7311339cc52590ed4b412cc131c7189722009e9fb06434c0fb0de46e26e89ad2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13850,7 +13955,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-me/statutes/36/5126-A.yaml":
     pending:
-      fingerprint: "sha256:71ee5bfa4fcec8077672a4cfb6e0a3f693c6d37ddea3fced401ccc222ec4539f"
+      fingerprint: "sha256:b54b904c3536d6832b910a7d3b0765b85709e6e78b705ba52220e3c856ed7e8b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13862,13 +13967,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-me/statutes/36/5219-S.yaml":
     pending:
-      fingerprint: "sha256:b299f292676755ee4ecb88ae1f0e1b842d437c0304af86c66b407f28f4bb7147"
+      fingerprint: "sha256:0c6442e722f825d09134794fc89089b15285d699bd0fcede1e1a5900498afb3e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/statutes/36/5219-SS.yaml":
     pending:
-      fingerprint: "sha256:7c156bea8a2359369816d891a208447fd14a9c9b7678421dc8585f3007b0e323"
+      fingerprint: "sha256:77c7ee712574ffb7f167edfc4a28a7a30db8f66a1e723889e39f3ba109d517fa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13964,7 +14069,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mn/statutes/290/0123.yaml":
     pending:
-      fingerprint: "sha256:66100c87bb9cf4801afd6d4e91611f757ff7f5fba1f3445d2e42de49e36e156b"
+      fingerprint: "sha256:bd46c288e4a4520facc78588fcaee0ff38112e3720b76694a79aaba59044bec0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13988,7 +14093,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mo/policies/cms/missouri-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:888111fe137619c9d314e941ad12ed0f155a33fad10bd30295ff4df340a6fb34"
+      fingerprint: "sha256:68623d8668b95af9939a49199baf31fbc65878ca9814d28797247def6b9c0a0f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16484,7 +16589,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/statutes/105/105-153.5/a.yaml":
     pending:
-      fingerprint: "sha256:7f4f1f81285adf09e3751aaf1ef7362ceecf99e10d4a9ed625d3b1d0ef9e1295"
+      fingerprint: "sha256:d0ae8cef94463ba35b124c4a26d4b97a1303858c73b96b7810db1e7cabadf145"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16604,7 +16709,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/20.yaml":
     pending:
-      fingerprint: "sha256:0784b6e419faba191bb8d00ff6390ad333938bf0d45fd74e44ee941f3a09e14e"
+      fingerprint: "sha256:f026b66fd65f2ccad3b5812118b74d94c1e3c5fc4a72aafa67ab5edffa722a2b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16616,13 +16721,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/8.yaml":
     pending:
-      fingerprint: "sha256:b3d8550623b80c85b9c2142ddb12e9c3066ce49eadf3eac5be391907d07fa1b2"
+      fingerprint: "sha256:f898214e1674936e50fba53e2d7b93d85cf403253a9a29782e5ea29573bff491"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nj/regulations/njac-10-90/10-90-3/9.yaml":
     pending:
-      fingerprint: "sha256:99c1ed33f6492fb573062600c8bff8280c78bcb44a27e25d524c5ec10eb61bb8"
+      fingerprint: "sha256:8ab5a405fca770eb6d65ef35d5aed53f0c3e39777cb2e9fdb8f776dcc3eb56d1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16682,7 +16787,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml":
     pending:
-      fingerprint: "sha256:bbc9b026ab928624445ca2e7aaf76f95fb5ce780a29ad5ceb0a0be4857eec1db"
+      fingerprint: "sha256:4f4c7cbb4a1f08e98fb1a79310fdabdb672460f07147b1a0be4c536622c9aa83"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16694,7 +16799,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/601-A.yaml":
     pending:
-      fingerprint: "sha256:f9b8ed32a40a0ef17a3853e88cb219544a3aa5f1995788ff720b8007a071af8d"
+      fingerprint: "sha256:81209afbe41752ca14110f9057ebc2f13e451ce1cea6c8c05a3576927878eae8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16718,13 +16823,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/614.yaml":
     pending:
-      fingerprint: "sha256:13d24e5ff29c033657c7319e420f6f842b8c7b6118b447dc021577cfdc4c1a73"
+      fingerprint: "sha256:bddf348d7f1e2c82ae251386cd57842f4a3402d6a2b6bd612545814854c786f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/616.yaml":
     pending:
-      fingerprint: "sha256:1aacf0fc361f67f451d0f004e3a45e9b67b29a836b0b25e3f3e5a182794fb1bf"
+      fingerprint: "sha256:7f870613e4322bffa42d37651fe168376fb1647d17f159202d3d8f8529cc98e6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16766,7 +16871,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/674.yaml":
     pending:
-      fingerprint: "sha256:9b1817aa38a433c6bd54fd67f9bd20e8d65635c3169a93e59465c6712e868c2e"
+      fingerprint: "sha256:41e053ef0f870f37301b0bd9146abd739a192df2347fbe6bed0abb5651d76587"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16898,7 +17003,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-sc/statutes/12-6-520.yaml":
     pending:
-      fingerprint: "sha256:8322c7a9a29cf8a0d32831394f60986548415e4fe14ae87726d0d265c127411c"
+      fingerprint: "sha256:0f0bc45e78fac89064df97774ace8b442601e537387bd9199510f3bb18f39cfe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17612,7 +17717,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml":
     pending:
-      fingerprint: "sha256:79491be1e93e448acf07678bd4f35f8e71ee1ecc39bcc7c08f2c59d44cc464b2"
+      fingerprint: "sha256:0c484cce843e538879d89b1598f5900a753ecd31ba5105c03cd0fdd54e9e95f8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17726,7 +17831,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wa/regulations/388/388-478/388-478-0055.yaml":
     pending:
-      fingerprint: "sha256:f128851be830f7d18fdb713fc58f7aa1c61ab3945f9c60b629d870912a5678d2"
+      fingerprint: "sha256:9d1bbb58aa35defb132b9496dc52892df8d11756fad7da6814cf56cf88a3c1a0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17846,7 +17951,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml":
     pending:
-      fingerprint: "sha256:885396c2d2a36b5598e62835c1f1e86a7d6d802c84f6211ec9ad3546d4078742"
+      fingerprint: "sha256:38cccecc98cea21ef3f7af3722c7e2d5638d707c33f4f76a497e8d7173e80dde"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18080,7 +18185,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/42-cfr/435/556.yaml":
     pending:
-      fingerprint: "sha256:fe8e512ba00d5e019918bf0b94637f4bf3cd425bb5d99ffe45422209985f8839"
+      fingerprint: "sha256:7979deea9d79148be87e710c11bb12ecf913c8dc3f249a0201b494fb82f82c32"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18590,7 +18695,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/199A.yaml":
     pending:
-      fingerprint: "sha256:d6b6d805f857670ce7cb2aa39ebb89f7f138ea7a549d7103f299f9911c586886"
+      fingerprint: "sha256:4ce91fbc649d108819efa50be0fc2395e7eec5f556c542343772ff8495a520a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18632,7 +18737,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/219/g.yaml":
     pending:
-      fingerprint: "sha256:043947bf19eddc38f22c97a7cfab9302fe701812436691c6f50108f609f95add"
+      fingerprint: "sha256:2d8c089252acafc99e5b65c1edbcdd4016f0174e65f13278776c2c636dc77333"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -19298,7 +19403,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3131/b/1.yaml":
     pending:
-      fingerprint: "sha256:285215b6e352f2ad9c9191ccb9272f1d89450b4cda964b3adac95e63b0e8b67a"
+      fingerprint: "sha256:e9d9c332a5fb028a4de62ad73df91c289984cc643a3de96df54e2822e9384be5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -4074,7 +4074,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:b05ce15c601ed05da8a980c76ffcaf7f82d9d4ee6fab9f3cb2e3273929efe97e"
+      fingerprint: "sha256:321124427489d8897601244e8d860d6f427b6a3481983fff2c7926ccd6504e46"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4096,7 +4096,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:cc70c373bf0fe4fc7e86d1f6c02f4e93223b45be9cead0251b1807c3fbbf2936"
+      fingerprint: "sha256:1ff37fd4020e0791fee184f1ed8a7620accea42ed67e69148a84d1912fa49bda"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4774,7 +4774,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:8da16ce391cc2de38c753311a4ddfd17cadeb219fb6f91540c74bdabfee6a5e5"
+      fingerprint: "sha256:78919d7c5bb4799c662b2ddec76b851a6be33abb37d538bb459e21cd51a157fb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4785,7 +4785,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:3f216a003998a7231a9b55e1fbfccc7086ce7a9c658cc3b0770c19ff09c13cfd"
+      fingerprint: "sha256:cd05a8a29fbfc51eb5a97e38c3819a0a38075051e1da582621570482fde1b6d3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4796,7 +4796,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:30dd435a234b238fd3a76da0d61c5c65fad6d1be3aeed298854ade018b2cf95f"
+      fingerprint: "sha256:b49bfa5ccdd0425b89e61cfb4759a4053406589ec4f35ad7f85b29c4d2fe9866"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4807,7 +4807,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:6b666af35a9c71455a5126428e1ba7834d6093c9dddd049f50b44d4657b884d9"
+      fingerprint: "sha256:b8d48c8aad564c74c46b2955bd1a892f3eb673992c1d9bd9c01a65af70005925"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4818,7 +4818,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:4415fcf8346ebaea099eda08adae42a5d4578121c57efca9bc8c31e351d123d8"
+      fingerprint: "sha256:6dc5b0b5be8498f8339a9db5bd9f2fa732bbbe3927ed84854e8bc39ac796168b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4829,7 +4829,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:0e4f2b04d5b62acbdcd2eb16ace1938e40a629128329ef2413fa185f8d7f3726"
+      fingerprint: "sha256:089aa3b92c0a7e4f97092b62d49a245ce1199331e9158de54f9570f0ca952695"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4840,7 +4840,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:65cba017235d0f84091e90f273f1aeed65b4047ee248a6a6a25ae17b1d906fd5"
+      fingerprint: "sha256:5a6e3c17d7972ead2dc596cc33fbf44a13acf5885338e72a8decfe4dfca7dd2f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4868,7 +4868,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:51d0819410cc74367be983d8121a2df87f307d2030ea0e4c1bdc2655c828fb40"
+      fingerprint: "sha256:e76e243587a1c97a015603d422c454c451615d206f656eae48932f521cfeb40d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4890,7 +4890,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:6148fd5e4730e3815ecd273cbe8abda5bc3c18a4f98a92775f0e0f557b4ba771"
+      fingerprint: "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4901,7 +4901,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:2734630a88c75b99d0fa5e1cb1e34f506308c25e2ecd7b5ec8c31d7a8fd03017"
+      fingerprint: "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Summary

Waiver-only approval transition after the protected encoder 0.2.1373 census. Adds or updates exactly 173 `pending` records whose isolated failure fingerprints differ from the protected base's active records.

This PR changes no RuleSpec modules, toolchain pins, active waiver records, or evidence files.

## Evidence

- Evidence PR: #1088 (merged at `9d762d8865125c08eb5fb2e21df959636ec6e355`)
- Isolated census: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/30134976400
- Durable artifact: `waiver-census-isolated`, SHA-256 `467fa2f8ff7d3651a6998d662e20613dc41cac3b66af9a5a75762e6a353a7172`
- Exact reconciliation: 173 replacement candidates; all 173 are represented by protected-base pending approvals after correcting 12 stale pending fingerprints; 205 stale active removals remain for the consuming hard-cut branch.
- All 378 candidates were isolated; 0 parallel false positives.

## Checks

- `python -m pytest -q tests/test_repository_layout.py`
- `git diff --check`
- Exactly 173 waiver records changed; active metadata is byte-preserved.

This PR must merge before the hard-cut consumer updates `known-validation-gaps.yaml` to consume the pending records.
