### PR TITLE
chore: pin Michigan oracle workflow bridge

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@6edfaa4e5bb4c9e206f11d3f4a2af564b39df13d # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@a2f3f753614ac44a6b57bde76708379daf583b4d # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- advance the immutable shared legacy-validation workflow pin to `.github` merge `a2f3f753614ac44a6b57bde76708379daf583b4d`
- activate encoder merge `616bffa7dc2ad1f791ee3a2171faa4a0f8bb1a27`, which contains oracle merge `343e9fae8a76e02c55c4e072c500b72a80656ef4`
- keep the workflow-pin bridge atomic and separate from Michigan RuleSpec changes

## Verification

- `git diff --check`
- exact one-line workflow-pin diff
- shared workflow post-merge test run 30189494794: success
- encoder post-merge CI 30189178584: success
- encoder signing 30189178569: success
- oracle post-merge CI 30188622027: success

This is the structural caller propagation step for the reviewed Michigan oracle mappings; it does not add or alter RuleSpec, waiver, or validation-gap entries.