### PR TITLE
NY TANF: clamp grant-schedule lookups to the table's domain

### DIFF
--- a/us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml
+++ b/us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml
@@ -88,7 +88,7 @@ rules:
     versions:
       - effective_from: '2012-10-01'
         formula: |-
-          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: regular_recurring_monthly_need_schedule[number_of_persons_in_household] else: regular_recurring_monthly_need_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * regular_recurring_monthly_need_each_additional_person)
+          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: regular_recurring_monthly_need_schedule[max(number_of_persons_in_household, 1)] else: regular_recurring_monthly_need_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * regular_recurring_monthly_need_each_additional_person)
 
   - name: monthly_grant_and_allowance_exclusive_of_home_energy_schedule
     kind: parameter
@@ -154,7 +154,7 @@ rules:
     versions:
       - effective_from: '2012-10-01'
         formula: |-
-          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_grant_and_allowance_exclusive_of_home_energy_schedule[number_of_persons_in_household] else: monthly_grant_and_allowance_exclusive_of_home_energy_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_grant_and_allowance_each_additional_person)
+          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_grant_and_allowance_exclusive_of_home_energy_schedule[max(number_of_persons_in_household, 1)] else: monthly_grant_and_allowance_exclusive_of_home_energy_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_grant_and_allowance_each_additional_person)
 
   - name: monthly_home_energy_payment_schedule
     kind: parameter
@@ -220,7 +220,7 @@ rules:
     versions:
       - effective_from: '1981-07-01'
         formula: |-
-          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_home_energy_payment_schedule[number_of_persons_in_household] else: monthly_home_energy_payment_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_home_energy_payment_each_additional_person)
+          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_home_energy_payment_schedule[max(number_of_persons_in_household, 1)] else: monthly_home_energy_payment_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_home_energy_payment_each_additional_person)
 
   - name: monthly_supplemental_home_energy_payment_schedule
     kind: parameter
@@ -286,7 +286,7 @@ rules:
     versions:
       - effective_from: '1986-01-01'
         formula: |-
-          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_supplemental_home_energy_payment_schedule[number_of_persons_in_household] else: monthly_supplemental_home_energy_payment_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_supplemental_home_energy_payment_each_additional_person)
+          if number_of_persons_in_household <= household_size_threshold_for_each_additional_person: monthly_supplemental_home_energy_payment_schedule[max(number_of_persons_in_household, 1)] else: monthly_supplemental_home_energy_payment_schedule[household_size_threshold_for_each_additional_person] + ((number_of_persons_in_household - household_size_threshold_for_each_additional_person) * monthly_supplemental_home_energy_payment_each_additional_person)
 
   - name: monthly_grant_and_allowance_with_home_energy
     kind: derived


### PR DESCRIPTION
## Problem
`us-ny/tanf` is the last package on axiom-api's known-unexecutable list: its sample request fails with `parameter monthly_grant_and_allowance_exclusive_of_home_energy_schedule has no value for key 0`. The four monthly schedules in `standard-of-need-and-monthly-grant.yaml` are keyed 1–6, but each below-threshold lookup indexes with raw `number_of_persons_in_household`, which defaults to 0 when unanswered.

## Fix
Clamp each lookup index with `max(number_of_persons_in_household, 1)` — the same table-domain clamp the federal SNAP encodings use (`snap_maximum_allotment_table[max(min(household_size, 8), 1)]`). Behavior for sizes ≥ 1 is unchanged; the above-threshold additional-person arithmetic is untouched.

## After merge
Program-artifacts release → bump the artifact pin in axiom-api, regenerate the registry, redeploy the Modal runtime, and delist `us-ny/tanf` from `data/known-unexecutable-packages.json` (the fleet-smoke ratchet will demand the delisting once it executes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)