### PR TITLE
Test California BHST oracle parameters

### DIFF
--- a/.axiom/encoding-manifests/us-ca/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ca/policies/income_tax/pilot_liability_pipeline.json
@@ -2,11 +2,7 @@
   "applied_files": [
     {
       "path": "us-ca/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "137e2a43f4d4190763a1f8bcadff97c09a0da12d323c98148968e058f743a5bb"
-    },
-    {
-      "path": "us-ca/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "0ae43c1f1879e7c1c124dac07c6a301e62c510c05606f67a7f301f39729d451b"
+      "sha256": "7189baea6036146f08ba476c5c21e06da78ca458ff7f41e541767cdd797501c0"
     }
   ],
   "axiom_encode_git": {
@@ -21,9 +17,9 @@
   "citation": "us-ca:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T17:17:23.635686+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzovkq8nn/sign-applied-files/us-ca/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpzovkq8nn",
+  "generated_at": "2026-07-27T19:40:22.607181+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp8ls3rwzb/sign-applied-files/us-ca/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp8ls3rwzb",
   "generated_output_sha256": "0ae43c1f1879e7c1c124dac07c6a301e62c510c05606f67a7f301f39729d451b",
   "generation_prompt_sha256": null,
   "model": "",
@@ -33,15 +29,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c3a15e57b744c4f545e32dfb4ad0e1f8ad46e9054975a39231896f66bf359a62"
+    "value": "25b7806cc1b86945b94082709a1396ab60454ec0ee5fde047fc868f1f795e121"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-06T17:33:07.798523+00:00",
+    "generated_at": "2026-07-23T17:17:23.635686+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "d473c2f6748d7f731a36c45469cad6c21d7d3c2c395e36704b1b1d7ccfe9b60f",
-    "prior_signature": "ee37809fa8b37b6ecc9aa216e37701f206e9cfaa5bae8edecaaf4792792af58a",
+    "manifest_sha256": "7f09248322864b91874cd15753a440a2396b6d2fd1e4a2d67e5869606588e4b0",
+    "prior_signature": "c3a15e57b744c4f545e32dfb4ad0e1f8ad46e9054975a39231896f66bf359a62",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-06T17:33:07.798523+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "d473c2f6748d7f731a36c45469cad6c21d7d3c2c395e36704b1b1d7ccfe9b60f",
+      "prior_signature": "ee37809fa8b37b6ecc9aa216e37701f206e9cfaa5bae8edecaaf4792792af58a",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/us-ca/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ca/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -126,6 +126,8 @@
     <<: *schedule_x
     us-ca:policies/income_tax/pilot_liability_pipeline#input.ca_pit_pilot_supplied_completed_taxable_income: 1000000
   output:
+    us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax_threshold: 1000000
+    us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax_rate: 0.01
     us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_estimated_tax_rate_schedule_amount: '103836.62'
     us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_behavioral_health_services_tax: '0'
     us-ca:policies/income_tax/pilot_liability_pipeline#ca_pit_pilot_estimated_tax_schedule_branch_total: '103836.62'


### PR DESCRIPTION
## Summary

- assert the TY2026 Behavioral Health Services Tax threshold parameter in the canonical companion suite
- assert the TY2026 Behavioral Health Services Tax rate parameter in the same exact boundary fixture
- refresh the signed legacy encoder apply manifest for the changed companion file
- close the two `--fail-on-untested-comparable` findings exposed by post-merge run 30297336367 without changing mappings, formulas, tolerances, or workflow gates

## Checks

- pinned legacy RuleSpec companion test: 44/44 cases passed
- pinned legacy `guard-generated` with protected apply-key wrapper: passed
- current `axiom-encode oracle-coverage --fail-on-unmapped --fail-on-untested-comparable`: exit 0; untested comparable 0; incomplete comparable 0
- `git diff --check`

## Review-fix cycle

1. Independent review of initial exact test commit `e1e3e0cb79648a2e20f01a8fd123c5d2b094ac33` against `453f8fab7c6bd83f0e0efe604377d4ef85b7db72`: CLEAN.
2. PR CI correctly required signed encoder provenance. Refreshed the existing legacy apply manifest with pinned clean encoder `3869d66d009f52258be35901edbef370e65a399c`; wrapper-verified guard passes.
3. Independent re-review of amended exact commit `a088f83ef5b9b9fa39ca6f4eb975e808d6e2d0a7`: CLEAN. Reviewer verified exact test-file hash, unchanged RuleSpec output hash, supersedes chain, clean/version-consistent encoder provenance, and combined diff.