### PR TITLE
Drain Utah 2026 oracle coverage pending entries

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2270
+ceiling: 2261
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -3056,33 +3056,6 @@ entries:
 - legal_id: us-ri:statutes/44-30-103#single_separate_head_widow_agi_limit
   source: bulk
   since: '2026-07-08'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_before_credit_schedule_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_income_tax_liability_before_payments
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_final_resident_liability_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_income_tax_rate
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_input_domain_is_valid
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_income_tax_before_credits
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_resident_state_taxable_income_boundary
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_credit_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-ut:policies/income_tax/2026_full_year_resident_before_credit_schedule#ut_pit_2026_taxpayer_tax_credit
-  source: manual
-  since: '2026-07-26'
 - legal_id: us-ut:policies/income_tax/pilot_liability_pipeline#ut_pit_pilot_income_tax_liability
   source: bulk
   since: '2026-07-08'


### PR DESCRIPTION
Removes the nine canonical Utah TY2026 full-year-resident before-credit outputs from `oracle-coverage-pending.yaml` now that the exact reviewed mapping chain is live:

- oracle merge: `51d0930ed337ecbb6d345ea6f36c9fe8243ee40d`
- encoder merge: `6015bc2a2ec441cc470499e800b95f2e71c3468e`
- shared workflow merge: `3ad53b88e97c5208335fbaa425c05872d548cd7a`
- RuleSpec caller merge: `8544d41fbc624222f3525c9e0c85f63236c34d4c`

The ceiling and actual entry count both move from 2,270 to 2,261. All other pending entries and their ordering remain unchanged.

Independent exact-head review is CLEAN for `157c2d368312c6f15890b9bf6d7999bfbd216801`. The merged classifier resolves the exact nine-output prefix as 2 comparable/tested (rate parameter and exemption-aware derived before-credit tax) plus 7 P4 known-not-comparable, with zero pending, unmapped, or untested outputs; all nine have fixtures.

The global ledger currently contains 45 pre-existing stale declarations outside this canonical Utah prefix (including Mississippi schedule and older pilot entries). This narrowly scoped PR does not silently expand into that separate bulk-drain campaign; canonical Utah stale count is zero.