### PR TITLE
Drain Ohio oracle coverage pending entries

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2261
+ceiling: 2230
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -2424,99 +2424,6 @@ entries:
   source: bulk
   since: '2026-07-08'
 - legal_id: us-nm:statutes/7-2-5/8#single_phaseout_rate
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_business_income_and_excess_exemption_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_credit_surface_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_final_return_ordering_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_income_tax_liability
-  source: manual
-  since: '2026-07-08'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_nonbusiness_taxable_income_construction_source_hold_applies
-  source: manual
-  since: '2026-07-26'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_schedule_tax
-  source: manual
-  since: '2026-07-08'
-- legal_id: us-oh:policies/income_tax/pilot_liability_pipeline#oh_pit_pilot_taxable_income
-  source: manual
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#annual_adjustment_rounding_multiple
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#estate_low_income_tax_rate
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#estate_low_income_threshold
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#excess_exemptions_deductible_from_taxable_business_income
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#individual_income_tax_no_tax_threshold
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_base_amount
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#individual_nonbusiness_income_tax_excess_rate
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#individual_taxable_business_income_tax_rate
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/02#taxable_business_income_after_excess_exemptions
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#adjusted_personal_exemption_amount
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_amount
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2025
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_eligibility_magi_cap_taxable_year_2026_and_after
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_high_income_band_lower_bound
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_income_band
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_low_income_band_upper_bound
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_magi_below_applicable_cap
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_lower_bound
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_middle_income_band_upper_bound
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#personal_exemption_rounding_multiple
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/025#statutory_personal_exemption_amount_by_income_band
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/71#earned_income_credit
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-oh:statutes/5747/71#federal_credit_percentage
   source: bulk
   since: '2026-07-08'
 - legal_id: us-or:policies/income_tax/2026_or_estimate_schedule#or_pit_2026_or_estimate_bracket_base


### PR DESCRIPTION
## Summary

- remove all 31 Ohio entries that are now classified by the merged Ohio registry
- lower the pending ledger ceiling and exact count from `2261` to `2230`

This intentionally includes seven `pilot_liability_pipeline` outputs and 24 Ohio statute outputs. The merged `us-oh:` P4 fallback classifies those 24 statute outputs as known-not-comparable source holds, so leaving them in the pending ledger would make them stale declarations.

## Validation

- exact removal: 31 Ohio rows, 7 pilot + 24 statute
- retained ledger entries are unchanged and remain unique/globally sorted
- ceiling equals count: `2230`
- executable Ohio coverage: 3 comparable + 4 P4, all seven fixture-tested
- pending check: zero Ohio stale; only pre-existing unrelated `us-ms` (4) and `us-ut` (41) stale rows remain
- `git diff --check`
- independent exact-head review CLEAN at `f4b0782fbe93494d0f5d66b4fa47fece7ef3d20b`

No RuleSpec, tests, sources, corpus, mappings, or workflow files change in this PR.