### PR TITLE
Compose the 2026 saver's credit grounded in Notice 2025-67

### DIFF
--- a/.axiom/encoding-manifests/us/policies/income_tax/savers_credit_pipeline.json
+++ b/.axiom/encoding-manifests/us/policies/income_tax/savers_credit_pipeline.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/income_tax/savers_credit_pipeline.test.yaml",
+      "sha256": "513552f93d4756bd21846d9a56e2ca6c346d3c92cb96de0fb1e148bbe608122c"
+    },
+    {
+      "path": "us/policies/income_tax/savers_credit_pipeline.yaml",
+      "sha256": "87a3bf8d1d656597d3818c4cd7eb75f685ed5e7e418e58662c81d6a2f6e10372"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:policies/income_tax/savers_credit_pipeline",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T17:36:00.585552+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy3_ay73i/sign-applied-files/us/policies/income_tax/savers_credit_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy3_ay73i",
+  "generated_output_sha256": "87a3bf8d1d656597d3818c4cd7eb75f685ed5e7e418e58662c81d6a2f6e10372",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "838a2029dae8b6a6ebda940706625f338fe0a509e756c7661f1f4eddc0984412"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us/policies/irs/notice-2025-67/savers-credit.json
+++ b/.axiom/encoding-manifests/us/policies/irs/notice-2025-67/savers-credit.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/irs/notice-2025-67/savers-credit.test.yaml",
+      "sha256": "45786d0c6888bd5e7675b866ab893b8bcebdde9fa99a54319ebb7db796cccac9"
+    },
+    {
+      "path": "us/policies/irs/notice-2025-67/savers-credit.yaml",
+      "sha256": "40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:policies/irs/notice-2025-67/savers-credit",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T17:36:00.587025+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy3_ay73i/sign-applied-files/us/policies/irs/notice-2025-67/savers-credit.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpy3_ay73i",
+  "generated_output_sha256": "40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "7324b0a3ff9976a71554610810cdebb1900c2a49d73091029bf5c6d6ccaa871f"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35399,6 +35399,38 @@
         ]
       }
     ],
+    "us/guidance/irs/notice-2025-67/page-3": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/policies/irs/notice-2025-67/savers-credit.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/guidance/irs/notice-2025-67/page-4": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/policies/irs/notice-2025-67/savers-credit.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/guidance/irs/rev-proc-2025-25": [
       {
         "module": "us/policies/aca/ptc_pipeline.yaml",
@@ -38297,6 +38329,48 @@
     "us/statute/26/25B": [
       {
         "module": "us/statutes/26/25B.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/25B/a": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/25B/b": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/policies/irs/notice-2025-67/savers-credit.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
+    "us/statute/26/25B/c": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/25B/e": [
+      {
+        "module": "us/policies/income_tax/savers_credit_pipeline.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2293
+ceiling: 2313
 entries:
 - legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_base
   source: manual
@@ -3992,6 +3992,39 @@ entries:
 - legal_id: us:policies/income_tax/qualified_business_income_deduction_pipeline#pipeline_trade_or_business_phasein_reduction
   source: manual
   since: '2026-07-23'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#federal_savers_credit
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_10_percent_agi_limit
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_20_percent_agi_limit
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_50_percent_agi_limit
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_filing_status_is_enumerated
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_modified_adjusted_gross_income
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_contributions_taken_into_account
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_contributions_taken_into_account
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_eligible
+  source: manual
+  since: '2026-07-27'
 - legal_id: us:policies/income_tax/self_employment_tax_pipeline#contribution_and_benefit_base_effective_for_calendar_year_in_which_taxable_year_begins
   source: manual
   since: '2026-07-23'
@@ -4025,6 +4058,33 @@ entries:
 - legal_id: us:policies/income_tax/self_employment_tax_pipeline#self_employment_tax_pipeline_person_is_included
   source: manual
   since: '2026-07-23'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_head_of_household
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_joint
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_all_other
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_head_of_household
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_joint
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_all_other
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_head_of_household
+  source: manual
+  since: '2026-07-27'
+- legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_joint
+  source: manual
+  since: '2026-07-27'
 - legal_id: us:policies/irs/rev-proc-2025-32/qualified-business-income#qualified_business_income_phase_in_range_end_all_other
   source: manual
   since: '2026-07-23'

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -3995,13 +3995,13 @@ entries:
 - legal_id: us:policies/income_tax/savers_credit_pipeline#federal_savers_credit
   source: manual
   since: '2026-07-27'
-- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_10_percent_agi_limit
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_10_applicable_ceiling_for_return_category
   source: manual
   since: '2026-07-27'
-- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_20_percent_agi_limit
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_20_applicable_ceiling_for_return_category
   source: manual
   since: '2026-07-27'
-- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_50_percent_agi_limit
+- legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category
   source: manual
   since: '2026-07-27'
 - legal_id: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage

--- a/us/policies/income_tax/savers_credit_pipeline.test.yaml
+++ b/us/policies/income_tax/savers_credit_pipeline.test.yaml
@@ -1,0 +1,378 @@
+# Hand-computed tax-year-2026 fixtures for 26 USC 25B and IRS Notice 2025-67.
+# Every exact upper-limit case below applies section 25B(b)'s inclusive
+# "not over" grammar. PolicyEngine #9151 digitizes these limits exclusively,
+# so exact-limit cases are intentional statute-first oracle divergences.
+#
+# Each per-person contribution is the completed net section 25B(d) amount
+# after testing-period distributions and exceptions. Every zero exclusion is
+# an explicit fact; the pipeline itself supplies no default for sections 911,
+# 931, or 933.
+
+- name: single-at-50-percent-limit-inclusive
+  period: &tax_year_2026
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    <<: &eligible_common
+      us:policies/income_tax/savers_credit_pipeline#input.section_911_excluded_income: 0
+      us:policies/income_tax/savers_credit_pipeline#input.section_931_excluded_income: 0
+      us:policies/income_tax/savers_credit_pipeline#input.section_933_excluded_income: 0
+      us:policies/income_tax/savers_credit_pipeline#input.primary_age_at_close_of_taxable_year: 30
+      us:policies/income_tax/savers_credit_pipeline#input.primary_is_student_under_section_152_f_2: false
+      us:policies/income_tax/savers_credit_pipeline#input.primary_may_be_claimed_as_dependent_by_another_taxpayer: false
+      us:policies/income_tax/savers_credit_pipeline#input.spouse_age_at_close_of_taxable_year: 30
+      us:policies/income_tax/savers_credit_pipeline#input.spouse_is_student_under_section_152_f_2: false
+      us:policies/income_tax/savers_credit_pipeline#input.spouse_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 24250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_modified_adjusted_gross_income: '24250'
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category: 24250
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_20_applicable_ceiling_for_return_category: 26250
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_10_applicable_ceiling_for_return_category: 40250
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_filing_status_is_enumerated: holds
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.5'
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible: holds
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_eligible: not_holds
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_contributions_taken_into_account: '2000'
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_contributions_taken_into_account: '0'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '1000'
+
+- name: single-one-over-50-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 24251
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: single-at-20-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 26250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: single-one-over-20-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 26251
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: single-at-10-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 40250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: single-one-over-10-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 40251
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: 0
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'
+
+- name: joint-at-50-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 48500
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category: 48500
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_20_applicable_ceiling_for_return_category: 52500
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_10_applicable_ceiling_for_return_category: 80500
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.5'
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_eligible: holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '1000'
+
+- name: joint-one-over-50-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 48501
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: joint-at-20-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 52500
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: joint-one-over-20-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 52501
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: joint-at-10-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 80500
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: joint-one-over-10-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 80501
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: 0
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'
+
+- name: head-of-household-at-50-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 36375
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category: 36375
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_20_applicable_ceiling_for_return_category: 39375
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_10_applicable_ceiling_for_return_category: 60375
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.5'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '1000'
+
+- name: head-of-household-one-over-50-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 36376
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: head-of-household-at-20-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 39375
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: head-of-household-one-over-20-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 39376
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: head-of-household-at-10-percent-limit-inclusive
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 60375
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.1'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '200'
+
+- name: head-of-household-one-over-10-percent-limit
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 3
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 60376
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: 0
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'
+
+- name: married-filing-separately-uses-all-other-limits
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 2
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 24250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 2000
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category: 24250
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_eligible: not_holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '1000'
+
+- name: surviving-spouse-uses-all-other-limits
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 4
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 24250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category: 24250
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '1000'
+
+- name: section-911-add-back-crosses-inclusive-limit
+  # Ordinary AGI is at the 50-percent ceiling, but $1 excluded under section
+  # 911 produces section 25B AGI of $24,251 and therefore the 20-percent tier.
+  period: *tax_year_2026
+  input:
+    us:policies/income_tax/savers_credit_pipeline#input.section_911_excluded_income: 1
+    us:policies/income_tax/savers_credit_pipeline#input.section_931_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_933_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.primary_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.primary_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.primary_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 24250
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_modified_adjusted_gross_income: '24251'
+    us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_applicable_percentage: '0.2'
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '400'
+
+- name: joint-separate-cap-for-each-spouse
+  # Each $5,000 contribution is independently limited to $2,000:
+  # 50% * ($2,000 primary + $2,000 spouse) = $2,000.
+  period: *tax_year_2026
+  input:
+    <<: *eligible_common
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 1
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 40000
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 5000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 5000
+  output:
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_contributions_taken_into_account: '2000'
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_contributions_taken_into_account: '2000'
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible: holds
+    us:policies/income_tax/savers_credit_pipeline#spouse_savers_credit_eligible: holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '2000'
+
+- name: age-screen
+  period: *tax_year_2026
+  input:
+    us:policies/income_tax/savers_credit_pipeline#input.section_911_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_931_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_933_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.primary_age_at_close_of_taxable_year: 17
+    us:policies/income_tax/savers_credit_pipeline#input.primary_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.primary_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 20000
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible: not_holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'
+
+- name: student-screen
+  period: *tax_year_2026
+  input:
+    us:policies/income_tax/savers_credit_pipeline#input.section_911_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_931_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_933_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.primary_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.primary_is_student_under_section_152_f_2: true
+    us:policies/income_tax/savers_credit_pipeline#input.primary_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 20000
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible: not_holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'
+
+- name: dependent-screen
+  period: *tax_year_2026
+  input:
+    us:policies/income_tax/savers_credit_pipeline#input.section_911_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_931_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.section_933_excluded_income: 0
+    us:policies/income_tax/savers_credit_pipeline#input.primary_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.primary_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.primary_may_be_claimed_as_dependent_by_another_taxpayer: true
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_age_at_close_of_taxable_year: 30
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_is_student_under_section_152_f_2: false
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_may_be_claimed_as_dependent_by_another_taxpayer: false
+    us:policies/income_tax/savers_credit_pipeline#input.filing_status: 0
+    us:policies/income_tax/savers_credit_pipeline#input.adjusted_gross_income: 20000
+    us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions: 2000
+    us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions: 0
+  output:
+    us:policies/income_tax/savers_credit_pipeline#primary_savers_credit_eligible: not_holds
+    us:policies/income_tax/savers_credit_pipeline#federal_savers_credit: '0'

--- a/us/policies/income_tax/savers_credit_pipeline.yaml
+++ b/us/policies/income_tax/savers_credit_pipeline.yaml
@@ -1,0 +1,622 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us/statute/26/25B/a
+      - us/statute/26/25B/b
+      - us/statute/26/25B/c
+      - us/statute/26/25B/e
+      - us/guidance/irs/notice-2025-67/page-3
+      - us/guidance/irs/notice-2025-67/page-4
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/26/25B/a
+        - us/statute/26/25B/b
+        - us/statute/26/25B/c
+        - us/statute/26/25B/e
+        - us/guidance/irs/notice-2025-67/page-3
+        - us/guidance/irs/notice-2025-67/page-4
+      rationale: |-
+        Section 25B supplies the 50-, 20-, 10-, and zero-percent rates, the
+        $2,000 contribution cap for each eligible individual, the eligibility
+        screens, the modified-AGI rule, and the inflation-adjustment method.
+        IRS Notice 2025-67 supplies the official tax-year-2026 AGI tier limits.
+        This module imports all nine grounded notice parameters and selects
+        among joint, head-of-household, and all-other limits from its declared
+        filing-status boundary.
+  summary: |-
+    Federal retirement savings contributions credit composition under
+    26 USC 25B for tax year 2026, before the aggregate limitation under
+    section 26. It imports the encoded statutory rates, individual
+    contribution cap, and minimum age, then wires the credit at TaxUnit level
+    using separate primary- and spouse-level eligibility facts and qualified
+    net contributions.
+
+    The encoded section exposes `savers_credit` as a TaxUnit scalar. That
+    output applies only one $2,000 cap and one eligibility screen, so it cannot
+    implement section 25B(a)'s per-eligible-individual cap on a joint return.
+    Its dependent screen also imports ordinary section 151 exemption
+    eligibility rather than whether another taxpayer may claim the
+    individual. A thin identity would therefore understate the P6 joint case
+    and would not faithfully implement section 25B(c).
+
+    Adjusted gross income plus sections 911, 931, and 933 excluded income is
+    computed locally, matching section 25B(e). Each exclusion is a required,
+    explicit input with no default: a caller may supply zero only as the
+    affirmative fact that no amount was excluded under that section.
+    Caller-supplied per-person qualified retirement savings contributions are
+    completed section 25B(d) amounts after testing-period distributions and
+    statutory exceptions.
+  deferred_outputs:
+    - output: us:statutes/26/25B#savers_credit
+      reason: |-
+        The encoded TaxUnit scalar applies one individual cap and eligibility
+        screen. Section 25B(a) instead allows each eligible spouse on a joint
+        return a separately capped contribution amount. The corrected pipeline
+        output below composes two explicit individual legs.
+      source_values:
+        - us:policies/income_tax/savers_credit_pipeline#input.primary_qualified_retirement_savings_contributions
+        - us:policies/income_tax/savers_credit_pipeline#input.spouse_qualified_retirement_savings_contributions
+    - output: us:statutes/26/25B/d#per_person_qualified_retirement_savings_contribution_composition
+      reason: |-
+        Contribution-category, testing-period-distribution, rollover, and
+        spouse-distribution attribution must be resolved separately for each
+        individual. This TaxUnit pipeline accepts each person's completed net
+        section 25B(d) amount and does not treat missing distributions as zero.
+imports:
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_joint
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_joint
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_joint
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_head_of_household
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_head_of_household
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_head_of_household
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_all_other
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_all_other
+  - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
+  - us:statutes/26/25B#savers_credit_contribution_cap
+  - us:statutes/26/25B#savers_credit_age_threshold
+  - us:statutes/26/25B#savers_credit_high_rate
+  - us:statutes/26/25B#savers_credit_middle_rate
+  - us:statutes/26/25B#savers_credit_low_rate
+  - us:statutes/26/25B#savers_credit_zero_rate
+rules:
+  - name: pipeline_savers_credit_modified_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 25B(e), AGI determined without regard to sections 911, 931, and 933
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/25B/e
+              excerpt: "determined without regard to sections 911, 931, and 933"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          adjusted_gross_income
+          + section_911_excluded_income
+          + section_931_excluded_income
+          + section_933_excluded_income
+
+  - name: pipeline_tier_50_applicable_ceiling_for_return_category
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IRS Notice 2025-67, applicable tax-year-2026 section 25B 50-percent AGI limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_joint
+              output: savers_credit_50_percent_agi_limit_joint
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_head_of_household
+              output: savers_credit_50_percent_agi_limit_head_of_household
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_all_other
+              output: savers_credit_50_percent_agi_limit_all_other
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          match filing_status:
+              0 => savers_credit_50_percent_agi_limit_all_other
+              1 => savers_credit_50_percent_agi_limit_joint
+              2 => savers_credit_50_percent_agi_limit_all_other
+              3 => savers_credit_50_percent_agi_limit_head_of_household
+              4 => savers_credit_50_percent_agi_limit_all_other
+
+  - name: pipeline_tier_20_applicable_ceiling_for_return_category
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IRS Notice 2025-67, applicable tax-year-2026 section 25B 20-percent AGI limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_joint
+              output: savers_credit_20_percent_agi_limit_joint
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_head_of_household
+              output: savers_credit_20_percent_agi_limit_head_of_household
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_all_other
+              output: savers_credit_20_percent_agi_limit_all_other
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          match filing_status:
+              0 => savers_credit_20_percent_agi_limit_all_other
+              1 => savers_credit_20_percent_agi_limit_joint
+              2 => savers_credit_20_percent_agi_limit_all_other
+              3 => savers_credit_20_percent_agi_limit_head_of_household
+              4 => savers_credit_20_percent_agi_limit_all_other
+
+  - name: pipeline_tier_10_applicable_ceiling_for_return_category
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: IRS Notice 2025-67, applicable tax-year-2026 section 25B 10-percent AGI limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_joint
+              output: savers_credit_10_percent_agi_limit_joint
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_head_of_household
+              output: savers_credit_10_percent_agi_limit_head_of_household
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
+              output: savers_credit_10_percent_agi_limit_all_other
+              hash: sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          match filing_status:
+              0 => savers_credit_10_percent_agi_limit_all_other
+              1 => savers_credit_10_percent_agi_limit_joint
+              2 => savers_credit_10_percent_agi_limit_all_other
+              3 => savers_credit_10_percent_agi_limit_head_of_household
+              4 => savers_credit_10_percent_agi_limit_all_other
+
+  - name: pipeline_savers_credit_filing_status_is_enumerated
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: Declared filing-status boundary mapped to the Notice 2025-67 return categories
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "for married taxpayers filing a joint return"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "household is increased from $35,625 to $36,375"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "for all other taxpayers"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          filing_status == 0
+          or filing_status == 1
+          or filing_status == 2
+          or filing_status == 3
+          or filing_status == 4
+
+  - name: pipeline_savers_credit_applicable_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 25B(b), using the applicable IRS Notice 2025-67 tax-year-2026 limits
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/25B/b
+              excerpt: "if the adjusted gross income of the taxpayer is not over $30,000, 50 percent"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/25B/b
+              excerpt: "if the adjusted gross income of the taxpayer is over $30,000 but not over $32,500, 20 percent"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/25B/b
+              excerpt: "if the adjusted gross income of the taxpayer is over $32,500 but not over $50,000, 10 percent"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/25B/b
+              excerpt: "if the adjusted gross income of the taxpayer is over $50,000, zero percent"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "for married taxpayers filing a joint return is increased from $47,500 to $48,500"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "household is increased from $35,625 to $36,375"
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "for all other taxpayers is increased from $23,750 to $24,250"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_50_applicable_ceiling_for_return_category
+              output: pipeline_tier_50_applicable_ceiling_for_return_category
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_20_applicable_ceiling_for_return_category
+              output: pipeline_tier_20_applicable_ceiling_for_return_category
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/income_tax/savers_credit_pipeline#pipeline_tier_10_applicable_ceiling_for_return_category
+              output: pipeline_tier_10_applicable_ceiling_for_return_category
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_high_rate
+              output: savers_credit_high_rate
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_middle_rate
+              output: savers_credit_middle_rate
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_low_rate
+              output: savers_credit_low_rate
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_zero_rate
+              output: savers_credit_zero_rate
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if pipeline_savers_credit_modified_adjusted_gross_income
+              <= pipeline_tier_50_applicable_ceiling_for_return_category:
+              savers_credit_high_rate
+          else:
+              if pipeline_savers_credit_modified_adjusted_gross_income
+                  <= pipeline_tier_20_applicable_ceiling_for_return_category:
+                  savers_credit_middle_rate
+              else:
+                  if pipeline_savers_credit_modified_adjusted_gross_income
+                      <= pipeline_tier_10_applicable_ceiling_for_return_category:
+                      savers_credit_low_rate
+                  else:
+                      savers_credit_zero_rate
+
+  - name: primary_savers_credit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 25B(c), primary individual's age, student, and dependent screens
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "The term “eligible individual” means any individual if such individual has attained the age of 18"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "any individual who is a student (as defined in section 152(f)(2))"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "any individual with respect to whom a deduction under section 151 is allowed to another taxpayer"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_age_threshold
+              output: savers_credit_age_threshold
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          primary_age_at_close_of_taxable_year >= savers_credit_age_threshold
+          and not primary_is_student_under_section_152_f_2
+          and not primary_may_be_claimed_as_dependent_by_another_taxpayer
+
+  - name: spouse_savers_credit_eligible
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 25B(a), (c), eligible spouse on a joint return
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/b
+              excerpt: "In the case of a joint return"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "The term “eligible individual” means any individual if such individual has attained the age of 18"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "any individual who is a student (as defined in section 152(f)(2))"
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/26/25B/c
+              excerpt: "any individual with respect to whom a deduction under section 151 is allowed to another taxpayer"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_age_threshold
+              output: savers_credit_age_threshold
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          filing_status == 1
+          and spouse_age_at_close_of_taxable_year >= savers_credit_age_threshold
+          and not spouse_is_student_under_section_152_f_2
+          and not spouse_may_be_claimed_as_dependent_by_another_taxpayer
+
+  - name: primary_savers_credit_contributions_taken_into_account
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 25B(a), primary individual's nonnegative qualified contributions capped at $2,000
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/25B/a
+              excerpt: "do not exceed $2,000"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_contribution_cap
+              output: savers_credit_contribution_cap
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+              max(0, primary_qualified_retirement_savings_contributions),
+              savers_credit_contribution_cap
+          )
+
+  - name: spouse_savers_credit_contributions_taken_into_account
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 25B(a), spouse's nonnegative qualified contributions capped at $2,000
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/25B/a
+              excerpt: "do not exceed $2,000"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/25B#savers_credit_contribution_cap
+              output: savers_credit_contribution_cap
+              hash: sha256:6b38b3bb321755359757828ffca75dd753694c05bf58c442a0d3922670076b6f
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          min(
+              max(0, spouse_qualified_retirement_savings_contributions),
+              savers_credit_contribution_cap
+          )
+
+  - name: federal_savers_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 25B(a), tax-unit credit from separately capped eligible-individual contributions
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/26/25B/a
+              excerpt: "an amount equal to the applicable percentage"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/income_tax/savers_credit_pipeline#pipeline_savers_credit_filing_status_is_enumerated
+              output: pipeline_savers_credit_filing_status_is_enumerated
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: |-
+          if pipeline_savers_credit_filing_status_is_enumerated:
+              pipeline_savers_credit_applicable_percentage
+              * (
+                  (
+                      if primary_savers_credit_eligible:
+                          primary_savers_credit_contributions_taken_into_account
+                      else:
+                          0
+                  )
+                  + (
+                      if spouse_savers_credit_eligible:
+                          spouse_savers_credit_contributions_taken_into_account
+                      else:
+                          0
+                  )
+              )
+          else:
+              0
+
+inputs:
+  - name: filing_status
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    description: Filing-status code; 0 single, 1 joint, 2 married filing separately, 3 head of household, and 4 surviving spouse.
+  - name: adjusted_gross_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Adjusted gross income before adding back sections 911, 931, and 933 exclusions.
+  - name: section_911_excluded_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Income excluded under section 911 and added back under section 25B(e).
+  - name: section_931_excluded_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Income excluded under section 931 and added back under section 25B(e).
+  - name: section_933_excluded_income
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Income excluded under section 933 and added back under section 25B(e).
+  - name: primary_age_at_close_of_taxable_year
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    description: Primary individual's age at the close of the taxable year.
+  - name: primary_is_student_under_section_152_f_2
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Whether the primary individual is a section 152(f)(2) student.
+  - name: primary_may_be_claimed_as_dependent_by_another_taxpayer
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Whether another taxpayer may claim the primary individual for a taxable year beginning in the same calendar year.
+  - name: primary_qualified_retirement_savings_contributions
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Primary individual's completed net section 25B(d) contribution amount after testing-period distributions and exceptions.
+  - name: spouse_age_at_close_of_taxable_year
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    description: Spouse's age at the close of the taxable year; ignored for nonjoint returns.
+  - name: spouse_is_student_under_section_152_f_2
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Whether the spouse is a section 152(f)(2) student.
+  - name: spouse_may_be_claimed_as_dependent_by_another_taxpayer
+    entity: TaxUnit
+    dtype: Boolean
+    period: Year
+    description: Whether another taxpayer may claim the spouse for a taxable year beginning in the same calendar year.
+  - name: spouse_qualified_retirement_savings_contributions
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    description: Spouse's completed net section 25B(d) contribution amount after testing-period distributions and exceptions.

--- a/us/policies/irs/notice-2025-67/savers-credit.test.yaml
+++ b/us/policies/irs/notice-2025-67/savers-credit.test.yaml
@@ -1,0 +1,18 @@
+- name: published_tax_year_2026_savers_credit_agi_limits
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    # IRS Notice 2025-67: joint, head-of-household, and all-other upper
+    # limits for the 50-, 20-, and 10-percent statutory tiers.
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_joint: 48500
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_joint: 52500
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_joint: 80500
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_head_of_household: 36375
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_head_of_household: 39375
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_head_of_household: 60375
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_all_other: 24250
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_all_other: 26250
+    us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other: 40250

--- a/us/policies/irs/notice-2025-67/savers-credit.yaml
+++ b/us/policies/irs/notice-2025-67/savers-credit.yaml
@@ -1,0 +1,318 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_paths:
+      - us/guidance/irs/notice-2025-67/page-3
+      - us/guidance/irs/notice-2025-67/page-4
+      - us/statute/26/25B/b
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/26/25B/b
+        - us/guidance/irs/notice-2025-67/page-3
+        - us/guidance/irs/notice-2025-67/page-4
+      rationale: |-
+        Section 25B(b)(3) requires annual inflation adjustment of the
+        retirement-savings-contribution-credit AGI limits, but the statute
+        does not state the indexed tax-year-2026 amounts. IRS Notice 2025-67
+        publishes the controlling official 2026 limits for joint returns,
+        heads of household, and all other taxpayers.
+    values:
+      savers_credit_50_percent_agi_limit_joint: 48500
+      savers_credit_20_percent_agi_limit_joint: 52500
+      savers_credit_10_percent_agi_limit_joint: 80500
+      savers_credit_50_percent_agi_limit_head_of_household: 36375
+      savers_credit_20_percent_agi_limit_head_of_household: 39375
+      savers_credit_10_percent_agi_limit_head_of_household: 60375
+      savers_credit_50_percent_agi_limit_all_other: 24250
+      savers_credit_20_percent_agi_limit_all_other: 26250
+      savers_credit_10_percent_agi_limit_all_other: 40250
+  summary: |-
+    IRS Notice 2025-67 publishes the tax-year-2026 adjusted gross income
+    limits for the retirement savings contributions credit under 26 USC
+    25B(b). The limits for the 50-, 20-, and 10-percent tiers are,
+    respectively, $48,500, $52,500, and $80,500 for joint returns;
+    $36,375, $39,375, and $60,375 for heads of household; and $24,250,
+    $26,250, and $40,250 for all other taxpayers.
+
+    This module publishes the nine per-category parameters only. Consumers
+    select the applicable category from their declared filing-status
+    boundary; the statutory percentage and inclusive tier grammar remain in
+    section 25B.
+  deferred_outputs:
+    - output: us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit
+      reason: |-
+        Selecting the applicable limit requires the taxpayer's filing-status
+        classification. This parameter module publishes each official return
+        category; a consuming composition performs the selection at its
+        declared filing-status boundary.
+      source_values:
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_joint
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_head_of_household
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_50_percent_agi_limit_all_other
+    - output: us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit
+      reason: Same filing-status classification dependency as the selected 50-percent limit.
+      source_values:
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_joint
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_head_of_household
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_20_percent_agi_limit_all_other
+    - output: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit
+      reason: Same filing-status classification dependency as the selected 50-percent limit.
+      source_values:
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_joint
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_head_of_household
+        - us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
+rules:
+  - name: savers_credit_50_percent_agi_limit_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 joint-return section 25B(b)(1)(A) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "is increased from $47,500 to $48,500"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '48500'
+
+  - name: savers_credit_20_percent_agi_limit_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 joint-return section 25B(b)(1)(B) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the limitation under section 25B(b)(1)(B) is increased from $51,000 to $52,500"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '52500'
+
+  - name: savers_credit_10_percent_agi_limit_joint
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 joint-return section 25B(b)(1)(C)-(D) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the limitation under sections 25B(b)(1)(C) and 25B(b)(1)(D) is increased from $79,000 to $80,500"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '80500'
+
+  - name: savers_credit_50_percent_agi_limit_head_of_household
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 head-of-household section 25B(b)(1)(A) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "household is increased from $35,625 to $36,375"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '36375'
+
+  - name: savers_credit_20_percent_agi_limit_head_of_household
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 head-of-household section 25B(b)(1)(B) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "the limitation under section 25B(b)(1)(B) is increased from $38,250 to $39,375"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '39375'
+
+  - name: savers_credit_10_percent_agi_limit_head_of_household
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 head-of-household section 25B(b)(1)(C)-(D) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "the limitation under sections 25B(b)(1)(C) and 25B(b)(1)(D) is increased from $59,250 to $60,375"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '60375'
+
+  - name: savers_credit_50_percent_agi_limit_all_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 all-other section 25B(b)(1)(A) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "is increased from $23,750 to $24,250"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '24250'
+
+  - name: savers_credit_20_percent_agi_limit_all_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 all-other section 25B(b)(1)(B) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "the limitation under section 25B(b)(1)(B) is increased from $25,500 to $26,250"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '26250'
+
+  - name: savers_credit_10_percent_agi_limit_all_other
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: IRS Notice 2025-67, tax-year-2026 all-other section 25B(b)(1)(C)-(D) limit
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-4
+              excerpt: "the limitation under sections 25B(b)(1)(C) and 25B(b)(1)(D) is increased from $39,500 to $40,250"
+          - path: versions[0].effective_from
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+          - path: versions[0].effective_to
+            kind: effective_period
+            source:
+              corpus_citation_path: us/guidance/irs/notice-2025-67/page-3
+              excerpt: "the amounts for 2026 are as follows"
+    versions:
+      - effective_from: '2026-01-01'
+        effective_to: '2026-12-31'
+        formula: '40250'


### PR DESCRIPTION
Revives the saver's-credit compose withheld from #1004, now grounded in the pinned corpus (pin #1134 → axiom-corpus `bf97b17ba` with IRS Notice 2025-67).

**What changed vs the preserved pipeline** (split out at `dc7a521fa`):
- **Notice 2025-67 parameter module** (`us/policies/irs/notice-2025-67/savers-credit.yaml`): 2026 AGI tier boundaries encoded from retained notice text (pages 3–4 cited in proof atoms) — no more unsourced embedded values.
- **26 USC 25B(e) AGI fix**: AGI determined without regard to §§911/931/933 — explicit add-backs with proof excerpt ("determined without regard to sections 911, 931, and 933").
- **Per-individual $2,000 cap** per 25B(a) ("do not exceed $2,000" excerpt) — PE's single-cap joint behavior remains upstream bug territory.
- Inclusive tier boundaries per 25B(b) text; the boundary case is expected to diverge from PE (policyengine-us#9151 digitizes the boundary exclusively) and will carry a source-linked disposition in the grid suite.

**Verification** (companion suites re-run by the main lane): 26/26 cases across pipeline + notice module; proof validation 69 atoms, 0/9 missing money obligations; boundary mutation (`<=`→`<`) fails 8 cases, restore passes; reverse index regenerated; oracle-pending ledger +20 savers/notice declarations (ceiling = entry count); manifests signed last (guard green at head).

Grid suite (us-savers-grid) follows on the axiom-oracles side; row flips covered only when the suite lands with dispositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)