### PR TITLE
Bound Ohio 2026 nonbusiness income tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-oh/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-oh/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "895f95175e6c7f0434d39e654f996ae66ef13b0857d8afa67c4f175ba298b32b"
+      "sha256": "02492251a5e735a2eb29a76fffe3bbe6014049d6f3bbd7fd2aa2f7543c504bdf"
     },
     {
       "path": "us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "29e6da6ea143e00c9526b9f73bd2cda04418837def4a6b3eae66a0627e1f4997"
+      "sha256": "5707cc37b8f0fa5401ce32cde38f2fcb48cdc8af5eeef1ce22371d3a33da5a4c"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-oh:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T03:52:31.446281+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpnn4cvvhn/sign-applied-files/us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpnn4cvvhn",
-  "generated_output_sha256": "29e6da6ea143e00c9526b9f73bd2cda04418837def4a6b3eae66a0627e1f4997",
+  "generated_at": "2026-07-26T12:03:21.391613+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpkmsnc1_m/sign-applied-files/us-oh/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpkmsnc1_m",
+  "generated_output_sha256": "5707cc37b8f0fa5401ce32cde38f2fcb48cdc8af5eeef1ce22371d3a33da5a4c",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +33,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "94c0c789d5f04c26d5feecfab3ad0d6abe611a74e6cadb37a9e042323bf752e8"
+    "value": "7e7acdb1ceefacf3cb0433f7bfd796113d53167ffb8838887abda0ff363e4a63"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T03:36:39.114317+00:00",
+    "generated_at": "2026-07-22T03:52:31.446281+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "db1aac947708dc0d711eb47c8c1b07d183032324befd2266d47528c963cbcd04",
-    "prior_signature": "4f1690480cd8133c356e3833afa6b439b88d77c9ffa39f7c3631c0b8ce4dba0f",
+    "manifest_sha256": "579b5fc25baf459ce714e3d20df1f9e75098c668abfdb42f34b616135df23edc",
+    "prior_signature": "94c0c789d5f04c26d5feecfab3ad0d6abe611a74e6cadb37a9e042323bf752e8",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-22T03:12:29.550157+00:00",
+      "generated_at": "2026-07-22T03:36:39.114317+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "7f48816082d017181522f3ce4c8a49fbc8d8dd69fa6cac6805c28ceda8d1c954",
-      "prior_signature": "322e5c8ab8db2afabbd41049b9e66cd322955770a7f6863ce7d7e3a20805acc4",
+      "manifest_sha256": "db1aac947708dc0d711eb47c8c1b07d183032324befd2266d47528c963cbcd04",
+      "prior_signature": "4f1690480cd8133c356e3833afa6b439b88d77c9ffa39f7c3631c0b8ce4dba0f",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-22T03:05:47.261208+00:00",
+        "generated_at": "2026-07-22T03:12:29.550157+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "96d1cf4925626205ca304363259044b1f19b5edb92e85ff4e4ead616f14d4389",
-        "prior_signature": "f296c552f0cf186461d84d62356b6fcf2fc250c61b83ba85127ff4842db13967",
+        "manifest_sha256": "7f48816082d017181522f3ce4c8a49fbc8d8dd69fa6cac6805c28ceda8d1c954",
+        "prior_signature": "322e5c8ab8db2afabbd41049b9e66cd322955770a7f6863ce7d7e3a20805acc4",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-08T21:15:16.745572+00:00",
+          "generated_at": "2026-07-22T03:05:47.261208+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "d0c20cf2dae13bb45f59430ccd9eb2819de1fa0a51b825a5e882d73467591588",
-          "prior_signature": "5fe06c5867842a91c517630a1b376c51bfb8b59b5bc36bfd776a90086d7df6a3",
+          "manifest_sha256": "96d1cf4925626205ca304363259044b1f19b5edb92e85ff4e4ead616f14d4389",
+          "prior_signature": "f296c552f0cf186461d84d62356b6fcf2fc250c61b83ba85127ff4842db13967",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-08T21:15:16.745572+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "d0c20cf2dae13bb45f59430ccd9eb2819de1fa0a51b825a5e882d73467591588",
+            "prior_signature": "5fe06c5867842a91c517630a1b376c51bfb8b59b5bc36bfd776a90086d7df6a3",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -16881,12 +16881,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-oh/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:51834b7517a7c7314c023029881a88d7d9bc12a0bc70a36c320eb853b45ec25e"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-oh/statutes/5747/02.yaml":
     pending:
       fingerprint: "sha256:45a2b1fdcc3dacd8c78afa5fb3477b7ab89e991ce36563863015c5b7e6750fbf"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2489
+ceiling: 2493
 entries:
 - legal_id: us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_alaska_adjusted_gross_income
   source: manual
@@ -2960,9 +2960,21 @@ entries:
 - legal_id: us-nv:policies/income_tax/2026_resident_zero_liability#nv_pit_2026_surtax_stage_applies
   source: manual
   since: '2026-07-23'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_credit_surface_source_hold_applies
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_return_ordering_source_hold_applies
+  source: manual
+  since: '2026-07-26'
 - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-08'
+- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies
+  source: manual
+  since: '2026-07-26'
 - legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax
   source: manual
   since: '2026-07-08'

--- a/us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-oh/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -9,6 +9,13 @@
   input:
     us-oh:policies/income_tax/pilot_liability_pipeline#input.oh_pit_pilot_state_taxable_income: -100
   output:
+    # These Judgment outputs are fail-closed scope sentinels, not monetary
+    # claims. The executable result below remains only schedule tax before
+    # nonrefundable credits.
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies: holds
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies: holds
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_credit_surface_source_hold_applies: holds
+    us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_return_ordering_source_hold_applies: holds
     us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_income: '0'
     us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax: '0'
     us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability: '0'

--- a/us-oh/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-oh/policies/income_tax/pilot_liability_pipeline.yaml
@@ -29,7 +29,11 @@ module:
     excess. Upstream Ohio adjusted gross income, taxable-business-income
     separation, personal exemptions, residency and allocation decisions are
     outside this legal schedule module, as are the separate three-percent
-    business-income tax and all credits.
+    business-income tax, all credits, and final-return ordering. Typed
+    source-hold Judgments keep those omitted stages fail closed. This module
+    does not claim to construct Ohio taxable income or final Ohio IT 1040
+    liability, and it does not expose caller-completed business income,
+    exemptions, credits, or final tax as shortcut inputs.
 
     PolicyEngine-US 1.752.2 directly feeds `oh_taxable_income` into the
     distinct `oh_income_tax_before_non_refundable_credits` schedule target and
@@ -42,7 +46,15 @@ module:
     incomes, not a substantive schedule difference. All rules fail closed
     outside tax year 2026.
   deferred_outputs:
-    - output: us-oh:statutes/5747.02/b#taxable_business_income_after_excess_exemptions
+    - output: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_constructed_nonbusiness_taxable_income
+      reason: |-
+        Section 5747.02(A)(3) constructs the nonbusiness balance from Ohio
+        adjusted gross income less taxable business income and exemptions.
+        The module's sole input is the completed-return result of that
+        construction; it does not derive the upstream components.
+      source_values:
+        - us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies
+    - output: us-oh:statutes/5747/02#taxable_business_income_after_excess_exemptions
       reason: |-
         Section 5747.02(A)(4)(b) coordinates personal exemptions with Ohio's
         separate three-percent taxable-business-income schedule. This module
@@ -50,11 +62,115 @@ module:
         ends before that separate business-income branch; encoding it requires
         completed-return taxable business income and the excess-exemption
         allocation that this one-boundary schedule does not claim to derive.
+      source_values:
+        - us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies
+    - output: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_tax_after_nonrefundable_credits
+      reason: |-
+        The two pinned sources establish the 2026 nonbusiness-income schedule,
+        not a complete tax-year-2026 credit inventory, eligibility surface,
+        limitations, or ordering chain.
+      source_values:
+        - us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_credit_surface_source_hold_applies
+    - output: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_it_1040_liability
+      reason: |-
+        A final resident IT 1040 liability requires the omitted income
+        construction, business-income and excess-exemption branch, credits,
+        and final-return ordering. No final tax-year-2026 IT 1040 is pinned,
+        so this bounded schedule makes no final-return claim.
+      source_values:
+        - us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_return_ordering_source_hold_applies
 imports:
   - us-oh:statutes/5747/02#individual_income_tax_no_tax_threshold
   - us-oh:statutes/5747/02#individual_nonbusiness_income_tax_base_amount
   - us-oh:statutes/5747/02#individual_nonbusiness_income_tax_excess_rate
 rules:
+  - name: oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Upstream Ohio adjusted-gross-income, business-income separation, and exemption construction is outside this bounded schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "the tax imposed by this section on income other than taxable business income shall be measured by Ohio adjusted gross income, less taxable business income and less an exemption"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Separate taxable-business-income tax and excess-exemption allocation are outside this bounded nonbusiness schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "the tax imposed by this section on taxable business income shall equal three per cent"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+              excerpt: "the excess shall be deducted from taxable business income before computing the tax"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: oh_pit_pilot_credit_surface_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Complete tax-year-2026 Ohio credit inventory, eligibility, limitations, and ordering are not pinned by the bounded schedule sources
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/guidance/lsc/hb96/final-analysis/tax/document-1
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: oh_pit_pilot_final_return_ordering_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Final tax-year-2026 Ohio IT 1040 liability and return ordering are not pinned
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/statute/5747.02
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-oh/guidance/lsc/hb96/final-analysis/tax/document-1
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
   - name: oh_pit_pilot_taxable_income
     kind: derived
     entity: TaxUnit
@@ -158,4 +274,4 @@ inputs:
     dtype: Money
     period: Year
     unit: USD
-    description: Completed-return Ohio taxable nonbusiness income supplied by the caller as the sole upstream oracle boundary.
+    description: Completed-return Ohio taxable nonbusiness income supplied by the caller as the sole lawful upstream oracle boundary; not business income, exemptions, credits, or final IT 1040 tax.


### PR DESCRIPTION
## Summary

- preserve the exact 2026 Ohio nonbusiness schedule: $332 plus 2.75% of nonbusiness taxable income over $26,050
- accept only a completed-return nonbusiness taxable-income boundary
- fail closed for income construction, business income and excess exemptions, credits, and final-return ordering
- correct the malformed deferred business-income target and update the exact oracle pending ratchet
- refresh the protected apply manifest for the changed module and companion suite

## Validation

- pinned corpus/engine validation: passed
- compilation: 17 resolved rules
- proof validation: 16 atoms, no missing money atoms
- companion suite: 8/8 passed
- repository layout/reverse-index subset: 15 passed
- reverse index: current; no Ohio edge change required
- protected generated-file guard: passed
- keyed manifest census: 6 encoder / 6 manual / 0 unmanifested under us-oh
- independent review found one actionable manifest-refresh issue; fixed and awaiting final re-review

## Boundary

This does not claim final 2026 IT 1040 liability. Taxable-income construction, business-income ordering, excess exemptions, credits, and final return ordering remain explicit fail-closed deferrals.