### PR TITLE
Bound Michigan 2026 resident income tax source-held pipeline

### DIFF
--- a/.axiom/encoding-manifests/us-mi/policies/income_tax/e2e_resident_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-mi/policies/income_tax/e2e_resident_liability_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.test.yaml",
+      "sha256": "fd05d1a2145453b2aaab10e1d45c9eb6a65c2f950cb8232d08722c5242d994a4"
+    },
+    {
+      "path": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+      "sha256": "df2c03edf076630809034550628a239cf34a2dfca0db74094e65a17c2f761b15"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-mi:policies/income_tax/e2e_resident_liability_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-26T02:44:15.429269+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmph5al3zil/sign-applied-files/us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmph5al3zil",
+  "generated_output_sha256": "df2c03edf076630809034550628a239cf34a2dfca0db74094e65a17c2f761b15",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4a197ab878163772087e9b5802807e0f373f7c8dfff1c8280e8cd072d7693de7"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -22230,6 +22230,13 @@
         ]
       },
       {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-mi/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -22256,6 +22263,13 @@
       }
     ],
     "us-mi/statute/206.272": [
+      {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-mi/statutes/206/272.yaml",
         "via": [
@@ -22292,6 +22306,13 @@
     ],
     "us-mi/statute/206.30/2": [
       {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-mi/statutes/206.30/2.yaml",
         "via": [
           "module",
@@ -22301,6 +22322,13 @@
     ],
     "us-mi/statute/206.30/3": [
       {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-mi/statutes/206.30/3.yaml",
         "via": [
           "module",
@@ -22309,6 +22337,13 @@
       }
     ],
     "us-mi/statute/206.30/7": [
+      {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-mi/statutes/206.30/7.yaml",
         "via": [
@@ -22322,6 +22357,15 @@
         "module": "us-mi/statutes/206.30/8.yaml",
         "via": [
           "module"
+        ]
+      }
+    ],
+    "us-mi/statute/206.51/1": [
+      {
+        "module": "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
         ]
       }
     ],

--- a/us-mi/policies/income_tax/e2e_resident_liability_pipeline.test.yaml
+++ b/us-mi/policies/income_tax/e2e_resident_liability_pipeline.test.yaml
@@ -1,0 +1,36 @@
+# Michigan's retained 2026 authority is incomplete for a full resident return.
+# These fixtures assert the source-held boundary and zero sentinels; no test
+# supplies caller-completed Michigan income, deductions, exemptions, tax, or
+# credit outputs.
+- name: valid-full-year-resident-return-is-source-held-through-signed-liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_federal_adjusted_gross_income: 60000
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_is_full_year_resident_return: true
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_federal_and_michigan_filing_units_are_aligned: true
+  output:
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_input_domain_is_valid: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_income_base_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_deduction_and_exemption_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_tax_and_surtax_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_credit_surface_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_complete_liability_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_fail_closed_sentinel: -1
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_net_income: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_deductions_and_exemptions: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_taxable_income: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_tax_before_credits_including_surtaxes: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_tax_after_nonrefundable_credits: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_refundable_credits: 0
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_net_income_tax_liability_before_payments: 0
+
+- name: part-year-return-is-outside-resident-program-domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_federal_adjusted_gross_income: 60000
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_is_full_year_resident_return: false
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#input.mi_pit_e2e_federal_and_michigan_filing_units_are_aligned: true
+  output:
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_input_domain_is_valid: not_holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_complete_liability_source_hold_applies: holds
+    us-mi:policies/income_tax/e2e_resident_liability_pipeline#mi_pit_e2e_net_income_tax_liability_before_payments: 0

--- a/us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml
+++ b/us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml
@@ -1,0 +1,342 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-mi/statute/206.30/2
+      - us-mi/statute/206.30/3
+      - us-mi/statute/206.30/7
+      - us-mi/statute/206.51/1
+      - us-mi/statute/206.272
+      - us-mi/guidance/treasury/taxpayer-notices/2026/04/15/individual-income-tax-rate/rate-determination
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-mi/statute/206.30/2
+        - us-mi/statute/206.30/3
+        - us-mi/statute/206.30/7
+        - us-mi/statute/206.51/1
+        - us-mi/statute/206.272
+      rationale: |-
+        The retained corpus contains current Michigan statute fragments and
+        the official Treasury 2026 rate determination. Those fragments do not
+        form a complete executable resident return chain: federal conformity
+        and all section 206.30(1) additions/subtractions, deduction ordering,
+        credit inventory, surtax/special-tax rules, and final-return ordering
+        remain incomplete. This module consequently accepts only federal AGI,
+        full-year-resident status, and aligned filing-unit status. It never
+        accepts caller-completed Michigan income, deductions, exemptions,
+        taxable income, tax, surtax, or credit amounts. Every incomplete stage
+        is represented by a typed source-hold Judgment and a zero Money
+        sentinel. The zero is a fail-closed sentinel, not a claim that tax is
+        zero. Payments, filing administration, local taxes, and nonresident
+        allocation are outside scope.
+  summary: |-
+    Michigan 2026 full-year-resident individual-income-tax source-held
+    program boundary. It preserves the requested federal AGI -> Michigan
+    income -> deductions/exemptions -> taxable income -> tax/surtax -> credits
+    -> signed net before payments stage names while refusing to invent missing
+    law. The public money outputs are zero sentinels while their stage holds
+    are active; no caller-completed state output or mechanical authority
+    bypass is accepted.
+rules:
+  - name: mi_pit_e2e_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Michigan full-year resident federal boundary
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: Tax is imposed on the taxable income of every resident.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          mi_pit_e2e_is_full_year_resident_return
+          and mi_pit_e2e_federal_and_michigan_filing_units_are_aligned
+          and (
+            mi_pit_e2e_federal_adjusted_gross_income >= 0
+            or mi_pit_e2e_federal_adjusted_gross_income < 0
+          )
+
+  - name: mi_pit_e2e_income_base_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete federal-to-Michigan income-base construction
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/statute/206.30/2
+              excerpt: Taxable income is computed after statutory subtractions.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: mi_pit_e2e_deduction_and_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete 2026 Michigan deduction and exemption chain
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/statute/206.30/3
+              excerpt: Additional exemptions are subject to statutory eligibility conditions.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: mi_pit_e2e_tax_and_surtax_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete 2026 Michigan tax and surtax/special-tax authority
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: Section 51 supplies the rate on taxable income but not the complete upstream resident chain.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: mi_pit_e2e_credit_surface_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete 2026 Michigan nonrefundable and refundable credit inventory
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: Section 272 supplies only the earned-income-credit slice and refund rule.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: mi_pit_e2e_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined hold for incomplete 2026 Michigan resident liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: The tax rate cannot execute without source-complete taxable income and credits.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          mi_pit_e2e_income_base_source_hold_applies
+          or mi_pit_e2e_deduction_and_exemption_source_hold_applies
+          or mi_pit_e2e_tax_and_surtax_source_hold_applies
+          or mi_pit_e2e_credit_surface_source_hold_applies
+
+  - name: mi_pit_e2e_fail_closed_sentinel
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Typed -1 indicator for the active source hold
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/guidance/treasury/taxpayer-notices/2026/04/15/individual-income-tax-rate/rate-determination
+              excerpt: The notice determines the annual rate but not a complete return.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: -1
+
+  - name: mi_pit_e2e_net_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan net income sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.30/2
+              excerpt: The source slice does not complete the federal-to-Michigan income base.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_deductions_and_exemptions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan deductions and exemptions sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.30/7
+              excerpt: Indexed exemptions and exceptions are not complete for this resident program.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan taxable-income sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.30/2
+              excerpt: Taxable income depends on incomplete upstream resident rules.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_tax_before_credits_including_surtaxes
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan tax and surtax sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: Section 51 rate is not composed without taxable income and the complete special-tax surface.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan post-nonrefundable-credit sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: The retained source does not establish the complete credit inventory or ordering.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Source-held Michigan refundable-credit sentinel
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.272
+              excerpt: Section 272 supplies one refundable EITC slice, not the complete current-year inventory.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+
+  - name: mi_pit_e2e_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Signed net resident liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-mi/statute/206.51/1
+              excerpt: Final signed liability remains source held until the resident chain is complete.
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: 0
+inputs:
+  - name: mi_pit_e2e_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income boundary; no completed Michigan state amount is accepted.
+  - name: mi_pit_e2e_is_full_year_resident_return
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Full-year Michigan resident return selector.
+  - name: mi_pit_e2e_federal_and_michigan_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Filing-unit alignment selector for the federal boundary.


### PR DESCRIPTION
## Summary
- add a bounded Michigan tax-year-2026 full-year-resident pipeline through signed net liability before payments
- preserve explicit federal AGI/residency/filing-unit boundary; no caller-completed Michigan stages
- fail closed with typed source holds and zero Money sentinels while the retained corpus lacks the complete current resident chain
- add companion fixtures, reverse-index entry, and signed pinned-toolchain apply manifest

## Validation
- exact refreshed base: `8b5e7a18a9f91d73d1f618cdc4931ad16eac46fc`
- exact refreshed head: `8ab27d3e1628f3356ad5070b02ca918d061e3080`
- retained corpus pin: `5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7`
- pinned validate: pass
- pinned proof-validate: pass (14 atoms)
- pinned companion test: pass (2 cases)
- full repository suite: 67 passed, 1 known warning
- `git diff --check`: pass
- semantic module, companion, and manifest are byte-for-byte unchanged from the prior reviewed head
- semantic scope: 4 files, 464 insertions

This remains draft while refreshed required CI and the independent review-fix cycle run. No merge is requested while checks are pending, red, or stale.