### PR TITLE
Bound Kentucky 2026 resident income tax source-held pipeline

### DIFF
--- a/.axiom/encoding-manifests/us-ky/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-ky/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ky/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
+      "sha256": "f5d7daa4ce8414deca73ebc493a34426ea8f27039f10621c66762f8bdb9bb69e"
+    },
+    {
+      "path": "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+      "sha256": "9faf54271eca242919e8df4a85b9a763e62ed3c35fc4f0a4daa44ef1fbc6516a"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ky:policies/income_tax/2026_full_year_resident_source_hold",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-25T00:34:21.006782+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpza_ba4eo/sign-applied-files/us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpza_ba4eo",
+  "generated_output_sha256": "9faf54271eca242919e8df4a85b9a763e62ed3c35fc4f0a4daa44ef1fbc6516a",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "1b9b538a75602ed3b3b170f04392fd006c06a3237d2d834f05b454118c0bc011"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -19640,6 +19640,15 @@
         ]
       }
     ],
+    "us-ky/form/individual-income-tax/2026/740-es/document-1": [
+      {
+        "module": "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ky/statute/11/141.020": [
       {
         "module": "us-ky/statutes/11/141/020.yaml",
@@ -19669,7 +19678,23 @@
     ],
     "us-ky/statute/krs/141.020/document-1": [
       {
+        "module": "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ky/policies/income_tax/pilot_liability_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ky/statute/krs/141.081/document-1": [
+      {
+        "module": "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us-ky/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-ky/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -1,0 +1,61 @@
+# The pinned Kentucky sources establish the 2026 rate and estimated-tax
+# standard-deduction amount but do not establish a complete 2026 final return.
+# These fixtures prove only the raw federal/domain boundary, typed holds, and
+# fail-closed Money sentinels. No zero is a substantive Kentucky tax result.
+
+- name: valid positive federal return is held through signed liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_adjusted_gross_income: 60000
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_is_full_year_kentucky_resident_return: true
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_and_kentucky_filing_units_are_aligned: true
+  output:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_input_domain_is_valid: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_final_return_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_income_and_modification_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deduction_and_exemption_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_and_surtax_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_nonrefundable_credit_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credit_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_state_income_after_modifications: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deductions_and_exemptions: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_taxable_income: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_before_credits_including_statewide_surtaxes: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_after_nonrefundable_credits: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credits: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: negative federal adjusted gross income remains a valid raw boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_adjusted_gross_income: -5000
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_is_full_year_kentucky_resident_return: true
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_and_kentucky_filing_units_are_aligned: true
+  output:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_input_domain_is_valid: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_state_income_after_modifications: '0'
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: part-year return is outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_adjusted_gross_income: 45000
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_is_full_year_kentucky_resident_return: false
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_and_kentucky_filing_units_are_aligned: true
+  output:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_input_domain_is_valid: not_holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: misaligned filing units are outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_adjusted_gross_income: 110000
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_is_full_year_kentucky_resident_return: true
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#input.ky_pit_2026_federal_and_kentucky_filing_units_are_aligned: false
+  output:
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_input_domain_is_valid: not_holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies: holds
+    us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments: '0'

--- a/us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -1,0 +1,476 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ky/statute/krs/141.020/document-1
+      - us-ky/statute/krs/141.081/document-1
+      - us-ky/form/individual-income-tax/2026/740-es/document-1
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-ky/statute/krs/141.020/document-1
+        - us-ky/statute/krs/141.081/document-1
+        - us-ky/form/individual-income-tax/2026/740-es/document-1
+      rationale: |-
+        The pinned official Kentucky corpus establishes that KRS 141.020
+        imposes an annual tax on every resident individual's net income,
+        supplies a 3.5 percent rate for taxable years beginning on or after
+        January 1, 2026, and requires allowable credits to be subtracted from
+        tax. KRS 141.081 establishes the optional standard-deduction indexing
+        authority. The official 2026 Form 740-ES instructions publish a $3,360
+        standard deduction and use the 3.5 percent rate in an estimated-tax
+        worksheet.
+
+        Those sources do not establish an executable final tax-year-2026
+        resident return. The pinned corpus lacks the operative 2026 Form 740
+        annual-return package and instructions, KRS 141.019 and the complete
+        federal-conformity addition and subtraction chain, complete itemized
+        deduction and election rules, a closed ordinary and specialty-tax
+        surface, and the complete nonrefundable and refundable credit
+        inventory with eligibility, limitations, ordering, carryforwards,
+        recaptures, and refundability. The 740-ES instructions expressly label
+        their family-size-credit table as tax year 2025, so it cannot supply
+        the operative 2026 final-return credit schedule.
+
+        This module accepts only an allowed federal-return output and raw
+        residency and filing-unit facts. It never accepts Kentucky adjusted
+        gross income, additions, subtractions, deductions, exemptions, net or
+        taxable income, tax rates, thresholds, tax, surtaxes, credits, or
+        liability. Typed source holds remain active, and every public Kentucky
+        Money stage is a fail-closed zero sentinel. Those sentinels are not
+        legal claims that Kentucky income, credits, tax, or liability are
+        zero. The existing pilot uses a prohibited completed Kentucky net
+        income input and is not composed into this resident program.
+  summary: |-
+    Tax-year-2026 Kentucky full-year-resident individual-income-tax
+    source-readiness boundary. It accepts federal adjusted gross income as an
+    allowed federal-return output and accepts raw full-year-residency and
+    filing-unit alignment facts.
+
+    Kentucky income after additions and subtractions, deductions and
+    exemptions, taxable income, tax before credits including any applicable
+    statewide surtaxes, tax after nonrefundable credits, refundable credits,
+    and signed liability before payments all fail closed while the pinned
+    final-return source gaps remain. The module is intentionally incomplete
+    and makes no final-return liability or oracle-parity claim.
+
+    Withholding, estimated payments, extension payments, penalties, interest,
+    refunds of payments, local taxes, nonresident sourcing, part-year
+    allocation, estates, and trusts are outside scope.
+  deferred_outputs:
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_state_income_after_modifications
+      reason: |-
+        The pinned corpus does not contain KRS 141.019, final 2026 Form 740
+        instructions, or the complete operative federal-conformity addition
+        and subtraction chain.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_income_and_modification_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deductions_and_exemptions
+      reason: |-
+        KRS 141.081 and the estimated-tax worksheet establish a 2026 standard
+        deduction amount, but they do not close the final-return itemized
+        deduction, election, and exemption surface.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deduction_and_exemption_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_taxable_income
+      reason: |-
+        Kentucky net or taxable income cannot be completed until the income,
+        modification, deduction, and exemption chains are source complete.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_income_and_modification_source_hold_applies
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_deduction_and_exemption_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_before_credits_including_statewide_surtaxes
+      reason: |-
+        The 3.5 percent regular rate is source complete, but final-return net
+        income and the complete statewide specialty-tax and surtax surface are
+        not.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_and_surtax_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_tax_after_nonrefundable_credits
+      reason: |-
+        Complete operative 2026 nonrefundable-credit eligibility,
+        limitations, ordering, recapture, and carryforward rules are absent.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_nonrefundable_credit_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credits
+      reason: |-
+        Complete operative 2026 refundable-credit eligibility, limitations,
+        ordering, recapture, and refundability rules are absent.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_refundable_credit_source_hold_applies
+    - output: us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_net_income_tax_liability_before_payments
+      reason: |-
+        Signed annual resident liability cannot be completed until every
+        income, deduction, tax, surtax, and credit source hold is cleared.
+      source_values:
+        - us-ky:policies/income_tax/2026_full_year_resident_source_hold#ky_pit_2026_complete_liability_source_hold_applies
+
+rules:
+  - name: ky_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Full-year Kentucky resident individual return with an aligned federal filing unit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "An annual tax shall be paid for each taxable year by every resident individual of this state"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ky_pit_2026_is_full_year_kentucky_resident_return
+          and ky_pit_2026_federal_and_kentucky_filing_units_are_aligned
+          and (
+            ky_pit_2026_federal_adjusted_gross_income >= 0
+            or ky_pit_2026_federal_adjusted_gross_income < 0
+          )
+
+  - name: ky_pit_2026_final_return_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing operative tax-year-2026 Kentucky Form 740 final-return package
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "INSTRUCTIONS FOR FILING ESTIMATED TAX VOUCHERS"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "The 2025 table is provided for your convenience."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ky_pit_2026_income_and_modification_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Kentucky income-base, addition, and subtraction authority
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "upon his or her entire net income as defined in this chapter"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "Enter estimated adjustments to income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ky_pit_2026_final_return_source_hold_applies
+
+  - name: ky_pit_2026_deduction_and_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Kentucky final-return deduction, election, and exemption chain
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.081/document-1
+              excerpt: "The standard deduction provided for in this section shall be in lieu of all deductions"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "estimated allowable itemized deductions or the standard deduction of $3,360.00"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ky_pit_2026_final_return_source_hold_applies
+          or ky_pit_2026_income_and_modification_source_hold_applies
+
+  - name: ky_pit_2026_tax_and_surtax_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Regular 2026 rate is known, but final-return net income and the complete statewide tax surface are held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "the tax shall be three and one-half percent (3.5%) of net income"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "This is your ESTIMATED NET INCOME"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ky_pit_2026_final_return_source_hold_applies
+          or ky_pit_2026_income_and_modification_source_hold_applies
+          or ky_pit_2026_deduction_and_exemption_source_hold_applies
+
+  - name: ky_pit_2026_nonrefundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete operative 2026 Kentucky nonrefundable-credit inventory and ordering
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "The following tax credits, when applicable, shall be deducted"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ky_pit_2026_refundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete operative 2026 Kentucky refundable-credit inventory and ordering
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "after subtracting your withholding and refundable credits"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "The 2025 table is provided for your convenience."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ky_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined source hold for incomplete tax-year-2026 Kentucky resident liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "applying the rates in subsection (2) of this section to net income and subtracting allowable tax credits"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "tax to be shown on your 2026 tax return"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ky_pit_2026_final_return_source_hold_applies
+          or ky_pit_2026_income_and_modification_source_hold_applies
+          or ky_pit_2026_deduction_and_exemption_source_hold_applies
+          or ky_pit_2026_tax_and_surtax_source_hold_applies
+          or ky_pit_2026_nonrefundable_credit_source_hold_applies
+          or ky_pit_2026_refundable_credit_source_hold_applies
+
+  - name: ky_pit_2026_state_income_after_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky income-after-modifications sentinel while the complete 2026 income chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "upon his or her entire net income as defined in this chapter"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_deductions_and_exemptions
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky deduction-and-exemption sentinel while the final-return election surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.081/document-1
+              excerpt: "The standard deduction provided for in this section shall be in lieu of all deductions"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "standard deduction of $3,360.00"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky net-income sentinel while income, deductions, and exemptions are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "the tax shall be three and one-half percent (3.5%) of net income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_tax_before_credits_including_statewide_surtaxes
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky tax-and-statewide-surtax sentinel while final-return net income and the complete tax surface are held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "the tax shall be three and one-half percent (3.5%) of net income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky tax-after-nonrefundable-credits sentinel while the complete credit surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "subtracting allowable tax credits provided in subsection (3)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Kentucky refundable-credit sentinel while the complete 2026 credit inventory and ordering are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "after subtracting your withholding and refundable credits"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ky_pit_2026_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed Kentucky resident income-tax liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/statute/krs/141.020/document-1
+              excerpt: "An annual tax shall be paid for each taxable year by every resident individual"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ky/form/individual-income-tax/2026/740-es/document-1
+              excerpt: "after subtracting your withholding and refundable credits"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+inputs:
+  - name: ky_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income from the aligned federal return; it is not a completed Kentucky income amount.
+  - name: ky_pit_2026_is_full_year_kentucky_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is within this program's full-year Kentucky resident scope.
+  - name: ky_pit_2026_federal_and_kentucky_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the federal and Kentucky returns cover the same filing unit.


### PR DESCRIPTION
## Summary
- add a bounded Kentucky tax-year-2026 full-year-resident pipeline through signed net liability before payments
- accept only federal AGI, full-year residency, and filing-unit alignment; no caller-completed Kentucky outputs
- preserve explicit source holds and typed zero Money sentinels for incomplete final-return authority
- add four companion cases, regenerated reverse index, and signed pinned-toolchain apply manifest

## Validation
- exact reviewed base: `9d762d8865125c08eb5fb2e21df959636ec6e355`
- exact head: `c3ee52e8` (local full SHA in branch)
- pinned validate/proof/test: green (23 proof atoms, 4 cases)
- full structural suite: 59 passed, 1 known warning
- semantic scope: four files, 604 insertions

Draft pending repository-level validation fingerprint guard reconciliation (`us-co/regulations/9-ccr-2503-6/3.606.1/E.yaml`, issue #782). No merge while required checks are red or baseline-stale.
