### PR TITLE
chore: pin Kansas oracle workflow bridge

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@a2f3f753614ac44a6b57bde76708379daf583b4d # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@4a6e5c09af130cc5cc9eecb3cc221d7cc63026f0 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- advance the immutable shared legacy-validation workflow pin to `.github` merge `4a6e5c09af130cc5cc9eecb3cc221d7cc63026f0`
- activate encoder merge `978db0821eedbaf553b1ac2fbe7e1da47d013852`, which contains oracle merge `eeca677b4bbce143fb0a109e4b63bcce59453e3d`
- keep the workflow-pin bridge atomic and separate from Kansas RuleSpec changes

## Verification

- `git diff --check`
- exact one-line workflow-pin diff
- shared workflow post-merge test run `30195007632`: terminal `SUCCESS`
- encoder post-merge CI `30194851195`: terminal `SUCCESS`
- encoder signing `30194851174`: terminal `SUCCESS` on macOS and Ubuntu
- oracle post-merge CI `30194102653`: terminal `SUCCESS`
- independent review cycle: no actionable findings; exact upstream merge parents/current-main status, caller routing/input/secret preservation, and identity of all RuleSpec/waiver/manifest/index/toolchain trees verified

This is the structural caller propagation step for the reviewed Kansas oracle repair; it does not add or alter RuleSpec, waiver, manifest, index, or validation-gap entries.