### PR TITLE
Pin full waiver oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@f224af52513f9254390e62a3d9988a0bee4d8217 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@b892fa1f5f3254441aee53ef393f4f323298830f # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
Pins the shared legacy validation workflow to TheAxiomFoundation/.github merge commit `b892fa1f5f3254441aee53ef393f4f323298830f` from PR #72.

That upstream fix routes `full-waiver-migration` through full oracle coverage and prevents the changed-file classifier from receiving the complete repository inventory.

Checks:
- workflow YAML parse
- `git diff --check`
- exact upstream commit resolved through GitHub API

This PR is intentionally separate from `known-validation-gaps.yaml` changes.