### PR TITLE
Add canonical DC 2026 statutory schedule

### DIFF
--- a/.axiom/encoding-manifests/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.json
+++ b/.axiom/encoding-manifests/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml",
+      "sha256": "32780aa706224430d20480f545d9d359f308393f3d912adde30db15f2023693f"
+    },
+    {
+      "path": "us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
+      "sha256": "5bec93bebb29e6736d28dff94bd49b173bb8d4e8dc74dec0725df77acc23d84c"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T15:21:40.654039+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3qthn1p0/sign-applied-files/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3qthn1p0",
+  "generated_output_sha256": "5bec93bebb29e6736d28dff94bd49b173bb8d4e8dc74dec0725df77acc23d84c",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "c6872c90dfe91e84ddf5dc0896019987b34a86ec72e40e106a1936d5f4e9a00f"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.json
+++ b/.axiom/encoding-manifests/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml",
-      "sha256": "32780aa706224430d20480f545d9d359f308393f3d912adde30db15f2023693f"
+      "sha256": "9857de5fb649647c1c338f945762096539da998ab5e499618419ae1d7a848c2b"
     },
     {
       "path": "us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
@@ -21,9 +21,9 @@
   "citation": "us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T15:21:40.654039+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3qthn1p0/sign-applied-files/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp3qthn1p0",
+  "generated_at": "2026-07-27T15:38:47.465039+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpz2qmbye4/sign-applied-files/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpz2qmbye4",
   "generated_output_sha256": "5bec93bebb29e6736d28dff94bd49b173bb8d4e8dc74dec0725df77acc23d84c",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c6872c90dfe91e84ddf5dc0896019987b34a86ec72e40e106a1936d5f4e9a00f"
+    "value": "f3290a6f92371d9c375294bd63676299ae4cc1d79a14bebbc0d227a2b2120845"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T15:21:40.654039+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "6e3857cdc2cbe9ac2efd6f760ca870ed66b21c5196af3cdfe53dfa1b336aa189",
+    "prior_signature": "c6872c90dfe91e84ddf5dc0896019987b34a86ec72e40e106a1936d5f4e9a00f",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16630,6 +16630,13 @@
         ]
       },
       {
+        "module": "us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
         "module": "us-dc/policies/income_tax/pilot_liability_pipeline.yaml",
         "via": [
           "module",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,8 +6,29 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2286
+ceiling: 2293
 entries:
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_base
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_floor
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_rate
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_upper
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits
+  source: manual
+  since: '2026-07-27'
+- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_taxable_income_boundary
+  source: manual
+  since: '2026-07-27'
 - legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
   source: manual
   since: '2026-07-22'

--- a/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml
+++ b/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml
@@ -1,0 +1,164 @@
+# Expected values use independent decimal arithmetic from D.C. Code section
+# 47-1806.03(a)(11). Every transition is tested at its published upper bound
+# and one dollar into the next band, with an interior case in every band.
+
+- name: negative completed boundary normalizes to zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: -1
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_taxable_income_boundary: '0'
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 0
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '0'
+
+- name: first band interior 5000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 5000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 0
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '200'
+
+- name: first band upper 10000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 10000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 0
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '400'
+
+- name: second band lower 10001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 10001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 1
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '400.06'
+
+- name: second band interior 25000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 25000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 1
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '1300'
+
+- name: second band upper 40000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 40000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 1
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '2200'
+
+- name: third band lower 40001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 40001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 2
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '2200.065'
+
+- name: third band interior 50000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 50000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 2
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '2850'
+
+- name: third band upper 60000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 60000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 2
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '3500'
+
+- name: fourth band lower 60001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 60001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 3
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '3500.085'
+
+- name: fourth band interior 100000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 100000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 3
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '6900'
+
+- name: fourth band upper 250000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 250000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 3
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '19650'
+
+- name: fifth band lower 250001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 250001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 4
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '19650.0925'
+
+- name: fifth band interior 375000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 375000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 4
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '31212.5'
+
+- name: fifth band upper 500000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 500000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 4
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '42775'
+
+- name: sixth band lower 500001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 500001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 5
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '42775.0975'
+
+- name: sixth band interior 750000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 750000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 5
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '67150'
+
+- name: sixth band upper 1000000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 1000000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 5
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '91525'
+
+- name: seventh band lower 1000001
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 1000001
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 6
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '91525.1075'
+
+- name: seventh band interior 1500000
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 1500000
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 6
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '145275'

--- a/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml
+++ b/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.test.yaml
@@ -11,6 +11,15 @@
     us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 0
     us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '0'
 
+- name: zero completed boundary remains zero
+  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+  input:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#input.dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income: 0
+  output:
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_taxable_income_boundary: '0'
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector: 0
+    us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits: '0'
+
 - name: first band interior 5000
   period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
   input:

--- a/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml
+++ b/us-dc/policies/income_tax/2026_section_47_1806_03_schedule_before_credits.yaml
@@ -1,0 +1,265 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us-dc/statute/47/47-1806.03/block-1
+      rationale: |-
+        D.C. Code section 47-1806.03(a)(11) imposes the seven-band
+        individual-income-tax schedule for taxable years beginning after
+        December 31, 2021. The populated official corpus block supplies every
+        upper bound, excess-over floor, cumulative base amount, and marginal
+        rate used here.
+
+        This bounded tax-year-2026 composition accepts only a completed
+        joint-method District taxable-income amount and applies that statutory
+        schedule. "Joint method" identifies the caller-owned computation
+        boundary and does not assert that this module determines filing method
+        or filing status. The module does not construct District taxable
+        income; select between joint and separate-return computations; apply
+        the optional Mayor-prescribed tax table; or cover deductions,
+        exemptions, credits, payments, rounding, residency, allocation,
+        return ordering, or final liability.
+  summary: |-
+    Canonical bounded District of Columbia tax-year-2026 section
+    47-1806.03(a)(11) schedule before credits. The caller supplies one
+    TaxUnit-level completed joint-method District taxable-income amount. The
+    module floors that boundary at zero and applies all seven statutory bands,
+    preserving the published cumulative base amounts.
+
+    The sole public output is a direct statutory schedule component. It is not
+    a complete D-40 calculation, an election between joint and separate-return
+    methods, tax-table tax, tax after credits, or final liability.
+  deferred_outputs:
+    - output: us-dc:statutes/47/47-1806.03/b#mayor_tax_table_election_tax
+      reason: |-
+        Subsection (b)'s optional Mayor-prescribed tax-table filing method,
+        including any table minimum and rounding mechanics, is outside this
+        direct subsection (a)(11) statutory-rate schedule.
+    - output: us-dc:statutes/47/47-1806.03/c#single_person_classification
+      reason: |-
+        Subsection (c)'s spouse or domestic-partner living-arrangement
+        classification is outside the completed joint-method taxable-income
+        boundary accepted by this module.
+    - output: us-dc:statutes/47/47-1806.03/d#section_applies_to_return
+      reason: |-
+        Subsection (d)'s fiduciary and spouse or domestic-partner return
+        applicability rules require return relationships outside this
+        schedule-only module.
+    - output: us-dc:statutes/47/47-1806.03/e#separate_return_single_person_treatment
+      reason: |-
+        Subsection (e)'s separate-return election and spouse or
+        domestic-partner treatment are outside the caller-completed
+        joint-method taxable-income boundary.
+rules:
+  - name: dc_pit_2026_section_47_1806_03_bracket_upper
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_2026_section_47_1806_03_bracket_selector
+    source: D.C. Code section 47-1806.03(a)(11), statutory bracket upper bounds
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $500,000 but not over $1,000,000 $42,775, plus 9.75% of the excess over $500,000"
+              table:
+                header: "tax determined in accordance with the following table"
+                row_key: taxable income band
+                column_key: upper bound
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 10000
+          1: 40000
+          2: 60000
+          3: 250000
+          4: 500000
+          5: 1000000
+
+  - name: dc_pit_2026_section_47_1806_03_bracket_floor
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_2026_section_47_1806_03_bracket_selector
+    source: D.C. Code section 47-1806.03(a)(11), statutory excess-over floors
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $1,000,000 $91,525, plus 10.75% of the excess over $1,000,000"
+              table:
+                header: "tax determined in accordance with the following table"
+                row_key: taxable income band
+                column_key: excess-over floor
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 10000
+          2: 40000
+          3: 60000
+          4: 250000
+          5: 500000
+          6: 1000000
+
+  - name: dc_pit_2026_section_47_1806_03_bracket_base
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: USD
+    indexed_by: dc_pit_2026_section_47_1806_03_bracket_selector
+    source: D.C. Code section 47-1806.03(a)(11), statutory cumulative base amounts
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $250,000 but not over $500,000 $19,650, plus 9.25% of the excess over $250,000"
+              table:
+                header: "tax determined in accordance with the following table"
+                row_key: taxable income band
+                column_key: cumulative base
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0
+          1: 400
+          2: 2200
+          3: 3500
+          4: 19650
+          5: 42775
+          6: 91525
+
+  - name: dc_pit_2026_section_47_1806_03_bracket_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    indexed_by: dc_pit_2026_section_47_1806_03_bracket_selector
+    source: D.C. Code section 47-1806.03(a)(11), statutory marginal rates
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $40,000 but not over $60,000 $2,200, plus 6.5% of the excess over $40,000"
+              table:
+                header: "tax determined in accordance with the following table"
+                row_key: taxable income band
+                column_key: marginal rate
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        values:
+          0: 0.04
+          1: 0.06
+          2: 0.065
+          3: 0.085
+          4: 0.0925
+          5: 0.0975
+          6: 0.1075
+
+  - name: dc_pit_2026_section_47_1806_03_taxable_income_boundary
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: D.C. Code section 47-1806.03(a)(11), caller-supplied completed joint-method taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "there is imposed on the taxable income of every resident a tax determined in accordance with the following table"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: max(0, dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income)
+
+  - name: dc_pit_2026_section_47_1806_03_bracket_selector
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: D.C. Code section 47-1806.03(a)(11), statutory band selected from taxable income
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "In the case of taxable years beginning after December 31, 2021"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[0]: 0
+          else: if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[1]: 1
+          else: if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[2]: 2
+          else: if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[3]: 3
+          else: if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[4]: 4
+          else: if dc_pit_2026_section_47_1806_03_taxable_income_boundary <= dc_pit_2026_section_47_1806_03_bracket_upper[5]: 5
+          else: 6
+
+  - name: dc_pit_2026_section_47_1806_03_schedule_before_credits
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: D.C. Code section 47-1806.03(a)(11), direct statutory schedule before credits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-dc/statute/47/47-1806.03/block-1
+              excerpt: "Over $1,000,000 $91,525, plus 10.75% of the excess over $1,000,000"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          dc_pit_2026_section_47_1806_03_bracket_base[dc_pit_2026_section_47_1806_03_bracket_selector]
+          + dc_pit_2026_section_47_1806_03_bracket_rate[dc_pit_2026_section_47_1806_03_bracket_selector]
+          * (
+            dc_pit_2026_section_47_1806_03_taxable_income_boundary
+            - dc_pit_2026_section_47_1806_03_bracket_floor[dc_pit_2026_section_47_1806_03_bracket_selector]
+          )
+
+inputs:
+  - name: dc_pit_2026_section_47_1806_03_completed_joint_method_taxable_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Completed joint-method District taxable income supplied by the caller as an upstream computation boundary.


### PR DESCRIPTION
## Summary
- add a bounded canonical TY2026 D.C. Code §47-1806.03(a)(11) seven-band joint-method schedule before credits
- expose one public schedule output over one caller-supplied completed joint-method taxable-income input, with six private helpers
- add 21 boundary/interior vectors, signed manifest, reverse-index entry, and seven pending oracle IDs

## Scope
This does not claim a complete D-40 calculation, taxable-income construction, joint/separate method selection, optional tax-table computation, deductions, exemptions, credits, payments, or final liability. Existing DC pilot and source-hold modules are unchanged.

## Validation
- full repository tests: 65 passed
- protected engine: 7 rules compiled; 21 companion cases passed
- proof validation: 7 atoms; 0 of 3 monetary obligations missing
- signed-manifest guard, reverse-index regeneration, repository layout, diff, and deterministic validation passed

## Review cycle
Independent review of `1733a8d593173f9149d3f113509fc4cee60703e5` found one actionable missing zero-input vector. Follow-up `db269ea73bb5afd15f9d1c902dd70ab25802d744` added the exact zero case and re-signed the manifest. Focused re-review was CLEAN with no remaining actionable findings.