### PR TITLE
Drain DC oracle coverage pending entries

### DIFF
--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,56 +6,8 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2293
+ceiling: 2277
 entries:
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_base
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_floor
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_rate
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_selector
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_bracket_upper
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_schedule_before_credits
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/2026_section_47_1806_03_schedule_before_credits#dc_pit_2026_section_47_1806_03_taxable_income_boundary
-  source: manual
-  since: '2026-07-27'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_base
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_floor
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_rate
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_bracket_upper
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_tax_on_supplied_taxable_income_before_credits
-  source: manual
-  since: '2026-07-22'
-- legal_id: us-dc:policies/income_tax/pilot_liability_pipeline#dc_pit_pilot_taxable_income
-  source: manual
-  since: '2026-07-15'
-- legal_id: us-dc:statutes/47/47-1806/03#considered_single_person_for_chapter
-  source: bulk
-  since: '2026-07-08'
-- legal_id: us-dc:statutes/47/47-1806/03#separate_return_living_together_treated_single_person
-  source: bulk
-  since: '2026-07-08'
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax
   source: manual
   since: '2026-07-22'


### PR DESCRIPTION
## Summary
- remove seven canonical DC section 47-1806.03 pending declarations now classified by merged exact mappings
- remove seven legacy DC pilot and two DC statute declarations now classified by the jurisdiction fallback
- lower the pending ceiling from 2,293 to 2,277

## Validation
- merged classifier: 21,786 outputs; comparable 997; known-not-comparable 18,557; pending 2,232
- pending ledger: 2,277 declared, 2,232 applied, 45 pre-existing stale
- DC stale/unmapped: 0/0
- preserved unrelated stale groups: Mississippi 4, Utah 41, all 45 raw YAML blocks byte-identical
- YAML count/schema/sort/uniqueness, pin-chain, secret, and diff checks passed

## Scope
The exact one-file delta removes 16 DC rows only: 7 canonical, 7 pilot, and 2 statute. There are no additions or surviving-entry mutations.

## Review cycle
Independent exact-head review of `9b3622914ccfc523d4fcb819c952babad8068199` found no actionable findings and confirmed the exact one-file/16-row scope, ceiling integrity, merged-classifier result, durable caller chain, preserved Mississippi/Utah entries, and clean worktree.