### PR TITLE
Align pending waiver evidence with protected ledger

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -31,6 +31,11 @@
       "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
       "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d"
+    },
+    "pending_evidence_sync": {
+      "base": "9d762d8865125c08eb5fb2e21df959636ec6e355",
+      "records": 152,
+      "reason": "Align protected-base evidence with existing pending approvals before waiver transition #1089"
     }
   },
   "modules": {
@@ -580,7 +585,7 @@
       "passed": false
     },
     "us-az/policies/des/faa5/na-categorical-eligibility/expanded-categorical-eligibility.yaml": {
-      "fingerprint": "sha256:7f078800c5069efb4bc4fb09eb353825dbdc3d8485d3e2eedfb5adde2265189d",
+      "fingerprint": "sha256:0523216af81c35fbf8838b2f315ef061be8c5aa95eb9c88c3c7fd6b45b15971a",
       "module_sha256": "sha256:c422e733ca353c9a207bfad53e8e3683e8f1fddf325faa5a82d8336d82022dd0",
       "passed": false
     },
@@ -600,7 +605,7 @@
       "passed": false
     },
     "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/gross-income-test.yaml": {
-      "fingerprint": "sha256:62cc80cab619d9dd90a1ea5d22567ea29a9ba2a10ac66e6db284f597307273e3",
+      "fingerprint": "sha256:c2c52639afb4ef74b5313b65bec2ed1287ff730d3566e98323a8091ec3ea5673",
       "module_sha256": "sha256:7c14a56b10f189a25aa51f3e4009e46395e5d91fb7e37cb1d02915049498d61f",
       "passed": false
     },
@@ -655,7 +660,7 @@
       "passed": false
     },
     "us-az/statutes/43-1023.yaml": {
-      "fingerprint": "sha256:542bcee01e5f8ae2fdf0901600d223fe1202dd4ea5bd6bb0111d1564329b3f87",
+      "fingerprint": "sha256:4381a9d0648e8d20df0c89f055de9f89a4a34c6f4253a0fc1bbb4c02aa44f7e2",
       "module_sha256": "sha256:b9a3279da8cba88cd1a1f9c9733fe143287064b2d42185f1bda731e0b097b56a",
       "passed": false
     },
@@ -690,12 +695,12 @@
       "passed": false
     },
     "us-ca/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml": {
-      "fingerprint": "sha256:22f5a0697b6f8e874a9d00f004fbca2b30b6d7d5f4cb75a05f91fc51e6db2079",
+      "fingerprint": "sha256:aef37b20677d59b800f61c0797b2485c36f654adfbddd1059c9bc76c2f0727f4",
       "module_sha256": "sha256:b074596ebc9236f63f90d1aa6d1c437fe4e4a91130391fba3c7c432edf873a14",
       "passed": false
     },
     "us-ca/policies/cdss/calworks/monthly-aid-payment.yaml": {
-      "fingerprint": "sha256:b664307194e918f742cd969c0b1f4d3eb09239a26e754abdb204e6a5caf1211b",
+      "fingerprint": "sha256:6734dfc183b5b25ed364bad9d2df4da2332211f07d17c8c56e311d2c9f125d7e",
       "module_sha256": "sha256:320eb02cea538742c5073ef198925040757a82fd76e16d9aac945ec0f855ed63",
       "passed": false
     },
@@ -2645,7 +2650,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.130.yaml": {
-      "fingerprint": "sha256:91f6c3068dab2eb6df55ff43b9e2c4749f5fd66067071a59f1ce49ce797b33d5",
+      "fingerprint": "sha256:cd5b5c56cbed725a888e9cc4f0e09e4a10429764ce5a5ebda02dce37cc85f99f",
       "module_sha256": "sha256:fbdbb08cf5937d1cc2f341de905a5f079eed983390c2130640a3dc9cef684614",
       "passed": false
     },
@@ -2815,7 +2820,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.206.yaml": {
-      "fingerprint": "sha256:5f766951776f604566abdefa2c6078fc4092b8d81be1f26688b9ab5453f694f7",
+      "fingerprint": "sha256:7398c867e9117ea114c5b462915f7ed7e0eb48c135a6bc7aae8c7877c1109464",
       "module_sha256": "sha256:805166c4e1b3218a96df4ecc2814929157172ea0313a24a71f1fac60ab7fe34b",
       "passed": false
     },
@@ -3170,7 +3175,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.405.2.yaml": {
-      "fingerprint": "sha256:7b57e5ad540a814c7b1e66b545298a5426d3a98520bec8a9c557e3148ae76fc0",
+      "fingerprint": "sha256:f1585b9890fdd3c83a7194d2386ce27102ea3cbf971ad9bae0a9fb08d70fc61d",
       "module_sha256": "sha256:fe3fdbfa5d4bb00ba6af857abbe5690740484c78c5532aa1a7841fac2c1e7509",
       "passed": false
     },
@@ -3720,7 +3725,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.801.41.yaml": {
-      "fingerprint": "sha256:3ab758faa8009c4034a74e55b07ab151e1ed1022308baec5e5345c649668bf5d",
+      "fingerprint": "sha256:677f3b77e7c97aafeec4c416adf4d083f17efd8b9257ccc026344835cc83e67c",
       "module_sha256": "sha256:44e4b3396367de768358b5476a34c9c66886fe607ff4b16d0dc8481d11cb7ee3",
       "passed": false
     },
@@ -3745,7 +3750,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.801.7.yaml": {
-      "fingerprint": "sha256:50abcad15eb187ae66f278c33827c56df22ba1f968156cffb5b73131208edcf2",
+      "fingerprint": "sha256:b27d97b6cf7bceaa848c4b6794d9fa88d5a98604d4ee3ad95df1b5f28167b30c",
       "module_sha256": "sha256:8fa0a665af6e90c52536328d25ccd386f70aa5bf5b5fec710c2ba454a2b50ebc",
       "passed": false
     },
@@ -3820,7 +3825,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.803.2.yaml": {
-      "fingerprint": "sha256:6b46dadf3034a8f2ee2cd385a667eba9bfe0b8d9a5dd4a6a518519ee0cfa51e4",
+      "fingerprint": "sha256:4a168740dcef2013f6a20619a965212294a4f61c88f60071b090fe9919310763",
       "module_sha256": "sha256:b862eca9fd535c5c7daf3c3e959ff15e9fe94cec7dcf9d0c1d4308fb0d7e3361",
       "passed": false
     },
@@ -3830,12 +3835,12 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.803.4.yaml": {
-      "fingerprint": "sha256:7d1bf3e42008bedf1a170d5a3a6b50b682654b4e6b074adb6f2c81e616414071",
+      "fingerprint": "sha256:9083d94abeb67aad62d156ffd7e1cffb2bd78001c962f775b7d3f906fa543463",
       "module_sha256": "sha256:4df91400a6ddbc71f935e1d846bdfe00e3d496a80f5e2a6e9b9bccc622366564",
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.803.41.yaml": {
-      "fingerprint": "sha256:ae61402e831ad6dff426ccf03339dcf8598fae75af49a9519d778a61f209b084",
+      "fingerprint": "sha256:addd1f1d0e91965cf68189e73455943b6dc53b5e33a7fe4dd2293475209fa809",
       "module_sha256": "sha256:559569deced280fb60fff48c32b93be701c77a9b642232f6b65d75791cc96816",
       "passed": false
     },
@@ -3880,7 +3885,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.804.1.yaml": {
-      "fingerprint": "sha256:87d5731d85ec94c2a6b3a0a776a6bb0d5d4232f5bdd3b329aa57d11e025ec4b3",
+      "fingerprint": "sha256:03396ef0426aab59c8c6cfb0101e3379b2f76afe45531c6309490e4a2f0595ab",
       "module_sha256": "sha256:962f5500e96939e854a0cc7d96f981631e2ff6113130436bcb4da60df533c285",
       "passed": false
     },
@@ -3955,7 +3960,7 @@
       "passed": false
     },
     "us-co/regulations/10-ccr-2506-1/4.903.31.yaml": {
-      "fingerprint": "sha256:0fcbd5cb8f797fbfae08b7b2015715af7f33667bb3d12e89b2ab5d8bb1c9d8f3",
+      "fingerprint": "sha256:df005b01c50dfb5442ee72256993bc2f193bedfd67ebdd059582beb99bb53ff6",
       "module_sha256": "sha256:aa9af4fa966301ac2e292a4afdd451597c1947886c159a217ce87541f7adc662",
       "passed": false
     },
@@ -4000,7 +4005,7 @@
       "passed": false
     },
     "us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml": {
-      "fingerprint": "sha256:a5fdb8551898e0d7713be4865a5e15d9b0d488a45c1f48c854c1ab756c002e05",
+      "fingerprint": "sha256:eccac935993a72fe7b83a828a35ba4e0e5ff88081ea3e054896bf3ba8d7d3509",
       "module_sha256": "sha256:fa720d263804218812f4e34e0c8a0fcd6dc80c2cdcdfdc7e70feb230f807984f",
       "passed": false
     },
@@ -4040,7 +4045,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.61.yaml": {
-      "fingerprint": "sha256:a22112a39f80a82ffed9f9691e2500dfbc7aa1464d83c2810d0de6b1f80f39be",
+      "fingerprint": "sha256:9b2e347cb8ac4965d4c74befc1a999a713b42c305ee74c6319a68e80578b1278",
       "module_sha256": "sha256:1cb5fb3090950d7884c37fd16651f0a205fcd43b0fe4356e65e9c39f45aefef4",
       "passed": false
     },
@@ -4055,7 +4060,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.64.yaml": {
-      "fingerprint": "sha256:877a29f4326eca73f5eca3a0ab92522135263abd99a58d9d7c5253c4d976fe63",
+      "fingerprint": "sha256:5b278ba3575d30737c45ac494e363483ea8ef224e8349365052ecc080088364b",
       "module_sha256": "sha256:7f7e8aff63da351199f0a5fb4c0c96cc0f4272cf793d64f0bf49a0b36e935700",
       "passed": false
     },
@@ -4080,17 +4085,17 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.69.yaml": {
-      "fingerprint": "sha256:5da22f2008ff1c639867fe1d81c5963a66a99c1ecd5d9a6269f9835c9c763c57",
+      "fingerprint": "sha256:42193a1cfe465f85c2c3bfe12ba35269468612b3b1fe5f5a60a7758e69e869a4",
       "module_sha256": "sha256:48cd5cd56301f9cb753538b482ee08b1e7dddc19b3937d57f45f781618df1a34",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.71.yaml": {
-      "fingerprint": "sha256:da9efa8d552feca0cbf1952cfe3fe491c54bf6d19ac566ffbf410354e03fcf8e",
+      "fingerprint": "sha256:ab489e93df13ce6fddba5b4a6f004b5bdd159552a42ac9b26abd2cc13f35ae1f",
       "module_sha256": "sha256:8f4292ab33b64441420e7b5c8f5372370e34333bc008f8ba79d31eabefe995c3",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.72.yaml": {
-      "fingerprint": "sha256:7dc60397a488ca544c730699462a0b4d07282500a0a4db882f92b4e7ba425ed6",
+      "fingerprint": "sha256:39bad003fd38bb407555dc80abff41a6af0622387ded383ed0abb794c0e3b0bb",
       "module_sha256": "sha256:f4251fd78c26aac368d154abdd18c9f4c07a12b042c622393cc80e81e11c67a0",
       "passed": false
     },
@@ -4100,12 +4105,12 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.741.yaml": {
-      "fingerprint": "sha256:584c9ba0f8c826747c221ba3ec97e66bdfa60074db8bd0df700c8be27eead02c",
+      "fingerprint": "sha256:35f2f6bcb4129fdc214a13c876b1d2adac94d9779daa94f47151179fc51c343c",
       "module_sha256": "sha256:a7236ec2ea839d9f1aa714535ef7eada6c30730391f124513be04e4eed266688",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.742.yaml": {
-      "fingerprint": "sha256:8f5ca45ebc9f85dfa1d9b37922c271c81d6bd6cb5ddea2820535cfef45593075",
+      "fingerprint": "sha256:7f0ac09ec4690ae0a1bd5f070db28835026ec6c50adebb2124fec5ebe1aaa92d",
       "module_sha256": "sha256:dfe2b56b093cb32ee81b24dd0f73ef43e78db8d53be841db3479937856e3cc9c",
       "passed": false
     },
@@ -4115,12 +4120,12 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.76.yaml": {
-      "fingerprint": "sha256:ebba75f4cb5219af83b6a4bc81a11deb5ef7ae134cfca75686c7c21ac00b832b",
+      "fingerprint": "sha256:13a69b88a7b31159a05d496c5424c52a10fe280d88c4a91d78029628fd7ed929",
       "module_sha256": "sha256:919dd791319c0515c574d54f866fa72ec6171346cd3826bece34156f1b647284",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.77.yaml": {
-      "fingerprint": "sha256:94434d42a37407c2a0d3b21b91a8bdee56bd79b0093985b7e9fcfacc836073e2",
+      "fingerprint": "sha256:d8c813a43a189fd61e46ac474b4c712c4268e7def370fb26ba1acc637bd0783e",
       "module_sha256": "sha256:9c16732912a4b9cbb420bec07b0a1c93dc54c6ad1284cc3574221864ab95c2c2",
       "passed": false
     },
@@ -4140,7 +4145,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.784.yaml": {
-      "fingerprint": "sha256:45f2eff3e6525fcfc0824a6138313c80d2a7c25257878cc8abf4df79852a24e9",
+      "fingerprint": "sha256:4f469f8ec58f97135288ab049ded9a333fae941531c06d0c215148ca6bc866ca",
       "module_sha256": "sha256:103a734d3ba2aabc92aa63e7a7070a9c30f741217fb3de7d469f88ae8c2f8855",
       "passed": false
     },
@@ -4155,7 +4160,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.520.79.yaml": {
-      "fingerprint": "sha256:74338a182fcc205d7bdac5f4258fc3c3859788e65125665d16e6ac84d2ec5d5b",
+      "fingerprint": "sha256:9e3b8387e12252d5cdfc47e70d803bc54a20103efbaf5afc6512264f76b556fc",
       "module_sha256": "sha256:96e41c4ccc27031c7df78d1f6a994275de804e48b626bfe741ad952097ba685c",
       "passed": false
     },
@@ -4165,7 +4170,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.530.yaml": {
-      "fingerprint": "sha256:ca80ed65103a412a5b493f7a2a5a1778149a435f7b2ceab836c2c884dbfb0624",
+      "fingerprint": "sha256:7b495c22546442023ae34c400478ad739ac22c2299ee9edd0784927d5d59c687",
       "module_sha256": "sha256:8b3031855cedaee3683e939c2794f44b088ebc47ee9e306130689130824bd48e",
       "passed": false
     },
@@ -4175,17 +4180,17 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.532.yaml": {
-      "fingerprint": "sha256:770c6a9d1ea3cc2215dd423ca5e53db2d486eaa43cd92ad7912e91afa4573cb2",
+      "fingerprint": "sha256:3b4a7226c87b7e4b2e5a3ff2d13adc35ba6846c365f3ba81d485f76b16df449e",
       "module_sha256": "sha256:d48a5566272aad224309ed64890c440d2602a0fd9f197cc4193ab0bf7aea71ff",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.533.yaml": {
-      "fingerprint": "sha256:738a19abce2fb318dc525dd32b74533d5aaa4d45f13ab16526c8ee923822e051",
+      "fingerprint": "sha256:8319f37fc9d9b24c2bb7d1e673f2b8da8a44baeafbc85f83e7f201d27603bff6",
       "module_sha256": "sha256:af2fcc1cb379209e8532b8982ca125d029dcbcf06619a17b3b5e8b35186a0bbf",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.534.yaml": {
-      "fingerprint": "sha256:3ead4061c5763ef2dac6ac0b325e2b8df5c734ef1e6da186f802df5a2c716363",
+      "fingerprint": "sha256:b6bf9b6bc921848200adbcc24b72167ac9751059dd5ce637db10ba18ab6403b4",
       "module_sha256": "sha256:7ab691502e6f7845e0efe8926a5403c7d22a548f5e1dc2925b66c89ef304be18",
       "passed": false
     },
@@ -4210,7 +4215,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.541.3.yaml": {
-      "fingerprint": "sha256:2b27b990fb68a304c6ab397e29c91fdec32275080903da67e865328d22263a0f",
+      "fingerprint": "sha256:0d50075b9c8abdd3ae2c5b5d94e3316eb0816d9a6832db06530a582d9b26a3fa",
       "module_sha256": "sha256:b9d1d0c6893e7ae8fb09fdd7a3ba4584e86652b8eba96afe072d333d3f8bc4dd",
       "passed": false
     },
@@ -4230,7 +4235,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.544.yaml": {
-      "fingerprint": "sha256:825f332a52a10cdfd5eefaff242ecf0690be7a9abc0ffcc8ab07a2f2b3968199",
+      "fingerprint": "sha256:0df41c986cc3f992b0875e3dfe813f8e519ceb01c4599dd78e0237f0cc663b52",
       "module_sha256": "sha256:8dc689f042acf23482d00c13e1119ae1b6644b5859678640ec2895da65329251",
       "passed": false
     },
@@ -4240,7 +4245,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.546.yaml": {
-      "fingerprint": "sha256:144a1e6f661ded8b30cfc4e218eaf520c75d7624ce9e41fe34ce47054bed80d9",
+      "fingerprint": "sha256:60e550323ca37ef10b6fa828c8e0bb959ffa03a2e244583ebb296b09dc823254",
       "module_sha256": "sha256:a3785d093a214f42b55cfaa9d4bd0e0129a5ccf131d32196a74d6c21deb7c462",
       "passed": false
     },
@@ -4250,22 +4255,22 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.548.yaml": {
-      "fingerprint": "sha256:4533d6266d2bdff3fb59e2d130eed57d756f2aee7ed9bbefcd9ee092f5474212",
+      "fingerprint": "sha256:9e3a06a2b3c9acdc06116587da9459205ca07373913cdf7e8259d835bf8b0569",
       "module_sha256": "sha256:78ecbac76e8a0d69e663503e4e5a02abb5408fae9a404a26ab8004b5f01e72c9",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.549.yaml": {
-      "fingerprint": "sha256:3231657b504073914980374036debdbd4cfe7cc0d9abcb5d276c3b611ca443f3",
+      "fingerprint": "sha256:f6a8b4349dc012c3d84319f6d83637b7ccc4ff1936be38bf9a054c1882639fc7",
       "module_sha256": "sha256:f41fbf028af99a72190dbf772ba8977e829dcfb10f12005c11018cda7667c887",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.550.yaml": {
-      "fingerprint": "sha256:001c92780909bd7316936ec0163a5e74aafecde196415617504875890a204ee1",
+      "fingerprint": "sha256:b6c07c24b1d786c71fc2bc627c26366af81bde9e421b251b53b31649b2194fd6",
       "module_sha256": "sha256:e11eda417b21b6b5f3350dc9a3465fed37f0bd000839317bfb3d64d6ffc13512",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.551.yaml": {
-      "fingerprint": "sha256:4fd1f16135e284952675a0dbc565a7054957416b00ec80f777e1f2b068131389",
+      "fingerprint": "sha256:e89d8b1801ff6ce90a20acd5fb818be9b6ec9123a937e026df7ae7bf308d0e6d",
       "module_sha256": "sha256:8a09ce064dd5ae4672a14b6d1cd2fca8860a2bca88a06cbbeef0d290cbdc0505",
       "passed": false
     },
@@ -4275,7 +4280,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.553.yaml": {
-      "fingerprint": "sha256:0cc26cc5c24f1dcf1b7edd905ca7e024e1d4bfd30eeab02620cc8b0ad5e45663",
+      "fingerprint": "sha256:fd4a7bc58afd02b479b089b4e00cb73c9d92056e6e9a28d9b1bb6293f3dcf8ae",
       "module_sha256": "sha256:1ccb8883d541576e6c1d227f0e86d9995b14c569b6af96d59dece8e4cc47bb08",
       "passed": false
     },
@@ -4290,7 +4295,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.11.yaml": {
-      "fingerprint": "sha256:960752bcdebf8166e94b29f56cdcf508851265c84d6c1540a7c56a7c159b7c40",
+      "fingerprint": "sha256:e9c3434fecafff55a364e35541f95324066299f7b8001e8149edd32042fbae7f",
       "module_sha256": "sha256:5a653b3546a89600dd2d70a17a9de13453dd5b7c2207c681e5659604dd04e7b4",
       "passed": false
     },
@@ -4305,17 +4310,17 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.14.yaml": {
-      "fingerprint": "sha256:5e0d485b41e666defe63e2f8c9b6422f0fea754bc102b900ba6390abea72bc68",
+      "fingerprint": "sha256:c157a2cc1c8fb354eb1664d646352061d7a8e20367526e44769102283c5976d6",
       "module_sha256": "sha256:d0090fe37507765656cf35592c1fa980bf17ad0f7304f602dce988bbee234a7a",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.15.yaml": {
-      "fingerprint": "sha256:d18256d653fa9a16012bbaf5533c2ecb4aabb88b688fdfad9f023d5dec9ff39e",
+      "fingerprint": "sha256:5e754f4200eb7fb670e0bfe7a2c92d4eec679f0467e00289c2469d5b1be717ed",
       "module_sha256": "sha256:aeda7bdf3897583256fd8c986300ad04ffabaff2821034f90f863a544fa1a20b",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.16.yaml": {
-      "fingerprint": "sha256:702b48e915196bcc288036d1e744992fbe7841f10031e4abf5de0f2fdf9b775a",
+      "fingerprint": "sha256:36183d434956049b03444907151673e68336ca5f2340a2e92fcf8644339c290d",
       "module_sha256": "sha256:db51b35f7385454e40ec219dd7a4c645a68202753dfe09c454c30a3d5d9a0768",
       "passed": false
     },
@@ -4325,7 +4330,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.18.yaml": {
-      "fingerprint": "sha256:31ad1314eb5e224eb94de3e059ab29d05c0f907efaf03207ab7d556960e3f02e",
+      "fingerprint": "sha256:913c9debed544875583b38b11699efa1c23b0bc3f1fce01fe2b6fff4bf4d5e91",
       "module_sha256": "sha256:2c29ceead0104c7976bae984207412ee0cceef37e9e4774659d216b2d5a02e66",
       "passed": false
     },
@@ -4340,7 +4345,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.570.43.yaml": {
-      "fingerprint": "sha256:83ae092d4dd23f29da29d288505ded3b672d5223bceb18c3a1ffcab79525162e",
+      "fingerprint": "sha256:e373632fde93e914b9435b032b591dded8bc121d1e894616b8fd05b14a947446",
       "module_sha256": "sha256:7ebc190a568d80df043c3ee265732e5e5a75f99aeea82a9c0e8ab7eda60bf85a",
       "passed": false
     },
@@ -4365,12 +4370,12 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.582.yaml": {
-      "fingerprint": "sha256:e981376b24ff900cbbd3045a6e79520e289748e76a9f82e8918084bbeb098bc4",
+      "fingerprint": "sha256:a25a8e7cc14f5901c114e4bbe74dfdda505da88f453ba72e7052a2f9b7ecbb45",
       "module_sha256": "sha256:d0f31d1f10f8476e28157cb8cb9875e21bb018c1d5d1a5dc00f6c09f32781113",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.583.yaml": {
-      "fingerprint": "sha256:9ec8a41e0695a3d220fdb741ea8ac109eaff9ba37e877b62cd2536da61cc8177",
+      "fingerprint": "sha256:2f74df0a04f06391b38fad393e49eecc24ae482a1935efe070710dcb2df4dc31",
       "module_sha256": "sha256:8d3067f487c4983d859d5403643191eceb3a754f753fc06de7f486abed8d4712",
       "passed": false
     },
@@ -4380,7 +4385,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.585.yaml": {
-      "fingerprint": "sha256:3fff79fde9dd72fead6f9ec88d3ec75a489bbf89eddf7ebccb988955b969bb40",
+      "fingerprint": "sha256:e5eb3e728a1ad686b999c73911bc2115a4516604835ca8927484df316ae42b56",
       "module_sha256": "sha256:b0217c5b3e2458ec9d9e8e008c3096ceb8cff18b097764e9ccea8f88d008cc8d",
       "passed": false
     },
@@ -4390,7 +4395,7 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-5/3.587.1.yaml": {
-      "fingerprint": "sha256:b4768a46d8defa0ea778ad7deafc9eff7e4cdcbe5c708a371da49450859ab39c",
+      "fingerprint": "sha256:5c7e214a8611df3e62223bda0cf095413072a78505197a4be4e292e02ef784f8",
       "module_sha256": "sha256:92c910a4f3fcef959c1ed561b9b0f823fbb4dd6be2315c65b2f942628b1729a9",
       "passed": false
     },
@@ -4410,17 +4415,17 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-6/3.606.1/E.yaml": {
-      "fingerprint": "sha256:d9375b14930a8362f5db779f54d5843eeb2570792add02fd87207d93a58ad3cf",
+      "fingerprint": "sha256:b4cc1c781dea7d3ca96043fcc8165edc6bc95b2d99fcaa6b9170f59ff2b4664d",
       "module_sha256": "sha256:b91036226116b60b4e58080d44b0edddc9bc52f675ad24b5acc4a2b8fb1cf784",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-6/3.606.1/F.yaml": {
-      "fingerprint": "sha256:dfc981e7244f26f9a085bf6e4e08ed7b6c385595ae33c4bf71ce5f03f1bc1b32",
+      "fingerprint": "sha256:5737f1cc0ad920873b546935588a901f07525621937a03a4e3384cea7746f0fd",
       "module_sha256": "sha256:0e23e38acdf4878503472ab8d268880d1f6bcbd69b7785a9617e121aa56a90d8",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-6/3.606.1/G.yaml": {
-      "fingerprint": "sha256:418faaa21ecc85196c7248ede2b45c903846b3283956e3083be2300d44a8e049",
+      "fingerprint": "sha256:c5bb260f4ac8e67b6c66b62a0887d303354ead1595064bd94d86c56e58079900",
       "module_sha256": "sha256:883a2406bafcde3aed8084c86a603cd139bdb0494e508a62cca5baa0a238595e",
       "passed": false
     },
@@ -4445,12 +4450,12 @@
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-6/3.606.2.yaml": {
-      "fingerprint": "sha256:ee917e7c4e61911abffd9f57bc8b7a3c0a59fefdf3e092c09ae6ccea65f4bd09",
+      "fingerprint": "sha256:0ed2ce23ff264219b2367888cbe13620e17c22e6c70a731007e3e81af440d827",
       "module_sha256": "sha256:1459e738d92fd374d6ad0db1a7f5a6013f11dd1f29d4bd761185b3defe3948a1",
       "passed": false
     },
     "us-co/regulations/9-ccr-2503-6/3.606.6.yaml": {
-      "fingerprint": "sha256:93aacbe77f4ff7d5c938dfe9a12abd154ada8c48849e104fce0adadef0af6b73",
+      "fingerprint": "sha256:9740986efc6338f0c392f57ba7b42efddebbc56de5e06a00d1aa243f9bf01b88",
       "module_sha256": "sha256:9381d75256e6ddbe0c6efdea05ec00acda0ff3add6266b40f5cc3e439e5b0070",
       "passed": false
     },
@@ -4490,7 +4495,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-1-105.5.yaml": {
-      "fingerprint": "sha256:85e27de39283c9c0f249a00cc4393fb79a8be24fba355ae8c26fffa4e59098be",
+      "fingerprint": "sha256:5fc56ff6379d7cb9ea22c92376e0d285782a50ee050fd36dcb14e9990500399a",
       "module_sha256": "sha256:7b891248f82bfa4d6c0b24722cf734275f8e52eadf58b2a1704cb334d82beb5a",
       "passed": false
     },
@@ -4540,7 +4545,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-1-113.yaml": {
-      "fingerprint": "sha256:90f8a79bc9d376bfa7621d0469c24d401876d037383cb467557e9510dae752d5",
+      "fingerprint": "sha256:d7e9781f56f59a60cc0a88c1c1ada50501411a2e7d0d1374bbe67b54ca076c91",
       "module_sha256": "sha256:3ca94a1f5f7b445909e397afcc4e5e0691063a5b9680002427d9f11734e94fa0",
       "passed": false
     },
@@ -4600,7 +4605,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/1.5.yaml": {
-      "fingerprint": "sha256:321124427489d8897601244e8d860d6f427b6a3481983fff2c7926ccd6504e46",
+      "fingerprint": "sha256:b05ce15c601ed05da8a980c76ffcaf7f82d9d4ee6fab9f3cb2e3273929efe97e",
       "module_sha256": "sha256:4609421763ad574218ec3adb6ee5d83db06dbb1a12bc1c3c949ea6efd3e0c4a9",
       "passed": false
     },
@@ -4635,7 +4640,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/3/d.yaml": {
-      "fingerprint": "sha256:78919d7c5bb4799c662b2ddec76b851a6be33abb37d538bb459e21cd51a157fb",
+      "fingerprint": "sha256:8da16ce391cc2de38c753311a4ddfd17cadeb219fb6f91540c74bdabfee6a5e5",
       "module_sha256": "sha256:45ce3178c702f59cbf956912969a87bd9f4ccf40715b73dbe8f4203ad22e38a4",
       "passed": false
     },
@@ -4660,7 +4665,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/3/l.yaml": {
-      "fingerprint": "sha256:480a3710bccc9deb5f374ccfce8c57127527c7e0820d06f2b08632452d37ea83",
+      "fingerprint": "sha256:e7103db7a94fc82a8432a8318bf274f5311296c00af1db69432a4b5204ab336d",
       "module_sha256": "sha256:e0dab6183505083a7e38e2a7a57b2416dbb7cb0b904fa6f8c6c4d6c011f107c6",
       "passed": false
     },
@@ -4680,17 +4685,17 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/3/p.yaml": {
-      "fingerprint": "sha256:cd05a8a29fbfc51eb5a97e38c3819a0a38075051e1da582621570482fde1b6d3",
+      "fingerprint": "sha256:3f216a003998a7231a9b55e1fbfccc7086ce7a9c658cc3b0770c19ff09c13cfd",
       "module_sha256": "sha256:cb612e4b19cd1da1571969b64817022313ff9dedffd34e1fe249b7dd2ab33b43",
       "passed": false
     },
     "us-co/statutes/39/39-22-104/3/p/5.yaml": {
-      "fingerprint": "sha256:b49bfa5ccdd0425b89e61cfb4759a4053406589ec4f35ad7f85b29c4d2fe9866",
+      "fingerprint": "sha256:30dd435a234b238fd3a76da0d61c5c65fad6d1be3aeed298854ade018b2cf95f",
       "module_sha256": "sha256:25487d34da087e0a82f547d275d5c5763eace79619e62f6afacc28d84594ba0b",
       "passed": false
     },
     "us-co/statutes/39/39-22-104/3/p/7.yaml": {
-      "fingerprint": "sha256:b8d48c8aad564c74c46b2955bd1a892f3eb673992c1d9bd9c01a65af70005925",
+      "fingerprint": "sha256:6b666af35a9c71455a5126428e1ba7834d6093c9dddd049f50b44d4657b884d9",
       "module_sha256": "sha256:e78dc15e92f678f346f4647d53fa3823cb9bb1f9a693e97d0d5c60186f64c587",
       "passed": false
     },
@@ -4725,7 +4730,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/f.yaml": {
-      "fingerprint": "sha256:6dc5b0b5be8498f8339a9db5bd9f2fa732bbbe3927ed84854e8bc39ac796168b",
+      "fingerprint": "sha256:4415fcf8346ebaea099eda08adae42a5d4578121c57efca9bc8c31e351d123d8",
       "module_sha256": "sha256:20af385c70fbc3ed4e83c8c9d3391c46949161fb4980dee1b93405d4dcb52bb7",
       "passed": false
     },
@@ -4735,12 +4740,12 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/i.yaml": {
-      "fingerprint": "sha256:089aa3b92c0a7e4f97092b62d49a245ce1199331e9158de54f9570f0ca952695",
+      "fingerprint": "sha256:0e4f2b04d5b62acbdcd2eb16ace1938e40a629128329ef2413fa185f8d7f3726",
       "module_sha256": "sha256:714289d6279ba31a1cda2724bd2ea71000394888086d4a14891ab40d87d6f7c5",
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/m.yaml": {
-      "fingerprint": "sha256:5a6e3c17d7972ead2dc596cc33fbf44a13acf5885338e72a8decfe4dfca7dd2f",
+      "fingerprint": "sha256:65cba017235d0f84091e90f273f1aeed65b4047ee248a6a6a25ae17b1d906fd5",
       "module_sha256": "sha256:8075fb0519bba457e399c8f6aaa63e36aaf63b77ea9f8bbe55653070ec387441",
       "passed": false
     },
@@ -4780,17 +4785,17 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/x.yaml": {
-      "fingerprint": "sha256:e76e243587a1c97a015603d422c454c451615d206f656eae48932f521cfeb40d",
+      "fingerprint": "sha256:51d0819410cc74367be983d8121a2df87f307d2030ea0e4c1bdc2655c828fb40",
       "module_sha256": "sha256:1cbf7cacfa1ad4f5866cddb65f9a12da766c9247ba111b6bd80ffb2b84d82413",
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/y.yaml": {
-      "fingerprint": "sha256:7afa9bd42436a651ce0bfab0b8409e3ddb67163c8a9148438d59e8e7a9efa970",
+      "fingerprint": "sha256:963d7d0b3970c12cdbb2cf0d76a7111b7f8431719bc4e89d86d7df1381accd90",
       "module_sha256": "sha256:5e6bffafbc8bfbb4e9e197c4abe64f2ca91049fe89a0ad6eaf7d8b9bb03b4277",
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/z.yaml": {
-      "fingerprint": "sha256:71dd37b615ca9531fbd2263ccf31dbba37305f639aa3655ca3ee43e43f8b4a18",
+      "fingerprint": "sha256:3ba88a6fc0e863ec29951ed7b45ce32dd6288120250a28841f79ca90befcf3fb",
       "module_sha256": "sha256:6f33dd51dce725cb92b9f6ce8f0006238eb3bbafa02e0a82b8c6bb0cfb0f4589",
       "passed": false
     },
@@ -4800,22 +4805,22 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-119.5.yaml": {
-      "fingerprint": "sha256:1ff37fd4020e0791fee184f1ed8a7620accea42ed67e69148a84d1912fa49bda",
+      "fingerprint": "sha256:cc70c373bf0fe4fc7e86d1f6c02f4e93223b45be9cead0251b1807c3fbbf2936",
       "module_sha256": "sha256:c5397fb8b64afd33a252271913c172d869f27efa3280ea0e929f189cde4f044f",
       "passed": false
     },
     "us-co/statutes/39/39-22-119.yaml": {
-      "fingerprint": "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356",
+      "fingerprint": "sha256:6148fd5e4730e3815ecd273cbe8abda5bc3c18a4f98a92775f0e0f557b4ba771",
       "module_sha256": "sha256:471d5b98a2bdae21448adba9585631328cb9dcdcab6672d4ed1e49c8a06c535c",
       "passed": false
     },
     "us-co/statutes/39/39-22-123.5.yaml": {
-      "fingerprint": "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232",
+      "fingerprint": "sha256:2734630a88c75b99d0fa5e1cb1e34f506308c25e2ecd7b5ec8c31d7a8fd03017",
       "module_sha256": "sha256:4b063b891583e67973bf071c32c20e86448500ebe4c876e221db19b17c372633",
       "passed": false
     },
     "us-co/statutes/39/39-22-2003.yaml": {
-      "fingerprint": "sha256:0a4911baa1c3bcfadad713fe1c91db2f7f92078c25dc48d1da5cfbc03051181f",
+      "fingerprint": "sha256:cd87598c64296f22a9dc2e7f44eb9e962355db9318259bc6d87b3bee7c744fce",
       "module_sha256": "sha256:e18dbdd75d5b066766c73b5f5335503c552bede665f9555cc83cfee974f19fd1",
       "passed": false
     },
@@ -4825,7 +4830,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-547.yaml": {
-      "fingerprint": "sha256:ed76868c2e844517b6ec40fd77923c85a557e65453eb38d6248d776aec2709ad",
+      "fingerprint": "sha256:a306a5d7463a2de62061e3f981c0d4fe83b3b6444dc81c554416696670ca3e60",
       "module_sha256": "sha256:9b011817bcab7a7c84542edbd5648f03fce5c2c5f019a3720736b83788e6de8f",
       "passed": false
     },
@@ -4845,7 +4850,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-103.5.yaml": {
-      "fingerprint": "sha256:00ea594d08c388542a84aa884fb2001897feca049f7fcadd5bca421c613d978a",
+      "fingerprint": "sha256:d552fcbff4e77769c0a2e24099d28d8c670e0b474256fd92403a12fef3524cc1",
       "module_sha256": "sha256:cd211cfe76acd7031bccd28ea049af275ec7de1cead69718a3a9597a16ea4173",
       "passed": false
     },
@@ -4855,7 +4860,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-104.yaml": {
-      "fingerprint": "sha256:103cd52256644050c73776dc440893783fc1284f77f3503aca0fba81702739a9",
+      "fingerprint": "sha256:e63410f47f8f059324cf6baf832faf60bd1c9ca86a46a7dce741409589344676",
       "module_sha256": "sha256:c0ad8e9b6802799f072835c44ba4f9de3c40b6a32ae67f74867fea13395fba97",
       "passed": false
     },
@@ -4865,7 +4870,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-105.4.yaml": {
-      "fingerprint": "sha256:7c359e7c695acb9604e2c95bdb6e06ab2e25580021203a086e71a081c977b8c7",
+      "fingerprint": "sha256:230d9507e197f3a5f43413e09fef95963e8b57a01f33826a17e58c5de8a9c487",
       "module_sha256": "sha256:05b49101a57e08dc4b0a2cf9d63044656a4c905ad3a8ec7cbc11aaed677b562d",
       "passed": false
     },
@@ -4895,7 +4900,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-112.yaml": {
-      "fingerprint": "sha256:6a4d17375ed52a065b5809807613b7b67667b3a2aa38e10a3df6365e3da9fc72",
+      "fingerprint": "sha256:488c650289ea1e38e02c885ce4b84b3930a4804f06c9000a824d7f2c8f67169a",
       "module_sha256": "sha256:d54dc8d9cf59c331cdce5c72e733f088f01669126ab6eb5654a3081569d3d54a",
       "passed": false
     },
@@ -4985,12 +4990,12 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-204.yaml": {
-      "fingerprint": "sha256:041990f4f05b7375ea524b3b7d89e641a3d3511c7252d92ecad4eec94cdad7b1",
+      "fingerprint": "sha256:c010c765a07a980439774ae266cfa17cd0337d01f17d8a6289454629c478d12e",
       "module_sha256": "sha256:0d6ff1c5ba958f6b36f5a5f07567ab740d8dbafaaae409085e130d9ecaa286b6",
       "passed": false
     },
     "us-co/statutes/39/39-26-205.yaml": {
-      "fingerprint": "sha256:a55a2ae3f53aaf474fbbdfce9928bba811de4c8942236ef0cff7eab6736f018d",
+      "fingerprint": "sha256:107b629ada3924b5f733770c1892689e14174f5221c9c19afdc3fef4daa3d205",
       "module_sha256": "sha256:b5fd916190c32f155849da9402631874ee031c4e9873823097d78ffd47fb45b2",
       "passed": false
     },
@@ -5045,12 +5050,12 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-704.yaml": {
-      "fingerprint": "sha256:18a218f461428a4d1d7510f5a37977440f1a073408ceefe729208e568a18d41d",
+      "fingerprint": "sha256:b819d2d3052e9c7a20495c08f390216cfdd63466f70197f8bdea23ae19b98383",
       "module_sha256": "sha256:3e2d6f9d82ccf1a908c7539168d6fd84ebc26cdce3b7c7c299af60bb6479dc57",
       "passed": false
     },
     "us-co/statutes/39/39-26-705.yaml": {
-      "fingerprint": "sha256:2932b8b41fc5788e2f9ebdf244fc7e8ea7d9bbd19ed2b2b20730a0799482e136",
+      "fingerprint": "sha256:58f6b7f014a001a3e9f6f4536f74a90e6331e909fe48c09f030b8391be8974c5",
       "module_sha256": "sha256:29c155a6ade746a1404345d7e61538586a144f77b3b9a3665fe915fd2ed42b0c",
       "passed": false
     },
@@ -5080,7 +5085,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-711.5.yaml": {
-      "fingerprint": "sha256:425ba81b4879415ac88c714259cc1edd51648174bf3984470d2339d3563b10ca",
+      "fingerprint": "sha256:f30acdcb53aeeabedd52bb7a50858725d145b3b0e5fcec73a30058f27fa5f62d",
       "module_sha256": "sha256:d9f36a3cb7fd3b20eac8de2a46f9de13f753cd0ce017531f211e9837c9cb6e54",
       "passed": false
     },
@@ -5110,7 +5115,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-715.yaml": {
-      "fingerprint": "sha256:faf15fa93948ba828869f230bc864a7bef130334424dd01a6813ed6a8495efa4",
+      "fingerprint": "sha256:45f31b8ef28fe3742ee61ffe1b41acf832739a934b5a7f7e8b29e6cade3017e3",
       "module_sha256": "sha256:70bf8e0fe201410f2455eda679469fbc27d39dcfee6383c948326ccd4cf15962",
       "passed": false
     },
@@ -5125,12 +5130,12 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-718.yaml": {
-      "fingerprint": "sha256:df39453408117097fb3d720fc4b153192a95fa2b7727fe0c8691f1d95d0f0edd",
+      "fingerprint": "sha256:91b578cc8ac45bbc83eba20fadf1e28a18edcf6e46dd4a8b4c3b17077e7816aa",
       "module_sha256": "sha256:5512daae7aaac24057e109e999947df79720613e86c360562fcea212faa2d922",
       "passed": false
     },
     "us-co/statutes/39/39-26-719.yaml": {
-      "fingerprint": "sha256:2be9dbf06cfd4cd9f7ea9fbbaae4bda91a3d6dd4bff9ee693bdcf7b033138a3a",
+      "fingerprint": "sha256:57b9b5af794b49f9445849f8f9f9dace710f31b33532f9a99b5ded40b9bb2a50",
       "module_sha256": "sha256:45dd17abbbb1338f8e7d3032149469c7a2db1964fcce7079493bb0cbc55e9632",
       "passed": false
     },
@@ -5195,7 +5200,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-26-734.yaml": {
-      "fingerprint": "sha256:4290200eff4a38619c9969bf750d0b9147ec28b22dd6f136b39c13a8a926a666",
+      "fingerprint": "sha256:d3298c58e3e79314c199aa5c253a04337b05f50349acab5d5714a4977dd6b79a",
       "module_sha256": "sha256:5a82c4d8d03dd5c7d8a1e86ac4c46ddd6911b0befe0a3255918d80afa30f26a6",
       "passed": false
     },
@@ -5245,7 +5250,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-27-104.yaml": {
-      "fingerprint": "sha256:918373277a4f9f77db3409123a836a4d46ba014c547639460041866062b03646",
+      "fingerprint": "sha256:fb1ea712e1d882a025cd60a5757dbda5a70aa1546d4bc63ac32990bb068ee36f",
       "module_sha256": "sha256:6025029721cd8957c504b3aa7b2a750ddf3389f90ebfd0f82f22c7e682f21b12",
       "passed": false
     },
@@ -5270,7 +5275,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-27-110.yaml": {
-      "fingerprint": "sha256:e18a4ec8f760222bf6f5f43a6c8008e9609da1108df65b9d998e2bf85f747f4e",
+      "fingerprint": "sha256:412f70be881c7641540dd656d51d89b67c999313b79e515283390fb1665f1bdc",
       "module_sha256": "sha256:548590f90b146c473ff3e0ea21fcc3c7f29fc93914308bdb6a6411293ff01c14",
       "passed": false
     },
@@ -5375,27 +5380,27 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-104.yaml": {
-      "fingerprint": "sha256:074b7b631e8a1d6abf9c636ee05a80486b8aa8f2c744b024f941a2788b51330d",
+      "fingerprint": "sha256:c6f9009e568c2cec43f32cc3ff285024cd88fe856ef3e47482045f75e80a33be",
       "module_sha256": "sha256:a68c1ea685288864a4352a6c2a31ad788b61098fb79a917ef27baf19d50ac112",
       "passed": false
     },
     "us-co/statutes/39/39-29-105.yaml": {
-      "fingerprint": "sha256:fce9b3a4a28d536342b36766f5aacde7f3d73b6328d9e5a8e5fec51ce9cc5046",
+      "fingerprint": "sha256:03cd57c025a1e71902ea573f7b81784fd8d319e7e6c9e5c161ef50e1ef660c1f",
       "module_sha256": "sha256:82b97494ca6eddf07f21ad0c7b999e2756df3a8725a8982b178ce79e24e1887f",
       "passed": false
     },
     "us-co/statutes/39/39-29-106.yaml": {
-      "fingerprint": "sha256:e9b9c2dd130e47faf074c888a0e5284184ac9bb0a4adb4afdd8fa8ccd47dd8c8",
+      "fingerprint": "sha256:05cca45a62426951d66be40e4baa277e500de2ee2b72eb42287a0c779ba9afbb",
       "module_sha256": "sha256:36ab247833ed74fbaafaa9e76922540e1f35c9fc533900c50f77cfea035327ea",
       "passed": false
     },
     "us-co/statutes/39/39-29-107.8.yaml": {
-      "fingerprint": "sha256:c1205366e51d04d40e3532efe723f92dd6f681f7dae679ef5b02f23023ba92cb",
+      "fingerprint": "sha256:3ed1406cdcb7a242e36e0110cef8a3617a231bebb38b22a185f2c33459899932",
       "module_sha256": "sha256:fe559cee8e050d36830406d09f6fd1b2422d5e036cd7d1e85372e0441102c86b",
       "passed": false
     },
     "us-co/statutes/39/39-29-107.yaml": {
-      "fingerprint": "sha256:3eb15b74fe44d3a849371a7285196c7e08f0394c9cd841f3891cecd2a052b21c",
+      "fingerprint": "sha256:e91841850990c3477bba14e0ac95c5b16c9feb8d12234d760cf056d174dda222",
       "module_sha256": "sha256:56293fd9a8f423f2bcbf1ba1335a221a25369878c6ca32ba139b605e8b502625",
       "passed": false
     },
@@ -5405,7 +5410,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-109.3.yaml": {
-      "fingerprint": "sha256:0ad8df785e00533d54116d047af0a7902b6ea3eb5bd85d3665e3a4e4f95c5e63",
+      "fingerprint": "sha256:5909e953e49cc33d2d225eda00cb93ec1865393c49557b915968b9eb0cb70491",
       "module_sha256": "sha256:bac220e7e0218e9e50919548510454b5aaaec1a2398cde2baad84a272a932df6",
       "passed": false
     },
@@ -5440,7 +5445,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-115.yaml": {
-      "fingerprint": "sha256:6cdacc5669b27163917c8618f28403e34d69ead6f65d18276cc8ec85e9b62ff6",
+      "fingerprint": "sha256:22564419cd5fb981885da7f37f55c046bc03ae0e653b8fd1a327f6552bbe2330",
       "module_sha256": "sha256:20529b6df104ba8b51befef4812340b4c9aec660d1f8da760e7eb2e36abfdc55",
       "passed": false
     },
@@ -5470,7 +5475,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-3-206.yaml": {
-      "fingerprint": "sha256:35421e664a82f96114d0d1f31ae383423683d45e841b03b629101633f0f891dc",
+      "fingerprint": "sha256:b0fc40493932d9da7facd169d420e4520263db1d2c386e1b8043738f1b641558",
       "module_sha256": "sha256:499cfbae84738d4d3603c08e058ee200b8c0ce06a0452254303d0ebfdd0cf987",
       "passed": false
     },
@@ -5505,7 +5510,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-31-104.5.yaml": {
-      "fingerprint": "sha256:e12490200535e6d4be9b28c849f34179bd0023f37f63e47f1d98826694ba1611",
+      "fingerprint": "sha256:39ff504d54c993770ca2150f9cdaaab0de9eecf579c4c0e9392cbe1f69c48fa2",
       "module_sha256": "sha256:8735e3483a1a23a343aec14e31629f1f013117c1fd103e56e38d6ca62acad331",
       "passed": false
     },
@@ -5575,17 +5580,17 @@
       "passed": false
     },
     "us-ct/statutes/17b-104.yaml": {
-      "fingerprint": "sha256:49f4ea201b3867c2b2d24551d69c3ebdaed2d02bc0378442982904e08a46e8c5",
+      "fingerprint": "sha256:ea505c3d133e8cd6a78715e3867b2bbca0eb968efb9533d3a8ddea48bcc1d40e",
       "module_sha256": "sha256:d50a4704d355edd0ccffac4303d07679b6f556f14fda3bedbf1307d6550dff17",
       "passed": false
     },
     "us-ct/statutes/17b-112.yaml": {
-      "fingerprint": "sha256:2ddd17796f0d1532cbabbdcb8377dd513699ae2bb28ad5396d1cf92b0563934b",
+      "fingerprint": "sha256:cb9870255de3acae32e12ebcb16354898e03558768c3ee0aae2fd236b8eb93cb",
       "module_sha256": "sha256:539de97f827b9c8ca637ba93a677c217db359231cbdbdb6105072b60d409017e",
       "passed": false
     },
     "us-ct/statutes/17b-600.yaml": {
-      "fingerprint": "sha256:9aa431dbbc84c58c70e5e14b068eff087e3968ac74aaa53c2d25bbdb3607249b",
+      "fingerprint": "sha256:fd9df09da5a525bbeabdbbc3be51ef706f52b919fb74dec08b2853f6ee8c529f",
       "module_sha256": "sha256:bc7081e6ffa746770bc05912699de95402515b79df0d059a886b183595697099",
       "passed": false
     },
@@ -5635,27 +5640,27 @@
       "passed": false
     },
     "us-de/statutes/30/1108.yaml": {
-      "fingerprint": "sha256:761d5e2f18227146d81c06d4de55e4f47cae8a4e89451459b05b48c0975d122a",
+      "fingerprint": "sha256:9bda110ae1909ee26c7a7e27caa668d470080e355143b26881557940d188ba69",
       "module_sha256": "sha256:efe1da8c17954115ee7698e477c2589f7cdf8dda4c174f4a239cb17dcca7fba2",
       "passed": false
     },
     "us-de/statutes/30/1109.yaml": {
-      "fingerprint": "sha256:431518ff5ab4f95cc4f7a27d1e0b1850adb67a63e2faf76666a12229abee48d6",
+      "fingerprint": "sha256:2eeb3069a444ba4f5f9fbc419a3ed221f7c91a1509d438e99308d2c0e8920e05",
       "module_sha256": "sha256:ace1926a7bb8c6fa276a3e395204f8a64febacc1df2c0fc2cb120e87aea3ad9a",
       "passed": false
     },
     "us-de/statutes/30/1110.yaml": {
-      "fingerprint": "sha256:31a7c04ebaf13f227635218dbd493a0bf985e5eec9af1999d49f746d5bdd6811",
+      "fingerprint": "sha256:831ac985b9aea213778c9efb08ac9995daa1e55fb4edf32d8421ee7062321314",
       "module_sha256": "sha256:a19ee5a14062e5f015026010b53d1714a3986e028f6681b09029f7f094c0d94b",
       "passed": false
     },
     "us-de/statutes/30/1114.yaml": {
-      "fingerprint": "sha256:4db2c58135bebad41f47f9beb944bf47d86db8a1e5de98a0a0e5c15b6261f67c",
+      "fingerprint": "sha256:17334a4bd47add3ee7aa8b4dfe5e624b03b00494e3ee89e8cd158db8ea951b6f",
       "module_sha256": "sha256:793cd5eed73c53ad5d2e0754881024261101031b2164b4b5cdf13e6e7b5390e1",
       "passed": false
     },
     "us-de/statutes/30/1117.yaml": {
-      "fingerprint": "sha256:6d427e9ecded2dc602254fee8afc05745e5b9459fa3237ce3e4da0881e4f3af2",
+      "fingerprint": "sha256:678102165d27aa1a310d58aba8052124beffa0cd8801ba9b9740e3495fc999b0",
       "module_sha256": "sha256:8cc23821498347b466183abcd5493e85e87735094958a397fce3ca48c77d8de1",
       "passed": false
     },
@@ -6130,7 +6135,7 @@
       "passed": false
     },
     "us-hi/regulations/har/17/680/17-680-12.yaml": {
-      "fingerprint": "sha256:30df6025e52afff121ee0701db1d665c879e99705cf230fbaacc0ac4fc2d234c",
+      "fingerprint": "sha256:51fee9c9ecdf8dc73aaee122128fecd7bb80ba8a6b5f4033eee69341e519c515",
       "module_sha256": "sha256:c263ccb2f500244a844d0934f80693b62d49a201c38deb003b85f759b69c9f5e",
       "passed": false
     },
@@ -6280,27 +6285,27 @@
       "passed": false
     },
     "us-id/statutes/63-3022D.yaml": {
-      "fingerprint": "sha256:5a0b3babd845e371b817089005d5f23abb31cc98a189ec4ce7c5ce661cf1a6cc",
+      "fingerprint": "sha256:2c3b62f0bf8c017be858b6a26a2050681189294c4c5a5b5a9091c32faabff655",
       "module_sha256": "sha256:a5a42e078d82ed98e1f8dc412c14861171af6c11f42dfd66302c4932ae395646",
       "passed": false
     },
     "us-id/statutes/63-3022E.yaml": {
-      "fingerprint": "sha256:bf972cb8563ea35d9db4560abaf56913fe1df4a5dc0578f68a8c8620b8e42eed",
+      "fingerprint": "sha256:3835131cbd00b851374b2319e9854d80fe594935be5e5f99c2974f22b7d00965",
       "module_sha256": "sha256:c897ab4f367ba3a131dd94967ccc5452aa6d2abbd0aad6829e5c3ae241681ad8",
       "passed": false
     },
     "us-id/statutes/63-3024.yaml": {
-      "fingerprint": "sha256:ca9683f4cdd253b1aff76f70c85c35b34425ce2710e3ec8ed43b1cfe5d932822",
+      "fingerprint": "sha256:ed677c90d81b54723a03daec6bb1f1a25117705a38b3be699f57c39903219ea4",
       "module_sha256": "sha256:943464ff714e3a06a965da01844522582ff119b1a6211b6d70be877680f1d0d6",
       "passed": false
     },
     "us-id/statutes/63-3024A.yaml": {
-      "fingerprint": "sha256:353f17baab59363920c29851390ec45e95653cdb5cad64bc8d802fecdb2bc2ce",
+      "fingerprint": "sha256:493748717208e04c3f35440af30c888899b10ab08e7785ce369cc2be1d6ac83b",
       "module_sha256": "sha256:ceb2204c1c528ab8777ece0e4b58758ad26211e746803b7cb4eba89e829ee992",
       "passed": false
     },
     "us-id/statutes/63-3025D.yaml": {
-      "fingerprint": "sha256:a261dbfe21ac3b3f6a5ca3f369870f2c10220aff936e75a78fbe979f4130e746",
+      "fingerprint": "sha256:d01c9b04d54ab7dd0fe1082fe8b636b82f5eee7305ad4c355b210d78d693714b",
       "module_sha256": "sha256:59b645495d044c1f18648077a2a5c6cdc624a3a4634244366b4a1c61cf31b72a",
       "passed": false
     },
@@ -6495,7 +6500,7 @@
       "passed": false
     },
     "us-in/statutes/6-3-3-9.yaml": {
-      "fingerprint": "sha256:98161a69813d294d4b4edce626abc6f1f117ecfe6c27d9caac70b4374064db23",
+      "fingerprint": "sha256:7c000b7da63cd2acf8b8aca7adcad364eb1d2f91e3e60468333792def2ab80ec",
       "module_sha256": "sha256:56794f69fd87a379a89aaaa8ec989fac5374dbf54d424e28999284045eda1d9a",
       "passed": false
     },
@@ -6530,12 +6535,12 @@
       "passed": false
     },
     "us-ky/statutes/11/141/067.yaml": {
-      "fingerprint": "sha256:355f37ba3912f8cd034b897f363d7aa15a9657765b1b1c7987e493d16d2f8049",
+      "fingerprint": "sha256:f8e8a156ef6a7ec43e5baf6dbc20e26d321f3ad1d9409f621c72836d4c3758ba",
       "module_sha256": "sha256:98711faf569c249df7926ef75c13a1920d352fad4a6f0be754efdcee6fefc07e",
       "passed": false
     },
     "us-ky/statutes/11/141/069.yaml": {
-      "fingerprint": "sha256:136c2bc1e44f4c73dbedbad65c9d23b3557d942c3729e156ac6e173282eb916b",
+      "fingerprint": "sha256:d1ed31f094c6f3562fea02f7b53ab08cd68812a5a2b8d5ec36764b3ea6b9d756",
       "module_sha256": "sha256:fe8100b2e594101760ca79b162c81d4bf7b982eb0f47286fe0d0e8e6367bef3e",
       "passed": false
     },
@@ -6565,7 +6570,7 @@
       "passed": false
     },
     "us-ma/policies/cms/massachusetts-chip-eligibility.yaml": {
-      "fingerprint": "sha256:107cc1a620ad112089f2e93b84e6ec431f10c7d3110f2bca63470fa60fb94d4c",
+      "fingerprint": "sha256:45dcfe16cc7aa38d38246ac3e40e42b7894a69d3ef92c570deb306ea2caa5b77",
       "module_sha256": "sha256:b374acc9420dde32989099203a67fe193fcaa3ffac52fc01479a49017c26d51a",
       "passed": false
     },
@@ -6845,7 +6850,7 @@
       "passed": false
     },
     "us-ma/regulations/106-cmr/363/230/block-1.yaml": {
-      "fingerprint": "sha256:827c074f88e81f61abf02d7fe3ec6040836c1dc1f38190d03cb0cd94f234c686",
+      "fingerprint": "sha256:046ba887409f8eab32d39bbb08389543c45a424fe3a66e2b4950c44069066da4",
       "module_sha256": "sha256:d8edc0e94eec7074811e184aae7e623fb3e70bf9f149f5e13660c5f029ab9c8f",
       "passed": false
     },
@@ -6875,7 +6880,7 @@
       "passed": false
     },
     "us-ma/regulations/106-cmr/364/360/block-1.yaml": {
-      "fingerprint": "sha256:545d6b6403580a2ab94667f2d5854e98f0aafd8cb98c48562799a6a5fe88e6a5",
+      "fingerprint": "sha256:5aa7dc34b0ce13fe3474118169aad8ce8575fed0ed71283f73067e8aa72634ee",
       "module_sha256": "sha256:c63bcb2bcbf84ae35c93f5254f62adc39865a219c8bb155248df0b6cfe2497bf",
       "passed": false
     },
@@ -6890,7 +6895,7 @@
       "passed": false
     },
     "us-ma/regulations/106-cmr/364/420/block-1.yaml": {
-      "fingerprint": "sha256:75a89306a1f3adf53cba6ced84dbb1544fe8077957deeb207af8b0af711b3a70",
+      "fingerprint": "sha256:e98166db92d71b2ca72d880555052ceac756aeb1853501f6ce23ba464e667afd",
       "module_sha256": "sha256:b65e9524857632f1a12c283eb0284a734ee3ae4db046d100f174108458f0b31e",
       "passed": false
     },
@@ -6990,7 +6995,7 @@
       "passed": false
     },
     "us-ma/regulations/106-cmr/365/030/block-1.yaml": {
-      "fingerprint": "sha256:cc08c57b05be7fa8754b6d04595ee1ba75e4eb189251b2e96e3c0f0e719bfa7e",
+      "fingerprint": "sha256:b014bb86f592abc95ff96f0385f4c0cc1fed28507bc188e0a024d50b212e59c4",
       "module_sha256": "sha256:e91f531c9f683eb4a2ae0cc17cabad09c39675940bd431b3f478ba66aea9d466",
       "passed": false
     },
@@ -7090,7 +7095,7 @@
       "passed": false
     },
     "us-ma/regulations/106-cmr/366/140/block-1.yaml": {
-      "fingerprint": "sha256:c6fbe453ef93dfda542a6bb0437d6adf5e10af8aa56e7ea7a305793a5a9c28a6",
+      "fingerprint": "sha256:528f257d99fcc879fd43a6067f13f5f75db0f08f138a833b4fed76f20a52b246",
       "module_sha256": "sha256:45ea9f24af6a79b2c1966ce5058de06aeb38c574e595bf2391182dc4251d48d2",
       "passed": false
     },
@@ -7320,7 +7325,7 @@
       "passed": false
     },
     "us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.yaml": {
-      "fingerprint": "sha256:9dbd467c895e84c469c85985f7602f61e3a56cdc1bff578cb6613e735e6b1cfd",
+      "fingerprint": "sha256:a962fe058b7f622c30e975a5a79d2ee5ca6b2883fb1533a0d24d7fd2b43a0ffc",
       "module_sha256": "sha256:04fd393fcdd80e24446f112f5e7e9e68aa97e65fc97347086ad7e10caccdbdf4",
       "passed": false
     },
@@ -7335,12 +7340,12 @@
       "passed": false
     },
     "us-md/statutes/gtg/10-105.yaml": {
-      "fingerprint": "sha256:fe0d9a470f332dff456635ce24e099b5ea0ae1bb8a633e6e1a5a4e63bdaf7bfa",
+      "fingerprint": "sha256:8ea8b5880f49e328d55d31535e78549abc390adee11b9cd9fcb6dabb9c915f48",
       "module_sha256": "sha256:715794ef8b789530b5ee9e906a0114d3ad0b848fb733b4915ba1aab6c953172e",
       "passed": false
     },
     "us-md/statutes/gtg/10-211.yaml": {
-      "fingerprint": "sha256:aaa6935cfb25b712480e561603d424b0ef53b0bfcfd224b30025288ddddf729f",
+      "fingerprint": "sha256:a1cced0f66ef9de8ec2f8ab1dab4a9a19c6a3cab4b6b7fc945649952cf7a2ca3",
       "module_sha256": "sha256:fa4d8ef467b7a2f186a3f7ce60591c936d0345227257fed45ab5e791561dfa0f",
       "passed": false
     },
@@ -7360,7 +7365,7 @@
       "passed": false
     },
     "us-me/statutes/36/5111.yaml": {
-      "fingerprint": "sha256:7311339cc52590ed4b412cc131c7189722009e9fb06434c0fb0de46e26e89ad2",
+      "fingerprint": "sha256:b8f07e6522c3a0512b634831da0c76206ef7ffc1f7673b800a4dfecad8bd89ec",
       "module_sha256": "sha256:acca484401c98c3b4223613d1827aae02a8cedaf9a8e2c4e7ba806eb7110aed8",
       "passed": false
     },
@@ -7370,7 +7375,7 @@
       "passed": false
     },
     "us-me/statutes/36/5126-A.yaml": {
-      "fingerprint": "sha256:b54b904c3536d6832b910a7d3b0765b85709e6e78b705ba52220e3c856ed7e8b",
+      "fingerprint": "sha256:71ee5bfa4fcec8077672a4cfb6e0a3f693c6d37ddea3fced401ccc222ec4539f",
       "module_sha256": "sha256:5c3094e945bf84e7c44cd2217f9b48107c36bee5189260c0157269dd8ed2ced7",
       "passed": false
     },
@@ -7380,12 +7385,12 @@
       "passed": false
     },
     "us-me/statutes/36/5219-S.yaml": {
-      "fingerprint": "sha256:0c6442e722f825d09134794fc89089b15285d699bd0fcede1e1a5900498afb3e",
+      "fingerprint": "sha256:b299f292676755ee4ecb88ae1f0e1b842d437c0304af86c66b407f28f4bb7147",
       "module_sha256": "sha256:29564f79d2bd6bf8bc866925c31a0fcc88946c74d85eb9b1617d3cf68c5e1d11",
       "passed": false
     },
     "us-me/statutes/36/5219-SS.yaml": {
-      "fingerprint": "sha256:77c7ee712574ffb7f167edfc4a28a7a30db8f66a1e723889e39f3ba109d517fa",
+      "fingerprint": "sha256:7c156bea8a2359369816d891a208447fd14a9c9b7678421dc8585f3007b0e323",
       "module_sha256": "sha256:d6f76732a059369cb82a0553d6ec02261357d96bac0628a94959fbeaa63f6387",
       "passed": false
     },
@@ -7455,7 +7460,7 @@
       "passed": false
     },
     "us-mn/policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026.yaml": {
-      "fingerprint": "sha256:2b9424a2f22c7f940955b7653f3522e980d3305e69947ec9f17904d3356237b4",
+      "fingerprint": "sha256:ded2d44fef7a4e9d7f7597fc8ec24b6f46e29a23925c4ae02b626ec7d312c5fe",
       "module_sha256": "sha256:ec5465e5253640c89b1becb085f1aed86d5dbbab69e4620f546578f8f0f2d723",
       "passed": false
     },
@@ -7475,7 +7480,7 @@
       "passed": false
     },
     "us-mn/statutes/290/0123.yaml": {
-      "fingerprint": "sha256:bd46c288e4a4520facc78588fcaee0ff38112e3720b76694a79aaba59044bec0",
+      "fingerprint": "sha256:66100c87bb9cf4801afd6d4e91611f757ff7f5fba1f3445d2e42de49e36e156b",
       "module_sha256": "sha256:2af775dbfe076fcc64ce8e99bb6a81a4eb5c4a233defe609c4884940fbae3237",
       "passed": false
     },
@@ -7495,7 +7500,7 @@
       "passed": false
     },
     "us-mo/policies/cms/missouri-chip-eligibility.yaml": {
-      "fingerprint": "sha256:68623d8668b95af9939a49199baf31fbc65878ca9814d28797247def6b9c0a0f",
+      "fingerprint": "sha256:888111fe137619c9d314e941ad12ed0f155a33fad10bd30295ff4df340a6fb34",
       "module_sha256": "sha256:4a211888b30ace6ddd74ef87829d4c2c8f759c2f18982f4caa320a3ce5000393",
       "passed": false
     },
@@ -9580,7 +9585,7 @@
       "passed": false
     },
     "us-nc/statutes/105/105-153.5/a.yaml": {
-      "fingerprint": "sha256:d0ae8cef94463ba35b124c4a26d4b97a1303858c73b96b7810db1e7cabadf145",
+      "fingerprint": "sha256:7f4f1f81285adf09e3751aaf1ef7362ceecf99e10d4a9ed625d3b1d0ef9e1295",
       "module_sha256": "sha256:0fffbe4189fed9d1b224f6f0482409902be54bcf25df47b5581e66790df51492",
       "passed": false
     },
@@ -9685,7 +9690,7 @@
       "passed": false
     },
     "us-nj/regulations/njac-10-90/10-90-3/20.yaml": {
-      "fingerprint": "sha256:f026b66fd65f2ccad3b5812118b74d94c1e3c5fc4a72aafa67ab5edffa722a2b",
+      "fingerprint": "sha256:0784b6e419faba191bb8d00ff6390ad333938bf0d45fd74e44ee941f3a09e14e",
       "module_sha256": "sha256:8c0eb538f8570119ef04d93dc55a83849530dc47f31df9395d21fcecabd506c3",
       "passed": false
     },
@@ -9695,12 +9700,12 @@
       "passed": false
     },
     "us-nj/regulations/njac-10-90/10-90-3/8.yaml": {
-      "fingerprint": "sha256:f898214e1674936e50fba53e2d7b93d85cf403253a9a29782e5ea29573bff491",
+      "fingerprint": "sha256:b3d8550623b80c85b9c2142ddb12e9c3066ce49eadf3eac5be391907d07fa1b2",
       "module_sha256": "sha256:6b4a89e46982ae467e45b0f4d769c8ea1c90eafff3fd2d7f03bba51b75395f5a",
       "passed": false
     },
     "us-nj/regulations/njac-10-90/10-90-3/9.yaml": {
-      "fingerprint": "sha256:8ab5a405fca770eb6d65ef35d5aed53f0c3e39777cb2e9fdb8f776dcc3eb56d1",
+      "fingerprint": "sha256:99c1ed33f6492fb573062600c8bff8280c78bcb44a27e25d524c5ec10eb61bb8",
       "module_sha256": "sha256:b207202a1bdd54c5433cf8fe3b3e82fce0366f3e91af714bb92e0f2f75ddd283",
       "passed": false
     },
@@ -9745,7 +9750,7 @@
       "passed": false
     },
     "us-ny/policies/otda/tanf-state-plan-2024-2026/financial-eligibility-and-income-disregards.yaml": {
-      "fingerprint": "sha256:a9c25b06c4705a1eaf3a85b0252514d7edd8b3f7708c57ef8b238945a41b955a",
+      "fingerprint": "sha256:36c1bbd2adf9e793e3ca3f025a02f1b7a1df94dfff9ebb2cf966bbdf87a7f887",
       "module_sha256": "sha256:2184d6442c4e6adadb02e3bc0812f132c63dd3c3570ca7a257035826879a22e5",
       "passed": false
     },
@@ -9760,17 +9765,17 @@
       "passed": false
     },
     "us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml": {
-      "fingerprint": "sha256:cea24e9a1a7645daf26ceb37e1036a85eceebf811e7a0d309d00255d3cf9a1ce",
+      "fingerprint": "sha256:f96e56414c70f8c49c87b49d1707826dd5442cd577c9ac467b96f382ac813ae8",
       "module_sha256": "sha256:41d403d4629ab8160bba4f359abdd6a8a7ad01ad8373443f413c0ad1642361f2",
       "passed": false
     },
     "us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml": {
-      "fingerprint": "sha256:b7a69436fc2161c2947b3aebe804992c4ce7e463a6c17fd2b2d0f8f86fdd7b76",
+      "fingerprint": "sha256:33446dc2051e3cab5e31882db17e1bdbec48b87b585dc8e1cdb6114a635f4e4b",
       "module_sha256": "sha256:b4ce08c868f15a04e3fedde5985a336383438c013f67837aabd97ee876a6dbbb",
       "passed": false
     },
     "us-ny/policies/tax/it-216-instructions/nyc-child-dependent-care-credit.yaml": {
-      "fingerprint": "sha256:4f4c7cbb4a1f08e98fb1a79310fdabdb672460f07147b1a0be4c536622c9aa83",
+      "fingerprint": "sha256:bbc9b026ab928624445ca2e7aaf76f95fb5ce780a29ad5ceb0a0be4857eec1db",
       "module_sha256": "sha256:b519fb659046c5a112a1740f57d093b2c4db939e701e88fcdabb68b22f9a231e",
       "passed": false
     },
@@ -9815,12 +9820,12 @@
       "passed": false
     },
     "us-ny/statutes/NYC/11-1701.yaml": {
-      "fingerprint": "sha256:988847e32cca202fa902b17c81ac23591b53be14664b2b5f670dc065f23ea070",
+      "fingerprint": "sha256:ff2bdbcf21676688527e8063003c8d61d13776d087073d3f2e85ca8ff2c09c8f",
       "module_sha256": "sha256:7bbba6387ec0ff1a813fdf9abc738f1f3c0588bea7ebdc16202520cbcbec50a7",
       "passed": false
     },
     "us-ny/statutes/NYC/11-1704/1.yaml": {
-      "fingerprint": "sha256:c885d942450e3d53f178b41238eb5ea879d13298dc923b10c347d86026522979",
+      "fingerprint": "sha256:65999eda50199d35e743749e9061a4ed8dc79dc54283d093139ccebea8427cb5",
       "module_sha256": "sha256:b3083732c31dbf3e3af434c2b76e62dd1db7c18fa80d3f1044c64964386a237b",
       "passed": false
     },
@@ -9830,7 +9835,7 @@
       "passed": false
     },
     "us-ny/statutes/TAX/601-A.yaml": {
-      "fingerprint": "sha256:81209afbe41752ca14110f9057ebc2f13e451ce1cea6c8c05a3576927878eae8",
+      "fingerprint": "sha256:f9b8ed32a40a0ef17a3853e88cb219544a3aa5f1995788ff720b8007a071af8d",
       "module_sha256": "sha256:0afde12da54d63434cc5c699f506162d66cbd739b0e52acefc0da0401f49fecd",
       "passed": false
     },
@@ -9850,12 +9855,12 @@
       "passed": false
     },
     "us-ny/statutes/TAX/614.yaml": {
-      "fingerprint": "sha256:bddf348d7f1e2c82ae251386cd57842f4a3402d6a2b6bd612545814854c786f3",
+      "fingerprint": "sha256:13d24e5ff29c033657c7319e420f6f842b8c7b6118b447dc021577cfdc4c1a73",
       "module_sha256": "sha256:3ba36cbd15ec565af1315e28b6dd27d773337155fea554d81db0c42db7c50a65",
       "passed": false
     },
     "us-ny/statutes/TAX/616.yaml": {
-      "fingerprint": "sha256:7f870613e4322bffa42d37651fe168376fb1647d17f159202d3d8f8529cc98e6",
+      "fingerprint": "sha256:1aacf0fc361f67f451d0f004e3a45e9b67b29a836b0b25e3f3e5a182794fb1bf",
       "module_sha256": "sha256:66d17d37659e2d14cae3360777c87de7f84a3cae051f557ff3a749c228378cd1",
       "passed": false
     },
@@ -9890,7 +9895,7 @@
       "passed": false
     },
     "us-ny/statutes/TAX/674.yaml": {
-      "fingerprint": "sha256:41e053ef0f870f37301b0bd9146abd739a192df2347fbe6bed0abb5651d76587",
+      "fingerprint": "sha256:9b1817aa38a433c6bd54fd67f9bd20e8d65635c3169a93e59465c6712e868c2e",
       "module_sha256": "sha256:45ab4d6ccfd5e91aabf0c3890031d189ad8e0d58390bc1e70dceb92ec17a9d7d",
       "passed": false
     },
@@ -10000,7 +10005,7 @@
       "passed": false
     },
     "us-sc/statutes/12-6-520.yaml": {
-      "fingerprint": "sha256:0f0bc45e78fac89064df97774ace8b442601e537387bd9199510f3bb18f39cfe",
+      "fingerprint": "sha256:8322c7a9a29cf8a0d32831394f60986548415e4fe14ae87726d0d265c127411c",
       "module_sha256": "sha256:de4574a16f949dbfb3e770f9889aa2bea3bc45202b3e37f9de81754e12da1802",
       "passed": false
     },
@@ -10595,7 +10600,7 @@
       "passed": false
     },
     "us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml": {
-      "fingerprint": "sha256:0c484cce843e538879d89b1598f5900a753ecd31ba5105c03cd0fdd54e9e95f8",
+      "fingerprint": "sha256:79491be1e93e448acf07678bd4f35f8e71ee1ecc39bcc7c08f2c59d44cc464b2",
       "module_sha256": "sha256:6341abf0027a5807566b3da92fad782ce36b223f2fbe1a35f89625481a588958",
       "passed": false
     },
@@ -10695,7 +10700,7 @@
       "passed": false
     },
     "us-wa/regulations/388/388-478/388-478-0055.yaml": {
-      "fingerprint": "sha256:9d1bbb58aa35defb132b9496dc52892df8d11756fad7da6814cf56cf88a3c1a0",
+      "fingerprint": "sha256:f128851be830f7d18fdb713fc58f7aa1c61ab3945f9c60b629d870912a5678d2",
       "module_sha256": "sha256:a711a44104d7aca3402f8afad682d3bc04a95a2cbe9bee1f9b4af3f4c0cef6fa",
       "passed": false
     },
@@ -10805,7 +10810,7 @@
       "passed": false
     },
     "us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml": {
-      "fingerprint": "sha256:38cccecc98cea21ef3f7af3722c7e2d5638d707c33f4f76a497e8d7173e80dde",
+      "fingerprint": "sha256:885396c2d2a36b5598e62835c1f1e86a7d6d802c84f6211ec9ad3546d4078742",
       "module_sha256": "sha256:f9d5b2c0549f5e8dadcb13c92dd159a648d94acd3afbad0b4898ac9d522209fb",
       "passed": false
     },
@@ -11025,7 +11030,7 @@
       "passed": false
     },
     "us/regulations/42-cfr/435/556.yaml": {
-      "fingerprint": "sha256:7979deea9d79148be87e710c11bb12ecf913c8dc3f249a0201b494fb82f82c32",
+      "fingerprint": "sha256:fe8e512ba00d5e019918bf0b94637f4bf3cd425bb5d99ffe45422209985f8839",
       "module_sha256": "sha256:aec3c435a43d56822b07026a17274b399f038ddac4f6e5f4c824d3c5e9dcd964",
       "passed": false
     },
@@ -11485,7 +11490,7 @@
       "passed": false
     },
     "us/statutes/26/199A.yaml": {
-      "fingerprint": "sha256:4ce91fbc649d108819efa50be0fc2395e7eec5f556c542343772ff8495a520a4",
+      "fingerprint": "sha256:d6b6d805f857670ce7cb2aa39ebb89f7f138ea7a549d7103f299f9911c586886",
       "module_sha256": "sha256:caa63943baa5fef539a7ae78ccf13c729149915e079f252cc44c97a7aa9db816",
       "passed": false
     },
@@ -11520,7 +11525,7 @@
       "passed": false
     },
     "us/statutes/26/219/g.yaml": {
-      "fingerprint": "sha256:2d8c089252acafc99e5b65c1edbcdd4016f0174e65f13278776c2c636dc77333",
+      "fingerprint": "sha256:043947bf19eddc38f22c97a7cfab9302fe701812436691c6f50108f609f95add",
       "module_sha256": "sha256:6c4e54a5eeb420d061f4423d5060253a2b794e58e00dade857d426091f268139",
       "passed": false
     },
@@ -12080,7 +12085,7 @@
       "passed": false
     },
     "us/statutes/26/3131/b/1.yaml": {
-      "fingerprint": "sha256:e9d9c332a5fb028a4de62ad73df91c289984cc643a3de96df54e2822e9384be5",
+      "fingerprint": "sha256:285215b6e352f2ad9c9191ccb9272f1d89450b4cda964b3adac95e63b0e8b67a",
       "module_sha256": "sha256:90783d4414cc88840de318f1ae40496a391b6d43aaa40579928d8ac667322818",
       "passed": false
     },


### PR DESCRIPTION
## Summary

Evidence-only correction required by the protected waiver transition checks. The prior evidence refresh recorded isolated fingerprints for rows that already had pending approvals on the protected base. This refresh aligns every pending evidence record with the protected base ledger fingerprint and current module bytes.

- 2,670 pending records checked
- 152 stale evidence fingerprints corrected
- 0 remaining pending-evidence mismatches locally
- no RuleSpec modules, waiver records, or toolchain pins changed

## Context

PR #1089 correctly exposed the mismatch: protected validation rejected the first transition candidate because the protected base ledger fingerprint and evidence fingerprint differed. This PR fixes the evidence layer before #1089 is rerun.

## Checks

- `python -m pytest -q tests/test_repository_layout.py`
- `git diff --check`
- exact pending/evidence/module SHA equality for all 2,670 pending records
