### PR TITLE
Drain Kansas oracle coverage pending entries

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2299
+ceiling: 2286
 entries:
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
@@ -845,45 +845,6 @@ entries:
 - legal_id: us-ia:statutes/422/12C#refundable_excess_credit_amount
   source: bulk
   since: '2026-07-08'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_joint_lower_bracket_ceiling
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_lower_rate
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_other_lower_bracket_ceiling
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_schedule_before_credits
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_taxable_income_boundary
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/2026_k40es_schedule_before_credits#ks_pit_2026_k40es_upper_rate
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_income_tax_liability
-  source: manual
-  since: '2026-07-16'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_joint_lower_bracket_ceiling
-  source: manual
-  since: '2026-07-21'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_lower_rate
-  source: manual
-  since: '2026-07-21'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_other_lower_bracket_ceiling
-  source: manual
-  since: '2026-07-21'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_schedule_tax
-  source: manual
-  since: '2026-07-16'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_taxable_income
-  source: manual
-  since: '2026-07-16'
-- legal_id: us-ks:policies/income_tax/pilot_liability_pipeline#ks_pit_pilot_upper_rate
-  source: manual
-  since: '2026-07-21'
 - legal_id: us-ky:statutes/11/141/020#part_year_resident_allowable_tax_credits
   source: bulk
   since: '2026-07-08'


### PR DESCRIPTION
## Summary
- remove the six canonical Kansas K-40ES pending declarations now classified by merged exact mappings
- remove the seven legacy Kansas pilot declarations now classified by the jurisdiction fallback
- lower the pending ceiling from 2299 to 2286

## Validation
- merged classifier: 21,779 outputs; comparable 995; known-not-comparable 18,543; pending 2,241
- pending ledger: 2,286 declared, 2,241 applied, 45 pre-existing stale
- Kansas stale: 0
- preserved unrelated stale groups: Mississippi 4, Utah 41
- YAML count/schema/order and diff checks passed

## Review cycle
Independent exact-head review of `66d5062666da4d722d05e154629338c06c71e22e` found no actionable findings and confirmed the exact one-file/13-row scope, ceiling integrity, merged-classifier result, and clean worktree.