### PR TITLE
Encode 7 CFR 273.1 household concept

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -37005,6 +37005,64 @@
         ]
       }
     ],
+    "us/regulation/7/273/1": [
+      {
+        "module": "us/regulations/7-cfr/273/1/a.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/1.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/2.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/3.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/4.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/5.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/6.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      },
+      {
+        "module": "us/regulations/7-cfr/273/1/b/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/7/273/10": [
       {
         "module": "us/regulations/7-cfr/273/10.yaml",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,10 +2,8 @@
 
 ## State
 
-Design complete for eight subsection-granular 7 CFR 273.1
-household-composition modules. Implementation will proceed in three coherent
-commits: core general/minor formation, special separate/boarder treatment, and
-remaining boundary/ineligible-member treatment.
+Core household formation is implemented and locally validated. Six remaining
+special-household modules will be implemented in two coherent commits.
 
 ## Done
 
@@ -30,10 +28,16 @@ remaining boundary/ineligible-member treatment.
   273.9 already consumes 273.10's `snap_total_gross_income`.
 - Confirmed the pinned validator rejects merge-anchor key overrides. New tests
   will spell every local factual input in every case.
+- Implemented `273/1/a` and `273/1/b/1` with strict source proofs and companion
+  tests.
+- Covered the live minor boundaries at ages 15, 16, 17, 18, 21, and 22,
+  including direct control, financial and other dependency, State-law
+  adulthood, foster status, parental co-residence, and spouses.
+- Pinned `axiom-encode` validation and proof validation pass for both core
+  modules; all 17 core companion cases pass on the available local engine.
 
 ## Next
 
-- Implement and commit `a` plus precision-focused `b/1` modules and tests.
 - Implement and commit `b/2` through `b/4` modules and tests.
 - Implement and commit `b/5` through `b/7` modules and tests.
 - Regenerate the reverse index; run the pinned validator, proof validator,

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,8 +2,10 @@
 
 ## State
 
-Researching the RuleSpec shape for 7 CFR 273.1 household-composition rules on
-branch `encode-273-1-household`.
+Design complete for eight subsection-granular 7 CFR 273.1
+household-composition modules. Implementation will proceed in three coherent
+commits: core general/minor formation, special separate/boarder treatment, and
+remaining boundary/ineligible-member treatment.
 
 ## Done
 
@@ -11,10 +13,29 @@ branch `encode-273-1-household`.
 - Read the full source row for `us/regulation/7/273/1`.
 - Read the 7 CFR 273.9, 273.10, and 273.2(j) sibling modules and tests.
 - Confirmed the worktree starts at `origin/main` commit `1158ba5b2`.
+- Inspected the RuleSpec schema, exact pinned validator, federal composition
+  relations, and Colorado household-concept precedents.
+- Chose modules at `273/1/a` and `273/1/b/1` through `273/1/b/7`, each with
+  strict proof validation and a companion test.
+- Defined the live minor surface precisely: no age floor for living alone;
+  strict under-22 and under-18 cutoffs; direct parental control separate from
+  dependency-based deeming; the State-law-adult exception applies to deeming;
+  and foster status defeats (b)(1)(iii) while (b)(4) independently bars
+  separate participation.
+- Chose source-backed membership/boundary predicates rather than inventing
+  pair identifiers or a new candidate relation. Existing
+  `member_of_household` relations remain downstream composition inputs.
+- Confirmed all 516 remote branches and all open PRs have no 273.1 encoding
+  overlap. Issue #28 is related only at the upstream unit boundary; current
+  273.9 already consumes 273.10's `snap_total_gross_income`.
+- Confirmed the pinned validator rejects merge-anchor key overrides. New tests
+  will spell every local factual input in every case.
 
 ## Next
 
-- Inspect repository schemas, validation commands, related household concepts,
-  issue context, and open work touching 7 CFR 273.1.
-- Design subsection-granular modules and complete test matrices.
-- Implement, validate, recheck coordination scope, push, and open PR #1135.
+- Implement and commit `a` plus precision-focused `b/1` modules and tests.
+- Implement and commit `b/2` through `b/4` modules and tests.
+- Implement and commit `b/5` through `b/7` modules and tests.
+- Regenerate the reverse index; run the pinned validator, proof validator,
+  companion tests, and repository tests.
+- Recheck coordination immediately before pushing, push, and open PR #1135.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,10 +2,9 @@
 
 ## State
 
-All eight household-concept modules and companion tests are implemented. A
-final semantic audit identified and resolved three integration edges; the
-focused suites pass, and repository-wide validation will be repeated before
-push.
+All eight household-concept modules and companion tests are implemented, the
+semantic-audit fixes are complete, and all required local validation passes.
+Coordination recheck, push, and PR creation are next.
 
 ## Done
 
@@ -64,9 +63,17 @@ push.
   cannot be converted into optional boarder status.
 - Focused validation and proof validation pass for the tightened (b)(2) and
   (b)(3) modules; their 19 companion cases pass.
+- Regenerated and checked `.axiom/index/provisions_to_rules.json`: 4,233
+  provisions, 5,075 edges, and 4,490 modules.
+- Pinned `axiom-encode` validation and proof validation pass for all eight
+  modules; all 77 companion cases pass on the available local rules engine.
+- Repository tests pass: 65 passed with the expected non-failing warning for
+  25 unmanifested modules.
+- The optional all-program artifact smoke check could not serve as a gate:
+  the available engine is `aa1ff025906c`, not the pinned `ffd821327194`, and
+  the available composer rejected pre-existing AL program transformation
+  patterns. No toolchain or pin files were changed.
 
 ## Next
 
-- Regenerate the reverse index; run the pinned validator, proof validator,
-  companion tests, and repository tests.
 - Recheck coordination immediately before pushing, push, and open PR #1135.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,20 @@
+# Progress
+
+## State
+
+Researching the RuleSpec shape for 7 CFR 273.1 household-composition rules on
+branch `encode-273-1-household`.
+
+## Done
+
+- Read `CLAUDE.md`.
+- Read the full source row for `us/regulation/7/273/1`.
+- Read the 7 CFR 273.9, 273.10, and 273.2(j) sibling modules and tests.
+- Confirmed the worktree starts at `origin/main` commit `1158ba5b2`.
+
+## Next
+
+- Inspect repository schemas, validation commands, related household concepts,
+  issue context, and open work touching 7 CFR 273.1.
+- Design subsection-granular modules and complete test matrices.
+- Implement, validate, recheck coordination scope, push, and open PR #1135.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,9 +2,10 @@
 
 ## State
 
-All eight household-concept modules and companion tests are implemented and
-locally validated. Repository-wide validation and generated-index refresh are
-next.
+All eight household-concept modules and companion tests are implemented. A
+final semantic audit identified and resolved three integration edges; the
+focused suites pass, and repository-wide validation will be repeated before
+push.
 
 ## Done
 
@@ -54,6 +55,15 @@ next.
   income, resource, and size treatment to the applicable later rules.
 - Pinned validation and proof validation pass for all three final boundary
   modules; all 38 companion cases pass on the available local engine.
+- Tightened paragraph (b)(2) so the disability must cause the inability to
+  purchase and prepare meals, and so the imported 165-percent poverty-table
+  size must equal the count of other residents after excluding the candidate
+  and spouse.
+- Tightened paragraph (b)(3) so the spouse, under-22 parent/child, and
+  under-18 nonparental-control combinations projected from paragraph (b)(1)
+  cannot be converted into optional boarder status.
+- Focused validation and proof validation pass for the tightened (b)(2) and
+  (b)(3) modules; their 19 companion cases pass.
 
 ## Next
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,9 +2,9 @@
 
 ## State
 
-Core household formation and the elderly/disabled, boarder, and foster-child
-exceptions are implemented and locally validated. Three remaining boundary
-modules will be implemented in the next coherent commit.
+All eight household-concept modules and companion tests are implemented and
+locally validated. Repository-wide validation and generated-index refresh are
+next.
 
 ## Done
 
@@ -41,10 +41,22 @@ modules will be implemented in the next coherent commit.
   rules, and the foster-child boundary.
 - Pinned validation and proof validation pass for all three special-household
   modules; all 17 companion cases pass on the available local engine.
+- Implemented `273/1/b/5` through `273/1/b/7`, with direct imports of the
+  paragraph (b)(1) mandatory-combination result for roomers, attendants, and
+  institution exceptions.
+- Encoded the strict institution meal-share boundary, boarder override, all
+  five institution-exception settings, the “unless otherwise stated” gate,
+  all paragraph (b)(7) ineligibility paths, and the optional cross-program
+  disqualification only when the State option is active.
+- Kept institution exceptions limited to removing the institution bar:
+  another paragraph (b)(7) bar still excludes the person. Kept excluded
+  household members distinct from host-unit nonmembers and left downstream
+  income, resource, and size treatment to the applicable later rules.
+- Pinned validation and proof validation pass for all three final boundary
+  modules; all 38 companion cases pass on the available local engine.
 
 ## Next
 
-- Implement and commit `b/5` through `b/7` modules and tests.
 - Regenerate the reverse index; run the pinned validator, proof validator,
   companion tests, and repository tests.
 - Recheck coordination immediately before pushing, push, and open PR #1135.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,8 +2,9 @@
 
 ## State
 
-Core household formation is implemented and locally validated. Six remaining
-special-household modules will be implemented in two coherent commits.
+Core household formation and the elderly/disabled, boarder, and foster-child
+exceptions are implemented and locally validated. Three remaining boundary
+modules will be implemented in the next coherent commit.
 
 ## Done
 
@@ -35,10 +36,14 @@ special-household modules will be implemented in two coherent commits.
   adulthood, foster status, parental co-residence, and spouses.
 - Pinned `axiom-encode` validation and proof validation pass for both core
   modules; all 17 core companion cases pass on the available local engine.
+- Implemented `273/1/b/2` through `273/1/b/4`, including the elderly/disabled
+  separate-household option, the boarder compensation and provider-election
+  rules, and the foster-child boundary.
+- Pinned validation and proof validation pass for all three special-household
+  modules; all 17 companion cases pass on the available local engine.
 
 ## Next
 
-- Implement and commit `b/2` through `b/4` modules and tests.
 - Implement and commit `b/5` through `b/7` modules and tests.
 - Regenerate the reverse index; run the pinned validator, proof validator,
   companion tests, and repository tests.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,9 @@
 ## State
 
 All eight household-concept modules and companion tests are implemented, the
-semantic-audit fixes are complete, and all required local validation passes.
-Coordination recheck, push, and PR creation are next.
+semantic-audit fixes are complete, all required local validation passes, and
+the pre-push coordination recheck found no overlapping 273.1 work. Push and PR
+creation are next.
 
 ## Done
 
@@ -73,7 +74,11 @@ Coordination recheck, push, and PR creation are next.
   the available engine is `aa1ff025906c`, not the pinned `ffd821327194`, and
   the available composer rejected pre-existing AL program transformation
   patterns. No toolchain or pin files were changed.
+- Rechecked coordination immediately before push: the remote branch inventory
+  remains at 516 branches, the four open PRs contain no
+  `us/regulations/7-cfr/273/1` files, and searches for `273.1` and household
+  work found no competing encoding.
 
 ## Next
 
-- Recheck coordination immediately before pushing, push, and open PR #1135.
+- Push and open the unmerged PR referencing #1135.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,10 @@
 
 All eight household-concept modules and companion tests are implemented, the
 semantic-audit fixes are complete, all required local validation passes, and
-the pre-push coordination recheck found no overlapping 273.1 work. Push and PR
-creation are next.
+the pre-push coordination recheck found no overlapping 273.1 work. Remote
+publication is blocked: shell networking cannot resolve or connect to GitHub,
+and the connected GitHub API declined write operations. No remote branch or PR
+was created.
 
 ## Done
 
@@ -78,7 +80,19 @@ creation are next.
   remains at 516 branches, the four open PRs contain no
   `us/regulations/7-cfr/273/1` files, and searches for `273.1` and household
   work found no competing encoding.
+- Attempted the requested push with
+  `git push --set-upstream origin encode-273-1-household`; the workspace denied
+  GitHub DNS/network access. The local `gh` credential is also invalid.
+- Tried the connected GitHub API as the authorized fallback. Its read checks
+  confirmed that neither the branch nor local HEAD exists remotely, but its
+  branch/blob write calls returned `user cancelled MCP tool call`. No partial
+  GitHub state was created.
 
 ## Next
 
-- Push and open the unmerged PR referencing #1135.
+- From a network-enabled, authenticated session, run
+  `git push --set-upstream origin encode-273-1-household`.
+- Open an unmerged PR titled `Encode 7 CFR 273.1 household concept`, referencing
+  #1135 and noting the upstream-only relationship to #28. Alternatively,
+  explicitly approve connected-GitHub writes and accept reconstructed,
+  equivalent-content commits whose SHAs differ from the local commits.

--- a/us/regulations/7-cfr/273/1/a.test.yaml
+++ b/us/regulations/7-cfr/273/1/a.test.yaml
@@ -1,0 +1,55 @@
+- name: individual_living_alone_meets_general_household_definition
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/a#input.individual_lives_alone: true
+    us:regulations/7-cfr/273/1/a#input.individual_lives_with_others: false
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_purchases_food_separate_and_apart: false
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_prepares_meals_for_home_consumption_separate_and_apart: false
+    us:regulations/7-cfr/273/1/a#input.individual_subject_to_special_household_requirement: false
+  output:
+    us:regulations/7-cfr/273/1/a#snap_individual_living_alone_meets_general_household_definition: holds
+    us:regulations/7-cfr/273/1/a#snap_individual_separate_purchase_and_preparation_meets_general_household_definition: not_holds
+
+- name: individual_who_purchases_and_prepares_separately_meets_general_definition
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/a#input.individual_lives_alone: false
+    us:regulations/7-cfr/273/1/a#input.individual_lives_with_others: true
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+    us:regulations/7-cfr/273/1/a#input.individual_subject_to_special_household_requirement: false
+  output:
+    us:regulations/7-cfr/273/1/a#snap_individual_living_alone_meets_general_household_definition: not_holds
+    us:regulations/7-cfr/273/1/a#snap_individual_separate_purchase_and_preparation_meets_general_household_definition: holds
+
+- name: special_household_requirement_overrides_separate_purchase_and_preparation
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/a#input.individual_lives_alone: false
+    us:regulations/7-cfr/273/1/a#input.individual_lives_with_others: true
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/a#input.individual_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+    us:regulations/7-cfr/273/1/a#input.individual_subject_to_special_household_requirement: true
+  output:
+    us:regulations/7-cfr/273/1/a#snap_individual_living_alone_meets_general_household_definition: not_holds
+    us:regulations/7-cfr/273/1/a#snap_individual_separate_purchase_and_preparation_meets_general_household_definition: not_holds
+
+- name: co_resident_group_that_purchases_and_prepares_together_is_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/a#input.group_members_live_together: true
+    us:regulations/7-cfr/273/1/a#input.group_customarily_purchases_food_together: true
+    us:regulations/7-cfr/273/1/a#input.group_customarily_prepares_meals_for_home_consumption_together: true
+    us:regulations/7-cfr/273/1/a#input.group_subject_to_special_household_requirement: false
+  output:
+    us:regulations/7-cfr/273/1/a#snap_group_joint_purchase_and_preparation_meets_general_household_definition: holds
+
+- name: group_that_does_not_prepare_meals_together_is_not_joint_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/a#input.group_members_live_together: true
+    us:regulations/7-cfr/273/1/a#input.group_customarily_purchases_food_together: true
+    us:regulations/7-cfr/273/1/a#input.group_customarily_prepares_meals_for_home_consumption_together: false
+    us:regulations/7-cfr/273/1/a#input.group_subject_to_special_household_requirement: false
+  output:
+    us:regulations/7-cfr/273/1/a#snap_group_joint_purchase_and_preparation_meets_general_household_definition: not_holds

--- a/us/regulations/7-cfr/273/1/a.yaml
+++ b/us/regulations/7-cfr/273/1/a.yaml
@@ -1,0 +1,114 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  deferred_outputs:
+    - output: us:regulations/7-cfr/273/1/c#snap_unregulated_household_determination
+      blocked_by:
+        - us:regulations/7-cfr/273/1/a#state_household_determination_policy_context
+      reason: >-
+        Paragraph (c) authorizes a State agency policy for situations not
+        clearly addressed by paragraphs (a) and (b). This sprint encodes the
+        federal household-formation rules; the State policy layer is deferred.
+    - output: us:regulations/7-cfr/273/1/d#snap_head_of_household_designation
+      blocked_by:
+        - us:regulations/7-cfr/273/1/a#certification_and_work_requirement_context
+      reason: >-
+        Paragraph (d) governs administrative head-of-household designation and
+        the principal-wage-earner rule for work-requirement sanctions, not the
+        point-in-time household-composition boundary encoded here.
+    - output: us:regulations/7-cfr/273/1/e#snap_striker_household_eligibility
+      blocked_by:
+        - us:regulations/7-cfr/273/1/a#strike_income_and_application_context
+      reason: >-
+        Paragraph (e) governs striker eligibility and income comparison. It is
+        outside this household-composition slice and requires application-date
+        and pre-strike income context.
+  summary: |-
+    7 CFR 273.1(a) supplies three provisional SNAP household forms, each
+    subject to paragraph (b): an individual living alone; an individual living
+    with others who customarily purchases food and prepares meals separately;
+    and a group that lives, purchases food, and prepares meals together. This
+    module keeps purchase and preparation as distinct facts and applies the
+    paragraph (b) override to each form.
+rules:
+  - name: snap_individual_living_alone_meets_general_household_definition
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: An individual living alone
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: unless otherwise specified in paragraph (b) of this section
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          individual_lives_alone
+          and not individual_subject_to_special_household_requirement
+
+  - name: snap_individual_separate_purchase_and_preparation_meets_general_household_definition
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: An individual living with others, but customarily purchasing food and preparing meals for home consumption separate and apart from others
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: unless otherwise specified in paragraph (b) of this section
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          individual_lives_with_others
+          and individual_customarily_purchases_food_separate_and_apart
+          and individual_customarily_prepares_meals_for_home_consumption_separate_and_apart
+          and not individual_subject_to_special_household_requirement
+
+  - name: snap_group_joint_purchase_and_preparation_meets_general_household_definition
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A group of individuals who live together and customarily purchase food and prepare meals together for home consumption
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: unless otherwise specified in paragraph (b) of this section
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          group_members_live_together
+          and group_customarily_purchases_food_together
+          and group_customarily_prepares_meals_for_home_consumption_together
+          and not group_subject_to_special_household_requirement

--- a/us/regulations/7-cfr/273/1/b/1.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/1.test.yaml
@@ -1,0 +1,272 @@
+- name: age_15_living_alone_meets_one_person_household_definition
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 15
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: false
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: false
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: false
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_co_resident_spouse_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_under_22_person_with_parent_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_17_living_alone_meets_one_person_household_definition
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 17
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: false
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: false
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: false
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_15_with_unrelated_people_may_purchase_and_prepare_separately
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 15
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_15_financially_dependent_on_nonparent_is_required_member
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 15
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: not_holds
+
+- name: age_16_otherwise_dependent_on_nonparent_is_required_member
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 16
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: not_holds
+
+- name: age_17_directly_under_nonparental_control_is_required_member
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 17
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: not_holds
+
+- name: state_law_adult_is_not_deemed_under_parental_control_from_dependency
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 17
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_17_foster_child_is_outside_nonparental_control_combination
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 17
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_18_is_outside_nonparental_control_combination
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 18
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_18_child_deemed_under_parental_control: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: age_21_living_with_parent_is_required_same_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 21
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_22_person_with_parent_required_same_household: holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: not_holds
+
+- name: age_22_living_with_parent_may_purchase_and_prepare_separately
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 22
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_under_22_person_with_parent_required_same_household: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: holds
+
+- name: co_resident_spouse_is_required_same_household_despite_separate_meals
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_alone: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_purchases_food_separate_and_apart: true
+    us:regulations/7-cfr/273/1/b/1#input.person_customarily_prepares_meals_for_home_consumption_separate_and_apart: true
+  output:
+    us:regulations/7-cfr/273/1/b/1#snap_co_resident_spouse_required_same_household: holds
+    us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination: holds
+    us:regulations/7-cfr/273/1/b/1#snap_individual_household_definition_after_required_combinations: not_holds

--- a/us/regulations/7-cfr/273/1/b/1.yaml
+++ b/us/regulations/7-cfr/273/1/b/1.yaml
@@ -1,0 +1,219 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(1) overrides actual food-purchase and meal-preparation
+    practice for three co-resident combinations: spouses; a person under age
+    22 living with a natural or adoptive parent or stepparent; and a non-foster
+    child under age 18 living with and under the parental control of a
+    nonparent candidate household member. Financial or other dependency deems
+    the under-18 child to be under parental control unless State law defines
+    the person as an adult. There is no minimum age for the paragraph (a)(1)
+    living-alone household form.
+rules:
+  - name: snap_parent_co_residence_age_limit
+    kind: parameter
+    dtype: Count
+    source: 7 CFR 273.1(b)(1)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A person under 22 years of age who is living with his or her natural or adoptive parent(s) or step-parent(s)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          22
+
+  - name: snap_nonparental_control_child_age_limit
+    kind: parameter
+    dtype: Count
+    source: 7 CFR 273.1(b)(1)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A child (other than a foster child) under 18 years of age who lives with and is under the parental control of a household member other than his or her parent
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          18
+
+  - name: snap_co_resident_spouse_required_same_household
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_has_spouse
+          and person_lives_with_spouse
+
+  - name: snap_under_22_person_with_parent_required_same_household
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A person under 22 years of age who is living with his or her natural or adoptive parent(s) or step-parent(s)
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_parent_co_residence_age_limit
+              output: snap_parent_co_residence_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_age < snap_parent_co_residence_age_limit
+          and person_lives_with_natural_adoptive_or_step_parent
+
+  - name: snap_under_18_child_deemed_under_parental_control
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: financially or otherwise dependent on a member of the household, unless State law defines such a person as an adult
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_nonparental_control_child_age_limit
+              output: snap_nonparental_control_child_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_age < snap_nonparental_control_child_age_limit
+          and (
+              person_is_financially_dependent_on_candidate_household_member
+              or person_is_otherwise_dependent_on_candidate_household_member
+          )
+          and not state_law_defines_person_as_adult
+
+  - name: snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A child (other than a foster child) under 18 years of age who lives with and is under the parental control of a household member other than his or her parent
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_nonparental_control_child_age_limit
+              output: snap_nonparental_control_child_age_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_age < snap_nonparental_control_child_age_limit
+          and not person_is_foster_child
+          and person_lives_with_candidate_household_member_other_than_parent
+          and (
+              person_is_under_parental_control_of_candidate_nonparent_household_member
+              or snap_under_18_child_deemed_under_parental_control
+          )
+
+  - name: snap_person_subject_to_required_household_combination
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: must be considered as customarily purchasing food and preparing meals with the others, even if they do not do so, and thus must be included in the same household
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_co_resident_spouse_required_same_household
+          or snap_under_22_person_with_parent_required_same_household
+          or snap_nonfoster_under_18_child_with_nonparent_controller_required_same_household
+
+  - name: snap_individual_household_definition_after_required_combinations
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)(1)-(2), (b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: An individual living alone
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: An individual living with others, but customarily purchasing food and preparing meals for home consumption separate and apart from others
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: must be considered as customarily purchasing food and preparing meals with the others, even if they do not do so, and thus must be included in the same household
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+              output: snap_person_subject_to_required_household_combination
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (
+              person_lives_alone
+              or (
+                  person_lives_with_others
+                  and person_customarily_purchases_food_separate_and_apart
+                  and person_customarily_prepares_meals_for_home_consumption_separate_and_apart
+              )
+          )
+          and not snap_person_subject_to_required_household_combination

--- a/us/regulations/7-cfr/273/1/b/2.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/2.test.yaml
@@ -6,8 +6,10 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2152
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
   output:
@@ -23,8 +25,10 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 59
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2152
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
   output:
@@ -40,10 +44,47 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2153
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
+
+- name: unrelated_inability_does_not_satisfy_disability_causation
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_person_has_qualifying_meal_preparation_disability: not_holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
+
+- name: poverty_table_size_must_equal_count_of_other_residents
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 2
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
   output:
     us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
     us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_includes_co_resident_spouse: not_holds
@@ -56,8 +97,10 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: false
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: true
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
   output:
@@ -73,8 +116,10 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: false
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: false
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
   output:
@@ -89,8 +134,10 @@
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_count_excluding_candidate_and_spouse: 1
     us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
     us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
   output:

--- a/us/regulations/7-cfr/273/1/b/2.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/2.test.yaml
@@ -1,0 +1,97 @@
+- name: age_60_ssa_permanent_disability_at_income_limit_may_be_separate_with_spouse
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2152
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_person_has_qualifying_meal_preparation_disability: holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_includes_co_resident_spouse: holds
+
+- name: age_59_is_below_elderly_disabled_separate_household_threshold
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 59
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2152
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_person_has_qualifying_meal_preparation_disability: holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_includes_co_resident_spouse: not_holds
+
+- name: income_one_dollar_over_165_percent_limit_blocks_separate_household
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2153
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: true
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_includes_co_resident_spouse: not_holds
+
+- name: non_disease_related_severe_permanent_disability_is_qualifying_path
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: false
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: true
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_person_has_qualifying_meal_preparation_disability: holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_includes_co_resident_spouse: not_holds
+
+- name: disability_that_does_not_prevent_meal_preparation_does_not_qualify
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: false
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_person_has_qualifying_meal_preparation_disability: not_holds
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds
+
+- name: otherwise_ineligible_person_cannot_use_elderly_disabled_exception
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_is_otherwise_snap_eligible: false
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_age: 60
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_lives_with_others: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_unable_to_purchase_and_prepare_meals: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_disability_considered_permanent_under_social_security_act: true
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_has_non_disease_related_severe_permanent_disability: false
+    us:regulations/7-cfr/273/1/b/2#input.other_residents_monthly_income_excluding_candidate_and_spouse: 2000
+    us:regulations/7-cfr/273/1/b/2#input.candidate_person_spouse_lives_there: false
+  output:
+    us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_available: not_holds

--- a/us/regulations/7-cfr/273/1/b/2.yaml
+++ b/us/regulations/7-cfr/273/1/b/2.yaml
@@ -11,7 +11,8 @@ module:
     spouse, when the monthly income of all other residents—excluding that
     person and spouse—does not exceed 165 percent of the poverty line. For
     this Colorado closure slice, the 165-percent amount is imported from the
-    USDA FY 2026 table for the number of those other residents.
+    USDA FY 2026 table, with the table household-size input required to equal
+    the number of those other residents.
 imports:
   - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_165_percent_fpl_48_states_dc
 rules:
@@ -50,6 +51,7 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           candidate_person_unable_to_purchase_and_prepare_meals
+          and candidate_person_inability_to_purchase_and_prepare_meals_is_caused_by_claimed_disability
           and (
               candidate_person_disability_considered_permanent_under_social_security_act
               or candidate_person_has_non_disease_related_severe_permanent_disability
@@ -93,6 +95,8 @@ rules:
           and candidate_person_age >= snap_elderly_disabled_separate_household_minimum_age
           and candidate_person_lives_with_others
           and snap_elderly_disabled_person_has_qualifying_meal_preparation_disability
+          and household_size
+              == other_residents_count_excluding_candidate_and_spouse
           and other_residents_monthly_income_excluding_candidate_and_spouse
               <= snap_gross_income_limit_165_percent_fpl_48_states_dc
 

--- a/us/regulations/7-cfr/273/1/b/2.yaml
+++ b/us/regulations/7-cfr/273/1/b/2.yaml
@@ -1,0 +1,117 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(2) permits an otherwise eligible person age 60 or older
+    who cannot purchase and prepare meals because of a qualifying permanent
+    disability to form a separate household, together with a co-resident
+    spouse, when the monthly income of all other residents—excluding that
+    person and spouse—does not exceed 165 percent of the poverty line. For
+    this Colorado closure slice, the 165-percent amount is imported from the
+    USDA FY 2026 table for the number of those other residents.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_165_percent_fpl_48_states_dc
+rules:
+  - name: snap_elderly_disabled_separate_household_minimum_age
+    kind: parameter
+    dtype: Count
+    source: 7 CFR 273.1(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: 60 years of age or older
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          60
+
+  - name: snap_elderly_disabled_person_has_qualifying_meal_preparation_disability
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: unable to purchase and prepare meals because he or she suffers from a disability considered permanent under the Social Security Act or a non disease-related, severe, permanent disability
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          candidate_person_unable_to_purchase_and_prepare_meals
+          and (
+              candidate_person_disability_considered_permanent_under_social_security_act
+              or candidate_person_has_non_disease_related_severe_permanent_disability
+          )
+
+  - name: snap_elderly_disabled_separate_household_available
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: may be considered, together with his or her spouse (if living there), a separate household from the others with whom the individual lives
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: excluding the income of the elderly and disabled individual and his or her spouse) exceeds 165 percent of the poverty line
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/2#snap_elderly_disabled_separate_household_minimum_age
+              output: snap_elderly_disabled_separate_household_minimum_age
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_165_percent_fpl_48_states_dc
+              output: snap_gross_income_limit_165_percent_fpl_48_states_dc
+              hash: sha256:94d8f5eaefa63fd65fc5f4d19ee1ff5c4dd07d26189e29007bc914218bd5c3a4
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          candidate_person_is_otherwise_snap_eligible
+          and candidate_person_age >= snap_elderly_disabled_separate_household_minimum_age
+          and candidate_person_lives_with_others
+          and snap_elderly_disabled_person_has_qualifying_meal_preparation_disability
+          and other_residents_monthly_income_excluding_candidate_and_spouse
+              <= snap_gross_income_limit_165_percent_fpl_48_states_dc
+
+  - name: snap_elderly_disabled_separate_household_includes_co_resident_spouse
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: together with his or her spouse (if living there)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_elderly_disabled_separate_household_available
+          and candidate_person_spouse_lives_there

--- a/us/regulations/7-cfr/273/1/b/3.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/3.test.yaml
@@ -9,6 +9,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -33,6 +36,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 297.99
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -51,6 +57,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 2
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 199
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -69,6 +78,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 2
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 198
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -87,6 +99,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: true
@@ -105,6 +120,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -124,6 +142,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -142,6 +163,9 @@
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
     us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
     us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
     us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
     us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
     us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
@@ -149,3 +173,71 @@
     us:regulations/7-cfr/273/1/b/3#snap_boarding_establishment_is_commercial_boarding_house: not_holds
     us:regulations/7-cfr/273/1/b/3#snap_commercial_boarding_house_resident_ineligible: not_holds
     us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: holds
+
+- name: provider_spouse_cannot_become_optional_boarder
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_required_to_join_provider_household_under_b_1: holds
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_independent_participation_prohibited: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_may_join_provider_household: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_treated_as_noninstitution_resident: not_holds
+
+- name: under_22_person_with_provider_parent_cannot_become_optional_boarder
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_required_to_join_provider_household_under_b_1: holds
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_may_join_provider_household: not_holds
+
+- name: controlled_nonfoster_child_cannot_become_optional_boarder
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_spouse_required_to_join_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_required_to_join_provider_household_under_b_1: holds
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_may_join_provider_household: not_holds

--- a/us/regulations/7-cfr/273/1/b/3.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/3.test.yaml
@@ -1,0 +1,151 @@
+- name: more_than_two_meals_at_maximum_allotment_is_reasonable_board
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarding_establishment_is_commercial_boarding_house: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_commercial_boarding_house_resident_ineligible: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_minimum_reasonable_board_compensation: 298
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_independent_participation_prohibited: holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_may_join_provider_household: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_underpaid_board_recipient_required_provider_household_member: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_treated_as_noninstitution_resident: holds
+
+- name: more_than_two_meals_one_cent_below_maximum_is_underpaid
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 297.99
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_underpaid_board_recipient_required_provider_household_member: holds
+
+- name: two_meals_at_199_dollars_meets_two_thirds_threshold
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 2
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 199
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: holds
+    us:regulations/7-cfr/273/1/b/3#snap_underpaid_board_recipient_required_provider_household_member: not_holds
+
+- name: two_meals_at_198_dollars_is_below_two_thirds_threshold
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 2
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 198
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_underpaid_board_recipient_required_provider_household_member: holds
+
+- name: provider_request_allows_boarder_unit_to_join_provider_household
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: false
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: holds
+    us:regulations/7-cfr/273/1/b/3#snap_boarder_unit_may_join_provider_household: holds
+
+- name: licensed_commercial_boarding_house_resident_is_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarding_establishment_is_commercial_boarding_house: holds
+    us:regulations/7-cfr/273/1/b/3#snap_commercial_boarding_house_resident_ineligible: holds
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: not_holds
+
+- name: unlicensed_for_profit_meal_and_lodging_establishment_is_commercial
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: false
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarding_establishment_is_commercial_boarding_house: holds
+    us:regulations/7-cfr/273/1/b/3#snap_commercial_boarding_house_resident_ineligible: holds
+
+- name: referenced_institution_exception_entity_is_not_commercial_boarding_house
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_resides_at_boarding_establishment: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_referenced_institution_exception_entity: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/3#input.project_area_has_boarding_house_licensing_requirements: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_offers_meals_and_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/3#input.boarding_establishment_intends_to_make_profit: true
+    us:regulations/7-cfr/273/1/b/3#input.boarder_unit_has_board_arrangement: true
+    us:regulations/7-cfr/273/1/b/3#input.board_arrangement_meals_per_day: 3
+    us:regulations/7-cfr/273/1/b/3#input.board_payment_amount: 298
+    us:regulations/7-cfr/273/1/b/3#input.provider_household_requests_boarder_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/3#snap_boarding_establishment_is_commercial_boarding_house: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_commercial_boarding_house_resident_ineligible: not_holds
+    us:regulations/7-cfr/273/1/b/3#snap_noncommercial_boarder: holds

--- a/us/regulations/7-cfr/273/1/b/3.yaml
+++ b/us/regulations/7-cfr/273/1/b/3.yaml
@@ -10,9 +10,13 @@ module:
     is a boarder, cannot participate independently of the provider household,
     and may join that household only at its request. The reasonable amount is
     the maximum allotment for more than two meals daily and two-thirds of that
-    allotment for two or fewer meals. An underpaying board recipient is not a
-    boarder and must join the provider household. The source's references to
-    paragraph (b)(7)(vii) are internally inconsistent with the current A-E
+    allotment for two or fewer meals. Paragraph (b)(1)'s mandatory
+    combinations remain controlling: a candidate unit containing a spouse, a
+    person under 22 living with a parent, or controlled non-foster child under
+    18 who must join the provider unit cannot instead become an optional
+    boarder unit. An underpaying board recipient is also not a boarder and must
+    join the provider household. The source's references to paragraph
+    (b)(7)(vii) are internally inconsistent with the current A-E
     institution-exception placement; the exception-entity fact here maps to
     the retained A-E list without relabeling the source.
 imports:
@@ -51,6 +55,37 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           2 / 3
+
+  - name: snap_boarder_unit_required_to_join_provider_household_under_b_1
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Spouses
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A person under 22 years of age who is living with his or her natural or adoptive parent(s) or step-parent(s)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A child (other than a foster child) under 18 years of age who lives with and is under the parental control of a household member other than his or her parent
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          boarder_unit_contains_spouse_required_to_join_provider_household
+          or boarder_unit_contains_under_22_person_required_to_join_parent_in_provider_household
+          or boarder_unit_contains_nonfoster_under_18_child_required_to_join_nonparent_controller_in_provider_household
 
   - name: snap_boarding_establishment_is_commercial_boarding_house
     kind: derived
@@ -168,11 +203,17 @@ rules:
             source:
               corpus_citation_path: us/regulation/7/273/1
               excerpt: individuals or groups of individuals paying a reasonable amount for meals or meals and lodging must be considered boarders
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: must be included in the same household, unless otherwise specified
     versions:
       - effective_from: '2025-10-01'
         formula: |-
           boarder_unit_has_board_arrangement
           and not snap_boarding_establishment_is_commercial_boarding_house
+          and not snap_boarder_unit_required_to_join_provider_household_under_b_1
           and board_payment_amount >= snap_minimum_reasonable_board_compensation
 
   - name: snap_boarder_independent_participation_prohibited

--- a/us/regulations/7-cfr/273/1/b/3.yaml
+++ b/us/regulations/7-cfr/273/1/b/3.yaml
@@ -1,0 +1,253 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(3) bars residents of commercial boarding houses. A
+    noncommercial person or group paying at least the reasonable board amount
+    is a boarder, cannot participate independently of the provider household,
+    and may join that household only at its request. The reasonable amount is
+    the maximum allotment for more than two meals daily and two-thirds of that
+    allotment for two or fewer meals. An underpaying board recipient is not a
+    boarder and must join the provider household. The source's references to
+    paragraph (b)(7)(vii) are internally inconsistent with the current A-E
+    institution-exception placement; the exception-entity fact here maps to
+    the retained A-E list without relabeling the source.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
+rules:
+  - name: snap_boarder_full_meal_daily_threshold
+    kind: parameter
+    dtype: Count
+    source: 7 CFR 273.1(b)(3)(ii)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: more than two meals per day
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          2
+
+  - name: snap_boarder_reduced_meal_compensation_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 CFR 273.1(b)(3)(ii)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: two-thirds of the maximum SNAP allotment for the appropriate size of the boarder household
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          2 / 3
+
+  - name: snap_boarding_establishment_is_commercial_boarding_house
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A commercial boarding house is an establishment licensed to offer meals and lodging for compensation
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: a commercial establishment that offers meals and lodging for compensation with the intent of making a profit
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: It does not include any of the entities listed in paragraph (b)(7)(vii) of this section
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          boarder_unit_resides_at_boarding_establishment
+          and not boarding_establishment_is_referenced_institution_exception_entity
+          and (
+              boarding_establishment_is_licensed_to_offer_meals_and_lodging_for_compensation
+              or (
+                  not project_area_has_boarding_house_licensing_requirements
+                  and boarding_establishment_offers_meals_and_lodging_for_compensation
+                  and boarding_establishment_intends_to_make_profit
+              )
+          )
+
+  - name: snap_commercial_boarding_house_resident_ineligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Residents of a commercial boarding house, regardless of the number of residents, are not eligible to participate in the Program
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_boarding_establishment_is_commercial_boarding_house
+
+  - name: snap_minimum_reasonable_board_compensation
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.1(b)(3)(ii)(A)-(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: For individuals whose board arrangement is for more than two meals per day, “reasonable compensation” must be an amount that equals or exceeds the maximum SNAP allotment for the appropriate size of the boarder household
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: For individuals whose board arrangement is for two meals or less per day, “reasonable compensation” must be an amount that equals or exceeds two-thirds of the maximum SNAP allotment for the appropriate size of the boarder household
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/3#snap_boarder_full_meal_daily_threshold
+              output: snap_boarder_full_meal_daily_threshold
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/3#snap_boarder_reduced_meal_compensation_rate
+              output: snap_boarder_reduced_meal_compensation_rate
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
+              output: snap_maximum_allotment
+              hash: sha256:2e4708b8df906b506f07d091fe93dbcc6aefe603a31500502ecc270d436e9f2e
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if board_arrangement_meals_per_day > snap_boarder_full_meal_daily_threshold:
+              snap_maximum_allotment
+          else:
+              snap_maximum_allotment * snap_boarder_reduced_meal_compensation_rate
+
+  - name: snap_noncommercial_boarder
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: individuals or groups of individuals paying a reasonable amount for meals or meals and lodging must be considered boarders
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          boarder_unit_has_board_arrangement
+          and not snap_boarding_establishment_is_commercial_boarding_house
+          and board_payment_amount >= snap_minimum_reasonable_board_compensation
+
+  - name: snap_boarder_independent_participation_prohibited
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: not eligible to participate in the Program independently of the household providing the board
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_noncommercial_boarder
+
+  - name: snap_boarder_unit_may_join_provider_household
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: only at the request of the household providing the boarder services
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_noncommercial_boarder
+          and provider_household_requests_boarder_unit_membership
+
+  - name: snap_underpaid_board_recipient_required_provider_household_member
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: An individual paying less than a reasonable amount for board must not be considered a boarder but must be considered, along with a spouse or children living with him or her, as a member of the household providing the board
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          boarder_unit_has_board_arrangement
+          and not snap_boarding_establishment_is_commercial_boarding_house
+          and board_payment_amount < snap_minimum_reasonable_board_compensation
+
+  - name: snap_boarder_treated_as_noninstitution_resident
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(3)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Boarders must not be considered to be residents of an institution
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_noncommercial_boarder

--- a/us/regulations/7-cfr/273/1/b/4.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/4.test.yaml
@@ -1,0 +1,32 @@
+- name: foster_care_placement_is_boarder_and_cannot_participate_independently
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/4#input.individual_placed_by_federal_state_or_local_foster_care_program: true
+    us:regulations/7-cfr/273/1/b/4#input.individual_lives_in_foster_provider_home: true
+    us:regulations/7-cfr/273/1/b/4#input.provider_household_requests_foster_care_unit_membership: false
+  output:
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_treated_as_boarder: holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_independent_participation_prohibited: holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_unit_may_join_provider_household: not_holds
+
+- name: provider_request_allows_foster_care_unit_to_join_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/4#input.individual_placed_by_federal_state_or_local_foster_care_program: true
+    us:regulations/7-cfr/273/1/b/4#input.individual_lives_in_foster_provider_home: true
+    us:regulations/7-cfr/273/1/b/4#input.provider_household_requests_foster_care_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_treated_as_boarder: holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_independent_participation_prohibited: holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_unit_may_join_provider_household: holds
+
+- name: private_living_arrangement_is_not_government_foster_care_placement
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/4#input.individual_placed_by_federal_state_or_local_foster_care_program: false
+    us:regulations/7-cfr/273/1/b/4#input.individual_lives_in_foster_provider_home: true
+    us:regulations/7-cfr/273/1/b/4#input.provider_household_requests_foster_care_unit_membership: true
+  output:
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_treated_as_boarder: not_holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_individual_independent_participation_prohibited: not_holds
+    us:regulations/7-cfr/273/1/b/4#snap_foster_care_unit_may_join_provider_household: not_holds

--- a/us/regulations/7-cfr/273/1/b/4.yaml
+++ b/us/regulations/7-cfr/273/1/b/4.yaml
@@ -1,0 +1,75 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(4) treats an individual placed in a provider home by a
+    Federal, State, or local foster care program as a boarder. The foster unit
+    cannot participate independently and may participate with the provider
+    household, together with a co-resident spouse or children, only when the
+    provider household requests inclusion. This rule independently governs a
+    foster minor even though foster status removes the child from
+    paragraph (b)(1)(iii).
+rules:
+  - name: snap_foster_care_individual_treated_as_boarder
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals placed in the home of relatives or other individuals or families by a Federal, State, or local governmental foster care program must be considered to be boarders
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          individual_placed_by_federal_state_or_local_foster_care_program
+          and individual_lives_in_foster_provider_home
+
+  - name: snap_foster_care_individual_independent_participation_prohibited
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: They cannot participate in the Program independently of the household providing the foster care services
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          individual_placed_by_federal_state_or_local_foster_care_program
+          and individual_lives_in_foster_provider_home
+
+  - name: snap_foster_care_unit_may_join_provider_household
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(4)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: only at the request of the household providing the foster care
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          individual_placed_by_federal_state_or_local_foster_care_program
+          and individual_lives_in_foster_provider_home
+          and provider_household_requests_foster_care_unit_membership

--- a/us/regulations/7-cfr/273/1/b/5.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/5.test.yaml
@@ -1,0 +1,113 @@
+- name: compensated_lodging_without_meals_allows_separate_roomer_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: holds
+
+- name: lodging_with_meals_is_not_roomer_status
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: true
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: not_holds
+
+- name: mandatory_household_combination_prevents_roomer_status
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: not_holds
+
+- name: uncompensated_lodging_is_not_roomer_status
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: false
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: not_holds
+
+- name: age_21_person_with_parent_cannot_be_roomer
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 21
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: not_holds
+
+- name: age_22_person_with_parent_may_be_roomer
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_lodging_for_compensation: true
+    us:regulations/7-cfr/273/1/b/5#input.host_household_furnishes_person_meals: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 22
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: true
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/5#snap_person_is_roomer_for_household_boundary: holds
+    us:regulations/7-cfr/273/1/b/5#snap_roomer_separate_household_available: holds

--- a/us/regulations/7-cfr/273/1/b/5.yaml
+++ b/us/regulations/7-cfr/273/1/b/5.yaml
@@ -1,0 +1,63 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(5) permits a person receiving compensated lodging, but not
+    meals, to participate as a separate roomer household. A person subject to
+    a mandatory household combination under paragraph (b)(1) cannot be
+    classified as a roomer and therefore cannot use this unit-boundary rule.
+imports:
+  - us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+rules:
+  - name: snap_person_is_roomer_for_household_boundary
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals to whom a household furnishes lodging for compensation, but not meals
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Persons described in paragraph (b)(1) of this section must not be considered roomers
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+              output: snap_person_subject_to_required_household_combination
+              hash: sha256:ffef0283116c859f60e9dc127ed5b444cb821b9ce64c9cf1da175f2562495e7b
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          host_household_furnishes_person_lodging_for_compensation
+          and not host_household_furnishes_person_meals
+          and not snap_person_subject_to_required_household_combination
+
+  - name: snap_roomer_separate_household_available
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: may participate as separate households
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_person_is_roomer_for_household_boundary

--- a/us/regulations/7-cfr/273/1/b/6.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/6.test.yaml
@@ -1,0 +1,53 @@
+- name: live_in_attendant_may_participate_as_separate_household
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/6#input.person_is_live_in_attendant_under_resolved_facts: true
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/6#snap_person_is_live_in_attendant_for_household_boundary: holds
+    us:regulations/7-cfr/273/1/b/6#snap_live_in_attendant_separate_household_available: holds
+
+- name: mandatory_household_combination_prevents_live_in_attendant_status
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/6#input.person_is_live_in_attendant_under_resolved_facts: true
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/6#snap_person_is_live_in_attendant_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/6#snap_live_in_attendant_separate_household_available: not_holds
+
+- name: non_attendant_does_not_receive_separate_attendant_status
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/6#input.person_is_live_in_attendant_under_resolved_facts: false
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 30
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+  output:
+    us:regulations/7-cfr/273/1/b/6#snap_person_is_live_in_attendant_for_household_boundary: not_holds
+    us:regulations/7-cfr/273/1/b/6#snap_live_in_attendant_separate_household_available: not_holds

--- a/us/regulations/7-cfr/273/1/b/6.yaml
+++ b/us/regulations/7-cfr/273/1/b/6.yaml
@@ -1,0 +1,62 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(6) permits a live-in attendant to participate as a separate
+    household. A person subject to a mandatory household combination under
+    paragraph (b)(1) cannot be classified as a live-in attendant and therefore
+    cannot use this unit-boundary rule.
+imports:
+  - us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+rules:
+  - name: snap_person_is_live_in_attendant_for_household_boundary
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A live-in attendant
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Persons described in paragraph (b)(1) of this section must not be considered live-in attendants
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+              output: snap_person_subject_to_required_household_combination
+              hash: sha256:ffef0283116c859f60e9dc127ed5b444cb821b9ce64c9cf1da175f2562495e7b
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_is_live_in_attendant_under_resolved_facts
+          and not snap_person_subject_to_required_household_combination
+
+  - name: snap_live_in_attendant_separate_household_available
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(6)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: A live-in attendant may participate as a separate household
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_person_is_live_in_attendant_for_household_boundary

--- a/us/regulations/7-cfr/273/1/b/7.test.yaml
+++ b/us/regulations/7-cfr/273/1/b/7.test.yaml
@@ -1,0 +1,640 @@
+- name: exactly_half_of_three_daily_meals_is_not_a_majority
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.institution_normal_services_share_of_three_daily_meals: 0.5
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_meets_institution_majority_meal_service_test: not_holds
+
+- name: more_than_half_of_three_daily_meals_without_exception_is_ineligible
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.institution_normal_services_share_of_three_daily_meals: 0.5001
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_treated_as_boarder_under_paragraph_b_3_or_b_4: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_meets_institution_majority_meal_service_test: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_nonexcepted_institution_resident: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_ineligible_household_member_under_273_1_b_7: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_excluded_from_participating_unit_under_273_1_b_7: holds
+
+- name: resolved_boarder_is_not_an_institution_resident_despite_majority_meal_service
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.institution_normal_services_share_of_three_daily_meals: 0.75
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_treated_as_boarder_under_paragraph_b_3_or_b_4: true
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_meets_institution_majority_meal_service_test: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_nonexcepted_institution_resident: not_holds
+
+- name: elderly_housing_exception_defaults_to_separate_household_treatment
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+    us:regulations/7-cfr/273/1/b/7#input.another_applicable_rule_overrides_default_institution_exception_household_treatment: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 40
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_not_barred_by_institution_residence: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_default_separate_household_treatment: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_subject_to_mandatory_household_combination: not_holds
+
+- name: treatment_program_resident_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: child_living_with_treatment_program_resident_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: spouse_only_of_treatment_program_resident_does_not_receive_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.institution_normal_services_share_of_three_daily_meals: 0.75
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_treated_as_boarder_under_paragraph_b_3_or_b_4: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_nonexcepted_institution_resident: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_ineligible_household_member_under_273_1_b_7: holds
+
+- name: independently_qualifying_treatment_resident_is_excepted_even_if_also_a_spouse
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: disabled_or_blind_group_living_resident_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: woman_in_battered_women_and_children_shelter_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: child_with_woman_in_battered_shelter_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: true
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: nonprofit_homeless_shelter_resident_receives_institution_exception
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: true
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+
+- name: institution_exception_remains_subject_to_b1_spouse_combination
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+    us:regulations/7-cfr/273/1/b/7#input.another_applicable_rule_overrides_default_institution_exception_household_treatment: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 40
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: true
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_default_separate_household_treatment: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_subject_to_mandatory_household_combination: holds
+
+- name: another_applicable_rule_overrides_default_separate_household_treatment
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+    us:regulations/7-cfr/273/1/b/7#input.another_applicable_rule_overrides_default_institution_exception_household_treatment: true
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 40
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_default_separate_household_treatment: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_subject_to_mandatory_household_combination: not_holds
+
+- name: ineligible_alien_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: ineligible_student_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: cash_out_state_ssi_recipient_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: work_requirement_disqualification_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: ssn_disqualification_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: intentional_program_violation_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: drug_related_felony_ineligibility_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: true
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: cross_program_disqualification_does_not_apply_when_state_option_is_off
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: not_holds
+
+- name: cross_program_disqualification_applies_when_state_option_is_on
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: fleeing_or_probation_or_parole_ineligibility_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: child_support_enforcement_noncooperation_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: true
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: child_support_delinquency_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: abawd_time_limit_ineligibility_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: sentence_noncompliance_after_certain_crime_has_noninstitution_participation_bar
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: true
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+
+- name: institution_exception_does_not_override_intentional_program_violation
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/1/b/7#input.institution_normal_services_share_of_three_daily_meals: 0.75
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_federally_subsidized_housing_for_elderly: true
+    us:regulations/7-cfr/273/1/b/7#input.person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_disabled_or_blind_resident_of_group_living_arrangement: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_woman_temporarily_residing_in_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_child_living_with_woman_at_battered_women_and_children_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_resides_in_public_or_private_nonprofit_homeless_shelter: false
+    us:regulations/7-cfr/273/1/b/7#input.person_treated_as_boarder_under_paragraph_b_3_or_b_4: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_alien: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ineligible_student_under_section_273_5: false
+    us:regulations/7-cfr/273/1/b/7#input.person_is_ssi_recipient_in_cash_out_state: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_noncompliance_with_section_273_7_work_requirements: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_failure_to_provide_ssn: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_intentional_program_violation: true
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction: false
+    us:regulations/7-cfr/273/1/b/7#input.state_agency_uses_section_273_11_k_cross_program_disqualification_option: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_in_another_assistance_program_under_section_273_11_k: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p: false
+    us:regulations/7-cfr/273/1/b/7#input.person_disqualified_for_child_support_delinquency_under_section_273_11_q: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_24_abawd_time_limit: false
+    us:regulations/7-cfr/273/1/b/7#input.person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime: false
+    us:regulations/7-cfr/273/1/b/7#input.another_applicable_rule_overrides_default_institution_exception_household_treatment: false
+    us:regulations/7-cfr/273/1/b/1#input.person_age: 40
+    us:regulations/7-cfr/273/1/b/1#input.person_has_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_spouse: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_natural_adoptive_or_step_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_foster_child: false
+    us:regulations/7-cfr/273/1/b/1#input.person_lives_with_candidate_household_member_other_than_parent: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_under_parental_control_of_candidate_nonparent_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_financially_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.person_is_otherwise_dependent_on_candidate_household_member: false
+    us:regulations/7-cfr/273/1/b/1#input.state_law_defines_person_as_adult: false
+  output:
+    us:regulations/7-cfr/273/1/b/7#snap_institution_participation_exception_applies: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_nonexcepted_institution_resident: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_has_noninstitution_b7_participation_bar: holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_default_separate_household_treatment: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_institution_exception_subject_to_mandatory_household_combination: not_holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_is_ineligible_household_member_under_273_1_b_7: holds
+    us:regulations/7-cfr/273/1/b/7#snap_person_excluded_from_participating_unit_under_273_1_b_7: holds

--- a/us/regulations/7-cfr/273/1/b/7.yaml
+++ b/us/regulations/7-cfr/273/1/b/7.yaml
@@ -1,0 +1,362 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+  summary: |-
+    7 CFR 273.1(b)(7) identifies people who are excluded from SNAP
+    participation as either a separate household or a participating member of
+    any household. It includes nonexcepted institution residents whose
+    institution supplies over half of three daily meals through normal
+    services. Five listed living arrangements are excepted from that
+    institution-residence bar and receive default separate-household
+    treatment, subject to paragraph (b)(1)'s mandatory combinations and the
+    source's “unless otherwise stated” qualifier. Boarders remain
+    noninstitution residents under paragraph (b)(3)(iii). These ineligible
+    household members are distinct from roomers, attendants, and unselected
+    boarders at a host-unit boundary: downstream rules, including
+    7 CFR 273.11(c) where applicable, govern how an excluded member affects
+    remaining members. The retained source calls the institution exceptions
+    (b)(7)(vii)(A)-(E), although A-E appear under (vi) and the next standalone
+    paragraph is also labeled (vii); this module maps A-E to the institution
+    exception without silently changing the source text.
+imports:
+  - us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+rules:
+  - name: snap_institution_majority_meal_share_threshold
+    kind: parameter
+    dtype: Rate
+    source: 7 CFR 273.1(b)(7)(vi)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: over 50 percent of three meals daily
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          0.5
+
+  - name: snap_person_meets_institution_majority_meal_service_test
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals must be considered residents of an institution when the institution provides them with the majority of their meals (over 50 percent of three meals daily) as part of the institution's normal services
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/7#snap_institution_majority_meal_share_threshold
+              output: snap_institution_majority_meal_share_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          institution_normal_services_share_of_three_daily_meals
+              > snap_institution_majority_meal_share_threshold
+
+  - name: snap_institution_participation_exception_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)(A)-(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are residents of federally subsidized housing for the elderly
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are narcotic addicts or alcoholics and reside at a facility or treatment center for the purpose of regular participation in a drug or alcohol treatment and rehabilitation program
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: This includes the children but not the spouses of such persons who live with them at the treatment center or facility
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are disabled or blind and are residents of group living arrangements
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individual women or women with their children who are temporarily residing in a shelter for battered women and children
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are residents of public or private nonprofit shelters for homeless persons
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_resides_in_federally_subsidized_housing_for_elderly
+          or person_is_narcotic_addict_or_alcoholic_residing_at_treatment_facility_for_regular_program_participation
+          or (
+              person_is_child_living_with_narcotic_or_alcohol_treatment_resident_at_facility
+              and not person_is_spouse_of_narcotic_or_alcohol_treatment_resident_at_facility
+          )
+          or person_is_disabled_or_blind_resident_of_group_living_arrangement
+          or person_is_woman_temporarily_residing_in_battered_women_and_children_shelter
+          or person_is_child_living_with_woman_at_battered_women_and_children_shelter
+          or person_resides_in_public_or_private_nonprofit_homeless_shelter
+
+  - name: snap_person_is_nonexcepted_institution_resident
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Residents of an institution, with some exceptions
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Exceptions to this requirement include only the individuals listed in paragraphs (b)(7)(vii)(A) through (b)(7)(vii)(E) of this section
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Boarders must not be considered to be residents of an institution
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_person_meets_institution_majority_meal_service_test
+          and not snap_institution_participation_exception_applies
+          and not person_treated_as_boarder_under_paragraph_b_3_or_b_4
+
+  - name: snap_institution_exception_not_barred_by_institution_residence
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)(A)-(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Exceptions to this requirement include only the individuals listed in paragraphs (b)(7)(vii)(A) through (b)(7)(vii)(E) of this section
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_institution_participation_exception_applies
+
+  - name: snap_institution_exception_default_separate_household_treatment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)(A)-(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: must be treated as separate households from the others with whom they reside, subject to the mandatory household combination requirements of paragraph (b)(1) of this section
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: unless otherwise stated
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+              output: snap_person_subject_to_required_household_combination
+              hash: sha256:ffef0283116c859f60e9dc127ed5b444cb821b9ce64c9cf1da175f2562495e7b
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_institution_participation_exception_applies
+          and not snap_person_subject_to_required_household_combination
+          and not snap_person_has_noninstitution_b7_participation_bar
+          and not another_applicable_rule_overrides_default_institution_exception_household_treatment
+
+  - name: snap_institution_exception_subject_to_mandatory_household_combination
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)(vi)(A)-(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: subject to the mandatory household combination requirements of paragraph (b)(1) of this section
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/7-cfr/273/1/b/1#snap_person_subject_to_required_household_combination
+              output: snap_person_subject_to_required_household_combination
+              hash: sha256:ffef0283116c859f60e9dc127ed5b444cb821b9ce64c9cf1da175f2562495e7b
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_institution_participation_exception_applies
+          and not snap_person_has_noninstitution_b7_participation_bar
+          and snap_person_subject_to_required_household_combination
+
+  - name: snap_person_has_noninstitution_b7_participation_bar
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Ineligible aliens and students as specified in §§ 273.4 and 273.5, respectively
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: SSI recipients in “cash-out” States as specified in § 273.20
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals disqualified for noncompliance with the work requirements of § 273.7
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals disqualified for failure to provide an SSN as specified in § 273.6
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals disqualified for an intentional Program violation as specified in § 273.16
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Residents of an institution, with some exceptions
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are ineligible under § 273.11(m) because of a drug-related felony conviction
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: At State agency option, individuals who are disqualified in another assistance program in accordance with § 273.11(k)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals who are fleeing to avoid prosecution or custody for a crime, or an attempt to commit a crime, or who are violating a condition of probation or parole who are ineligible under § 273.11(n)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals disqualified for failure to cooperate with child support enforcement agencies in accordance with § 273.11(o) or (p), or for being delinquent in any court-ordered child support obligation in accordance with § 273.11(q)
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Persons ineligible under § 273.24, the time limit for able-bodied adults
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Individuals convicted of certain crimes and who are out of compliance with the terms of their sentence and ineligible under § 273.11(s)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          person_is_ineligible_alien
+          or person_is_ineligible_student_under_section_273_5
+          or person_is_ssi_recipient_in_cash_out_state
+          or person_disqualified_for_noncompliance_with_section_273_7_work_requirements
+          or person_disqualified_for_failure_to_provide_ssn
+          or person_disqualified_for_intentional_program_violation
+          or person_ineligible_under_section_273_11_m_for_drug_related_felony_conviction
+          or (
+              state_agency_uses_section_273_11_k_cross_program_disqualification_option
+              and person_disqualified_in_another_assistance_program_under_section_273_11_k
+          )
+          or person_ineligible_under_section_273_11_n_for_fleeing_or_probation_or_parole_violation
+          or person_disqualified_for_child_support_enforcement_noncooperation_under_section_273_11_o_or_p
+          or person_disqualified_for_child_support_delinquency_under_section_273_11_q
+          or person_ineligible_under_section_273_24_abawd_time_limit
+          or person_ineligible_under_section_273_11_s_for_sentence_noncompliance_after_certain_crime
+
+  - name: snap_person_is_ineligible_household_member_under_273_1_b_7
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: The following persons are not eligible to participate as separate households or as a member of any household
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: Residents of an institution, with some exceptions
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_person_has_noninstitution_b7_participation_bar
+          or snap_person_is_nonexcepted_institution_resident
+
+  - name: snap_person_excluded_from_participating_unit_under_273_1_b_7
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/7/273/1
+              excerpt: The following persons are not eligible to participate as separate households or as a member of any household
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_person_is_ineligible_household_member_under_273_1_b_7


### PR DESCRIPTION
Closes a named closure gap: § 273.1 (household concept) had no encoding, only references. Part of the CO SNAP closure sprint (#1135).

## Modules

`us/regulations/7-cfr/273/1/a.yaml` and `273/1/b/1.yaml` … `273/1/b/7.yaml` — 8 modules, each with a companion test.

## Validation

- Pinned validation and proof validation: 8/8 modules
- Companion tests: 77/77
- Repository tests: 65 passed
- Reverse index check passed
- No changes to workflows, toolchain, pins, CODEOWNERS, or anything under `programs/` — the composed program is deliberately untouched, so no currently-green verdict is perturbed by this PR

## Judgment calls (please review these specifically)

- Strict under-22 / under-18 boundaries as written, with no invented age floor for living alone
- Direct-control and dependency-deeming treated as separate rules
- Disability causation and resident counting under (b)(2)
- Mandatory household formation prevails over boarder elections
- Institutional exceptions remove only the institutional bar

## Related

A federal-parity lane is separately adjudicating lone-minor household formation on the AL/NC suites, currently arguing from bare regulation text; the (b) exception rules here are the surface that adjudication concerns.

#28 (undefined `snap_gross_monthly_income` in 7-cfr/273/9) was checked and left out of scope: § 273.1 defines membership, not the downstream income aggregate.

Draft until a human reviews the law, per the sprint rule that nothing merges unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)