### PR TITLE
Pin California BHST oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@de6c5d02c8c6d77db4f91524cbf3ec6be7db09de # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@3bc378e935ce1a4b6d381611df6723aebea06f26 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary
- pin the repository validation caller to shared-workflow merge `3bc378e935ce1a4b6d381611df6723aebea06f26`
- carry the merged California 2026 BHST oracle bundle into the full RuleSpec validation matrix
- leave the local toolchain pin and pending ledger unchanged

## Durable chain
- shared-workflow merge: `3bc378e935ce1a4b6d381611df6723aebea06f26`
- encoder merge: `acdb75593bb6506270310a675c75a32ac24b50eb` (`axiom-encode` 0.2.1399)
- oracle merge: `076ad9d458e5539db8d71cd4a06a43ad9b632d19`
- each merge is verified two-parent and present at its repository main tip

## Validation
- caller workflow YAML parses and exact `jobs.validate.uses` assertion passes
- shared, encoder, and oracle merge objects and parentage verified
- old caller ref absent; exact new ref count is one
- forbidden-surface, secret, and diff checks passed
- California needs no pending-ledger drain: ledger has zero `us-ca:` declarations and all 64 CA tax outputs classify as 4 comparable plus 60 known-not-comparable

## Review cycle
Independent review of original exact head `f9e575da93efab425683e713597ca75b239c085b` found no actionable findings. After base advanced with unrelated South Carolina SNAP work, the unchanged one-line patch was rebased to exact head `1458c47610426b6f0ccace0f0be86e93b38483af` and received a second CLEAN review. The pre/post-rebase patch SHA-256 is identical: `077c93fd74fe3a1a3cb5e0a43af222bc5d450ef8bd6919310b4cf09b7806f59c`.