### PR TITLE
Pin Kansas oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@27ed35874b219a8596601260fdf0720ed0b603a4 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@9ccbc5799ce062649a7b4dff255123279c7a9eb0 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- pin the repository validation caller to shared-workflow merge `9ccbc5799ce062649a7b4dff255123279c7a9eb0`
- carry the merged Kansas encoder bundle into the full RuleSpec validation matrix

## Validation
- caller workflow YAML parses
- shared merge object and parentage verified
- diff check passed

## Review cycle
Independent lightweight review of exact head `9d2234f217ec7dbca64dfc172caf1195b4235455` found no actionable findings and confirmed the exact one-line/one-file scope, Kansas canonical base, valid YAML, and clean worktree.