### PR TITLE
Bump axiom-corpus pin to db1279557 (§1401 coordination repair)

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "bf97b17baebfdf12601f7c23697524bf5adcdaed"
+axiom_corpus_ref = "db12795577c5809009168982cf8a72fb58440620"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Pin-only PR (#999/#1134 pattern): bumps `axiom_corpus_ref` to the axiom-corpus#523 merge commit — the §1401(b)(2)(B) scrivener's-error chain (corpus text stays byte-faithful to OLRC; 26 CFR 1.1401-1(d)(2)(i) ingested as the operative coordination authority), plus the collision-aware USC traversal fix (both enacted §45X(d)(4) siblings survive; true Title-26 total 58,351) and retained-eCFR formal-subpart/document-order fixes (45 CFR 1302.1 now carries its body).

Unblocks: the additional-Medicare-tax SE leg restore (next PR).

No other changes; toolchain edit authorized as a dedicated pin-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)