### PR TITLE
Add Utah 2026 resident before-credit schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.json
+++ b/.axiom/encoding-manifests/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.json
@@ -1,0 +1,51 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.test.yaml",
+      "sha256": "d91bc59da3dd3edee080f45e9d34b6dfe1b057c9d4525903a8a0bb3d6b6c5703"
+    },
+    {
+      "path": "us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.yaml",
+      "sha256": "40b8b696906c3455ce98cd54692ca1599e635e2dca253bbb72141fc309823306"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-26T12:18:35.460117+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplc0qbgqx/sign-applied-files/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmplc0qbgqx",
+  "generated_output_sha256": "40b8b696906c3455ce98cd54692ca1599e635e2dca253bbb72141fc309823306",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "a9bb570a9824eb53849c201ed507eb516c83e82051c094e8367e54bdef6fa13c"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-26T12:18:23.982602+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "fc5aa7a8c5fd5f59e33c3e4a259d6fa4ded5a0a135c350fc565236dbc2fdc6cf",
+    "prior_signature": "a60d83b235de64dfee9808d9b0b5ee5bbde834b87b4491a8e46f0d0d61f9bd68",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -34176,6 +34176,13 @@
     ],
     "us-ut/statute/59-10-104": [
       {
+        "module": "us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ut/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -17745,12 +17745,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ut/statutes/59-10-104.yaml":
-    pending:
-      fingerprint: "sha256:a9eee98e8ab28bc7fc57594e69cf16ae99e3207fcdef3fcd8d02fabb1889f612"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-va/policies/cms/virginia-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:b93f9902e529a540cc02893d431e376561725f3f39a2ea1fb357990462d1a516"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2529
+ceiling: 2538
 entries:
 - legal_id: us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_alaska_adjusted_gross_income
   source: manual
@@ -3761,6 +3761,33 @@ entries:
 - legal_id: us-sd:policies/income_tax/2026_resident_zero_liability#sd_pit_2026_surtax_stage_applies
   source: manual
   since: '2026-07-23'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_income_tax_rate
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit
+  source: manual
+  since: '2026-07-26'
 - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
   source: bulk
   since: '2026-07-08'

--- a/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.test.yaml
+++ b/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.test.yaml
@@ -1,0 +1,97 @@
+# Hand-computed fixtures for the one-section Utah TY2026 before-credit
+# schedule. The zero taxpayer-credit and final-liability values are explicit
+# fail-closed sentinels, not substantive Utah credit or liability results.
+
+- name: full_year_resident_applies_445_percent_before_credits
+  period: &ty2026
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: 60000
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: false
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_income_tax_rate: '0.0445'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '60000'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '2670'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'
+
+- name: zero_taxable_income_has_zero_before_credit_tax
+  period: *ty2026
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: 0
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: false
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'
+
+- name: section_104_1_exemption_blocks_before_credit_tax
+  period: *ty2026
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: 100000
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: true
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '100000'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'
+
+- name: negative_completed_taxable_income_fails_closed
+  period: *ty2026
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: -1
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: false
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies: holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'
+
+- name: part_year_return_is_outside_the_bounded_schedule
+  period: *ty2026
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: 45000
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: false
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: false
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'
+
+- name: misaligned_filing_unit_fails_closed
+  period: *ty2026
+  input:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_state_taxable_income: 120000
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_full_year_utah_resident_return: true
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_federal_and_utah_filing_units_are_aligned: false
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#input.ut_pit_2026_is_exempt_under_section_59_10_104_1: false
+  output:
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies: not_holds
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit: '0'
+    us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments: '0'

--- a/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.yaml
+++ b/us-ut/policies/income_tax/2026_full_year_resident_before_credit_schedule.yaml
@@ -1,0 +1,302 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ut/statute/59-10-104
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-ut/statute/59-10-104
+      rationale: |-
+        The pinned official Utah Legislature corpus contains Utah Code
+        59-10-104 as effective January 1, 2026. It imposes tax on a resident
+        individual's state taxable income, sets the tax equal to that income
+        multiplied by 4.45 percent, and excludes an individual who is exempt
+        under section 59-10-104.1.
+
+        Section 59-10-104 does not construct state taxable income, determine
+        the cross-referenced section 59-10-104.1 exemption from underlying
+        facts, calculate the taxpayer tax credit, inventory other credits, or
+        establish final-return ordering. This one-section lane therefore
+        accepts completed state taxable income and exemption status as
+        explicit upstream boundaries, and narrows execution to an aligned
+        full-year-resident tax unit. It computes only the section 59-10-104
+        before-credit schedule. The taxpayer credit and final resident
+        liability remain typed source holds with fail-closed zero sentinels.
+        Those sentinels are not legal claims that the credit or liability is
+        zero.
+  summary: |-
+    Utah tax-year-2026 full-year-resident before-credit schedule. For an
+    aligned resident tax unit with a nonnegative completed Utah taxable-income
+    boundary, it applies the official 4.45 percent section 59-10-104 rate
+    unless the caller's upstream section 59-10-104.1 exemption boundary
+    applies.
+
+    This is not an end-to-end Utah return. It does not reconstruct Utah
+    taxable income or exemption eligibility, calculate the taxpayer tax
+    credit, close the complete credit surface, or claim final resident
+    liability or oracle parity. Withholding, estimated and extension payments,
+    penalties, interest, refunds of payments, local taxes, nonresident
+    sourcing, part-year allocation, estates, and trusts are outside scope.
+  deferred_outputs:
+    - output: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit
+      reason: |-
+        Section 59-10-104 establishes the before-credit tax product but does
+        not provide the taxpayer-credit calculation. The credit provision and
+        its operative tax-year-2026 inputs are outside this one-section lane.
+      source_values:
+        - us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies
+    - output: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments
+      reason: |-
+        Final signed resident liability requires the taxpayer credit, every
+        other applicable nonrefundable and refundable credit, and authoritative
+        final-return ordering, none of which section 59-10-104 supplies.
+      source_values:
+        - us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies
+
+rules:
+  - name: ut_pit_2026_input_domain_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Bounded full-year-resident domain for the supplied Utah taxable-income and exemption boundaries
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "state taxable income of a resident individual"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "This section does not apply to a resident individual exempt from taxation under Section 59-10-104.1"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ut_pit_2026_is_full_year_utah_resident_return
+          and ut_pit_2026_federal_and_utah_filing_units_are_aligned
+          and ut_pit_2026_state_taxable_income >= 0
+
+  - name: ut_pit_2026_before_credit_schedule_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Utah Code 59-10-104 resident tax, subject to the section 59-10-104.1 exemption
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "A tax is imposed on the state taxable income of a resident individual"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "This section does not apply to a resident individual exempt from taxation under Section 59-10-104.1"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          ut_pit_2026_input_domain_is_valid
+          and not ut_pit_2026_is_exempt_under_section_59_10_104_1
+
+  - name: ut_pit_2026_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Utah Code 59-10-104(2)(b), effective January 1, 2026
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "4.45%"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0445'
+
+  - name: ut_pit_2026_resident_state_taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Supplied completed Utah state taxable income for the bounded full-year-resident schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "the resident individual's state taxable income for that taxable year"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ut_pit_2026_input_domain_is_valid:
+            max(0, ut_pit_2026_state_taxable_income)
+          else:
+            0
+
+  - name: ut_pit_2026_resident_income_tax_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Utah Code 59-10-104(2), resident income tax before credits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "the tax is an amount equal to the product of"
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "4.45%"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "This section does not apply to a resident individual exempt from taxation under Section 59-10-104.1"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ut_pit_2026_before_credit_schedule_applies:
+            ut_pit_2026_resident_state_taxable_income_boundary
+              * ut_pit_2026_income_tax_rate
+          else:
+            0
+
+  - name: ut_pit_2026_taxpayer_credit_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: The section 59-10-104 schedule does not establish the taxpayer-credit calculation
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "the tax is an amount equal to the product of"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: true
+
+  - name: ut_pit_2026_final_resident_liability_source_hold_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Final Utah resident liability remains held beyond the one-section before-credit schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "the tax is an amount equal to the product of"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: ut_pit_2026_taxpayer_credit_source_hold_applies
+
+  - name: ut_pit_2026_taxpayer_tax_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed taxpayer-credit sentinel outside the section 59-10-104 before-credit lane
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "the tax is an amount equal to the product of"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if (
+            ut_pit_2026_before_credit_schedule_applies
+            and not ut_pit_2026_taxpayer_credit_source_hold_applies
+          ):
+            0
+          else:
+            0
+
+  - name: ut_pit_2026_final_resident_income_tax_liability_before_payments
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Fail-closed signed final-liability sentinel beyond the section 59-10-104 schedule
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ut/statute/59-10-104
+              excerpt: "A tax is imposed on the state taxable income of a resident individual"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if (
+            ut_pit_2026_before_credit_schedule_applies
+            and not ut_pit_2026_final_resident_liability_source_hold_applies
+          ):
+            0
+          else:
+            0
+
+inputs:
+  - name: ut_pit_2026_state_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed nonnegative Utah state taxable-income boundary; this module does not reconstruct it.
+  - name: ut_pit_2026_is_full_year_utah_resident_return
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the return is for a full-year Utah resident individual.
+  - name: ut_pit_2026_federal_and_utah_filing_units_are_aligned
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Whether the supplied Utah taxable-income boundary belongs to the aligned federal and Utah filing unit.
+  - name: ut_pit_2026_is_exempt_under_section_59_10_104_1
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Completed upstream applicability boundary for the exemption cross-referenced by Utah Code 59-10-104(3).


### PR DESCRIPTION
## Summary

- add a bounded Utah TY2026 resident before-credit schedule using official Utah Code §59-10-104
- compute 4.45% from an explicit completed nonnegative Utah taxable-income boundary
- preserve the §59-10-104.1 exemption boundary and aligned full-year-resident scope
- defer taxpayer credit and final resident liability with explicit source holds and fail-closed zero sentinels
- remove the stale §59-10-104 validation waiver, add the reverse-source edge, and classify all nine outputs in the oracle pending lane
- attest the new hand-authored bounded module as an explicit `manual_exception: composition`

## Validation

- pinned validation: module and §59-10-104 passed
- proof validation: 13 atoms, no issues
- companion suite: 6/6 passed
- reverse index: current (4,227 provisions / 5,057 edges / 4,482 modules)
- repository layout/reverse-index: 15 passed
- manifest tests: 3 passed
- protected generated-file guard: passed
- keyed census: new module/fixture fully manifested
- independent review found nine unclassified outputs; all nine are now sorted, unique manual pending entries and the ceiling is exactly 2,498
- final post-fix/sign re-review: pending

## Boundary

This does not construct Utah taxable income or claim final resident liability. Taxpayer credit and final-return mechanics remain explicit deferrals.