### PR TITLE
Add canonical Kansas 2026 K-40ES schedule

### DIFF
--- a/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.json
+++ b/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml",
+      "sha256": "b4b7e805ec1fca9fab3ce216f0a09360a92956d60764565a6031091d6077304d"
+    },
+    {
+      "path": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+      "sha256": "ec8b4d8cab87c00cf2bbdd081da1682740751033dd6e874fa19bc4909c67ad71"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/state-income-tax-ecps/axiom-encode-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ks:policies/income_tax/2026_k40es_schedule_before_credits",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T10:55:28.496498+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3t_l788o/sign-applied-files/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3t_l788o",
+  "generated_output_sha256": "ec8b4d8cab87c00cf2bbdd081da1682740751033dd6e874fa19bc4909c67ad71",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "32e97f76c435a77a726237805132b71ecfe80cf91f535543993e1505c802ce3d"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.json
+++ b/.axiom/encoding-manifests/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml",
-      "sha256": "b4b7e805ec1fca9fab3ce216f0a09360a92956d60764565a6031091d6077304d"
+      "sha256": "08e44344041bd771806d9839a8dd005c78c0471ae0cd24d9dc4e8ee90a9008b4"
     },
     {
       "path": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
-      "sha256": "ec8b4d8cab87c00cf2bbdd081da1682740751033dd6e874fa19bc4909c67ad71"
+      "sha256": "e5476d226820a4b4496660fe115e871d6a36f6e40c0ae8b65635d3c28e50a6d6"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ks:policies/income_tax/2026_k40es_schedule_before_credits",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T10:55:28.496498+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3t_l788o/sign-applied-files/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3t_l788o",
-  "generated_output_sha256": "ec8b4d8cab87c00cf2bbdd081da1682740751033dd6e874fa19bc4909c67ad71",
+  "generated_at": "2026-07-27T11:11:33.450197+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp2_35j7pa/sign-applied-files/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp2_35j7pa",
+  "generated_output_sha256": "e5476d226820a4b4496660fe115e871d6a36f6e40c0ae8b65635d3c28e50a6d6",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,25 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "32e97f76c435a77a726237805132b71ecfe80cf91f535543993e1505c802ce3d"
+    "value": "24a4b96d6cb39f3a281d81a6d98efe36e545155dcb964edfbaa8d173396ba834"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T11:10:27.961784+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6939cddd2b0a55b1c3204b5364cd8881ffd7700f8c4eb54fa3503b9acc19b9b4",
+    "prior_signature": "fa2aa2daf8aefe47f14688365c5632f904c55aafa47347504dce7ccb7662f383",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-27T10:55:28.496498+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "2e43d70292d6824dcf4c38fb99832f60de6dc27bd1151c444ac1cd9de17ead65",
+      "prior_signature": "32e97f76c435a77a726237805132b71ecfe80cf91f535543993e1505c802ce3d",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -19408,6 +19408,13 @@
     ],
     "us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1": [
       {
+        "module": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-ks/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",
@@ -19551,6 +19558,30 @@
         "via": [
           "module",
           "proof_atom"
+        ]
+      }
+    ],
+    "us-ks/statute/79-32-110": [
+      {
+        "module": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
+    "us-ks/statute/79-32-110c": [
+      {
+        "module": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
+    "us-ks/statute/79-32-116": [
+      {
+        "module": "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml",
+        "via": [
+          "module"
         ]
       }
     ],

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2230
+ceiling: 2236
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -845,6 +845,24 @@ entries:
 - legal_id: us-ia:statutes/422/12C#refundable_excess_credit_amount
   source: bulk
   since: '2026-07-08'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_joint_lower_bracket_ceiling
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_lower_rate
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_other_lower_bracket_ceiling
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_upper_rate
+  source: manual
+  since: '2026-07-27'
 - legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability
   source: manual
   since: '2026-07-16'

--- a/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml
+++ b/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml
@@ -1,0 +1,78 @@
+# Fixtures are independently hand-computed from the tax-year-2026 schedules in
+# K.S.A. 79-32,110(a), as confirmed by the Kansas Department of Revenue's 2026
+# Form K-40ES. The supplied boundary is completed-return Kansas taxable income.
+- name: negative nonjoint taxable income is floored
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: -1000
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: false
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_lower_rate: '0.052'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_upper_rate: '0.0558'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_joint_lower_bracket_ceiling: 46000
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_other_lower_bracket_ceiling: 23000
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '0'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '0'
+
+- name: nonjoint at lower bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 23000
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: false
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '23000'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '1196'
+
+- name: nonjoint one dollar above lower bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 23001
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: false
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '23001'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '1196.0558'
+
+- name: nonjoint upper bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 137235
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: false
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '137235'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '7570.313'
+
+- name: joint zero taxable income
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 0
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: true
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '0'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '0'
+
+- name: joint at lower bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 46000
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: true
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '46000'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '2392'
+
+- name: joint one dollar above lower bracket ceiling
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 46001
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: true
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '46001'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '2392.0558'
+
+- name: joint upper bracket
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_completed_taxable_income: 93440
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#input.ks_pit_2026_k40es_married_joint_schedule_applies: true
+  output:
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary: '93440'
+    us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits: '5039.152'

--- a/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml
+++ b/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.test.yaml
@@ -1,6 +1,7 @@
 # Fixtures are independently hand-computed from the tax-year-2026 schedules in
 # K.S.A. 79-32,110(a), as confirmed by the Kansas Department of Revenue's 2026
 # Form K-40ES. The supplied boundary is completed-return Kansas taxable income.
+# The first fixture also locks all four private schedule parameters.
 - name: negative nonjoint taxable income is floored
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:

--- a/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml
+++ b/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml
@@ -1,0 +1,175 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+      - us-ks/statute/79-32-110
+      - us-ks/statute/79-32-110c
+      - us-ks/statute/79-32-116
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-ks/statute/79-32-110
+        - us-ks/statute/79-32-110c
+        - us-ks/statute/79-32-116
+      rationale: |-
+        K.S.A. 79-32,110(a) imposes tax on Kansas taxable income and provides
+        the underlying individual schedules, 79-32,110c subjects those rates
+        to an annual rate-reduction determination, and 79-32,116 defines
+        Kansas taxable income. The Kansas Department of Revenue's official
+        2026 Form K-40ES, revised August 26, 2025, is the controlling current
+        parameter source because it publishes the schedules applicable for
+        tax year 2026 after the 2025 determination window.
+
+        This bounded composition accepts only completed-return Kansas taxable
+        income and the caller's determination that the joint schedule applies.
+        It does not construct Kansas taxable income, determine filing status,
+        or cover deductions, exemptions, special income classes, credits,
+        nonresident apportionment, estimated-payment mechanics, final return
+        ordering, final liability, or future annual rate adjustments.
+  summary: |-
+    Canonical bounded Kansas tax-year-2026 K-40ES schedule before credits. The
+    caller supplies one TaxUnit-level completed Kansas taxable-income amount
+    and whether the joint schedule applies. The module floors that completed
+    boundary at zero and applies the exact official K-40ES lower and upper
+    rates and bracket ceilings.
+
+    This is not a complete Kansas income-tax pipeline or a final-liability
+    calculation. It deliberately excludes every upstream taxable-income
+    construction step and every downstream credit, payment, apportionment,
+    return-ordering, and final-liability step.
+rules:
+  - name: ks_pit_2026_k40es_lower_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Kansas 2026 Form K-40ES, tax computation schedules, lower rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              table:
+                header: "TAX COMPUTATION SCHEDULES"
+                row: "$0.00 through $46,000; $0.00 through $23,000"
+                column: "Enter on line 6"
+              excerpt: "5.2% of line 5"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.052'
+
+  - name: ks_pit_2026_k40es_upper_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    source: Kansas 2026 Form K-40ES, tax computation schedules, upper rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              table:
+                header: "TAX COMPUTATION SCHEDULES"
+                row: "Over $46,000; Over $23,000"
+                column: "Enter on line 6"
+              excerpt: "5.58% of excess over $46,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '0.0558'
+
+  - name: ks_pit_2026_k40es_joint_lower_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Kansas 2026 Form K-40ES, Schedule I joint lower-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$ 0.00 $46,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '46000'
+
+  - name: ks_pit_2026_k40es_other_lower_bracket_ceiling
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Kansas 2026 Form K-40ES, Schedule II nonjoint lower-bracket ceiling
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$ 0.00 $23,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '23000'
+
+  - name: ks_pit_2026_k40es_taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Kansas 2026 Form K-40ES line 5, supplied completed-return Kansas taxable income
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "5. Kansas taxable income (subtract line 4 from line 1)"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, ks_pit_2026_k40es_completed_taxable_income)
+
+  - name: ks_pit_2026_k40es_schedule_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: Kansas 2026 Form K-40ES, individual tax computation schedules before credits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$46,000 ................................................. $2,392 plus 5.58% of excess over $46,000"
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ks/guidance/department-of-revenue/forms/2026/k-40es/document-1
+              excerpt: "$23,000 ................................................. $1,196 plus 5.58% of excess over $23,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if ks_pit_2026_k40es_married_joint_schedule_applies:
+            ks_pit_2026_k40es_lower_rate * min(ks_pit_2026_k40es_taxable_income_boundary, ks_pit_2026_k40es_joint_lower_bracket_ceiling)
+            + ks_pit_2026_k40es_upper_rate * max(0, ks_pit_2026_k40es_taxable_income_boundary - ks_pit_2026_k40es_joint_lower_bracket_ceiling)
+          else:
+            ks_pit_2026_k40es_lower_rate * min(ks_pit_2026_k40es_taxable_income_boundary, ks_pit_2026_k40es_other_lower_bracket_ceiling)
+            + ks_pit_2026_k40es_upper_rate * max(0, ks_pit_2026_k40es_taxable_income_boundary - ks_pit_2026_k40es_other_lower_bracket_ceiling)

--- a/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml
+++ b/us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml
@@ -47,6 +47,7 @@ rules:
     period: Year
     source: Kansas 2026 Form K-40ES, tax computation schedules, lower rate
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -69,6 +70,7 @@ rules:
     period: Year
     source: Kansas 2026 Form K-40ES, tax computation schedules, upper rate
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -92,6 +94,7 @@ rules:
     unit: USD
     source: Kansas 2026 Form K-40ES, Schedule I joint lower-bracket ceiling
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -111,6 +114,7 @@ rules:
     unit: USD
     source: Kansas 2026 Form K-40ES, Schedule II nonjoint lower-bracket ceiling
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -131,6 +135,7 @@ rules:
     unit: USD
     source: Kansas 2026 Form K-40ES line 5, supplied completed-return Kansas taxable income
     metadata:
+      private: true
       proof:
         atoms:
           - path: versions[0].formula
@@ -173,3 +178,16 @@ rules:
           else:
             ks_pit_2026_k40es_lower_rate * min(ks_pit_2026_k40es_taxable_income_boundary, ks_pit_2026_k40es_other_lower_bracket_ceiling)
             + ks_pit_2026_k40es_upper_rate * max(0, ks_pit_2026_k40es_taxable_income_boundary - ks_pit_2026_k40es_other_lower_bracket_ceiling)
+
+inputs:
+  - name: ks_pit_2026_k40es_completed_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed Kansas taxable income supplied by the caller as an upstream return boundary.
+  - name: ks_pit_2026_k40es_married_joint_schedule_applies
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    description: Caller classification that the Kansas married-joint K-40ES schedule applies to the completed return.


### PR DESCRIPTION
## Summary

- add a canonical, bounded Kansas TY2026 K-40ES schedule-before-credits module
- expose one public schedule output backed by five private schedule helpers and two explicit typed inputs
- preserve the existing pilot and broader full-year resident core unchanged
- add a wrapper-signed applied manifest, regenerate the reverse index, and add six pending oracle IDs (`2230 → 2236`)

This module accepts completed-return Kansas taxable income plus the caller determination that the married-joint schedule applies. It does not claim to construct taxable income or compute credits, payments, return ordering, or final annual liability.

## Validation

- exact protected engine `ffd8213271947b0189a9dd61a055c1e0e78908a0`
- compile: exactly 6 rules
- companion fixtures: 8/8 pass
- proof validation: 7 atoms, 0 missing money obligations
- signed-manifest guard PASS before and after the fix commit
- reverse index current: 4,232 provisions / 5,055 edges / 4,481 modules
- pending ledger sorted/unique; count equals ceiling 2,236
- focused repository suite: 52 passed
- diff check clean

## Review cycle

Initial independent review found two interface defects: helper visibility and missing typed input declarations. Both were fixed, the module was re-signed, all focused checks were rerun, and exact-head re-review is CLEAN at `32005465cd33af61ee0c4642651483aa276998ae`.