### PR TITLE
Preapprove isolated hard-cut waiver fingerprints

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -4345,6 +4345,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c46ad79f1cd1d390caa77601d5ad7a4b832b1eb6c5a58b882fb266454bb91fbf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/152/c.yaml":
     active:
       fingerprint: "sha256:2efdd8fedc3f6d30a82eaaee35e0d78cc66f305707eb42d7fcee1a09de9fd85b"
@@ -5998,15 +6003,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:95599ecfe1053130f5178e24ab412c5d9a76da6c4943969b06a60197a2c006ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml":
     active:
       fingerprint: "sha256:a0426cb3ae5be118065e5a7cae8740b1bfceffcaa36af3e05d6c7f8a15d088bc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e07ea599c08ff108181a502ec5c29843445e4731512b992ead4be7a459d45536"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml":
     active:
       fingerprint: "sha256:b945e06453572a6a7cd56979a7a35df5fcd36c3877013c09ae022f4079444357"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:840bcbb9f5fae93869f1337c7a25224ddfc5aa11997c0d8d62e143a2804c4ccc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6046,6 +6066,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1fb6bc10ce849113aac100031af50ab4d2402a4e4aac04a64cbe531bc9c83501"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-340-deductions/page-22.yaml":
     active:
       fingerprint: "sha256:15a064d0bf5632817390d84e0b4a52b6abb2bc426d2fac1bef51520c1c4595bf"
@@ -6061,6 +6086,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml":
     active:
       fingerprint: "sha256:a788e2a2ed25f01571117ddc13bf8858d0e0b09c1a90510f44773c10eed4be21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7b6aef13d7d22b60ee668a49c69cc56890be2635b60bb6c7df65e6b01a86a06a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6127,6 +6157,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml":
     active:
       fingerprint: "sha256:ee1e6a743452892647a9719a4b8e9ddafaafdb95b2fb1e5c1144dc39a6e83998"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2ddc29000eec5c43e1b4a856f40271e120233ec041cfe880cd51f85e1f807716"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6280,9 +6315,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c31134f866ebc0f449307decfe7ffa19ddf9be74e4dffbf068c5c18d16d10065"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml":
     active:
       fingerprint: "sha256:5c6ccec3728481617c138d8f6300207cb52edae4c3d52a4204e10c80b2b159f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:874550359cb45dfeca692f9dee535b8fdb09d90bd1f7302cc00034a22a9b8aac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6313,6 +6358,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml":
     active:
       fingerprint: "sha256:6f6909aabfb3b2e12eab7b9a355bd9a0f3a05282c9adb75b0e209f9cd7ae385e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2771fc3dc86de455bb8421a565e007efec2f764e1bbbd5fc0de1744e5876e954"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6496,6 +6546,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b135dc74bc279292cdd7ab5ca577e934d1f841037027cd3a629ee2660153ac24"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-sc/policies/dss/snap-policy-manual/page-126.yaml":
     active:
       fingerprint: "sha256:b87a745a21e100fe9bfd584e8a9ebaff8103773d3c54ea82ddc119a06a4af729"
@@ -6625,6 +6680,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-sc/policies/dss/snap-policy-manual/page-314.yaml":
     active:
       fingerprint: "sha256:fc77e1795e70b8b4b6649b3ea1c33476d3151e879d6c83ccec8ed23ce40048f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8627243507046dfbdf2e2e48a0c4e0a465d0117d2e971a787e7e556c78059757"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7138,6 +7198,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5b203210fa46184bf3eb0ff59d1efccd1d3cceb8fc56e736e7df2e191515ff27"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-tn/regulations/1240-01/14/09/block-1.yaml":
     active:
       fingerprint: "sha256:c1dbccc62213d4a54a2b4721aa7358c38f19f9de7c5ddbab6ec06caa0f2cd219"
@@ -7288,6 +7353,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:76377c19ffa1080e3c713c852c1cad450270075648d3d2330c28b18fe8505032"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-9.yaml":
     active:
       fingerprint: "sha256:f10e257306c897d6ff3dcf844c91a06c04bbe874b9c4dc58ef354f5fb82c83db"
@@ -7357,6 +7427,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml":
     active:
       fingerprint: "sha256:cdd0a1317e78e07b991e999b3b2a826b9079fb0fac8ff5a497416a7b627a7af3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b3cd4b767cf8783bd362333b2ba7dfd8878bbee370859660086e1daf546b02bf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7444,6 +7519,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e94778664870df9506ac2618c7a4e3ea7d3cc623a8b06f78f2246e6e516b52ea"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/decal/caps/appendix-c-payment-zones.yaml":
     active:
       fingerprint: "sha256:56d1760be5b422a9028e4043f619cb919b00371b0a717e0f6496f9dd8ed9a21a"
@@ -7453,6 +7533,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml":
     active:
       fingerprint: "sha256:ab8818ddadeede78a363551b8c77c35eccbe24c70a0ad8e165af69e1be42a2f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9d380849295103fa48e2f03f75326a6628ff485f57bd489210f3241083591450"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -7498,6 +7583,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c933127697b98f68792b9883a7b5695f1baa188f2f4417333947bf4af1ff8c4f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml":
     active:
       fingerprint: "sha256:cd8b7e4c4044ce01019c5418ee6e33f35510c06f918ce9742b14876e812e8268"
@@ -7539,6 +7629,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3680f94624d40bbb0a3af77d6b7d5090051eefca1b7b71447919c74a00887e69"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-financial-eligibility-benefit-calculation.yaml":
     active:
       fingerprint: "sha256:2342e46a0edf6cd01b90efb435402ec062e88cc5766a086507d9f9c3602379fc"
@@ -7563,6 +7658,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a0baa03196157ee7dd3f5d26c7fe88711386c8c7bea84675c866409895862dcf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mi/policies/mdhhs/bridges/bem/660.yaml":
     active:
       fingerprint: "sha256:3c0148f0c07a846addb454ce8666aa960c8f9c97d2f377f63b5ca872da4cf581"
@@ -7572,6 +7672,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-mi/policies/mdhhs/rft/248.yaml":
     active:
       fingerprint: "sha256:dc5ed1633e543ecf1e861f5392614cde7b25d46f5fb335b9020361e63d71912b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d359d4061373dc352fef16f5fecf873081087d1f8cef9ee01ef2cfc7972c2375"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Summary
- add the 21 protected-base pending approvals still missing for the hard-cut waiver reconciliation
- bind every pending fingerprint to the completed protected isolated census
- preserve all active records and unrelated ledger content unchanged

## Evidence
- tracking issue: #1080
- protected census run: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/30134976400
- evidence artifact: `waiver-census-isolated`
- artifact SHA-256: `467fa2f8ff7d3651a6998d662e20613dc41cac3b66af9a5a75762e6a353a7172`
- reconciliation coverage after this PR: 173/173 replacement fingerprints preapproved (152 already present, 21 added here)
- exact refs: RuleSpec census `83cf4dbcee74a2679159782e4117823b320f3de2`, encoder `caebbda1a190181ef8184ed7aaffedb3789202a3`, engine `05eac9d2f89dabe5c6673176260762cef3a58f47`, corpus `0fd35bfbda98836c406ec539a492c4e661c6695d`

## Checks
- structured base/head comparison: exactly 21 pending additions; active records unchanged
- protected transition simulation: 0 issues
- `git diff --check`
- `uv run pytest -q tests/test_validation_waivers.py tests/test_validation_waiver_audit_cli.py` (66 passed)

## Review Cycle
Independent review found no actionable findings. It rechecked all 21 paths against the isolated census and the corresponding hard-cut active metadata, confirmed the waiver-only shape, and ran the focused repository-layout test.
