### PR TITLE
Pin DC oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@9ccbc5799ce062649a7b4dff255123279c7a9eb0 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@de6c5d02c8c6d77db4f91524cbf3ec6be7db09de # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- pin the repository validation caller to shared-workflow merge `de6c5d02c8c6d77db4f91524cbf3ec6be7db09de`
- carry the merged DC 2026 joint-method schedule oracle bundle into the full RuleSpec validation matrix
- leave the local toolchain pin and pending ledger unchanged

## Durable chain
- shared-workflow merge: `de6c5d02c8c6d77db4f91524cbf3ec6be7db09de`
- encoder merge: `64f3ffdc16ac753d4ee32aac4bcc3a922acca750` (`axiom-encode` 0.2.1398)
- oracle merge: `9b889a27432e84804938bd3b374b4f5f7466792e`
- each merge is verified two-parent and present on its repository main branch

## Validation
- caller workflow YAML parses
- shared, encoder, and oracle merge objects and parentage verified
- old caller ref absent; exact new ref count is one
- forbidden-surface and diff checks passed

## Review cycle
Independent lightweight review of exact head `89a960372cd26daba7410d8b5f681801b13ab440` found no actionable findings and confirmed the exact one-line/one-file scope, valid durable pin chain, unchanged `.axiom/toolchain.toml` and pending ledger, valid YAML, and clean worktree.