### PR TITLE
Add Colorado 2026 resident source-held boundary

### DIFF
--- a/.axiom/encoding-manifests/us-co/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-co/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
+      "sha256": "9e02aee4e9bc5f7e1398e1a1b44ae0fe2adba76e19c7f0626f273ae9bd7abc32"
+    },
+    {
+      "path": "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+      "sha256": "78278f3cfcf186f3f3ba2c97d24a555b0ce630ade183d48861a8f477158d9e61"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-co:policies/income_tax/2026_full_year_resident_source_hold",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-24T20:45:55.646122+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62y9g_oc/sign-applied-files/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62y9g_oc",
+  "generated_output_sha256": "78278f3cfcf186f3f3ba2c97d24a555b0ce630ade183d48861a8f477158d9e61",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "473f682234a3189ffde73d6e66de83073439e20d73f7829990be369016b184e4"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-24T20:44:47.135142+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "2c0a00ed04cd219f81844fdccfb5ebb0d1fd83a8ce45add38fe7ae64b3fdea03",
+    "prior_signature": "a5af665a5e5e9a624ecb83df3e863ddd0e8836a2cbaf2d286d53b2ef28525913",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-co/policies/income_tax/2026_full_year_resident_source_hold.json
+++ b/.axiom/encoding-manifests/us-co/policies/income_tax/2026_full_year_resident_source_hold.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml",
-      "sha256": "9e02aee4e9bc5f7e1398e1a1b44ae0fe2adba76e19c7f0626f273ae9bd7abc32"
+      "sha256": "dce095e7fbbccfebac14d3174efbf26e2119f41ffa6b232fe9b70573d10a67c6"
     },
     {
       "path": "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
-      "sha256": "78278f3cfcf186f3f3ba2c97d24a555b0ce630ade183d48861a8f477158d9e61"
+      "sha256": "6d913e1865583586284e7796f92ceefc357bd166760c096072365b6ebc9740ef"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-co:policies/income_tax/2026_full_year_resident_source_hold",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-24T20:45:55.646122+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62y9g_oc/sign-applied-files/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp62y9g_oc",
-  "generated_output_sha256": "78278f3cfcf186f3f3ba2c97d24a555b0ce630ade183d48861a8f477158d9e61",
+  "generated_at": "2026-07-24T20:55:43.637193+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp1myty2uc/sign-applied-files/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp1myty2uc",
+  "generated_output_sha256": "6d913e1865583586284e7796f92ceefc357bd166760c096072365b6ebc9740ef",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,15 +34,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "473f682234a3189ffde73d6e66de83073439e20d73f7829990be369016b184e4"
+    "value": "0e5105a12ff070f876acb88ffdb042c188441b396579af75bdcb92c0105dab10"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-24T20:44:47.135142+00:00",
+    "generated_at": "2026-07-24T20:45:55.646122+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "2c0a00ed04cd219f81844fdccfb5ebb0d1fd83a8ce45add38fe7ae64b3fdea03",
-    "prior_signature": "a5af665a5e5e9a624ecb83df3e863ddd0e8836a2cbaf2d286d53b2ef28525913",
+    "manifest_sha256": "e1a1961eaee024b8b5cf430cef4b8c26b71569dac162df2677a2bc4e17ac76cf",
+    "prior_signature": "473f682234a3189ffde73d6e66de83073439e20d73f7829990be369016b184e4",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-24T20:44:47.135142+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "2c0a00ed04cd219f81844fdccfb5ebb0d1fd83a8ce45add38fe7ae64b3fdea03",
+      "prior_signature": "a5af665a5e5e9a624ecb83df3e863ddd0e8836a2cbaf2d286d53b2ef28525913",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -10386,6 +10386,13 @@
     ],
     "us-co/statute/39/39-22-104": [
       {
+        "module": "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-co/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -10977,6 +10984,13 @@
       }
     ],
     "us-co/statute/39/39-22-123.5": [
+      {
+        "module": "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-co/policies/income_tax/eitc_pilot_pipeline.yaml",
         "via": [
@@ -12857,6 +12871,13 @@
       }
     ],
     "us-co/statute/39/39-22-627": [
+      {
+        "module": "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
       {
         "module": "us-co/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -11217,12 +11217,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-co/statutes/39/39-22-627.yaml":
-    pending:
-      fingerprint: "sha256:71f243ea1d6040b013ffdb2510a02d1d152e0ac4b266123891a25f2493f353ad"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-co/statutes/39/39-26-102.5.yaml":
     pending:
       fingerprint: "sha256:9bb252d466f12075d658590f0f66516a93a159dc37bf1431f245ae77449768c6"

--- a/us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -1,0 +1,66 @@
+# The pinned corpus establishes the federal taxable-income starting point but
+# does not complete Colorado's 2026 modifications, annual rate determination,
+# surtax surface, or credit ordering. These fixtures prove the federal boundary
+# and domain gate while every completed Colorado Money stage fails closed.
+
+- name: valid positive federal return is held through signed liability
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_taxable_income: 43900.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_adjusted_gross_income: 60000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_is_full_year_colorado_resident_return: true
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_and_colorado_filing_units_are_aligned: true
+  output:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_federal_taxable_income_boundary: '43900'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_input_domain_is_valid: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_modification_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_rate_adjustment_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_surtax_surface_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_credit_surface_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_taxable_income: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_before_credits_including_rate_adjustment_and_surtaxes: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_after_nonrefundable_credits: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_refundable_credits: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: negative federal outputs remain valid raw boundaries
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_taxable_income: -5000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_adjusted_gross_income: -1000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_is_full_year_colorado_resident_return: true
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_and_colorado_filing_units_are_aligned: true
+  output:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_federal_taxable_income_boundary: '-5000'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_input_domain_is_valid: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: part-year return is outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_taxable_income: 30000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_adjusted_gross_income: 45000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_is_full_year_colorado_resident_return: false
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_and_colorado_filing_units_are_aligned: true
+  output:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_federal_taxable_income_boundary: '30000'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_input_domain_is_valid: not_holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments: '0'
+
+- name: misaligned filing units are outside the bounded domain
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_taxable_income: 1000000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_adjusted_gross_income: 1100000.0
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_is_full_year_colorado_resident_return: true
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#input.co_pit_2026_federal_and_colorado_filing_units_are_aligned: false
+  output:
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_federal_taxable_income_boundary: '1000000'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_input_domain_is_valid: not_holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments: '0'

--- a/us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
+++ b/us-co/policies/income_tax/2026_full_year_resident_source_hold.test.yaml
@@ -18,7 +18,7 @@
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_surtax_surface_source_hold_applies: holds
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_credit_surface_source_hold_applies: holds
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
-    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_income_after_modifications: '0'
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_taxable_income: '0'
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_before_credits_including_rate_adjustment_and_surtaxes: '0'
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_after_nonrefundable_credits: '0'
@@ -36,7 +36,7 @@
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_federal_taxable_income_boundary: '-5000'
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_input_domain_is_valid: holds
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies: holds
-    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications: '0'
+    us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_income_after_modifications: '0'
     us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments: '0'
 
 - name: part-year return is outside the bounded domain

--- a/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -55,7 +55,7 @@ module:
     refunds of payments, local taxes, nonresident sourcing, part-year
     allocation, estates, and trusts are outside scope.
   deferred_outputs:
-    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_income_after_modifications
       reason: |-
         Section 39-22-104 requires additions and subtractions before applying
         the rate, but the pinned authority does not resolve every operative
@@ -76,6 +76,7 @@ module:
         source-complete taxable income, and a closed surtax and specialty-tax
         surface.
       source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_modification_source_hold_applies
         - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_rate_adjustment_source_hold_applies
         - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_surtax_surface_source_hold_applies
     - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_after_nonrefundable_credits
@@ -251,13 +252,13 @@ rules:
           or co_pit_2026_surtax_surface_source_hold_applies
           or co_pit_2026_credit_surface_source_hold_applies
 
-  - name: co_pit_2026_state_modifications
+  - name: co_pit_2026_state_income_after_modifications
     kind: derived
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    source: Fail-closed Colorado modification sentinel while the complete 2026 addition and subtraction chain is source held
+    source: Fail-closed Colorado income-after-modifications sentinel while the complete 2026 addition and subtraction chain is source held
     metadata:
       proof:
         atoms:

--- a/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml
+++ b/us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml
@@ -1,0 +1,401 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-co/statute/39/39-22-104
+      - us-co/statute/39/39-22-123.5
+      - us-co/statute/39/39-22-627
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-co/statute/39/39-22-104
+        - us-co/statute/39/39-22-123.5
+        - us-co/statute/39/39-22-627
+      rationale: |-
+        The pinned official 2025 Colorado Revised Statutes Title 39 corpus
+        supplies the federal-taxable-income starting point and modification
+        direction in section 39-22-104, one refundable-credit provision in
+        section 39-22-123.5, and the temporary-rate mechanism in section
+        39-22-627. Its expression date is August 31, 2025.
+
+        That authority does not pin a complete executable tax-year-2026
+        return. Section 39-22-104 contains conditional 2026 modification
+        branches and amounts that depend on ballot outcomes or agency
+        determinations. Section 39-22-627 makes the annual rate depend on
+        certified excess revenue, adjusted thresholds, executive estimates,
+        approval, and coordination with other refund methods. The corpus also
+        does not establish a closed 2026 individual surtax or specialty-tax
+        surface, complete credit eligibility and limitation rules, or credit
+        ordering through signed liability. Final 2026 return forms and
+        instructions are not pinned.
+
+        Consequently, this module accepts only federal-return outputs and raw
+        resident/filing-unit facts. It never accepts Colorado adjusted gross
+        income, modifications, taxable income, tax, surtax, credits, or
+        liability. Typed source holds remain active, and every public Colorado
+        Money stage is a fail-closed zero sentinel. Those sentinels are not
+        legal claims that Colorado income, credits, or tax are zero.
+  summary: |-
+    Tax-year-2026 Colorado full-year-resident individual-income-tax
+    source-readiness boundary. It preserves federal taxable income as the
+    starting point required by C.R.S. section 39-22-104 and accepts federal
+    adjusted gross income plus raw residency and filing-unit facts needed for
+    future modification work.
+
+    Colorado modifications, taxable income, tax including the section
+    39-22-627 annual rate adjustment and any surtaxes, tax after
+    nonrefundable credits, refundable credits, and signed liability before
+    payments all fail closed while the pinned source gaps remain. The module
+    is intentionally incomplete and makes no annual liability or oracle-parity
+    claim.
+
+    Withholding, estimated payments, extension payments, penalties, interest,
+    refunds of payments, local taxes, nonresident sourcing, part-year
+    allocation, estates, and trusts are outside scope.
+  deferred_outputs:
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_state_modifications
+      reason: |-
+        Section 39-22-104 requires additions and subtractions before applying
+        the rate, but the pinned authority does not resolve every operative
+        2026 conditional branch and agency-determined amount into an
+        executable annual-return chain.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_modification_source_hold_applies
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_taxable_income
+      reason: |-
+        Colorado taxable income cannot be completed until the entire 2026
+        modification chain is source complete.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_modification_source_hold_applies
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_before_credits_including_rate_adjustment_and_surtaxes
+      reason: |-
+        The permanent section 39-22-104 rate cannot establish tax-year-2026
+        tax before credits without the annual section 39-22-627 determination,
+        source-complete taxable income, and a closed surtax and specialty-tax
+        surface.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_rate_adjustment_source_hold_applies
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_surtax_surface_source_hold_applies
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_tax_after_nonrefundable_credits
+      reason: |-
+        Complete 2026 nonrefundable-credit eligibility, limitations,
+        carryforwards, and ordering are not pinned.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_credit_surface_source_hold_applies
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_refundable_credits
+      reason: |-
+        The pinned earned-income-credit provision is not a complete 2026
+        refundable-credit inventory or ordering chain.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_credit_surface_source_hold_applies
+    - output: us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_net_income_tax_liability_before_payments
+      reason: |-
+        Signed annual resident liability cannot be completed until every
+        modification, annual-rate, surtax, and credit source hold is cleared.
+      source_values:
+        - us-co:policies/income_tax/2026_full_year_resident_source_hold#co_pit_2026_complete_liability_source_hold_applies
+
+rules:
+  - name: co_pit_2026_federal_taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: C.R.S. section 39-22-104 federal taxable income starting point from the aligned federal return
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "the federal taxable income, as determined pursuant to section 63 of the internal revenue code"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: co_pit_2026_federal_taxable_income
+
+  - name: co_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: C.R.S. section 39-22-104 full-year resident individual federal-return boundary
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "the federal taxable income shall be modified as provided in subsections (3) and (4) of this section"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          co_pit_2026_is_full_year_colorado_resident_return
+          and co_pit_2026_federal_and_colorado_filing_units_are_aligned
+          and (
+            co_pit_2026_federal_taxable_income >= 0
+            or co_pit_2026_federal_taxable_income < 0
+          )
+          and (
+            co_pit_2026_federal_adjusted_gross_income >= 0
+            or co_pit_2026_federal_adjusted_gross_income < 0
+          )
+
+  - name: co_pit_2026_modification_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Unresolved operative 2026 additions, subtractions, conditional branches, and agency-determined amounts under C.R.S. section 39-22-104
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "Prior to the application of the rate of tax prescribed in subsection (1), (1.5), or (1.7) of this section, the federal taxable income shall be modified as provided in subsections (3) and (4) of this section."
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: co_pit_2026_rate_adjustment_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Missing final tax-year-2026 C.R.S. section 39-22-627 temporary-rate determination
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-627
+              excerpt: "the executive director shall temporarily reduce the state income tax rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: co_pit_2026_surtax_surface_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 individual surtax and specialty-tax applicability is not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "a tax of four and forty one-hundredths percent is imposed on the federal taxable income"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: co_pit_2026_credit_surface_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 nonrefundable and refundable credit inventory, limitations, carryforwards, and ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-123.5
+              excerpt: "permanent and refundable state earned income tax credit for eligible Colorado taxpayers"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: co_pit_2026_complete_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Combined source hold for incomplete tax-year-2026 Colorado resident liability
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "Except as otherwise provided in section 39-22-627"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-627
+              excerpt: "the executive director shall temporarily reduce the state income tax rate"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          co_pit_2026_modification_source_hold_applies
+          or co_pit_2026_rate_adjustment_source_hold_applies
+          or co_pit_2026_surtax_surface_source_hold_applies
+          or co_pit_2026_credit_surface_source_hold_applies
+
+  - name: co_pit_2026_state_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Colorado modification sentinel while the complete 2026 addition and subtraction chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "the federal taxable income shall be modified as provided in subsections (3) and (4) of this section"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: co_pit_2026_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Colorado taxable-income sentinel while the complete 2026 modification chain is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "the federal taxable income shall be modified"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: co_pit_2026_tax_before_credits_including_rate_adjustment_and_surtaxes
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Colorado tax sentinel while taxable income, annual rate adjustment, and the complete surtax surface are source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "a tax of four and forty one-hundredths percent is imposed on the federal taxable income"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-627
+              excerpt: "the state income tax rate for the income tax year"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: co_pit_2026_tax_after_nonrefundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Colorado tax-after-nonrefundable-credits sentinel while the credit surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-123.5
+              excerpt: "earned income tax credit against the taxes due under this article 22"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: co_pit_2026_refundable_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed Colorado refundable-credit sentinel while the complete 2026 credit surface is source held
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-123.5
+              excerpt: "permanent and refundable state earned income tax credit"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+  - name: co_pit_2026_net_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed Colorado resident income-tax liability sentinel before payments
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-co/statute/39/39-22-104
+              excerpt: "a tax of four and forty one-hundredths percent is imposed"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0'
+
+inputs:
+  - name: co_pit_2026_federal_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal taxable income from the aligned federal return; it is not a completed Colorado income amount.
+  - name: co_pit_2026_federal_adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Federal adjusted gross income from the aligned federal return for future raw modification tests; it is not a completed Colorado income amount.
+  - name: co_pit_2026_is_full_year_colorado_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is within this program's full-year Colorado resident scope.
+  - name: co_pit_2026_federal_and_colorado_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the federal and Colorado returns cover the same filing unit.


### PR DESCRIPTION
## Summary

- add a source-grounded Colorado TY2026 full-year-resident boundary from federal taxable income and federal AGI
- fail closed on unresolved Colorado modifications, annual-rate determination, credits, and final liability through explicit deferred zero sentinels
- add four companion cases covering positive and negative income, part-year residence, and filing-unit mismatch
- remove the single stale validation-gap entry for `39-22-627`, which now validates under the protected legacy toolchain
- update the signed encoding manifest and reverse source index

## Validation

- pinned RuleSpec validation: passed for the new module and `39-22-627`
- proof validation: 15 atoms for the source-held module; 2 atoms for the source-gated statute
- companion suite: 4/4 passed
- reverse index: 4,227 provisions / 5,054 edges / 4,480 modules
- focused layout/index tests: passed
- exact manifest SHA closure and `git diff --check`: passed
- protected `guard-generated`: passed for `us-co`
- independent review cycle: no actionable findings

## Boundary

This module intentionally exposes only the lawful federal-income entry boundary. All Colorado-specific stages remain deferred and their zeros are non-substantive sentinels. It does not claim complete TY2026 liability or oracle parity.

## Relationship to existing work

Merged PR #986 is the distinct narrow base-tax pilot. This PR does not alter that pipeline. The `39-22-627` waiver was removed by #986 and later mechanically reintroduced during protected-base approval migration; direct pinned validation confirms the cleanup is legitimate.