### PR TITLE
Pin exact Connecticut 12-700(a)(10) corpus scope

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "5dfd89d131564e4ee0e1e763571dbb5d7fc7f5e7"
+axiom_corpus_ref = "111a91baaf867b3120138da522cfe6e65a58ced5"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "111a91baaf867b3120138da522cfe6e65a58ced5"
+axiom_corpus_ref = "f7fe8471c415908b26cfac1e199e92d1580c8ff3"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- advance the shared RuleSpec corpus pin to durable axiom-corpus `main` merge commit `f7fe8471c415908b26cfac1e199e92d1580c8ff3`
- make the exact `us-ct/statute/12-700-a-10/operative-text` source available to downstream validation
- keep this caller/toolchain mutation isolated from CT semantic and validation-gap changes

## Dependency

TheAxiomFoundation/axiom-corpus#546 merged cleanly to `main` as `f7fe8471c415908b26cfac1e199e92d1580c8ff3`. That merge commit has the prior corpus main and reviewed feature head `111a91baaf867b3120138da522cfe6e65a58ced5` as its two parents.

The corpus change is additive only. No R2 publication, Supabase load, named-release mutation, or production-row deletion was performed.

## Checks

- exact referenced corpus commit is the current remote `main`
- corpus PR #546: full local suite green, hosted PR CI terminal green, independent review clean
- corpus post-merge CI: running at the exact durable merge commit
- diff is limited to `.axiom/toolchain.toml`
- previous branch-head matrix: 59 successes and one expected skip, zero failures
- fresh durable-pin exact-head matrix and independent review are required before readiness

## Review state

Draft at exact head `b00e13a2`. The PR remains draft while fresh exact-head CI and independent review run. No waiver or validation boundary is changed.