### PR TITLE
Pin New York oracle coverage workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@3bc378e935ce1a4b6d381611df6723aebea06f26 # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@0d14abd3dfa3c573cd4f879a3974ae212a829220 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- pin the repository validation caller to shared-workflow merge `0d14abd3dfa3c573cd4f879a3974ae212a829220`
- carry the merged New York TY2026 main-income-tax oracle bundle into the full RuleSpec validation matrix
- leave the local toolchain, all RuleSpec/test content, signed manifests, generated indexes, and pending ledger unchanged

## Durable chain

- shared-workflow merge: `0d14abd3dfa3c573cd4f879a3974ae212a829220`
- encoder merge: `1c0fce6bd311063bbbc7686fce84c104da74b2df` (`axiom-encode` 0.2.1400)
- oracle merge: `9e6d93662da32ad423c177b8265720eed40e6660`
- each merge was verified as a two-parent merge on its repository main lineage; exact post-merge shared and encoder CI are green

## Validation

- caller workflow YAML parses and exact `jobs.validate.uses` assertion passes
- reverse index is current (4,239 provisions, 5,078 edges, 4,486 modules)
- 12 focused manifest/layout guard tests pass
- shared, encoder, and oracle merge objects, parentage, and pin chain verified
- old caller ref absent; exact new ref count is one
- forbidden-surface, added-line secret-pattern, and diff checks pass
- pending ledger contains zero `us-ny:` declarations, so no drain mutation is required

## Review cycle

Independent review of exact staged head content found no actionable findings. Reviewed patch SHA-256: `88f99f338fcb960ca6a6c122bf82a3fa6ec6c0947e22a3e195b89b1265eaa4b6`; reviewed name-list SHA-256: `97a1912e465ce739092df952270f2c59e3ac888c8b62ee2cda2bd1cb1e2c4539`.