### PR TITLE
Test New York 2026 bracket thresholds

### DIFF
--- a/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-ny/policies/income_tax/pilot_liability_pipeline.json
@@ -2,11 +2,7 @@
   "applied_files": [
     {
       "path": "us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "4b5bf3902cf6c14912d2f843049c2409c4d153f0f21878e47c7332697911fa5f"
-    },
-    {
-      "path": "us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c"
+      "sha256": "8e8c58a9c5f4ab34601d7c7c10ffaa24e50da9257f5ca6674e9d2c84c5f6cb39"
     }
   ],
   "axiom_encode_git": {
@@ -21,9 +17,9 @@
   "citation": "us-ny:policies/income_tax/pilot_liability_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-23T17:41:05.957431+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpka3i977a/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpka3i977a",
+  "generated_at": "2026-07-27T21:16:05.980995+00:00",
+  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp4hfed8s7/sign-applied-files/us-ny/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmp4hfed8s7",
   "generated_output_sha256": "e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c",
   "generation_prompt_sha256": null,
   "model": "",
@@ -33,29 +29,38 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "6a686c0ae9b2ae76cd86530feea4ae5b491ccf2e60cf155c91ed9d0e79b333fb"
+    "value": "709acfaf2a1d8be74f0626862fb147ac4e172c7e5cea2fdddb5498c0009bf91b"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-22T10:58:56.863637+00:00",
+    "generated_at": "2026-07-23T17:41:05.957431+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "4343b0910ca19633331bd53916443f22e650204619a1630cb47cf62a0e2723fe",
-    "prior_signature": "2bec9ce33d3223ea90c330321d2c3d85f8d66b39a3fc4143498d1e7298804e6c",
+    "manifest_sha256": "3e2adad52c76f7020a975e9d83a1d9073ed4791d9d899ebdc71b08ccb19e841a",
+    "prior_signature": "6a686c0ae9b2ae76cd86530feea4ae5b491ccf2e60cf155c91ed9d0e79b333fb",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-22T09:21:07.368809+00:00",
+      "generated_at": "2026-07-22T10:58:56.863637+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "8343167e4b6a1e2718298a3bed909d94b3e2059da68a3ac8a4569e3081978640",
-      "prior_signature": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a",
+      "manifest_sha256": "4343b0910ca19633331bd53916443f22e650204619a1630cb47cf62a0e2723fe",
+      "prior_signature": "2bec9ce33d3223ea90c330321d2c3d85f8d66b39a3fc4143498d1e7298804e6c",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-06T17:33:07.803431+00:00",
+        "generated_at": "2026-07-22T09:21:07.368809+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
-        "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+        "manifest_sha256": "8343167e4b6a1e2718298a3bed909d94b3e2059da68a3ac8a4569e3081978640",
+        "prior_signature": "f0f6c41fc4ea91b0509bef1b0d30921d57bc401e92836a6529b74b7adbe2024a",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-06T17:33:07.803431+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "6ff45de77581b4dc7bb474cc21669a51de1b0dd882283044758cc42abe77d2be",
+          "prior_signature": "c01e5efe40586e284bbe2e3f5fbb8febd77ecf3911ec8b68f9ce2adfdccc10e5",
+          "run_id": null,
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-ny/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -27,6 +27,14 @@
     us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '17150'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_first_upper_bound: 17150
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_second_upper_bound: 23600
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_third_upper_bound: 27900
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_fourth_upper_bound: 161550
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_fifth_upper_bound: 323200
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_sixth_upper_bound: 2155350
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_seventh_upper_bound: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_eighth_upper_bound: 25000000
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_joint_or_surviving_bracket_selector: 0
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '668.85'
 
@@ -231,6 +239,14 @@
     us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: true
   output:
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '12800'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_first_upper_bound: 12800
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_second_upper_bound: 17650
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_third_upper_bound: 20900
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_fourth_upper_bound: 107650
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_fifth_upper_bound: 269300
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_sixth_upper_bound: 1616450
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_seventh_upper_bound: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_eighth_upper_bound: 25000000
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_head_of_household_bracket_selector: 0
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '499.2'
 
@@ -435,6 +451,14 @@
     us-ny:policies/income_tax/pilot_liability_pipeline#input.ny_pit_pilot_filing_status_head_of_household: false
   output:
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_taxable_income: '8500'
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_first_upper_bound: 8500
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_second_upper_bound: 11700
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_third_upper_bound: 13900
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_fourth_upper_bound: 80650
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_fifth_upper_bound: 215400
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_sixth_upper_bound: 1077550
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_seventh_upper_bound: 5000000
+    us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_eighth_upper_bound: 25000000
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_single_or_separate_bracket_selector: 0
     us-ny:policies/income_tax/pilot_liability_pipeline#ny_pit_pilot_main_income_tax: '331.5'
 


### PR DESCRIPTION
Closes #1147.

This is the structural repair for the full-matrix main failure in run 30305073418. The New York oracle activation made 24 real TY2026 bracket upper-bound outputs comparable, while the existing companion suite did not assert them. This change adds the eight joint/surviving, eight head-of-household, and eight single/separate thresholds to three existing first-boundary fixtures and refreshes the signed companion manifest. The RuleSpec module, oracle mappings, classifier strictness, and tolerances are unchanged.

Validation:
- Protected encoder 3869 + engine ffd821 companion suite: 58 cases passed
- Exact production classifier 1c0fce full tree: 21,815 outputs; 1,027 comparable; 0 untested comparable; 0 incomplete; exit 0
- Protected generated-change guard: passed with no issues
- Encoding manifest tests: 3 passed
- Main module SHA unchanged and signed supersedes chain verified
- Diff/security checks clean

Review cycle:
- Independent staged review: CLEAN, no actionable findings
- Reviewer recomputed exact companion, manifest, staged-patch, and filename-set hashes
- Post-review tree remained unchanged through commit

The PR changed-file jobs are necessary but not sufficient for this activation-path repair. After merge, the exact full push matrix must be terminal green before #1147 is considered resolved.