### PR TITLE
Enforce Kansas deduction count domain and source proof

### DIFF
--- a/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_full_year_resident_core.json
+++ b/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_full_year_resident_core.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ks/policies/income_tax/2026_full_year_resident_core.test.yaml",
-      "sha256": "6fb431edce20c75d961dd6da45b45cb08eb95ef595c55ec8f8be6061e8376306"
+      "sha256": "d054e3251cb811c38ba8a7096693cdbe88a947e65b25b99bda67175d81480591"
     },
     {
       "path": "us-ks/policies/income_tax/2026_full_year_resident_core.yaml",
-      "sha256": "19cd2a21024c6b4d4b66df2e97d7b5ae7cf2aecd555753f9a03be40e68075738"
+      "sha256": "4ef7e97ef6886989b66c1d4933947779c15e9d6e9ef9ea3d672789943dd954fa"
     }
   ],
   "axiom_encode_git": {
@@ -21,12 +21,12 @@
   "citation": "us-ks:policies/income_tax/2026_full_year_resident_core",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-25T00:05:37.801332+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmppjb3m8py/sign-applied-files/us-ks/policies/income_tax/2026_full_year_resident_core.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmppjb3m8py",
-  "generated_output_sha256": "19cd2a21024c6b4d4b66df2e97d7b5ae7cf2aecd555753f9a03be40e68075738",
+  "generated_at": "2026-07-26T08:03:27.040870+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5n3kpzlc/sign-applied-files/us-ks/policies/income_tax/2026_full_year_resident_core.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp5n3kpzlc",
+  "generated_output_sha256": "4ef7e97ef6886989b66c1d4933947779c15e9d6e9ef9ea3d672789943dd954fa",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
+  "manual_exception": "repair",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,29 +34,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ecdfbac955ec42835eadadc5c5a4733a111cbae85f70b3fc3ce762421497e147"
+    "value": "606caac204be3c85d0a964ee2f03630f6615c9d529257b092f3b2bf7c1924309"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-24T13:30:25.653526+00:00",
+    "generated_at": "2026-07-25T00:05:37.801332+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "b1752673efdc32b2ea0e6142e12da1897746a03f10a44aea3505f354a99905dd",
-    "prior_signature": "debcfb357c899a6284e90687b37d3d76dc09532cf95037d131550480993800d7",
+    "manifest_sha256": "27ee127b37974a709460b501b2fa442bb75e6f006b22aa83d18f92fa298a97e6",
+    "prior_signature": "ecdfbac955ec42835eadadc5c5a4733a111cbae85f70b3fc3ce762421497e147",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-24T13:07:24.119257+00:00",
+      "generated_at": "2026-07-24T13:30:25.653526+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "7601b1ba944ca196029674bf2ef545b37985fa55b7dd75912061c7117b5dc3d4",
-      "prior_signature": "fa898a3f6c9a8f51b53bc08bf88a5b517abda160d1d497e46aecf5879b9dc81d",
+      "manifest_sha256": "b1752673efdc32b2ea0e6142e12da1897746a03f10a44aea3505f354a99905dd",
+      "prior_signature": "debcfb357c899a6284e90687b37d3d76dc09532cf95037d131550480993800d7",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-24T13:00:10.369847+00:00",
+        "generated_at": "2026-07-24T13:07:24.119257+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "0dd857a387a245ac72be48d30264df754fa2035385f809c4dd18bc16e10934d9",
-        "prior_signature": "d48c61038e0dc292519904a6223a697bba6cec89e8b2f89a13d30b4b9725c42b",
+        "manifest_sha256": "7601b1ba944ca196029674bf2ef545b37985fa55b7dd75912061c7117b5dc3d4",
+        "prior_signature": "fa898a3f6c9a8f51b53bc08bf88a5b517abda160d1d497e46aecf5879b9dc81d",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-24T13:00:10.369847+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "0dd857a387a245ac72be48d30264df754fa2035385f809c4dd18bc16e10934d9",
+          "prior_signature": "d48c61038e0dc292519904a6223a697bba6cec89e8b2f89a13d30b4b9725c42b",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -40468,6 +40468,13 @@
     ],
     "us/statute/26/63": [
       {
+        "module": "us-ks/policies/income_tax/2026_full_year_resident_core.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us/statutes/26/63.yaml",
         "via": [
           "module"

--- a/us-ks/policies/income_tax/2026_full_year_resident_core.test.yaml
+++ b/us-ks/policies/income_tax/2026_full_year_resident_core.test.yaml
@@ -8,7 +8,6 @@
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_is_full_year_resident_individual_return: true
       - &joint_facts
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_adjusted_gross_income: 100000
-        us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 2
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_dependent_count: 2
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_other_state_local_bond_interest_excluded_from_federal_agi: 500
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_income_taxes_deducted_in_federal_agi: 0
@@ -23,6 +22,8 @@
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_disallowed_depreciation_in_itemized_deductions: 0
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_qualifying_gun_storage_expenditures: 0
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_earned_income_credit: 3000
+      - &joint_additional_standard_deduction_count_two
+        us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 2
       - &clear_holds
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_addition: false
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_subtraction: false
@@ -65,7 +66,6 @@
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_is_full_year_resident_individual_return: true
       - &itemizer_facts
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_adjusted_gross_income: 60000
-        us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 0
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_dependent_count: 1
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_other_state_local_bond_interest_excluded_from_federal_agi: 0
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_income_taxes_deducted_in_federal_agi: 0
@@ -80,6 +80,8 @@
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_disallowed_depreciation_in_itemized_deductions: 500
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_qualifying_gun_storage_expenditures: 0
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_earned_income_credit: 0
+      - &single_additional_standard_deduction_count_zero
+        us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 0
       - *clear_holds
   output:
     us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_supported_kansas_adjusted_gross_income: '60000'
@@ -126,6 +128,7 @@
     <<:
       - *joint_status
       - *joint_facts
+      - *joint_additional_standard_deduction_count_two
       - &agi_addition_hold
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_addition: true
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_subtraction: false
@@ -145,12 +148,65 @@
     us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_supported_refundable_credits: '0'
     us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_supported_net_income_tax_liability: '0'
 
+- name: single additional standard deduction count two is valid
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *single_status
+      - *itemizer_facts
+      - *clear_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 2
+  output:
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_input_domain_is_valid: holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_standard_deduction: '5305'
+
+- name: single additional standard deduction count three fails closed
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *single_status
+      - *itemizer_facts
+      - *clear_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 3
+  output:
+    <<: *held_outputs
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_input_domain_is_valid: not_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_base_profile_applies: not_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_supported_profile_applies: not_holds
+
+- name: joint additional standard deduction count four is valid
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *joint_status
+      - *joint_facts
+      - *clear_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 4
+  output:
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_input_domain_is_valid: holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_standard_deduction: '11040'
+
+- name: joint additional standard deduction count five fails closed
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    <<:
+      - *joint_status
+      - *joint_facts
+      - *clear_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_federal_additional_standard_deduction_count: 5
+  output:
+    <<: *held_outputs
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_input_domain_is_valid: not_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_base_profile_applies: not_holds
+    us-ks:policies/income_tax/2026_full_year_resident_core#ks_pit_2026_supported_profile_applies: not_holds
+
 - name: pass through credit hold suppresses all public stages
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     <<:
       - *joint_status
       - *joint_facts
+      - *joint_additional_standard_deduction_count_two
       - &pass_through_hold
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_addition: false
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_has_other_kansas_agi_subtraction: false
@@ -197,5 +253,6 @@
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_filing_status_joint: true
         us-ks:policies/income_tax/2026_full_year_resident_core#input.ks_pit_2026_is_full_year_resident_individual_return: true
       - *joint_facts
+      - *joint_additional_standard_deduction_count_two
       - *clear_holds
   output: *held_outputs

--- a/us-ks/policies/income_tax/2026_full_year_resident_core.yaml
+++ b/us-ks/policies/income_tax/2026_full_year_resident_core.yaml
@@ -4,6 +4,7 @@ module:
     required: true
   source_verification:
     corpus_citation_paths:
+      - us/statute/26/63
       - us-ks/statute/2026/79-32-109/block-1
       - us-ks/statute/2026/79-32-110/block-1
       - us-ks/statute/2026/79-32-110c/block-1
@@ -23,16 +24,19 @@ module:
     upstream_source_check:
       status: checked_higher_authority
       checked_paths:
+        - us/statute/26/63
         - us-ks/statute/2026/79-32-109/block-1
         - us-ks/statute/2026/79-32-110/block-1
         - us-ks/statute/2026/79-32-110c/block-1
         - us-ks/guidance/revenue/notice-25-06/document-1
+        - us-ks/statute/2026/79-32-116/block-1
         - us-ks/statute/2026/79-32-117/block-1
         - us-ks/statute/2026/79-32-119/block-1
         - us-ks/statute/2026/79-32-120/block-1
         - us-ks/statute/2026/79-32-121/block-1
         - us-ks/statute/2026/79-32-121b/block-1
         - us-ks/statute/2026/79-32-205/block-1
+        - us-ks/statute/2026/79-32-288/block-1
         - us-ks/statute/session-2026/hb-2029/page-60
         - us-ks/statute/session-2026/hb-2029/page-61
         - us-ks/statute/session-2026/hb-2029/page-62
@@ -142,6 +146,21 @@ rules:
             source:
               corpus_citation_path: us-ks/statute/2026/79-32-117/block-1
               excerpt: "federal adjusted gross income for the taxable year, with the modifications specified in this section"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ks/statute/2026/79-32-119/block-1
+              excerpt: "for each such deduction allowable to such individual or to such husband and wife under the federal internal revenue code"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for himself if he has attained age 65 before the close of his taxable year"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for himself if he is blind at the close of the taxable year"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
@@ -156,6 +175,22 @@ rules:
           )
           and ks_pit_2026_federal_additional_standard_deduction_count >= 0
           and floor(ks_pit_2026_federal_additional_standard_deduction_count) == ks_pit_2026_federal_additional_standard_deduction_count
+          and (
+            (
+              ks_pit_2026_filing_status_single
+              and (
+                ks_pit_2026_federal_additional_standard_deduction_count
+                <= ks_pit_2026_single_additional_standard_deduction_count_ceiling
+              )
+            )
+            or (
+              ks_pit_2026_filing_status_joint
+              and (
+                ks_pit_2026_federal_additional_standard_deduction_count
+                <= ks_pit_2026_joint_additional_standard_deduction_count_ceiling
+              )
+            )
+          )
           and ks_pit_2026_federal_dependent_count >= 0
           and floor(ks_pit_2026_federal_dependent_count) == ks_pit_2026_federal_dependent_count
           and ks_pit_2026_other_state_local_bond_interest_excluded_from_federal_agi >= 0
@@ -326,6 +361,60 @@ rules:
               excerpt: "Not over $23,000"
     versions:
       - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '23000'}
+
+  - name: ks_pit_2026_single_additional_standard_deduction_count_ceiling
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: K.S.A. 79-32,119(a) incorporating 26 USC 63(f)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/statute/2026/79-32-119/block-1
+              excerpt: "for each such deduction allowable to such individual or to such husband and wife under the federal internal revenue code"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for himself if he has attained age 65 before the close of his taxable year"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for himself if he is blind at the close of the taxable year"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '2'}
+
+  - name: ks_pit_2026_joint_additional_standard_deduction_count_ceiling
+    kind: parameter
+    dtype: Count
+    period: Year
+    source: K.S.A. 79-32,119(a) incorporating 26 USC 63(f)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-ks/statute/2026/79-32-119/block-1
+              excerpt: "for each such deduction allowable to such individual or to such husband and wife under the federal internal revenue code"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for the spouse of the taxpayer if the spouse has attained age 65 before the close of the taxable year"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/63
+              excerpt: "for the spouse of the taxpayer if the spouse is blind as of the close of the taxable year"
+    versions:
+      - {effective_from: '2026-01-01', effective_to: '2026-12-31', formula: '4'}
 
   - name: ks_pit_2026_single_standard_deduction
     kind: parameter
@@ -851,7 +940,7 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-ks/statute/2026/79-32-205/block-1
-              excerpt: "if any excess credit exists, such amount shall be refundable"
+              excerpt: "such excess amount shall be refunded to the taxpayer"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'


### PR DESCRIPTION
## Summary

- enforce the source-defined Kansas additional-standard-deduction count domain: maximum 2 for nonjoint returns and 4 for joint returns, after the existing nonnegative-integer validation
- express both ceilings as named private `Count` parameters instead of burying them in a permissive supplied-input path
- add 26 USC 63 to the checked source set, add the omitted Kansas checked paths, and correct the refundable-credit proof to the exact statutory refund language
- add valid-at-ceiling and invalid-above-ceiling companion cases for both filing-status groups; invalid profiles fail closed across all seven public outputs
- regenerate the provision reverse index and supersede the prior signed apply manifest with a repair manifest covering the exact module/test hashes

## Structural repair

This is not a waiver or oracle workaround. The old profile accepted any nonnegative integral additional-deduction count, even though the source limits the count by filing status. This change repairs that input domain in the RuleSpec itself, makes the legal ceilings explicit and proof-grounded, and tests both sides of each boundary. The two new executable ceiling outputs are classified by the reviewed oracle registry as P4 `known_not_comparable`, bringing the Kansas contract to exactly 34 classified outputs.

The existing bounded supported-profile boundary remains intact; this PR does not claim universal Kansas return coverage or add payments/administrative stages.

## Validation

- protected-base encoder `3869d66d009f52258be35901edbef370e65a399c` signed `guard-generated`: PASS
- deterministic RuleSpec validation: PASS
- pinned rules-engine companion execution: 11/11 cases PASS
- proof validation: 52 atoms PASS
- reverse-index regeneration: exact at 4,227 provisions / 5,051 edges / 4,479 modules
- full repository Python suite: 67 passed, 1 existing manifest-backlog warning
- current oracle classifier: exactly 34 Kansas outputs = 4 comparable + 30 `known_not_comparable`; zero unmapped, pending, or incomplete comparable outputs
- `git diff --check`; clean exact-head worktree

## Dependency chain

- oracle repair true merge `eeca677b4bbce143fb0a109e4b63bcce59453e3d`; post-merge CI `30194102653`: success
- encoder true merge `978db0821eedbaf553b1ac2fbe7e1da47d013852`; post-merge CI `30194851195` and signing `30194851174`: success
- shared workflow true merge `4a6e5c09af130cc5cc9eecb3cc221d7cc63026f0`; post-merge test `30195007632`: success
- caller true merge `6b561e985ce9fe933d7bda56f243abb08708d657`; post-merge repository matrix `30195347433` and source/reverse run `30195346949`: success

## Review cycle

Independent review first found and drove the oracle-rationale correction and explicit classifier entries upstream. The exact RuleSpec repair was then independently source-reviewed. After rebasing onto the final caller merge, exact head `a9fad7642ae64640c703bbd60bd5a70e8818bc8b` was re-reviewed clean with no actionable findings. Its stable patch ID and all four changed blobs are byte-identical to the prior reviewed repair; the reviewer independently confirmed the count ceilings, source excerpts, fail-closed outputs, four boundary cases, manifest hashes/supersession, and deterministic index.