### PR TITLE
Pin Virginia 2026 Form 760ES corpus source

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,8 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7"
+# Virginia TY2026 Form 760ES source from axiom-corpus PR #541.
+axiom_corpus_ref = "a6bf21461e7aa27117f003bf0b800375e63b5966"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary
- pin the exact reviewed axiom-corpus commit from corpus PR #541
- keep the corpus/toolchain transition separate from the dependent Virginia semantic and waiver changes

## Dependency
- Depends on TheAxiomFoundation/axiom-corpus#541 at exact commit `a6bf21461e7aa27117f003bf0b800375e63b5966`.
- No RuleSpec semantics, waivers, oracle declarations, or generated manifests change in this PR.

## Validation
- exact one-file diff against `main`
- dependent Virginia validation and review run on the stacked branch

This PR remains draft until the corpus dependency is available.