### PR TITLE
Pin shared Mississippi oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@ec2479e42904bda561a2947777249f830276e64c # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@6685f6cd9f0a5ac7c6ba21cbc710bd92cc91588b # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Scope

Advance the repository-checks caller to merged shared workflow `6685f6cd9f0a5ac7c6ba21cbc710bd92cc91588b`.

That reusable workflow pins merged encoder `7c02247ceb31c08e3cde62339a52ac538ca1f1b4`, which pins merged oracle `89d2a710f070a421b29f18fdec22df983250d19b` and carries the canonical Mississippi TY2026 mappings. This is the consumer end of the structural oracle → encoder → shared workflow → RuleSpec caller chain. No RuleSpec content changes are included.

## Validation

- `git diff --check`
- immutable shared workflow merge provenance verified through GitHub
- one-file, one-line caller diff

## Review-fix cycle

Independent lightweight exact-head review of `96e6fa2a9f709f320a1016740df4b0442a9fb1f7` found no actionable issues. The reviewer verified the exact one-line diff, both upstream merge commits, the dependency order, current shared and encoder main heads, and absence of RuleSpec content changes.