### PR TITLE
Encode South Carolina SNAP utility allowances (manual pages 159, 163, 165)

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-159.test.yaml",
-      "sha256": "c6e2dcfdf6a52c66bea7801fd3669d5e52b7470967a3b5b4f466205508ffb0e4"
+      "sha256": "3ef05ee9d0c4b35499275be9b29201f058df888715f405068b2e898a123e3a9b"
     },
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-159.yaml",
-      "sha256": "61ebdb98f03fff6cdc16fe55361389ac877a838ffd954f703b72c2ace8f12358"
+      "sha256": "ac0c3cb1712f9f3688cba7ce1a411f948aad69303bf437ff8eeb06a78be7ad08"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-sc:policies/dss/snap-policy-manual/page-159",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T17:15:54.006399+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-159.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
-  "generated_output_sha256": "61ebdb98f03fff6cdc16fe55361389ac877a838ffd954f703b72c2ace8f12358",
+  "generated_at": "2026-07-27T18:23:11.665705+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-159.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
+  "generated_output_sha256": "ac0c3cb1712f9f3688cba7ce1a411f948aad69303bf437ff8eeb06a78be7ad08",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "f6f9a77da3cf9609cb5f9b6d4d42d197f90e4a7a27c685f2effb3e151ed4fdc9"
+    "value": "cfed54519f85a8471ec711434f0fec5669cbbb0637845aa699c22c5c8805ae5e"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T17:15:54.006399+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "fbd6db0ab974ff94b7b50958d0178b13b987255bebae54564a21be2b9e060fde",
+    "prior_signature": "f6f9a77da3cf9609cb5f9b6d4d42d197f90e4a7a27c685f2effb3e151ed4fdc9",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-159.test.yaml",
+      "sha256": "c6e2dcfdf6a52c66bea7801fd3669d5e52b7470967a3b5b4f466205508ffb0e4"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-159.yaml",
+      "sha256": "61ebdb98f03fff6cdc16fe55361389ac877a838ffd954f703b72c2ace8f12358"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-159",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T17:15:54.006399+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-159.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
+  "generated_output_sha256": "61ebdb98f03fff6cdc16fe55361389ac877a838ffd954f703b72c2ace8f12358",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "f6f9a77da3cf9609cb5f9b6d4d42d197f90e4a7a27c685f2effb3e151ed4fdc9"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-163.test.yaml",
-      "sha256": "d0af9f28903eb14fd02059e926cd9d846ba4baf251403df1a7c395a64a16bd23"
+      "sha256": "80d986299f5eefd7f87679533fb04066e0df54fcb7937824977d1ae85a62bc6a"
     },
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-163.yaml",
-      "sha256": "5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360"
+      "sha256": "c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-sc:policies/dss/snap-policy-manual/page-163",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T17:15:54.012616+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-163.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
-  "generated_output_sha256": "5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360",
+  "generated_at": "2026-07-27T18:23:11.666800+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
+  "generated_output_sha256": "c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "cf9a1ff88a3b4ef5b3665cca582ffe5b4ab3770c298a430b00f87ae5dc55c676"
+    "value": "5f03c4ded6893dc197e3901b73efde78971cfa53d8d63c45597dacff44d565b1"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T17:15:54.012616+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "2167974aa281aa8d6bad1694ea126468da6b03ca7f60307b82b10f9457fd0c1d",
+    "prior_signature": "cf9a1ff88a3b4ef5b3665cca582ffe5b4ab3770c298a430b00f87ae5dc55c676",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.test.yaml",
+      "sha256": "d0af9f28903eb14fd02059e926cd9d846ba4baf251403df1a7c395a64a16bd23"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+      "sha256": "5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-163",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T17:15:54.012616+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
+  "generated_output_sha256": "5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "cf9a1ff88a3b4ef5b3665cca582ffe5b4ab3770c298a430b00f87ae5dc55c676"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
@@ -1,0 +1,42 @@
+{
+  "applied_files": [
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.test.yaml",
+      "sha256": "65cbc3ddc0049fb5bfd5956e3664b428cc6308893d46a8b3549f30975c374f88"
+    },
+    {
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+      "sha256": "15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-sc:policies/dss/snap-policy-manual/page-165",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-07-27T17:15:54.013666+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
+  "generated_output_sha256": "15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759",
+  "generation_prompt_sha256": null,
+  "manual_exception": "composition",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4b42eaa4f2150c94ee01c1ff4b28a5011e1b1cde7bd861830ecee1f79c38d145"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-165.test.yaml",
-      "sha256": "65cbc3ddc0049fb5bfd5956e3664b428cc6308893d46a8b3549f30975c374f88"
+      "sha256": "d7079aeece02315ad0ba61533072e4e65bcc1f0a0833f41db8cb4758eb131924"
     },
     {
       "path": "us-sc/policies/dss/snap-policy-manual/page-165.yaml",
-      "sha256": "15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759"
+      "sha256": "072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-sc:policies/dss/snap-policy-manual/page-165",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T17:15:54.013666+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-165.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp42iur8cg",
-  "generated_output_sha256": "15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759",
+  "generated_at": "2026-07-27T18:23:11.667306+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
+  "generated_output_sha256": "072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
   "model": "",
@@ -34,7 +34,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "4b42eaa4f2150c94ee01c1ff4b28a5011e1b1cde7bd861830ecee1f79c38d145"
+    "value": "edbe1515b4ab641a1462ccc916073d91f36d6accfd59ee7cf9b062ebabaf6b0a"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-27T17:15:54.013666+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "988b4315af775eff35141ac4e7c66dded62e47a4a0ee673bd52a4d07207f71bc",
+    "prior_signature": "4b42eaa4f2150c94ee01c1ff4b28a5011e1b1cde7bd861830ecee1f79c38d145",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -29442,6 +29442,15 @@
         ]
       }
     ],
+    "us-sc/manual/dss/snap-policy-manual/page-159": [
+      {
+        "module": "us-sc/policies/dss/snap-policy-manual/page-159.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-sc/manual/dss/snap-policy-manual/page-16": [
       {
         "module": "us-sc/policies/dss/snap-policy-manual/page-16.yaml",

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -13,6 +13,8 @@
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -32,6 +32,8 @@
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
@@ -102,6 +104,90 @@
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27
     us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 27
+
+- name: shared_residence_disagreement_blocks_mua_assignment
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: shared_residence_disagreement_blocks_bua_assignment
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: shared_residence_disagreement_blocks_actual_and_telephone_assignment
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
 
 - name: household_without_qualifying_utility_cost_receives_no_allowance
   period: 2026-01

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -1,0 +1,278 @@
+- name: current_monthly_utility_allowance_amounts
+  period: 2026-01
+  input: {}
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#mandatory_utility_allowance_amount: 388
+    us-sc:policies/dss/snap-policy-manual/page-159#basic_utility_allowance_amount: 265
+    us-sc:policies/dss/snap-policy-manual/page-159#telephone_allowance_amount: 27
+
+- name: heating_cost_household_receives_mua
+  period: 2026-01
+  input:
+    <<: &constant_inputs
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
+
+- name: two_non_heating_utilities_receive_bua
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 265
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 265
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 265
+
+- name: coherent_telephone_only_household_receives_telephone_allowance
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 27
+
+- name: household_without_qualifying_utility_cost_receives_no_allowance
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: mua_wins_when_mua_and_bua_raw_prerequisites_overlap
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
+
+- name: bua_without_submitted_verification_receives_no_allowance
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: bua_raw_prerequisites_with_utilities_in_rent_receive_no_allowance
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: telephone_only_without_verified_actual_cost_receives_no_allowance
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+
+- name: state_energy_assistance_basis_receives_mua
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
+
+- name: supplemental_heating_source_without_liheap_receives_no_mua
+  period: 2026-01
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
+    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -49,9 +49,11 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
   output:
+    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
     us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
 
@@ -74,9 +76,11 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
   output:
+    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 265
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 265
     us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 265
 
@@ -99,9 +103,11 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
   output:
+    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 27
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27
     us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 27
 
@@ -208,9 +214,11 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
   output:
+    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
+    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
     us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
 

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -34,7 +34,6 @@
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
@@ -50,6 +49,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
@@ -77,6 +77,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
@@ -104,6 +105,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
@@ -132,7 +134,6 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
@@ -160,7 +161,6 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
@@ -187,7 +187,6 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
@@ -215,6 +214,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
@@ -242,6 +242,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
@@ -267,6 +268,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
@@ -292,6 +294,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
@@ -317,6 +320,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
@@ -342,6 +346,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
@@ -366,6 +371,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -19,10 +19,13 @@ module:
     Mandatory Utility Allowance, $265 for the Basic Utility Allowance, and $27
     for the telephone allowance. The household receives at most one: MUA,
     otherwise verified BUA, otherwise the verified telephone-only standard.
+    The current setters supersede page 369's historical September 2009
+    utility-standard setters when both pages are composed.
 imports:
   - us:regulations/7-cfr/273/9
   - us-sc:policies/dss/snap-policy-manual/page-163
   - us-sc:policies/dss/snap-policy-manual/page-165
+  - us-sc:policies/dss/snap-policy-manual/page-369
 rules:
   - name: sets_sc_current_snap_standard_utility_allowance
     kind: source_relation

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -138,7 +138,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
               output: multiple_utility_allowance_entitlement
-              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
+              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
     versions:
       - effective_from: '2026-01-01'
         formula: |-
@@ -168,19 +168,19 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
+              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed
               output: household_basic_utility_allowance_deduction_allowed
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
     versions:
       - effective_from: '2026-01-01'
         formula: |-
@@ -214,19 +214,19 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
+              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
               output: household_entitled_to_telephone_only_standard
-              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
+              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
     versions:
       - effective_from: '2026-01-01'
         formula: |-

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -133,13 +133,13 @@ rules:
           - path: versions[0].formula
             kind: import
             import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+              output: multiple_utility_allowance_entitlement
+              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if household_entitled_to_mandatory_utility_allowance:
+          if multiple_utility_allowance_entitlement:
             mandatory_utility_allowance_amount
           else:
             0
@@ -171,7 +171,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
           - path: versions[0].formula
             kind: import
             import:
@@ -217,13 +217,13 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
               output: household_entitled_to_telephone_only_standard
-              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
     versions:
       - effective_from: '2026-01-01'
         formula: |-

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -138,7 +138,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
               output: multiple_utility_allowance_entitlement
-              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
+              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
     versions:
       - effective_from: '2026-01-01'
         formula: |-
@@ -174,7 +174,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
+              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
           - path: versions[0].formula
             kind: import
             import:
@@ -220,13 +220,13 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
-              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
+              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
           - path: versions[0].formula
             kind: import
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
               output: household_entitled_to_telephone_only_standard
-              hash: sha256:9146cdfbf1bb21723f93fde96984037005c87b5d440906e54ea17db7569050ef
+              hash: sha256:dfdef163527e511e01870b3a486c1d4f46917813794ea41c010032d106cdaaef
     versions:
       - effective_from: '2026-01-01'
         formula: |-

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -1,0 +1,272 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+    upstream_source_check:
+      status: delegated_parameter_source
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: |-
+        7 CFR 273.9(d)(6)(iii) delegates utility standards to state agencies
+        and supplies the federal standard, limited, and individual allowance
+        hooks. South Carolina SNAP Manual page 159 is the current state source
+        for the MUA, BUA, and telephone amounts.
+  summary: |-
+    South Carolina's current monthly SNAP utility standards are $388 for the
+    Mandatory Utility Allowance, $265 for the Basic Utility Allowance, and $27
+    for the telephone allowance. The household receives at most one: MUA,
+    otherwise verified BUA, otherwise the verified telephone-only standard.
+imports:
+  - us:regulations/7-cfr/273/9
+  - us-sc:policies/dss/snap-policy-manual/page-163
+  - us-sc:policies/dss/snap-policy-manual/page-165
+rules:
+  - name: sets_sc_current_snap_standard_utility_allowance
+    kind: source_relation
+    source: SNAP Manual page 159, mandatory utility allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_sc_current_snap_limited_utility_allowance
+    kind: source_relation
+    source: SNAP Manual page 159, basic utility allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+      authority: state
+      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: sets_sc_current_snap_individual_utility_allowance
+    kind: source_relation
+    source: SNAP Manual page 159, telephone allowance
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      authority: state
+      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+
+  - name: mandatory_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$388 Mandatory utility allowance (MUA)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          388
+
+  - name: basic_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$265 Basic utility allowance (BUA)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          265
+
+  - name: telephone_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+              excerpt: "$27 Telephone allowance"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          27
+
+  - name: sc_current_snap_standard_utility_allowance_state_value
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(D)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#mandatory_utility_allowance_amount
+              output: mandatory_utility_allowance_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if household_entitled_to_mandatory_utility_allowance:
+            mandatory_utility_allowance_amount
+          else:
+            0
+
+  - name: sc_current_snap_limited_utility_allowance_state_value
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(E)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#basic_utility_allowance_amount
+              output: basic_utility_allowance_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+              output: basic_utility_allowance_entitlement
+              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed
+              output: household_basic_utility_allowance_deduction_allowed
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            not household_entitled_to_mandatory_utility_allowance
+            and basic_utility_allowance_entitlement
+            and household_basic_utility_allowance_deduction_allowed
+          ):
+            basic_utility_allowance_amount
+          else:
+            0
+
+  - name: sc_current_snap_individual_utility_allowance_state_value
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Section 12.1(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#telephone_allowance_amount
+              output: telephone_allowance_amount
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+              output: basic_utility_allowance_entitlement
+              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
+              output: household_entitled_to_telephone_only_standard
+              hash: sha256:15aefb4d09c0bb173285a3c7f1f7f42ca411315d1d5170b5a7ff35d291d2c759
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            not household_entitled_to_mandatory_utility_allowance
+            and not basic_utility_allowance_entitlement
+            and household_entitled_to_telephone_only_standard
+          ):
+            telephone_allowance_amount
+          else:
+            0
+
+  - name: local_snap_utility_allowance_for_shelter_costs
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    source: SNAP Manual page 159, Sections 12.1(D)-(F)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
+              output: sc_current_snap_standard_utility_allowance_state_value
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
+              output: sc_current_snap_limited_utility_allowance_state_value
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
+              output: sc_current_snap_individual_utility_allowance_state_value
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          sc_current_snap_standard_utility_allowance_state_value
+          + sc_current_snap_limited_utility_allowance_state_value
+          + sc_current_snap_individual_utility_allowance_state_value

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -2,11 +2,6 @@
   period: 2026-05
   input:
     <<: &constant_inputs
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
@@ -20,6 +15,11 @@
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -39,6 +39,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -59,6 +64,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -78,6 +88,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
@@ -97,6 +112,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
@@ -116,6 +136,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -135,6 +160,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -153,6 +183,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
@@ -172,6 +207,10 @@
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -189,7 +228,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -207,7 +250,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -225,7 +272,11 @@
   input:
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
@@ -244,6 +295,9 @@
     <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -5,6 +5,8 @@
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
@@ -163,3 +165,94 @@
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+
+- name: next_season_heating_cost_separate_from_rent_entitles_household_to_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+
+- name: cooling_cost_incurred_during_year_separate_from_rent_entitles_household_to_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+
+- name: next_season_cooling_cost_separate_from_rent_entitles_household_to_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+
+- name: stale_incurred_heating_cost_outside_year_does_not_establish_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+
+- name: next_season_heating_cost_included_in_rent_does_not_establish_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -1,72 +1,165 @@
 - name: heating_cost_entitles_household_to_mua
   period: 2026-05
   input:
+    <<: &constant_inputs
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
-    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+
 - name: liheap_payment_over_threshold_entitles_household_to_mua
   period: 2026-05
   input:
+    <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
-    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua: 20
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-- name: actual_verified_cost_applies_only_without_mua_or_bua
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+
+- name: page_164_bua_prerequisite_and_verification_allow_bua_deduction
   period: 2026-05
   input:
+    <<: *constant_inputs
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
-- name: bua_deduction_requires_verification
-  period: 2026-05
-  input:
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
-    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_entitled_to_basic_utility_allowance: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+
+- name: actual_verified_cost_applies_only_without_mua_or_bua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
+
+- name: mua_precedence_blocks_simultaneous_bua_and_actual_allowances
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+
+- name: state_energy_assistance_basis_entitles_household_to_mua
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+
+- name: supplemental_heating_source_does_not_establish_mua_without_liheap
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: true
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
+    us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+
+- name: actual_cost_signal_without_submitted_verification_is_not_allowed
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -18,9 +18,10 @@ module:
     At initial certification, a household is assigned one utility allowance:
     actual verified utility cost only if it is not entitled to MUA or BUA,
     MUA if entitled, BUA if entitled, or no utility deduction. MUA applies
-    when the household incurs and is billed for, or expects to incur during
-    the next season, heating or cooling costs, or received a LIHEAP payment
-    greater than $20 in the prior 12 months. Page 164's additional state
+    when, separately from rent or mortgage, the household incurs and is billed
+    during the year for, or expects to incur during the next season, heating
+    or cooling costs; or when it received a LIHEAP payment greater than $20 in
+    the prior 12 months. Page 164's additional state
     energy-assistance, rental, and public-housing bases and its MUA exclusions
     also govern the final entitlement. Actual costs and BUA deductions require
     submitted verification.
@@ -59,13 +60,22 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+              excerpt: "During the year, separately from their rent or mortgage, the households must incur and be billed for, or expect to incur during the next heating or cooling season:"
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          household_incurred_and_billed_separately_for_heating_cost
-          or household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-          or household_incurred_and_billed_separately_for_cooling_cost
-          or household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+          household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage
+          and (
+            (
+              household_incurred_heating_or_cooling_cost_during_year
+              and (
+                household_incurred_and_billed_separately_for_heating_cost
+                or household_incurred_and_billed_separately_for_cooling_cost
+              )
+            )
+            or household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+            or household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+          )
 
   - name: household_received_mua_qualifying_liheap_payment
     kind: derived

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -4,8 +4,28 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: |-
+        7 CFR 273.9(d)(6)(iii) permits state utility standards, requires at
+        least two utilities for a limited allowance, and prevents overlapping
+        standards for the same expense. This page supplies South Carolina's
+        one-allowance assignment and MUA prerequisites under that authority.
   summary: |-
-    At initial certification, a household will be assigned one utility allowance based on utility cost: actual verified utility cost if not entitled to MUA or BUA, MUA if entitled, BUA if entitled, or no utility deduction. To be entitled to the MUA, the household must incur and be billed for, or expect to incur during the next heating or cooling season, heating or cooling costs; or must have received a LIHEAP payment greater than $20 within the past 12 months.
+    At initial certification, a household is assigned one utility allowance:
+    actual verified utility cost only if it is not entitled to MUA or BUA,
+    MUA if entitled, BUA if entitled, or no utility deduction. MUA applies
+    when the household incurs and is billed for, or expects to incur during
+    the next season, heating or cooling costs, or received a LIHEAP payment
+    greater than $20 in the prior 12 months. Page 164's additional state
+    energy-assistance, rental, and public-housing bases and its MUA exclusions
+    also govern the final entitlement. Actual costs and BUA deductions require
+    submitted verification.
+imports:
+  - us-sc:policies/dss/snap-policy-manual/page-164
 rules:
   - name: liheap_payment_threshold_for_mua
     kind: parameter
@@ -98,11 +118,60 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment
               output: household_received_mua_qualifying_liheap_payment
               hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua
+              output: household_may_receive_mua
+              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap
+              output: household_barred_from_mua_unless_liheap
+              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          household_has_mua_heating_or_cooling_cost
-          or household_received_mua_qualifying_liheap_payment
+          household_received_mua_qualifying_liheap_payment
+          or (
+            (
+              household_has_mua_heating_or_cooling_cost
+              or household_may_receive_mua
+            )
+            and not household_barred_from_mua_unless_liheap
+          )
+
+  - name: household_entitled_to_basic_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: SNAP Manual 12.5(1), 12.5(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
+              output: household_may_receive_bua
+              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_may_receive_bua
+          and not household_entitled_to_mandatory_utility_allowance
 
   - name: household_actual_verified_utility_cost_allowance_applies
     kind: derived
@@ -123,10 +192,17 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
               hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+              output: household_entitled_to_basic_utility_allowance
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           household_has_actual_verified_utility_cost
+          and household_submitted_utility_verification
           and not household_entitled_to_mandatory_utility_allowance
           and not household_entitled_to_basic_utility_allowance
 
@@ -143,6 +219,12 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+              output: household_entitled_to_basic_utility_allowance
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -27,7 +27,6 @@
       us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
       us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
@@ -46,6 +45,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
@@ -74,6 +74,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
@@ -102,6 +103,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
@@ -126,6 +128,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
@@ -152,6 +155,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: true
@@ -180,6 +184,7 @@
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -186,3 +186,30 @@
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+
+- name: utility_in_rent_does_not_block_separate_verified_actual_water_cost
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -5,6 +5,8 @@
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
       us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
       us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -1,74 +1,80 @@
-- name: bua-covered-costs-entitle-household-and-block-actual-costs
+- name: two_non_heating_utilities_receive_bua_and_block_actual_costs
   period: 2026-05
   input:
+    <<: &constant_inputs
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
+      us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+      us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_liheap: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_energy_assistance_under_state_law: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-    : true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
-    : false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
-    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: not_holds
-- name: one-or-no-utilities-blocks-bua-and-actual-water-deduction-is-allowed
+
+- name: coherent_telephone_only_household_receives_telephone_standard
   period: 2026-05
   input:
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_liheap: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_energy_assistance_under_state_law: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-    : true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
-    : true
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
-    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
@@ -76,85 +82,107 @@
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
-- name: utilities-in-rent-blocks-bua-and-agreed-households-satisfy-same-residence-rule
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: holds
+
+- name: telephone_charge_must_be_anticipated_to_continue
   period: 2026-05
   input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: true
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_liheap: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_energy_assistance_under_state_law: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-    : true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: true
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
-    : false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
-    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
-- name: mua-entitlement-blocks-actual-utility-costs
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+
+- name: mua_precedence_blocks_bua_actual_and_telephone_allowances
   period: 2026-05
   input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
-    : false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_heating_or_cooling_costs: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_liheap: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_received_energy_assistance_under_state_law: true
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-    : true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
-    : false
-    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
-    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+
+- name: utilities_in_rent_receive_no_allowance_and_shared_cost_rules_remain
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: true
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
+
+- name: telephone_only_household_without_verified_actual_cost_gets_no_standard
+  period: 2026-05
+  input:
+    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -167,7 +167,6 @@ rules:
         formula: |-
           not multiple_utility_allowance_entitlement
           and not basic_utility_allowance_entitlement
-          and not household_utility_costs_included_in_rent_payment
           and same_residence_utility_allowance_agreement_requirement_satisfied
 
   - name: actual_utility_cost_deduction_allowed

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -4,8 +4,28 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us:regulations/7-cfr/273/9
+        - us:regulations/7-cfr/273/9/d/6/iii
+      rationale: |-
+        7 CFR 273.9(d)(6)(ii)(C) recognizes recurring telephone service as
+        an allowable utility cost, while paragraph (d)(6)(iii) controls state
+        standards and prevents overlapping standards. This page supplies South
+        Carolina's BUA exclusions and actual/telephone verification rules.
   summary: |-
-    "The BUA must not be given" to households with one or no utility expenses or whose utility costs are included in rent. "Actual utility costs are only allowed for households not entitled to the MUA or BUA." Multiple households in the same residence must agree on MUA, BUA, or actual costs; the Agency will not prorate the MUA or BUA in the stated shared-expense cases.
+    BUA is not given to households with one or no utility expenses or whose
+    utility costs are included in rent, and these exclusions govern the final
+    BUA entitlement. Actual utility costs are deductible only when the
+    household is not entitled to MUA or BUA, submitted verification supports
+    an actual cost, and claimed charges are reasonably anticipated to continue
+    during the certification period. A telephone-only household may receive
+    South Carolina's telephone standard on that verified actual-cost path.
+    Shared-residence households must agree on the allowance type, and MUA or
+    BUA is not prorated in the listed shared-cost circumstances.
+imports:
+  - us-sc:policies/dss/snap-policy-manual/page-163
 rules:
   - name: basic_utility_allowance_covered_cost_exists
     kind: derived
@@ -59,13 +79,21 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+              output: household_entitled_to_basic_utility_allowance
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited
+              output: basic_utility_allowance_prohibited
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          basic_utility_allowance_covered_cost_exists
+          household_entitled_to_basic_utility_allowance
           and not basic_utility_allowance_prohibited
 
   - name: multiple_utility_allowance_entitlement
@@ -78,15 +106,15 @@ rules:
       proof:
         atoms:
           - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+              output: household_entitled_to_mandatory_utility_allowance
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
     versions:
       - effective_from: '0001-01-01'
         formula: |-
-          household_has_heating_or_cooling_costs
-          or household_received_liheap
-          or household_received_energy_assistance_under_state_law
+          household_entitled_to_mandatory_utility_allowance
 
   - name: actual_utility_costs_allowed
     kind: derived
@@ -101,11 +129,24 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+              output: multiple_utility_allowance_entitlement
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+              output: basic_utility_allowance_entitlement
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           not multiple_utility_allowance_entitlement
           and not basic_utility_allowance_entitlement
+          and not household_utility_costs_included_in_rent_payment
 
   - name: actual_utility_cost_deduction_allowed
     kind: derived
@@ -120,19 +161,61 @@ rules:
             kind: formula
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed
+              output: actual_utility_costs_allowed
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies
+              output: household_actual_verified_utility_cost_allowance_applies
+              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           actual_utility_costs_allowed
+          and household_actual_verified_utility_cost_allowance_applies
           and agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-          and (claimed_utility_is_heating_fuel
-          or claimed_utility_is_cooking_fuel
-          or claimed_utility_is_water
-          or claimed_utility_is_sewerage
-          or claimed_utility_is_electricity
-          or claimed_utility_is_garbage_or_trash_collection
-          or claimed_utility_is_utility_installation_fee
-          or claimed_utility_is_state_standard_for_telephone)
+          and (
+            claimed_utility_is_heating_fuel
+            or claimed_utility_is_cooking_fuel
+            or claimed_utility_is_water
+            or claimed_utility_is_sewerage
+            or claimed_utility_is_electricity
+            or claimed_utility_is_garbage_or_trash_collection
+            or claimed_utility_is_utility_installation_fee
+            or claimed_utility_is_state_standard_for_telephone
+          )
+
+  - name: household_entitled_to_telephone_only_standard
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: SNAP Manual p. 165, actual utility costs and telephone standard
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed
+              output: actual_utility_cost_deduction_allowed
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_has_one_or_no_utility_expenses
+          and household_has_telephone_expense
+          and actual_utility_cost_deduction_allowed
+          and claimed_utility_is_state_standard_for_telephone
 
   - name: same_residence_utility_allowance_agreement_requirement_satisfied
     kind: derived

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -83,7 +83,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
               output: household_entitled_to_basic_utility_allowance
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
           - path: versions[0].formula
             kind: import
             import:
@@ -117,7 +117,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
           - path: versions[0].formula
             kind: import
             import:
@@ -193,7 +193,7 @@ rules:
             import:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies
               output: household_actual_verified_utility_cost_allowance_applies
-              hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
     versions:
       - effective_from: '0001-01-01'
         formula: |-

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -90,11 +90,18 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited
               output: basic_utility_allowance_prohibited
               hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+              output: same_residence_utility_allowance_agreement_requirement_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           household_entitled_to_basic_utility_allowance
           and not basic_utility_allowance_prohibited
+          and same_residence_utility_allowance_agreement_requirement_satisfied
 
   - name: multiple_utility_allowance_entitlement
     kind: derived
@@ -111,10 +118,17 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
               output: household_entitled_to_mandatory_utility_allowance
               hash: sha256:5d0a3f0f05f58b0ebd1a9fd4dba093718aaec2062c6970e6c3d6e7066143b360
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+              output: same_residence_utility_allowance_agreement_requirement_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           household_entitled_to_mandatory_utility_allowance
+          and same_residence_utility_allowance_agreement_requirement_satisfied
 
   - name: actual_utility_costs_allowed
     kind: derived
@@ -129,6 +143,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+              excerpt: "Actual utility costs are only allowed for households not entitled to the MUA or BUA."
           - path: versions[0].formula
             kind: import
             import:
@@ -141,12 +156,19 @@ rules:
               target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
               output: basic_utility_allowance_entitlement
               hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+              output: same_residence_utility_allowance_agreement_requirement_satisfied
+              hash: sha256:local
     versions:
       - effective_from: '0001-01-01'
         formula: |-
           not multiple_utility_allowance_entitlement
           and not basic_utility_allowance_entitlement
           and not household_utility_costs_included_in_rent_payment
+          and same_residence_utility_allowance_agreement_requirement_satisfied
 
   - name: actual_utility_cost_deduction_allowed
     kind: derived
@@ -230,6 +252,7 @@ rules:
             kind: condition
             source:
               corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+              excerpt: "Multiple households living in the same residence must agree on the type of utility allowance, either MUA, BUA or actual."
     versions:
       - effective_from: '0001-01-01'
         formula: |-


### PR DESCRIPTION
Encodes the SC DSS SNAP policy-manual utility-allowance pages from retained corpus text (all three cited pages verified present — no ingest prerequisite): allowance assignment (p.163), exclusions + telephone standard (p.165), and amounts (p.159), each with companion tests.

**Verification** (re-run by the main lane): 25/25 companion cases; 48 proof atoms; strict validation; reverse index regenerated; manifests signed last, guard green at head.

**Deliberately excluded — program-spec scoping**: the FY2026 SC program spec update (activating these under `snap_total_allowable_shelter_expenses`) is held out because the pinned `axiom-encode sign-applied-files` cannot attest `programs/` paths (jurisdiction-prefix resolution crashes on `programs/us-sc/snap/fy-2026.yaml`; existing program manifests like us-az came through a different flow). Until scoped, these encodes are inactive — the same state as TN's retained utility table. The SNAP-SC-UTIL worklist rows therefore stay open; scoping + drain follow via the bulk-encode lane that provably signs program specs.

**Residual context** (from the SNAP residual sweep): 0 of 129 SC snap-ecps residuals are utility-attributable under current report inputs (PE also assigns $0 allowances there); 64 belong to the categorical-eligibility class tracked separately. So this PR is correctness/coverage for utility-bearing cases, not a residual killer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)