### PR TITLE
Test Mississippi 2026 schedule parameters

### DIFF
--- a/.axiom/encoding-manifests/us-ms/policies/income_tax/2026_section_27_7_5_schedule.json
+++ b/.axiom/encoding-manifests/us-ms/policies/income_tax/2026_section_27_7_5_schedule.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "us-ms/policies/income_tax/2026_section_27_7_5_schedule.test.yaml",
-      "sha256": "21b1d96478abaf0c155718ec185dc6f8cd577fecd1f932b9c4334e69c9d0a5fc"
+      "sha256": "0c677a80e7e5fe8d1ed826551f753bc61a2aa943743db12cb1d2f445a7d92744"
     },
     {
       "path": "us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml",
@@ -21,12 +21,12 @@
   "citation": "us-ms:policies/income_tax/2026_section_27_7_5_schedule",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-26T14:15:35.594560+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmppkejxmzp/sign-applied-files/us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmppkejxmzp",
+  "generated_at": "2026-07-27T05:43:42.154956+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp0lu106v7/sign-applied-files/us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp0lu106v7",
   "generated_output_sha256": "cffa859e5b5531298d32f11bdecf3837bd72b796a1ec60aa394b3e67f64b53d5",
   "generation_prompt_sha256": null,
-  "manual_exception": "repair",
+  "manual_exception": "fixtures",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,7 +34,34 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ecf7a72bcc097a60731facd23a5912f41a5d16785b609a80ad9b13bcbf454896"
+    "value": "4a13e8912a7da36818a4996ebf7b2d5bfc162988e39c3a931536e7b03ae7a685"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T05:40:34.848772+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "bb85147be78997cadd9cb9c3df6c8d7d41aa55595feb841e5b05d184e5f65303",
+    "prior_signature": "0462c3a0dc34cd0a4cf530569a5083c823839a5d69f7f5c09ae5bbf31bcf7474",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-27T05:39:47.561892+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "311ccc5714bf91b06d352c89503ff2468c672597e3031d1e2c3de28affe34cd5",
+      "prior_signature": "c14b38812ebe38f0b0d9ee956763a2c84c5b6d7c5a5cd3c9a7f7344123bc5dd0",
+      "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-26T14:15:35.594560+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "80db277d22b586b8a467a0aa7961cece4d8a6357b8702c5ea4c0b2a076639ad1",
+        "prior_signature": "ecf7a72bcc097a60731facd23a5912f41a5d16785b609a80ad9b13bcbf454896",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/us-ms/policies/income_tax/2026_section_27_7_5_schedule.test.yaml
+++ b/us-ms/policies/income_tax/2026_section_27_7_5_schedule.test.yaml
@@ -22,6 +22,8 @@
   input:
     us-ms:policies/income_tax/2026_section_27_7_5_schedule#input.ms_pit_2026_supplied_taxable_income: 10000
   output:
+    us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_zero_tax_ceiling: 10000
+    us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_rate: '0.04'
     us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_schedule_taxable_income: '10000'
     us-ms:policies/income_tax/2026_section_27_7_5_schedule#ms_pit_2026_section_27_7_5_schedule_tax: '0'
 


### PR DESCRIPTION
## Summary

- assert the Mississippi 2026 section 27-7-5 zero-tax ceiling and rate parameters in the companion fixture
- regenerate the signed applied-files manifest covering both the RuleSpec module and fixture

## Scope

This only strengthens tests for the existing Person-grain schedule over completed Mississippi taxable income. It does not expand into taxable-income construction, filing-method selection, credits, allocation, proration, or final-return liability.

## Validation

- `axiom-encode guard-generated --repo . --roots us-ms --all --json`
- `axiom-encode test us-ms/policies/income_tax/2026_section_27_7_5_schedule.test.yaml --axiom-rules-engine-path <protected engine repo>` — 1 file, 6 cases
- proof validation — 5 atoms
- emulated newly pinned classifier — all four outputs represented and tested; three comparable, one known P4 non-comparable
- `git diff --check`

## Review-fix cycle

Independent review found that the first regenerated manifest only covered the fixture and left the live module unattested. Fixed by regenerating one signed manifest covering both files. The first exact-head follow-up review found no actionable issues.

After the structural oracle → encoder → shared workflow → caller repair merged, this branch was rebased onto caller merge `ff8e8e4eae882327a7babfbac4f993b76ba0c7e4`. Independent exact-head post-rebase review at `029a5e4a29039b6c68c5a2b98666c640a676706b` found no actionable issues and confirmed that the patch, module, manifest, and fixture bytes are identical to the previously reviewed head. Signed guards, hashes, proof atoms, all six cases, and the newly pinned classifier chain pass.