### PR TITLE
Add Maryland 2026 resident source-held boundary

### DIFF
--- a/.axiom/encoding-manifests/us-md/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-md/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -1,0 +1,60 @@
+{
+  "applied_files": [
+    {
+      "path": "us-md/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
+      "sha256": "22a7e21cc43b8b105dda0c0aa247f9d739f0f8454f21f074abba33e39c6dd085"
+    },
+    {
+      "path": "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+      "sha256": "9f6bfbf703b886720e65a6d9e30a561683ea95e4d6c55f2618519c5492dae382"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-md:policies/income_tax/2026_full_year_resident_source_hold",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-25T02:48:34.841773+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp6glu4i64/sign-applied-files/us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp6glu4i64",
+  "generated_output_sha256": "9f6bfbf703b886720e65a6d9e30a561683ea95e4d6c55f2618519c5492dae382",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "0a203f4003f0ff24ce98f1170133c2bdf379e321da5504d90be56aa62840c35d"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-25T02:47:47.222656+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "2d5b90ea3f2933e90881c6ce6be831971297111d2c119227bc9a4a0cd315892b",
+    "prior_signature": "c4f00c20d1ff6a685fb48129b9842cd6d93a898cf4bacec87a0ace8e65c9fe29",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-25T02:38:39.408936+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "19829f8e819b97b2fd5f7b96a55f15577ea97d8db6090af1d2d772d35583fc80",
+      "prior_signature": "940f5cf7c90de541691126e70698f924050ea18bf52e581aca50823d0848f321",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -22069,6 +22069,13 @@
     ],
     "us-md/statute/gtg/10-105": [
       {
+        "module": "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-md/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -22084,6 +22091,13 @@
       }
     ],
     "us-md/statute/gtg/10-211": [
+      {
+        "module": "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-md/statutes/gtg/10-211.yaml",
         "via": [

--- a/us-md/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-md/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -1,0 +1,64 @@
+# The pinned Maryland income-tax scope contains only current Tax-General
+# sections 10-105 and 10-211 plus non-operative 2023/2024 return discovery.
+# These fixtures prove only the allowed federal boundary, full-year-resident
+# domain gate, typed source holds, and fail-closed State Money sentinels. No
+# zero is a substantive Maryland tax result.
+
+- name: valid positive federal return is held through signed State liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_adjusted_gross_income: 60000.0
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_is_full_year_maryland_resident_return: true
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_and_maryland_filing_units_are_aligned: true
+  output:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_preserved_federal_return_agi_diagnostic: '60000'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_input_domain_is_valid: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_income_and_modification_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_deduction_and_exemption_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_tax_schedule_and_surtax_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_nonrefundable_credit_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_refundable_credit_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_complete_liability_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_income_after_modifications: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_taxable_income: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_tax_before_credits_including_capital_gain_tax: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_tax_after_nonrefundable_credits: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_refundable_credits: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_net_state_income_tax_liability_before_payments: '0'
+
+- name: negative federal adjusted gross income remains a valid raw boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_adjusted_gross_income: -5000.0
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_is_full_year_maryland_resident_return: true
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_and_maryland_filing_units_are_aligned: true
+  output:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_preserved_federal_return_agi_diagnostic: '-5000'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_input_domain_is_valid: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_complete_liability_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_income_after_modifications: '0'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_net_state_income_tax_liability_before_payments: '0'
+
+- name: part-year return is outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_adjusted_gross_income: 45000.0
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_is_full_year_maryland_resident_return: false
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_and_maryland_filing_units_are_aligned: true
+  output:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_preserved_federal_return_agi_diagnostic: '45000'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_input_domain_is_valid: not_holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_complete_liability_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_net_state_income_tax_liability_before_payments: '0'
+
+- name: misaligned filing units are outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_adjusted_gross_income: 1100000.0
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_is_full_year_maryland_resident_return: true
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#input.md_pit_2026_federal_and_maryland_filing_units_are_aligned: false
+  output:
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_preserved_federal_return_agi_diagnostic: '1100000'
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_input_domain_is_valid: not_holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_complete_liability_source_hold_applies: holds
+    us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_net_state_income_tax_liability_before_payments: '0'

--- a/us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -1,0 +1,391 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-md/statute/gtg/10-105
+      - us-md/statute/gtg/10-211
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-md/statute/gtg/10-105
+        - us-md/statute/gtg/10-211
+      rationale: |-
+        The pinned official Maryland corpus snapshot contains current codified
+        text for Tax-General sections 10-105 and 10-211. Section 10-105
+        establishes the State individual-income-tax rate schedules and the
+        additional tax on certain net capital gain. Section 10-211 establishes
+        personal-exemption amounts and federal-adjusted-gross-income
+        limitations.
+
+        Those two sections do not establish an executable tax-year-2026
+        resident return. The pinned corpus does not contain the operative 2026
+        resident Form 502 and instructions, the complete federal starting-point
+        and Maryland addition/subtraction chain, the complete deduction chain,
+        the filed tax tables and rounding rules, or a closed inventory and
+        ordering of nonrefundable and refundable State credits. The available
+        form discovery scope contains only 2023 and 2024 resident materials.
+
+        This module accepts only an allowed federal-return output and raw
+        residency and filing-unit facts. It never accepts Maryland adjusted
+        gross income, taxable income, deductions, exemptions, rates, brackets,
+        thresholds, tax, surtax, credits, or liability. Typed source holds
+        remain active, and every public Maryland Money stage is a fail-closed
+        zero sentinel. Those sentinels are not legal claims that Maryland
+        income, credits, or tax are zero.
+  summary: |-
+    Tax-year-2026 Maryland full-year-resident State individual-income-tax
+    source-readiness boundary. It preserves federal adjusted gross income as
+    an allowed federal-return output and accepts raw residency and filing-unit
+    alignment facts for the future executable return.
+
+    Maryland income after additions and subtractions, taxable income after
+    deductions and exemptions, State tax including the regular schedule and
+    additional capital-gain tax, tax after nonrefundable credits, refundable
+    credits, and signed State liability before payments all fail closed while
+    the pinned source gaps remain. The module is intentionally incomplete and
+    makes no annual liability or oracle-parity claim.
+
+    County and other local income taxes, withholding, estimated payments,
+    extension payments, penalties, interest, refunds of payments, nonresident
+    sourcing, part-year allocation, estates, and trusts are outside scope.
+  deferred_outputs:
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_income_after_modifications
+      reason: |-
+        The pinned corpus does not contain the complete operative 2026
+        Maryland federal starting-point, addition, and subtraction chain.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_income_and_modification_source_hold_applies
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_taxable_income
+      reason: |-
+        Maryland taxable income cannot be completed until the income,
+        modification, deduction, and exemption chains are source complete.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_income_and_modification_source_hold_applies
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_deduction_and_exemption_source_hold_applies
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_tax_before_credits_including_capital_gain_tax
+      reason: |-
+        State tax before credits cannot be completed without source-complete
+        taxable income, operative filed tax-table and rounding rules, and the
+        complete additional-capital-gain-tax fact and enumerated asset-treatment
+        surface.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_income_and_modification_source_hold_applies
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_deduction_and_exemption_source_hold_applies
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_tax_schedule_and_surtax_source_hold_applies
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_tax_after_nonrefundable_credits
+      reason: |-
+        Complete 2026 State nonrefundable-credit eligibility, limitations,
+        carryforwards, recaptures, and ordering are not pinned.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_nonrefundable_credit_source_hold_applies
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_state_refundable_credits
+      reason: |-
+        Complete 2026 State refundable-credit eligibility, limitations, and
+        ordering are not pinned.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_refundable_credit_source_hold_applies
+    - output: us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_net_state_income_tax_liability_before_payments
+      reason: |-
+        Signed annual resident State liability cannot be completed until every
+        income, deduction, schedule, surtax, and credit source hold is cleared.
+      source_values:
+        - us-md:policies/income_tax/2026_full_year_resident_source_hold#md_pit_2026_complete_liability_source_hold_applies
+
+rules:
+  - name: md_pit_2026_preserved_federal_return_agi_diagnostic
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Allowed federal adjusted gross income boundary; the Maryland starting-point rule remains source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: md_pit_2026_federal_adjusted_gross_income
+
+  - name: md_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Full-year Maryland resident individual return with an aligned federal filing unit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          md_pit_2026_is_full_year_maryland_resident_return
+          and md_pit_2026_federal_and_maryland_filing_units_are_aligned
+          and (
+            md_pit_2026_federal_adjusted_gross_income >= 0
+            or md_pit_2026_federal_adjusted_gross_income < 0
+          )
+
+  - name: md_pit_2026_income_and_modification_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Maryland income-base, addition, and subtraction authority in the pinned corpus
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: md_pit_2026_deduction_and_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing complete official 2026 Maryland deduction chain despite the pinned personal-exemption section
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: md_pit_2026_tax_schedule_and_surtax_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing operative 2026 filed tax-table and rounding rules and complete additional-capital-gain-tax fact surface
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: md_pit_2026_nonrefundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Maryland State nonrefundable-credit inventory, limitations, recaptures, and ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: md_pit_2026_refundable_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Maryland State refundable-credit inventory, eligibility, and ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: md_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined source hold for incomplete tax-year-2026 Maryland resident State liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          md_pit_2026_income_and_modification_source_hold_applies
+          or md_pit_2026_deduction_and_exemption_source_hold_applies
+          or md_pit_2026_tax_schedule_and_surtax_source_hold_applies
+          or md_pit_2026_nonrefundable_credit_source_hold_applies
+          or md_pit_2026_refundable_credit_source_hold_applies
+
+  - name: md_pit_2026_state_income_after_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Maryland income-after-modifications sentinel while the complete 2026 income, addition, and subtraction chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: md_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Maryland taxable-income sentinel while the complete 2026 income, deduction, and exemption chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: md_pit_2026_state_tax_before_credits_including_capital_gain_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Maryland State tax sentinel while taxable income, filed tax tables, and additional capital-gain tax are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: md_pit_2026_state_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Maryland State tax-after-nonrefundable-credits sentinel while the complete credit surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: md_pit_2026_state_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Maryland State refundable-credit sentinel while the complete 2026 State credit inventory and ordering are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: md_pit_2026_net_state_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed Maryland resident State income-tax liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-105
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-md/statute/gtg/10-211
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+inputs:
+  - name: md_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income from the aligned federal return; it is not a completed Maryland income amount.
+  - name: md_pit_2026_is_full_year_maryland_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is within this program's full-year Maryland resident scope.
+  - name: md_pit_2026_federal_and_maryland_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the federal and Maryland returns cover the same filing unit.


### PR DESCRIPTION
## Summary

- add a source-grounded Maryland TY2026 resident income-tax boundary that fails closed when final return mechanics are unavailable
- preserve explicit deferrals for income construction, deductions, filed tables/rounding, capital-gain facts, credits, and final liability
- add four companion cases proving sentinel-zero/deferred behavior without treating zero as a tax-law result
- update the signed encoding manifest and reverse source index

## Validation

- deterministic RuleSpec validation: passed
- proof validation: 16 atoms, 0 issues
- companion suite: 4 cases, 1 compiled program, 0 failures
- focused repository tests: 18 passed
- reverse index: 4,227 provisions / 5,053 edges / 4,480 modules
- exact changed-file classifier: 14/14 outputs tested and `known_not_comparable`
- protected `guard-generated`: passed for `us-md`
- independent review-fix cycle: no actionable findings

## Boundary

This is intentionally not an annual-liability implementation or oracle-parity claim. The currently pinned official corpus contains only 2023/2024 resident return materials. Consumers must honor deferred metadata; sentinel zero values are fail-closed stage outputs, not actual Maryland tax.

## Relationship to existing work

Merged PR #998 is the distinct statutory regular-rate schedule from completed taxable income. This PR adds the resident E2E source boundary around missing return construction and ordering mechanics; it does not replace or relabel that pilot.