### PR TITLE
Pin Alabama oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@d11ec03c4043003b563b5b5e5bf614fea851862a # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@ec2479e42904bda561a2947777249f830276e64c # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- advance the repository-checks reusable workflow pin from `.github` merge `d11ec03c` to Alabama oracle-coverage merge `ec2479e4`
- keep the caller change isolated from RuleSpec validation-debt changes

The shared workflow update changes only the oracle-coverage encoder default to post-merge-green axiom-encode `261702e3`; protected validation behavior is unchanged.

## Validation

- parsed workflow and verified the exact reusable-workflow SHA
- verified `ec2479e4` exists on TheAxiomFoundation/.github
- `git diff --check`
- `.github` #80 independent review clean, hosted CI green, post-merge CI green

This PR must merge independently before the Alabama RuleSpec semantic PR is pushed.