### PR TITLE
Pin Kentucky oracle coverage classifier

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,11 +19,10 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@4a6e5c09af130cc5cc9eecb3cc221d7cc63026f0 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@d11ec03c4043003b563b5b5e5bf614fea851862a # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto
-      oracle-coverage-axiom-encode-ref: 9156bb919801e692497cbcc59090e86367368006
 
   drift-alarm:
     # Red-main alarm. A full validation runs on every push to main and on the

--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -23,6 +23,7 @@ jobs:
     secrets: inherit
     with:
       validate-roots: auto
+      oracle-coverage-axiom-encode-ref: 9156bb919801e692497cbcc59090e86367368006
 
   drift-alarm:
     # Red-main alarm. A full validation runs on every push to main and on the


### PR DESCRIPTION
## Summary

- advance the reusable validation workflow’s dedicated oracle-coverage classifier pin to merged axiom-encode `9156bb919801e692497cbcc59090e86367368006` (`0.2.1389`)
- keep the legacy execution/validation toolchain independently pinned at `3869d66...`
- land this trust-input change separately from Kentucky RuleSpec and pending-debt changes, as required by the repository guard

## Why

The previous classifier pin predates the reviewed Kentucky registry migration, so it reports the three canonical Kentucky schedule outputs as unmapped. The reusable workflow explicitly provides this separate input so reviewed registry updates can advance without replacing the legacy validator.

## Checks

- YAML parsed successfully
- exact 40-character commit pin verified
- `git diff --check`
- full repository CI pending

## Cycle

Independent review requested; draft until CI and the review-fix loop are clean.