### PR TITLE
MA: bound 2026 resident income tax pipeline

### DIFF
--- a/.axiom/encoding-manifests/us-ma/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-ma/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
+      "sha256": "28f0f5510d120744b3f45b5b25685520504b95aa5008a8c618916911d168c3fd"
+    },
+    {
+      "path": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+      "sha256": "4819f5ab42b1928772fc1d97918af64d4cda9d5acd1d7786fb210f669a80d62f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ma:policies/income_tax/2026_full_year_resident_source_hold",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-25T01:55:53.886971+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpj9b3xalz/sign-applied-files/us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpj9b3xalz",
+  "generated_output_sha256": "4819f5ab42b1928772fc1d97918af64d4cda9d5acd1d7786fb210f669a80d62f",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "b4d18259ce8538a9d50a548ede2c77245bc4a0f05acc41b94e6d14b0b01b11ab"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -19923,6 +19923,13 @@
     ],
     "us-ma/form/individual-income-tax/2026/1-es/document-1": [
       {
+        "module": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -19931,6 +19938,13 @@
       }
     ],
     "us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation": [
+      {
+        "module": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
@@ -21939,6 +21953,15 @@
         ]
       }
     ],
+    "us-ma/statute/62/3/block-2": [
+      {
+        "module": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ma/statute/62/4": [
       {
         "module": "us-ma/statutes/62/4.yaml",
@@ -21949,6 +21972,13 @@
       }
     ],
     "us-ma/statute/62/4/block-2": [
+      {
+        "module": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-ma/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
@@ -21977,6 +22007,15 @@
     "us-ma/statute/62/6": [
       {
         "module": "us-ma/statutes/62/6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us-ma/statute/62/6/block-2": [
+      {
+        "module": "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us-ma/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-ma/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -1,0 +1,67 @@
+# The pinned Massachusetts corpus contains important current Chapter 62
+# sections, the 2026 estimated-tax form, and current 2026 surtax guidance, but
+# not the operative final Form 1 chain. These fixtures prove only the allowed
+# federal boundary, full-year-resident domain gate, typed source holds, and
+# fail-closed Money sentinels. No zero is a substantive Massachusetts tax
+# result.
+
+- name: valid positive federal return is held through signed liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_adjusted_gross_income: 85000.0
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_is_full_year_massachusetts_resident_return: true
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned: true
+  output:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_federal_adjusted_gross_income_boundary: '85000'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_input_domain_is_valid: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_income_and_modification_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_deduction_and_exemption_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_income_classification_and_rate_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_surtax_integration_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_nonrefundable_credit_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_refundable_credit_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_final_return_ordering_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_complete_liability_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_state_income_after_modifications: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_taxable_income: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_tax_before_credits_including_surtax: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_tax_after_nonrefundable_credits: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_refundable_credits: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: negative federal adjusted gross income remains a valid raw boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_adjusted_gross_income: -4200.0
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_is_full_year_massachusetts_resident_return: true
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned: true
+  output:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_federal_adjusted_gross_income_boundary: '-4200'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_input_domain_is_valid: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_complete_liability_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_state_income_after_modifications: '0'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: part-year return is outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_adjusted_gross_income: 54000.0
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_is_full_year_massachusetts_resident_return: false
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned: true
+  output:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_federal_adjusted_gross_income_boundary: '54000'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_input_domain_is_valid: not_holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_complete_liability_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: misaligned filing units are outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_adjusted_gross_income: 1200000.0
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_is_full_year_massachusetts_resident_return: true
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#input.ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned: false
+  output:
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_federal_adjusted_gross_income_boundary: '1200000'
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_input_domain_is_valid: not_holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_complete_liability_source_hold_applies: holds
+    us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_net_income_tax_liability_before_payments: '0'

--- a/us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -1,0 +1,455 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ma/statute/62/3/block-2
+      - us-ma/statute/62/4/block-2
+      - us-ma/statute/62/6/block-2
+      - us-ma/form/individual-income-tax/2026/1-es/document-1
+      - us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-ma/statute/62/3/block-2
+        - us-ma/statute/62/4/block-2
+        - us-ma/statute/62/6/block-2
+        - us-ma/form/individual-income-tax/2026/1-es/document-1
+        - us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+      rationale: |-
+        The pinned official Massachusetts corpus contains current Chapter 62
+        sections 3, 4, and 6, the official tax-year-2026 Form 1-ES
+        estimated-tax worksheet, and current Department of Revenue guidance
+        for the 2026 4 per cent surtax. Those sources establish important
+        pieces of the deduction, exemption, rate, surtax, and credit surfaces.
+
+        They do not establish an executable tax-year-2026 final resident
+        return. The pinned corpus does not contain the operative 2026 Form 1
+        and instructions, the complete Chapter 62 income-definition and
+        adjustment chain, all annual deduction and exemption determinations,
+        every external eligibility and certification source referenced by
+        section 6, or the final-return credit ordering and signed-liability
+        instructions. Form 1-ES expressly certifies estimated tax only and
+        accepts completed taxable-income and credit amounts.
+
+        This module therefore accepts only an allowed federal-return output
+        and raw residency and filing-unit facts. It never accepts
+        Massachusetts adjusted gross income, taxable income, deductions,
+        exemptions, income-class amounts, rates, surtax, credits, or tax.
+        Typed source holds remain active, and every public Massachusetts Money
+        stage is a fail-closed zero sentinel. Those sentinels are not legal
+        claims that Massachusetts income, credits, or tax are zero.
+  summary: |-
+    Tax-year-2026 Massachusetts full-year-resident individual-income-tax
+    source-readiness boundary. It preserves federal adjusted gross income as
+    an allowed federal-return output and accepts raw residency and filing-unit
+    alignment facts for the future executable return.
+
+    Massachusetts income after additions and subtractions, taxable income
+    after deductions and exemptions, tax across the Part A, Part B, and Part C
+    classifications including the 4 per cent surtax, tax after nonrefundable
+    credits, refundable credits, and signed liability before payments all
+    fail closed while the pinned final-return source gaps remain. The module is
+    intentionally incomplete and makes no annual liability or oracle-parity
+    claim.
+
+    Withholding, estimated payments, extension payments, penalties, interest,
+    refunds of payments, local taxes, nonresident sourcing, part-year
+    allocation, estates, trusts, and corporate taxes are outside scope.
+  deferred_outputs:
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_state_income_after_modifications
+      reason: |-
+        The pinned corpus does not contain the complete operative 2026
+        Massachusetts income-definition, classification, addition, and
+        subtraction chain for a final Form 1 return.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_income_and_modification_source_hold_applies
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_taxable_income
+      reason: |-
+        Massachusetts taxable income cannot be completed until the income
+        chain and all applicable annual deductions and exemptions are source
+        complete for tax year 2026.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_income_and_modification_source_hold_applies
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_deduction_and_exemption_source_hold_applies
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_tax_before_credits_including_surtax
+      reason: |-
+        Tax before credits cannot be completed without source-complete Part A,
+        Part B, and Part C taxable income, final-return special-rate
+        classification and loss ordering, and the complete surtax integration.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_income_classification_and_rate_source_hold_applies
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_surtax_integration_source_hold_applies
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_tax_after_nonrefundable_credits
+      reason: |-
+        The complete 2026 nonrefundable-credit inventory, external
+        certifications, limitations, carryforwards, and final-return ordering
+        are not pinned.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_nonrefundable_credit_source_hold_applies
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_refundable_credits
+      reason: |-
+        Section 6 contains refundable credit provisions, but the pinned corpus
+        does not close their external eligibility, certification, annual
+        authorization, limitation, and final-return ordering requirements.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_refundable_credit_source_hold_applies
+    - output: us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_net_income_tax_liability_before_payments
+      reason: |-
+        Signed annual resident liability cannot be completed until every
+        income, deduction, classification, surtax, credit, and final-return
+        ordering source hold is cleared.
+      source_values:
+        - us-ma:policies/income_tax/2026_full_year_resident_source_hold#ma_pit_2026_complete_liability_source_hold_applies
+
+rules:
+  - name: ma_pit_2026_federal_adjusted_gross_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Allowed federal adjusted gross income boundary; the Massachusetts starting-point and classification rules remain source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ma_pit_2026_federal_adjusted_gross_income
+
+  - name: ma_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Full-year Massachusetts resident individual return with an aligned federal filing unit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ma_pit_2026_is_full_year_massachusetts_resident_return
+          and ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned
+          and (
+            ma_pit_2026_federal_adjusted_gross_income >= 0
+            or ma_pit_2026_federal_adjusted_gross_income < 0
+          )
+
+  - name: ma_pit_2026_income_and_modification_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Massachusetts income-definition, classification, addition, and subtraction authority in the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_deduction_and_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Massachusetts deduction and exemption determinations and final-return instructions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_income_classification_and_rate_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete final-return classification and loss-ordering rules for all 2026 Part A, Part B, and Part C income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_surtax_integration_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: The official 2026 surtax threshold and rate are pinned, but source-complete taxable Parts and final-return integration are not
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_nonrefundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Massachusetts nonrefundable-credit eligibility, certifications, limitations, carryforwards, and ordering
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_refundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Massachusetts refundable-credit eligibility, certifications, annual authorizations, limitations, and ordering
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_final_return_ordering_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: The operative tax-year-2026 final Form 1 and instructions are absent from the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/form/individual-income-tax/2026/1-es/document-1
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ma_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined source hold for incomplete tax-year-2026 Massachusetts resident liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ma_pit_2026_income_and_modification_source_hold_applies
+          or ma_pit_2026_deduction_and_exemption_source_hold_applies
+          or ma_pit_2026_income_classification_and_rate_source_hold_applies
+          or ma_pit_2026_surtax_integration_source_hold_applies
+          or ma_pit_2026_nonrefundable_credit_source_hold_applies
+          or ma_pit_2026_refundable_credit_source_hold_applies
+          or ma_pit_2026_final_return_ordering_source_hold_applies
+
+  - name: ma_pit_2026_state_income_after_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Massachusetts income-after-modifications sentinel while the complete 2026 income, classification, addition, and subtraction chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ma_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Massachusetts taxable-income sentinel while the complete 2026 income, deduction, and exemption chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/3/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ma_pit_2026_tax_before_credits_including_surtax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Massachusetts tax sentinel while taxable Parts, special-rate classification, loss ordering, and surtax integration are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/guidance/department-of-revenue/4-percent-surtax/2026/taxable-income-calculation
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ma_pit_2026_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Massachusetts tax-after-nonrefundable-credits sentinel while the complete credit surface and ordering are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ma_pit_2026_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Massachusetts refundable-credit sentinel while complete 2026 eligibility, certifications, annual authorizations, limitations, and ordering are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: ma_pit_2026_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed Massachusetts resident income-tax liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/4/block-2
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ma/statute/62/6/block-2
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+inputs:
+  - name: ma_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income from the aligned federal return; it is not a completed Massachusetts income amount.
+  - name: ma_pit_2026_is_full_year_massachusetts_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is within this program's full-year Massachusetts resident scope.
+  - name: ma_pit_2026_federal_and_massachusetts_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the federal and Massachusetts returns cover the same filing unit.


### PR DESCRIPTION
Adds a fail-closed 2026 Massachusetts full-year resident income-tax RuleSpec with official-source holds for unavailable stages.

Post-baseline refresh evidence:
- exact head: `2cc4325c6fbaa3c5ad66fd1b6d05a1a05b6d00d5`
- exact base: `8b5e7a18a9f91d73d1f618cdc4931ad16eac46fc`
- semantic patch ID preserved: `a5888fb418f4783a061ca53b4419a0701955e2f4`
- retained corpus pin: `5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7`
- pinned validate: PASS
- pinned proof-validate: PASS (22 atoms)
- pinned companion test: PASS (1 file, 4 cases)
- repository suite: PASS (59 tests; existing manifest warning only)
- reverse index regenerated with no additional diff; `git diff --check` clean

Draft retained for the required independent review/CI cycle; do not merge yet.