### PR TITLE
Encode bounded Virginia 2026 estimated-tax schedule

### DIFF
--- a/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-va/policies/income_tax/pilot_liability_pipeline.json
@@ -2,17 +2,17 @@
   "applied_files": [
     {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "a07e4b63fd5c8f71c0757370df387fe922e9573019fb86e8f16614c578b1dd16"
+      "sha256": "f0c9ed20036e180efcf43543d02fe9e797c40e123aefe8c37ddc6fb046f7cc27"
     },
     {
       "path": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc"
+      "sha256": "73930c01037e53289d8ffc089e0e8a3fff528824c6106bff78589b2f63d5d267"
     }
   ],
   "axiom_encode_git": {
     "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
     "version": "0.2.1200",
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
@@ -21,12 +21,11 @@
   "citation": "us-va:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-22T01:15:35.629419+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpy07q2h8r/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpy07q2h8r",
-  "generated_output_sha256": "19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc",
+  "generated_at": "2026-07-26T12:45:50.262838+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjr7w4bnh/sign-applied-files/us-va/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpjr7w4bnh",
+  "generated_output_sha256": "73930c01037e53289d8ffc089e0e8a3fff528824c6106bff78589b2f63d5d267",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,29 +33,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6175e617056c80a0369a93016731634dbdf5e716297e91dd7f972f2b861663b0"
+    "value": "2259a1fd1bca14fdb6f7c9291567083d7f79590985cc74e5208416778b11a8b4"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T01:13:23.645976+00:00",
+    "generated_at": "2026-07-22T01:15:35.629419+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "28185088bb6a65c0c489bdb3f55c32aec4be966ce87f78ea0c0436e4ecbb6b43",
-    "prior_signature": "d2a7bbe67b5137f57245060d712249e1087f8fc53f3b80ee0209e37f545fce18",
+    "manifest_sha256": "627765560d8c2b871cac7519b311d9f150fa7259688b10b3b63bd47b485b4770",
+    "prior_signature": "6175e617056c80a0369a93016731634dbdf5e716297e91dd7f972f2b861663b0",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-22T00:52:47.321632+00:00",
+      "generated_at": "2026-07-22T01:13:23.645976+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "b47c41422cc63fca7d49e1af95215fc0aeeace643c613e9e99df80084659f177",
-      "prior_signature": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74",
+      "manifest_sha256": "28185088bb6a65c0c489bdb3f55c32aec4be966ce87f78ea0c0436e4ecbb6b43",
+      "prior_signature": "d2a7bbe67b5137f57245060d712249e1087f8fc53f3b80ee0209e37f545fce18",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-08T23:52:08.083717+00:00",
+        "generated_at": "2026-07-22T00:52:47.321632+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
-        "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+        "manifest_sha256": "b47c41422cc63fca7d49e1af95215fc0aeeace643c613e9e99df80084659f177",
+        "prior_signature": "710c9dd658ea253316c4b045f5d83a65e10e207539d33b6037dc2e9ce8be0d74",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-08T23:52:08.083717+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "1191cc115912fa451a551922f528fbcc79b971d93e867511566c1f6400907910",
+          "prior_signature": "09c1f54d0c1b9bb38f21df9db4299485d3da9d3cfc5af29eb29f46ef1f159e8e",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -34197,14 +34197,16 @@
         ]
       }
     ],
-    "us-va/statute/58.1/58.1-320": [
+    "us-va/form/individual-income-tax/2026/760es/tax-rate-schedule": [
       {
         "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"
         ]
-      },
+      }
+    ],
+    "us-va/statute/58.1/58.1-320": [
       {
         "module": "us-va/statutes/58.1/58/1-320.yaml",
         "via": [
@@ -34214,13 +34216,6 @@
       }
     ],
     "us-va/statute/58.1/58.1-321": [
-      {
-        "module": "us-va/policies/income_tax/pilot_liability_pipeline.yaml",
-        "via": [
-          "module",
-          "proof_atom"
-        ]
-      },
       {
         "module": "us-va/statutes/58.1/58/1-321.yaml",
         "via": [

--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -10644,11 +10644,6 @@
       "module_sha256": "sha256:b9b034ff72d2a9fb3b7ad5199631fc0e405512fd6001bdd740eb8e2de768c6cc",
       "passed": false
     },
-    "us-va/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f",
-      "module_sha256": "sha256:19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc",
-      "passed": false
-    },
     "us-va/statutes/58.1/58/1-320.yaml": {
       "fingerprint": "sha256:68ffe41b2387b5a3a10040c178b3e6d0d8e1bf6a2f65b10868d33d17c512ca64",
       "module_sha256": "sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b",

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -17751,12 +17751,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
-    pending:
-      fingerprint: "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-va/statutes/58.1/58/1-320.yaml":
     pending:
       fingerprint: "sha256:68ffe41b2387b5a3a10040c178b3e6d0d8e1bf6a2f65b10868d33d17c512ca64"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2538
+ceiling: 2544
 entries:
 - legal_id: us-ak:policies/income_tax/2026_resident_zero_liability#ak_pit_2026_alaska_adjusted_gross_income
   source: manual
@@ -3911,12 +3911,30 @@ entries:
 - legal_id: us-ut:statutes/59-10-104#resident_individual_income_tax_rate
   source: bulk
   since: '2026-07-08'
-- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability
-  source: bulk
-  since: '2026-07-08'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_base
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_floor
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_rate
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_first_bracket_upper
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_second_bracket_upper
+  source: manual
+  since: '2026-07-26'
+- legal_id: us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_third_bracket_upper
+  source: manual
+  since: '2026-07-26'
 - legal_id: us-va:statutes/58.1/58/1-320#first_bracket_rate
   source: bulk
   since: '2026-07-08'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,112 +1,90 @@
-# Hand-computed fixtures for the completed-return Virginia taxable-income and
-# filing-requirement boundaries. Section 58.1-320 imposes 2% through $3,000,
-# 3% from $3,000 through $5,000, 5% from $5,000 through $17,000, and 5.75%
-# above $17,000. The first three brackets therefore contribute $720 at the
-# $17,000 top-bracket threshold.
-- name: nonfiler_returns_zero
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+# Hand-computed tax-year-2026 Form 760ES Tax Rate Schedule fixtures. Expected
+# values apply the printed cumulative-base-plus-excess rows directly and do
+# not use a final-return oracle.
+- name: defensive_negative_input_floors_to_zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 100000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: false
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: -100
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5492.5'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '0'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '0'
 
 - name: zero_taxable_income
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 0
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '0'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '0'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '0'
 
 - name: first_bracket
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 1000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '20'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '20'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '20'
 
-- name: first_bracket_boundary
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+- name: first_bracket_upper_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 3000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '60'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '60'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 0
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '60'
 
-- name: second_bracket_boundary
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+- name: one_cent_into_second_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 3000.01
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 1
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '60.0003'
+
+- name: second_bracket_upper_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 5000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '120'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '120'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 1
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '120'
 
-- name: third_bracket
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+- name: one_cent_into_third_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 10000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 5000.01
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '370'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '370'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 2
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '120.0005'
 
-- name: top_bracket_boundary
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+- name: third_bracket_upper_boundary
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 17000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '720'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '720'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 2
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '720'
+
+- name: one_cent_into_top_bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 17000.01
+  output:
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 3
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '720.000575'
 
 - name: top_bracket
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 20000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '892.5'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '892.5'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 3
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '892.5'
 
 - name: high_taxable_income
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:
     us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_state_taxable_income: 100000
-    us-va:policies/income_tax/pilot_liability_pipeline#input.va_pit_pilot_must_file: true
   output:
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_tax: '5492.5'
-    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_income_tax_liability: '5492.5'
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_bracket_selector: 3
+    us-va:policies/income_tax/pilot_liability_pipeline#va_pit_pilot_2026_760es_estimated_schedule_tax: '5492.5'

--- a/us-va/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-va/policies/income_tax/pilot_liability_pipeline.yaml
@@ -3,132 +3,247 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_paths:
-      - us-va/statute/58.1/58.1-320
-      - us-va/statute/58.1/58.1-321
+    corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+        - us-va/statute/58.1/58.1-320
+      rationale: |-
+        Virginia Code section 58.1-320 was checked as the higher-authority
+        individual-income-tax schedule. The Virginia Department of Taxation's
+        final 2026 Form 760ES is the current official tax-year parameter source
+        for this estimated-tax rate-schedule slice. Its Tax Rate Schedule
+        supplies all four cumulative-base-plus-excess rows: 2 percent through
+        $3,000; $60 plus 3 percent over $3,000 through $5,000; $120 plus 5
+        percent over $5,000 through $17,000; and $720 plus 5.75 percent over
+        $17,000.
+
+        The caller supplies completed nonnegative Virginia taxable income.
+        This module applies only the published schedule and does not construct
+        taxable income or claim final Form 760 liability.
   summary: |-
-    Composed Virginia individual income-tax pipeline for tax year 2026. It
-    accepts two TaxUnit-level completed-return boundaries: Virginia taxable
-    income and whether the return is within the Virginia filing requirement.
-    For an applicable return, it computes the section 58.1-320 marginal
-    schedule using the bracket bounds and rates imported from the encoded
-    statute module; otherwise it returns zero. The boundaries already reflect
-    the upstream federal and Virginia income, deduction, exemption, residency,
-    and filing-status mechanics, so this module makes no independent claim
-    about that chain. It deliberately targets tax before nonrefundable credits
-    and excludes every credit and payment. Both rules are bounded to 2026 so
-    adjacent years fail closed. This narrow boundary is suitable for comparison
-    with PolicyEngine's va_taxable_income and va_must_file feeding
-    va_income_tax_before_non_refundable_credits across full-year resident tax
-    units in the certified Populace.
-imports:
-  - us-va:statutes/58.1/58/1-320#first_bracket_upper_income
-  - us-va:statutes/58.1/58/1-320#first_bracket_rate
-  - us-va:statutes/58.1/58/1-320#second_bracket_upper_income
-  - us-va:statutes/58.1/58/1-320#second_bracket_rate
-  - us-va:statutes/58.1/58/1-320#third_bracket_upper_income
-  - us-va:statutes/58.1/58/1-320#third_bracket_rate
-  - us-va:statutes/58.1/58/1-320#top_bracket_rate
+    Virginia tax-year-2026 resident estimated-tax rate-schedule amount from a
+    single caller-supplied completed Virginia taxable-income boundary. The
+    calculation preserves the four exact Form 760ES rows and cumulative base
+    amounts, floors a defensive negative input to zero, and fails closed
+    outside 2026. It is an estimated-tax schedule component, not final Form
+    760 liability.
+  deferred_outputs:
+    - output: us-va:forms/760es#constructed_state_taxable_income
+      reason: Form 760ES taxable-income construction requires upstream federal and Virginia income adjustments that are outside the completed taxable-income boundary.
+    - output: us-va:forms/760es#deductions
+      reason: Virginia standard and itemized deductions are already reflected in the supplied completed taxable-income boundary and are not reconstructed here.
+    - output: us-va:forms/760es#credits_and_spouse_tax_adjustment
+      reason: Form 760ES credits and spouse tax adjustment occur after the rate schedule and require source and filing-unit surfaces outside this module.
+    - output: us-va:forms/760py#part_year_tax
+      reason: Part-year residency and allocation require Form 760PY and related authority, not the resident 760ES schedule encoded here.
+    - output: us-va:forms/760es#withholding_and_estimated_payments
+      reason: Withholding and estimated-payment accounting are payment stages downstream of the rate schedule.
+    - output: us-va:forms/760c#underpayment_additions
+      reason: Underpayment additions require timing, installment, exception, and prior-year facts outside this rate-schedule slice.
+    - output: us-va:forms/760#income_tax_liability
+      reason: Final Form 760 liability requires taxable-income construction, deductions, credits, spouse adjustment, residency handling, and final-return ordering not established by Form 760ES.
 rules:
-  - name: va_pit_pilot_bracket_tax
-    kind: derived
-    entity: TaxUnit
+  - name: va_pit_pilot_first_bracket_upper
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: Va. Code 58.1-320, marginal tax on supplied completed-return Virginia taxable income
+    source: Virginia 2026 Form 760ES first-bracket upper bound
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#first_bracket_upper_income
-              output: first_bracket_upper_income
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#first_bracket_rate
-              output: first_bracket_rate
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#second_bracket_upper_income
-              output: second_bracket_upper_income
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#second_bracket_rate
-              output: second_bracket_rate
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#third_bracket_upper_income
-              output: third_bracket_upper_income
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#third_bracket_rate
-              output: third_bracket_rate
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-va:statutes/58.1/58/1-320#top_bracket_rate
-              output: top_bracket_rate
-              hash: sha256:c091b41b254398e27d46641db00799f7e38ea2e17d3f5a3fd3acf58ffac13d4b
-          - path: versions[0].formula
-            kind: formula
+            kind: amount
             source:
-              corpus_citation_path: us-va/statute/58.1/58.1-320
-              excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual as follows"
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "Not over $3,000, your tax is 2% of your Virginia taxable income."
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
-        formula: |-
-          first_bracket_rate * min(va_pit_pilot_state_taxable_income, first_bracket_upper_income)
-          + second_bracket_rate * max(0, min(va_pit_pilot_state_taxable_income, second_bracket_upper_income) - first_bracket_upper_income)
-          + third_bracket_rate * max(0, min(va_pit_pilot_state_taxable_income, third_bracket_upper_income) - second_bracket_upper_income)
-          + top_bracket_rate * max(0, va_pit_pilot_state_taxable_income - third_bracket_upper_income)
-  - name: va_pit_pilot_income_tax_liability
-    kind: derived
-    entity: TaxUnit
+        formula: '3000'
+
+  - name: va_pit_pilot_second_bracket_upper
+    kind: parameter
     dtype: Money
     period: Year
     unit: USD
-    source: Va. Code 58.1-320 tax, subject to the Va. Code 58.1-321 no-tax and no-return threshold, before credits
+    source: Virginia 2026 Form 760ES second-bracket upper bound
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
+            kind: amount
             source:
-              corpus_citation_path: us-va/statute/58.1/58.1-320
-              excerpt: "A tax is hereby annually imposed on the Virginia taxable income for each taxable year of every individual"
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 3,000 $ 5,000 $ 60 + 3% $ 3,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '5000'
+
+  - name: va_pit_pilot_third_bracket_upper
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Virginia 2026 Form 760ES third-bracket upper bound
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 5,000 $ 17,000 $ 120 + 5% $ 5,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '17000'
+
+  - name: va_pit_pilot_bracket_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: va_pit_pilot_bracket_selector
+    source: Virginia 2026 Form 760ES excess-over floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              table: {header: "TAX RATE SCHEDULE", row_key: bracket, column_key: excess_over}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 3000, 2: 5000, 3: 17000}
+
+  - name: va_pit_pilot_bracket_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: va_pit_pilot_bracket_selector
+    source: Virginia 2026 Form 760ES cumulative bracket bases
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              table: {header: "TAX RATE SCHEDULE", row_key: bracket, column_key: base_tax}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0, 1: 60, 2: 120, 3: 720}
+
+  - name: va_pit_pilot_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: va_pit_pilot_bracket_selector
+    source: Virginia 2026 Form 760ES marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              table: {header: "TAX RATE SCHEDULE", row_key: bracket, column_key: marginal_rate}
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values: {0: 0.02, 1: 0.03, 2: 0.05, 3: 0.0575}
+
+  - name: va_pit_pilot_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: Virginia 2026 Form 760ES row selection for supplied completed Virginia taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us-va/statute/58.1/58.1-321
-              excerpt: "No tax levied pursuant to § 58.1-320 is imposed, nor any return required to be filed"
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "Not over $3,000, your tax is 2% of your Virginia taxable income."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 3,000 $ 5,000 $ 60 + 3% $ 3,000"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 5,000 $ 17,000 $ 120 + 5% $ 5,000"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 17,000 $ 720 + 5.75% $ 17,000"
     versions:
       - effective_from: '2026-01-01'
         effective_to: '2026-12-31'
         formula: |-
-          if va_pit_pilot_must_file: va_pit_pilot_bracket_tax else: 0
+          if max(0, va_pit_pilot_state_taxable_income) <= va_pit_pilot_first_bracket_upper: 0 else: if max(0, va_pit_pilot_state_taxable_income) <= va_pit_pilot_second_bracket_upper: 1 else: if max(0, va_pit_pilot_state_taxable_income) <= va_pit_pilot_third_bracket_upper: 2 else: 3
+
+  - name: va_pit_pilot_2026_760es_estimated_schedule_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Virginia Department of Taxation 2026 Form 760ES Tax Rate Schedule applied to supplied completed Virginia taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "Not over $3,000, your tax is 2% of your Virginia taxable income."
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 3,000 $ 5,000 $ 60 + 3% $ 3,000"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 5,000 $ 17,000 $ 120 + 5% $ 5,000"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-va/form/individual-income-tax/2026/760es/tax-rate-schedule
+              excerpt: "$ 17,000 $ 720 + 5.75% $ 17,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          va_pit_pilot_bracket_base[va_pit_pilot_bracket_selector]
+          + va_pit_pilot_bracket_rate[va_pit_pilot_bracket_selector]
+          * (max(0, va_pit_pilot_state_taxable_income) - va_pit_pilot_bracket_floor[va_pit_pilot_bracket_selector])
 inputs:
   - name: va_pit_pilot_state_taxable_income
     entity: TaxUnit
     dtype: Money
     period: Year
     unit: USD
-    description: Nonnegative completed-return Virginia taxable income supplied by the caller as an upstream oracle boundary.
-  - name: va_pit_pilot_must_file
-    entity: TaxUnit
-    dtype: Boolean
-    period: Year
-    description: Whether the tax unit is within Virginia's filing requirement, supplied by the caller as an upstream applicability boundary.
+    description: Completed nonnegative Virginia taxable income supplied by the caller; all income, deduction, residency, and filing-status construction is upstream.


### PR DESCRIPTION
## Summary
- encode the exact four-row tax-rate schedule published in final Virginia Form 760ES for tax year 2026
- accept only completed Virginia taxable income and compute the schedule amount
- fail closed on taxable-income construction, deductions, credits/spouse adjustment, residency allocation, payments, underpayment additions, and final Form 760 liability
- retire only the stale validation waiver for the replaced Virginia pilot module and declare its outputs in the visible oracle-pending lane

## Source boundary
This is an estimated-tax rate-schedule component, not a claim that the final 2026 Form 760 resident liability package is complete.

## Dependencies
- stacked on the separate corpus pin PR from branch `chore/pin-va-2026-760es-corpus-20260726`
- that pin depends on axiom-corpus PR #541 at exact commit `a6bf21461e7aa27117f003bf0b800375e63b5966`

## Checks
- protected manifest guard passes for the module and companion fixture
- manifest census: 8 encoder-generated, 6 manual, 0 unmanifested under `us-va`
- proof validation: 14 atoms
- companion fixtures: 11/11
- reverse index exact
- independent semantic review found no issue before protected re-attestation

This PR remains draft until its pin dependency lands and the final review-fix cycle is complete.