### PR TITLE
Pin shared Utah oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@6685f6cd9f0a5ac7c6ba21cbc710bd92cc91588b # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@3ad53b88e97c5208335fbaa425c05872d548cd7a # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
Advances the repository-checks caller from shared workflow `6685f6cd…` to exact merged Utah coverage workflow `3ad53b88e97c5208335fbaa425c05872d548cd7a` (TheAxiomFoundation/.github#82). The caller contract, inputs, inherited secrets, and temporary migration-bridge semantics are unchanged.

Independent exact-head review is CLEAN for `e2090b60b326c333c92152c8ad1306715b2881ea`: the sole delta is the `uses:` SHA, YAML parses to the same normalized caller structure, shared-workflow provenance was verified, no stale relevant pin remains, and `git diff --check` passes.