### PR TITLE
Bump axiom-corpus pin to bf97b17ba (Part 416 + Notice 2025-67)

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "f7fe8471c415908b26cfac1e199e92d1580c8ff3"
+axiom_corpus_ref = "bf97b17baebfdf12601f7c23697524bf5adcdaed"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Pin-only PR (#999 pattern): bumps `axiom_corpus_ref` to axiom-corpus merge commit `bf97b17ba` — brings in **axiom-corpus#506** (20 CFR Part 416 deeming slice + IRS Notice 2025-67, both ingest-manifest-signed, round-3 review APPROVE).

Unblocks on this repo:
- saver's credit compose revival (Notice 2025-67 tier tables now in pinned corpus)
- SSI §1382c(f) deeming encode (Part 416 subpart-K slice now pinned)

No other changes. Toolchain edit is authorized here because this is a dedicated pin-only PR (.github#39 discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)