### PR TITLE
Encode §152(c)(4) claimant tiebreakers (EITC frontier)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -37994,7 +37994,36 @@
         "via": [
           "module"
         ]
-      },
+      }
+    ],
+    "us/statute/26/152/c/1": [
+      {
+        "module": "us/statutes/26/152/c.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/152/c/2": [
+      {
+        "module": "us/statutes/26/152/c.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/152/c/3": [
+      {
+        "module": "us/statutes/26/152/c.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/152/c/4": [
       {
         "module": "us/statutes/26/152/c.yaml",
         "via": [
@@ -39347,6 +39376,15 @@
       },
       {
         "module": "us/statutes/26/32/c/2.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/32/c/3": [
+      {
+        "module": "us/statutes/26/32.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -36,24 +36,32 @@
   `count_where`, and filtered derived relations; it has no maximum
   aggregator, so strict maxima will be encoded as the absence of an equal-
   or-higher competing row.
-- Identified downstream integration work: replace the six former conclusion
-  inputs in both companions, refresh section 32's five import proof hashes,
-  refresh authoritative manifests, and regenerate the provision index.
+- Identified downstream integration work: replace the former conclusion
+  inputs in both companions, preserve section 32's statutory disregard of
+  the section 152(c)(1)(D) support test, refresh import proof hashes and
+  authoritative manifests, and regenerate the provision index.
 - Encoded all six assigned outputs in `us/statutes/26/152/c.yaml`.
 - Added a complete other-taxpayer relation with row-local qualifying-child,
   parent, actual-claim, and copied-AGI facts. Strict maxima are implemented by
   rejecting any equal-or-higher competing row.
 - Added a private support-omitted claimant surface so section 32 can apply its
   paragraph-(1)(D) disregard without changing generic section 152 results.
-- Added 16 companion cases covering the assigned statutory boundaries plus
-  fail-closed relation completeness and existing section 152(c) behavior.
-- Confirmed the section 152(c) companion passes all 16 cases in the pinned
+- Added 20 companion cases covering the assigned statutory boundaries,
+  disabled-child and strict-age edges, eligible nonclaimants, ineligible
+  claimants and parents, AGI ties, fail-closed relation completeness, and
+  existing section 152(c) behavior.
+- Confirmed the section 152(c) companion passes all 20 cases in the pinned
   runtime; module validation and proof validation pass.
+- Integrated the tiebreaker into section 32 through private, support-omitted
+  eligibility rules, matching section 32(c)(3)(A)'s express disregard of
+  section 152(c)(1)(D).
+- Repaired section 32's stale earned-income companion inputs, replaced the
+  former direct tiebreaker conclusions with statutory inputs, and added a
+  support-disregard integration case. All five section 32 cases pass in the
+  pinned runtime; module validation and proof validation pass.
 
 ## Next
 
-- Add the section 32 support-disregarded tiebreaker composition and repair its
-  companion inputs.
-- Refresh proof hashes, manifests, and the provision index.
-- Run focused and repository validation, update this file, commit each
+- Refresh authoritative manifests and the provision index.
+- Run focused and repository-wide validation, update this file, commit each
   coherent step, push, and open the draft PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -70,10 +70,16 @@
   absent. No manifest was fabricated or altered. Consequently,
   `guard-generated` reports those four changed RuleSpec files as lacking a
   matching signed manifest.
+- Direct Git delivery is unavailable in this session: `git push` cannot
+  resolve `github.com`, and the connected GitHub write was canceled before it
+  created a branch. No remote branch or pull request was created.
 
 ## Next
 
 - Have an authorized signer run `sign-applied-files` for the two changed
   modules, then rerun `guard-generated` and the repository test suite.
-- Complete human review of the draft PR; do not merge while the signed
-  manifest gate remains unresolved.
+- Push `closure/w2-eitc-152-tiebreak` and open the required draft PR titled
+  `Encode §152(c)(4) claimant tiebreakers (EITC frontier)`, referencing
+  `rulespec-us#1135`.
+- Complete human review; do not merge while the signed-manifest gate remains
+  unresolved.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -59,9 +59,21 @@
   former direct tiebreaker conclusions with statutory inputs, and added a
   support-disregard integration case. All five section 32 cases pass in the
   pinned runtime; module validation and proof validation pass.
+- Regenerated the provision-to-rules reverse index. Its six consistency tests
+  pass.
+- Ran the repository test suite: 72 tests pass and the sole failure is the
+  manifest-sync test for the two edited modules.
+- Confirmed `sign-applied-files --dry-run` selects exactly the section 152(c)
+  and section 32 module/companion pairs. Actual signing is unavailable in this
+  session: `AXIOM_ENCODE_APPLY_SIGNING_KEY` is unset, the approved
+  `agent-secret` helper is locked, and the matching macOS Keychain item is
+  absent. No manifest was fabricated or altered. Consequently,
+  `guard-generated` reports those four changed RuleSpec files as lacking a
+  matching signed manifest.
 
 ## Next
 
-- Refresh authoritative manifests and the provision index.
-- Run focused and repository-wide validation, update this file, commit each
-  coherent step, push, and open the draft PR.
+- Have an authorized signer run `sign-applied-files` for the two changed
+  modules, then rerun `guard-generated` and the repository test suite.
+- Complete human review of the draft PR; do not merge while the signed
+  manifest gate remains unresolved.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,9 +4,12 @@
 
 - Branch: `closure/w2-eitc-152-tiebreak`
 - Base: `origin/main` at `ecb057ef3`
-- Scope: EITC frontier items 10–15 for 26 U.S.C. § 152(c)(4)
+- Scope: the six named EITC frontier items assigned as 10–15 (global
+  classification rows 19–24), governed by 26 U.S.C. § 152(c)(3)–(4)
 - Worktree: isolated under `.git/codex-worktrees/w2-eitc-152-tiebreak`
   because the sandbox denied creation at the requested sibling path
+- Corpus provisions: `us/statute/26/152/c/3` and
+  `us/statute/26/152/c/4`, expression date `2026-07-13`
 
 ## Done
 
@@ -14,11 +17,34 @@
 - Read repository `CLAUDE.md`.
 - Created the required branch from `origin/main` without disturbing the
   repository's dirty detached checkout.
+- Read every assigned classification row before implementation and treated
+  the user's six explicit fact names as controlling over shifted global row
+  numbers.
+- Resolved the governing provisions by exact `citation_path` across every
+  statute inventory record and read their retained text and official USLM
+  source.
+- Read the mandatory sibling modules and companions, the existing
+  section 152(c) fragment, the section 32 consumer, and the
+  `closure/eitc-2026` context branch.
+- Confirmed that reported adjusted gross income is the classification's
+  declarable Form 1040 boundary fact. No assigned output requires computing
+  AGI through sections 62/61 or invoking section 1402, so no item is
+  deferred.
+- Confirmed the pinned engine supports complete candidate relations,
+  `count_where`, and filtered derived relations; it has no maximum
+  aggregator, so strict maxima will be encoded as the absence of an equal-
+  or-higher competing row.
+- Identified downstream integration work: replace the six former conclusion
+  inputs in both companions, refresh section 32's five import proof hashes,
+  refresh authoritative manifests, and regenerate the provision index.
 
 ## Next
 
-- Read classification rows 10–15 before implementation.
-- Resolve § 152(c)(4) by `citation_path` across the corpus inventory.
-- Inspect `closure/eitc-2026`, sibling statute encodings, and validation tools.
-- Encode only assigned tiebreakers, add statutory-boundary tests, validate,
-  update this file, commit each coherent step, push, and open the draft PR.
+- Encode the six outputs from primitive age, claimant, parent, actual-claim,
+  relation-completeness, and reported-AGI facts.
+- Add companion boundaries for equal ages, one/two claimants, empty and
+  multiple-parent sets, declining parents, parent-AGI equality, and tied
+  claimant AGIs.
+- Repair the section 32 fixtures, refresh derived artifacts, validate the
+  exact pinned toolchain, commit each coherent step, push, and open the draft
+  PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,8 +6,10 @@
 - Base: `origin/main` at `ecb057ef3`
 - Scope: the six named EITC frontier items assigned as 10–15 (global
   classification rows 19–24), governed by 26 U.S.C. § 152(c)(3)–(4)
-- Worktree: isolated under `.git/codex-worktrees/w2-eitc-152-tiebreak`
-  because the sandbox denied creation at the requested sibling path
+- Worktree: isolated under
+  `.git/codex-worktrees/rulespec-us-w2-eitc-152-tiebreak` because the sandbox
+  denied creation at the requested sibling path. The `rulespec-us-*`
+  basename is required for canonical module IDs in the pinned validator.
 - Corpus provisions: `us/statute/26/152/c/3` and
   `us/statute/26/152/c/4`, expression date `2026-07-13`
 
@@ -37,14 +39,21 @@
 - Identified downstream integration work: replace the six former conclusion
   inputs in both companions, refresh section 32's five import proof hashes,
   refresh authoritative manifests, and regenerate the provision index.
+- Encoded all six assigned outputs in `us/statutes/26/152/c.yaml`.
+- Added a complete other-taxpayer relation with row-local qualifying-child,
+  parent, actual-claim, and copied-AGI facts. Strict maxima are implemented by
+  rejecting any equal-or-higher competing row.
+- Added a private support-omitted claimant surface so section 32 can apply its
+  paragraph-(1)(D) disregard without changing generic section 152 results.
+- Added 16 companion cases covering the assigned statutory boundaries plus
+  fail-closed relation completeness and existing section 152(c) behavior.
+- Confirmed the section 152(c) companion passes all 16 cases in the pinned
+  runtime; module validation and proof validation pass.
 
 ## Next
 
-- Encode the six outputs from primitive age, claimant, parent, actual-claim,
-  relation-completeness, and reported-AGI facts.
-- Add companion boundaries for equal ages, one/two claimants, empty and
-  multiple-parent sets, declining parents, parent-AGI equality, and tied
-  claimant AGIs.
-- Repair the section 32 fixtures, refresh derived artifacts, validate the
-  exact pinned toolchain, commit each coherent step, push, and open the draft
-  PR.
+- Add the section 32 support-disregarded tiebreaker composition and repair its
+  companion inputs.
+- Refresh proof hashes, manifests, and the provision index.
+- Run focused and repository validation, update this file, commit each
+  coherent step, push, and open the draft PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,24 @@
+# Progress — § 152(c)(4) claimant tiebreakers
+
+## State
+
+- Branch: `closure/w2-eitc-152-tiebreak`
+- Base: `origin/main` at `ecb057ef3`
+- Scope: EITC frontier items 10–15 for 26 U.S.C. § 152(c)(4)
+- Worktree: isolated under `.git/codex-worktrees/w2-eitc-152-tiebreak`
+  because the sandbox denied creation at the requested sibling path
+
+## Done
+
+- Read `ENCODER-PREAMBLE.md`.
+- Read repository `CLAUDE.md`.
+- Created the required branch from `origin/main` without disturbing the
+  repository's dirty detached checkout.
+
+## Next
+
+- Read classification rows 10–15 before implementation.
+- Resolve § 152(c)(4) by `citation_path` across the corpus inventory.
+- Inspect `closure/eitc-2026`, sibling statute encodings, and validation tools.
+- Encode only assigned tiebreakers, add statutory-boundary tests, validate,
+  update this file, commit each coherent step, push, and open the draft PR.

--- a/us/statutes/26/152/c.test.yaml
+++ b/us/statutes/26/152/c.test.yaml
@@ -27,7 +27,7 @@
       - &root_parents_joint
         us:statutes/26/152/c#input.parents_filing_status: 1
       - &relation_complete
-        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent: true
+        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: true
       - &claimant_static
         us:statutes/26/152/c#input.claimant_individual_is_child_of_taxpayer_or_descendant_of_such_child: true
         us:statutes/26/152/c#input.claimant_individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
@@ -387,7 +387,7 @@
       - *root_return_normal
       - *root_parents_joint
       - &relation_incomplete
-        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent: false
+        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: false
       - *claimant_static
       - *claimant_support_over_half
       - *claimant_return_normal
@@ -461,3 +461,119 @@
     us:statutes/26/152/c#claimant_qualifying_child_before_tiebreaker: holds
     us:statutes/26/152/c#claimant_taxpayer_is_parent_and_may_claim_individual_before_tiebreaker: holds
     us:statutes/26/152/c#other_claiming_eligible_taxpayer_adjusted_gross_income_at_least_evaluated_taxpayer: holds
+
+- name: two_eligible_other_taxpayers_trigger_multi_claimant_when_evaluated_taxpayer_is_ineligible
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_over_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_nonparent_claims
+          - *claimant_agi_40000
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_nonparent_claims
+          - *claimant_agi_30000
+  output:
+    us:statutes/26/152/c#qualifying_child_before_tiebreaker: not_holds
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+
+- name: ineligible_parent_with_equal_agi_still_blocks_strict_higher_than_any_parent
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_over_half
+          - *claimant_return_normal
+          - *claimant_parent_declines
+          - *claimant_agi_equal
+  output:
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: not_holds
+    us:statutes/26/152/c#taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: not_holds
+
+- name: eligible_higher_agi_nonclaimant_counts_as_candidate_but_not_claimant_agi_blocker
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - &claimant_nonparent_does_not_claim
+            us:statutes/26/152/c#input.claimant_taxpayer_is_parent_of_individual: false
+            us:statutes/26/152/c#input.claimant_taxpayer_claims_individual_as_qualifying_child: false
+          - &claimant_agi_60000
+            us:statutes/26/152/c#input.claimant_adjusted_gross_income: 60000
+            us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
+  output:
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+    us:statutes/26/152/c#taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
+
+- name: ineligible_higher_agi_actual_claimant_does_not_block_eligible_claimant
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_over_half
+          - *claimant_return_normal
+          - *claimant_nonparent_claims
+          - *claimant_agi_60000
+  output:
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: not_holds
+    us:statutes/26/152/c#taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds

--- a/us/statutes/26/152/c.test.yaml
+++ b/us/statutes/26/152/c.test.yaml
@@ -1,168 +1,463 @@
-- name: under_19_child_qualifies_without_competing_claimants
-  period:
+- name: claimant_context_support_disregard_and_equal_agi_boundaries
+  period: &tax_year_2026
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
-    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
-    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
-    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
-    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
-    us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.5
-    us:statutes/26/152/c#input.filing_status: 0
-    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
-    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
-    us:statutes/26/152/c#input.parents_filing_status: 1
-    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
-    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
-    : false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    <<:
+      - &root_static
+        us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+        us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+        us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
+        us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: false
+        us:statutes/26/152/c#input.taxpayer_claims_individual_as_qualifying_child: true
+        us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
+        ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
+        : false
+      - &root_age_standard
+        us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+        us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
+        us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 40
+        us:statutes/26/152/c#input.individual_is_student: false
+      - &root_support_at_half
+        us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.5
+      - &root_return_normal
+        us:statutes/26/152/c#input.filing_status: 0
+        us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+      - &root_parents_joint
+        us:statutes/26/152/c#input.parents_filing_status: 1
+      - &relation_complete
+        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent: true
+      - &claimant_static
+        us:statutes/26/152/c#input.claimant_individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+        us:statutes/26/152/c#input.claimant_individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+        us:statutes/26/152/c#input.claimant_individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
+        us:statutes/26/152/c#input.claimant_individual_is_permanently_and_totally_disabled: false
+        us:statutes/26/152/c#input.claimant_individual_age_at_close_of_calendar_year: 18
+        us:statutes/26/152/c#input.claimant_taxpayer_age_at_close_of_calendar_year: 40
+        us:statutes/26/152/c#input.claimant_individual_is_student: false
+      - &claimant_support_over_half
+        us:statutes/26/152/c#input.claimant_individual_own_support_fraction_provided_by_individual: 0.75
+      - &claimant_return_normal
+        us:statutes/26/152/c#input.claimant_individual_filing_status: 0
+        us:statutes/26/152/c#input.claimant_individual_return_filed_only_for_claim_of_refund: false
+      - &claimant_parent_claims
+        us:statutes/26/152/c#input.claimant_taxpayer_is_parent_of_individual: true
+        us:statutes/26/152/c#input.claimant_taxpayer_claims_individual_as_qualifying_child: true
+      - &claimant_agi_equal
+        us:statutes/26/152/c#input.claimant_adjusted_gross_income: 50000
+        us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
+    us:statutes/26/152/c#claimant_qualifying_child_relationship: holds
+    us:statutes/26/152/c#claimant_individual_is_younger_than_claimant_taxpayer: holds
+    us:statutes/26/152/c#claimant_age_requirements_met: holds
+    us:statutes/26/152/c#claimant_individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund: not_holds
+    us:statutes/26/152/c#claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement: holds
+    us:statutes/26/152/c#claimant_qualifying_child_before_tiebreaker: not_holds
+    us:statutes/26/152/c#claimant_taxpayer_is_parent_and_claims_individual: holds
+    us:statutes/26/152/c#claimant_taxpayer_is_parent_and_may_claim_individual_before_tiebreaker: not_holds
+    us:statutes/26/152/c#claimant_taxpayer_is_parent_and_meets_qualifying_child_requirements_without_individual_support: holds
+    us:statutes/26/152/c#claimant_parent_adjusted_gross_income_at_least_evaluated_taxpayer_adjusted_gross_income: holds
+    us:statutes/26/152/c#other_claiming_eligible_taxpayer_adjusted_gross_income_at_least_evaluated_taxpayer: not_holds
+    us:statutes/26/152/c#other_claiming_eligible_taxpayer_without_individual_support_adjusted_gross_income_at_least_evaluated_taxpayer: holds
+
+- name: sole_eligible_claimant_qualifies_and_empty_parent_set_has_no_parent_claim
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
   output:
     us:statutes/26/152/c#qualifying_child_relationship: holds
+    us:statutes/26/152/c#individual_is_younger_than_taxpayer: holds
     us:statutes/26/152/c#age_requirements_met: holds
     us:statutes/26/152/c#individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund: not_holds
     us:statutes/26/152/c#parents_claiming_child_do_not_file_joint_return_together: not_holds
     us:statutes/26/152/c#qualifying_child_before_tiebreaker: holds
+    us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement: holds
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: not_holds
+    us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer: holds
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: not_holds
+    us:statutes/26/152/c#taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: not_holds
+    us:statutes/26/152/c#taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: holds
     us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
     us:statutes/26/152/c#qualifying_child: holds
-- name: under_19_child_qualifies_without_competing_claimants_scalar_outputs
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: section_152_c_scalar_thresholds
+  period: *tax_year_2026
   input:
-    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
-    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
-    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
-    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
-    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
-    us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.5
-    us:statutes/26/152/c#input.filing_status: 0
-    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
-    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
-    us:statutes/26/152/c#input.parents_filing_status: 1
-    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
-    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
-    : false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
   output:
     us:statutes/26/152/c#abode_fraction_threshold: 0.5
     us:statutes/26/152/c#support_fraction_threshold: 0.5
     us:statutes/26/152/c#child_age_limit: 19
     us:statutes/26/152/c#student_age_limit: 24
-- name: own_support_over_one_half_prevents_qualifying_child
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: equal_age_individual_is_not_younger_and_fails_non_disabled_age_rule
+  period: *tax_year_2026
   input:
-    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
-    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
-    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
-    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
-    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
-    us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.6
-    us:statutes/26/152/c#input.filing_status: 0
-    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
-    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
-    us:statutes/26/152/c#input.parents_filing_status: 1
-    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
-    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
-    : false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    <<:
+      - *root_static
+      - &root_age_equal
+        us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+        us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
+        us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 18
+        us:statutes/26/152/c#input.individual_is_student: false
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
   output:
-    us:statutes/26/152/c#qualifying_child_relationship: holds
+    us:statutes/26/152/c#individual_is_younger_than_taxpayer: not_holds
+    us:statutes/26/152/c#age_requirements_met: not_holds
+
+- name: disabled_individual_need_not_be_younger
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - &root_age_disabled_older
+        us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: true
+        us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 40
+        us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 30
+        us:statutes/26/152/c#input.individual_is_student: false
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
+    us:statutes/26/152/c#individual_is_younger_than_taxpayer: not_holds
     us:statutes/26/152/c#age_requirements_met: holds
+
+- name: support_over_one_half_fails_generic_test_but_not_support_omitted_component
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - &root_support_over_half
+        us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.5001
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
     us:statutes/26/152/c#qualifying_child_before_tiebreaker: not_holds
+    us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement: holds
     us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
     us:statutes/26/152/c#qualifying_child: not_holds
-- name: joint_return_other_than_refund_claim_prevents_qualifying_child
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: joint_return_other_than_refund_claim_fails_both_before_tiebreaker_components
+  period: *tax_year_2026
   input:
-    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
-    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
-    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
-    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
-    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 18
-    us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.5
-    us:statutes/26/152/c#input.filing_status: 1
-    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
-    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
-    us:statutes/26/152/c#input.parents_filing_status: 1
-    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
-    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
-    : false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - &root_return_joint_nonrefund
+        us:statutes/26/152/c#input.filing_status: 1
+        us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
   output:
     us:statutes/26/152/c#individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund: holds
     us:statutes/26/152/c#qualifying_child_before_tiebreaker: not_holds
+    us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement: not_holds
     us:statutes/26/152/c#qualifying_child: not_holds
-- name: disabled_individual_meets_age_rule_and_no_parent_claiming_tiebreaker
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: second_eligible_nonparent_triggers_tiebreaker_and_lower_agi_loses
+  period: *tax_year_2026
   input:
-    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: false
-    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: true
-    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.8
-    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: true
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: false
-    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 30
-    us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.25
-    us:statutes/26/152/c#input.filing_status: 0
-    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: true
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: true
-    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: false
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: true
-    us:statutes/26/152/c#input.parents_filing_status: 1
-    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
-    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
-    : false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - &claimant_support_eligible
+            us:statutes/26/152/c#input.claimant_individual_own_support_fraction_provided_by_individual: 0.25
+          - *claimant_return_normal
+          - &claimant_nonparent_claims
+            us:statutes/26/152/c#input.claimant_taxpayer_is_parent_of_individual: false
+            us:statutes/26/152/c#input.claimant_taxpayer_claims_individual_as_qualifying_child: true
+          - &claimant_agi_40000
+            us:statutes/26/152/c#input.claimant_adjusted_gross_income: 40000
+            us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
   output:
-    us:statutes/26/152/c#qualifying_child_relationship: holds
-    us:statutes/26/152/c#age_requirements_met: holds
-    us:statutes/26/152/c#qualifying_child_before_tiebreaker: holds
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+    us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer: holds
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: not_holds
+    us:statutes/26/152/c#taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: holds
     us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
     us:statutes/26/152/c#qualifying_child: holds
-- name: auto_positive_parents_claiming_child_do_not_file_joint_return_together
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+
+- name: equal_top_claimant_agi_has_no_unique_highest_claimant
+  period: *tax_year_2026
   input:
-    us:statutes/26/152/c#input.parents_filing_status: 999999
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_nonparent_claims
+          - *claimant_agi_equal
+  output:
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+    us:statutes/26/152/c#taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: not_holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: not_holds
+    us:statutes/26/152/c#qualifying_child: not_holds
+
+- name: two_eligible_parents_decline_and_lower_parent_agis_allow_nonparent_claim
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - &claimant_parent_declines
+            us:statutes/26/152/c#input.claimant_taxpayer_is_parent_of_individual: true
+            us:statutes/26/152/c#input.claimant_taxpayer_claims_individual_as_qualifying_child: false
+          - &claimant_agi_30000
+            us:statutes/26/152/c#input.claimant_adjusted_gross_income: 30000
+            us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_parent_declines
+          - *claimant_agi_40000
+  output:
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+    us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer: holds
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: holds
+    us:statutes/26/152/c#taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
+    us:statutes/26/152/c#qualifying_child: holds
+
+- name: taxpayer_agi_equal_to_parent_agi_fails_strict_higher_test
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_parent_declines
+          - *claimant_agi_equal
+  output:
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: holds
+    us:statutes/26/152/c#taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: not_holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: not_holds
+    us:statutes/26/152/c#qualifying_child: not_holds
+
+- name: one_of_multiple_parents_claiming_prevents_no_parent_and_declining_parent_branches
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_parent_claims
+          - *claimant_agi_30000
+      - <<:
+          - *claimant_static
+          - *claimant_support_eligible
+          - *claimant_return_normal
+          - *claimant_parent_declines
+          - &claimant_agi_20000
+            us:statutes/26/152/c#input.claimant_adjusted_gross_income: 20000
+            us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
+  output:
+    us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer: not_holds
+    us:statutes/26/152/c#parents_of_individual_may_claim_individual_but_no_parent_claims: not_holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: not_holds
+
+- name: unresolved_other_taxpayer_relation_fails_tiebreaker_closed
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - &relation_incomplete
+        us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent: false
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
+    us:statutes/26/152/c#individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: not_holds
+    us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer: not_holds
+    us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: not_holds
+    us:statutes/26/152/c#qualifying_child: not_holds
+
+- name: non_joint_parent_filing_status_is_detected
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - &root_parents_nonjoint
+        us:statutes/26/152/c#input.parents_filing_status: 999999
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
   output:
     us:statutes/26/152/c#parents_claiming_child_do_not_file_joint_return_together: holds
+
+- name: claimant_joint_return_other_than_refund_claim_is_detected
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_over_half
+      - &claimant_return_joint_nonrefund
+        us:statutes/26/152/c#input.claimant_individual_filing_status: 1
+        us:statutes/26/152/c#input.claimant_individual_return_filed_only_for_claim_of_refund: false
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
+    us:statutes/26/152/c#claimant_individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund: holds
+
+- name: eligible_parent_claimant_row_exercises_generic_claimant_helpers
+  period: *tax_year_2026
+  input:
+    <<:
+      - *root_static
+      - *root_age_standard
+      - *root_support_at_half
+      - *root_return_normal
+      - *root_parents_joint
+      - *relation_complete
+      - *claimant_static
+      - *claimant_support_eligible
+      - *claimant_return_normal
+      - *claimant_parent_claims
+      - *claimant_agi_equal
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker: []
+  output:
+    us:statutes/26/152/c#claimant_qualifying_child_before_tiebreaker: holds
+    us:statutes/26/152/c#claimant_taxpayer_is_parent_and_may_claim_individual_before_tiebreaker: holds
+    us:statutes/26/152/c#other_claiming_eligible_taxpayer_adjusted_gross_income_at_least_evaluated_taxpayer: holds

--- a/us/statutes/26/152/c.yaml
+++ b/us/statutes/26/152/c.yaml
@@ -3,10 +3,52 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/statute/26/152
+    corpus_citation_paths:
+      - us/statute/26/152/c/1
+      - us/statute/26/152/c/2
+      - us/statute/26/152/c/3
+      - us/statute/26/152/c/4
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us/statute/26/152/c/1
+        - us/statute/26/152/c/2
+        - us/statute/26/152/c/3
+        - us/statute/26/152/c/4
+      rationale: |-
+        Each row of the other-taxpayer relation is one complete taxpayer
+        context for the same individual. The relation excludes the evaluated
+        taxpayer and must include every other potential qualifying-child
+        claimant, every actual claimant, and every parent, including a parent
+        who does not independently satisfy paragraph (1). The caller attests
+        that rows are complete and unique and that each row's copied evaluated-
+        taxpayer AGI is consistent. This closed-world contract makes empty and
+        multiple-parent cases explicit.
+
+        The pinned engine has no relation maximum and does not portably compare
+        a related entity's scalar with the current entity's scalar. AGI maxima
+        are therefore expressed as the absence of an equal-or-higher row, with
+        the evaluated taxpayer's reported AGI copied onto each comparison row.
+        Equality fails both strict-higher and unique-highest tests.
+
+        Section 32(c)(3)(A) adopts section 152(c) without paragraph (1)(D).
+        This module exposes private before-tiebreaker components both with and
+        without the support requirement so the section 32 consumer can apply
+        paragraph (4) to its modified qualifying-child definition without
+        changing the generic section 152 result.
   summary: |-
     (c) Qualifying child For purposes of this section— (1) In general The term “qualifying child” means, with respect to any taxpayer for any taxable year, an individual— (A) who bears a relationship to the taxpayer described in paragraph (2), (B) who has the same principal place of abode as the taxpayer for more than one-half of such taxable year, (C) who meets the age requirements of paragraph (3), (D) who has not provided over one-half of such individual’s own support for the calendar year in which the taxable year of the taxpayer begins, and (E) who has not filed a joint return (other than only for a claim of refund) with the individual’s spouse under section 6013 for the taxable year beginning in the calendar year in which the taxable year of the taxpayer begins. (2) Relationship For purposes of paragraph (1)(A), an individual bears a relationship to the taxpayer described in this paragraph if such individual is— (A) a child of the taxpayer or a descendant of such a child, or (B) a brother, sister, stepbrother, or stepsister of the taxpayer or a descendant of any such relative. (3) Age requirements (A) In general For purposes of paragraph (1)(C), an individual meets the requirements of this paragraph if such individual is younger than the taxpayer claiming such individual as a qualifying child and— (i) has not attained the age of 19 as of the close of the calendar year in which the taxable year of the taxpayer begins, or (ii) is a student who has not attained the age of 24 as of the close of such calendar year. (B) Special rule for disabled In the case of an individual who is permanently and totally disabled (as defined in section 22(e)(3)) at any time during such calendar year, the requirements of subparagraph (A) shall be treated as met with respect to such individual. (4) Special rule relating to 2 or more who can claim the same qualifying child (A) In general Except as provided in subparagraphs (B) and (C), if (but for this paragraph) an individual may be claimed as a qualifying child by 2 or more taxpayers for a taxable year beginning in the same calendar year, such individual shall be treated as the qualifying child of the taxpayer who is— (i) a parent of the individual, or (ii) if clause (i) does not apply, the taxpayer with the highest adjusted gross income for such taxable year. (B) More than 1 parent claiming qualifying child If the parents claiming any qualifying child do not file a joint return together, such child shall be treated as the qualifying child of— (i) the parent with whom the child resided for the longest period of time during the taxable year, or (ii) if the child resides with both parents for the same amount of time during such taxable year, the parent with the highest adjusted gross income. (C) No parent claiming qualifying child If the parents of an individual may claim such individual as a qualifying child but no parent so claims the individual, such individual may be claimed as the qualifying child of another taxpayer but only if the adjusted gross income of such taxpayer is higher than the highest adjusted gross income of any parent of the individual.
 rules:
+  - name: other_taxpayer_context_for_qualifying_child_tiebreaker
+    kind: data_relation
+    source: 26 USC 152(c)(4), complete other-taxpayer tiebreaker contexts
+    data_relation:
+      predicate: other_taxpayer_context_for_qualifying_child_tiebreaker
+      arity: 2
+      arguments:
+        - Person
+        - TaxUnit
+
   - name: abode_fraction_threshold
     kind: parameter
     dtype: Decimal
@@ -17,7 +59,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/1
               excerpt: "more than one-half of such taxable year"
     versions:
       - effective_from: '1990-01-01'
@@ -34,7 +76,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/1
               excerpt: "has not provided over one-half of such individual’s own support"
     versions:
       - effective_from: '1990-01-01'
@@ -51,7 +93,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/3
               excerpt: "has not attained the age of 19"
     versions:
       - effective_from: '1990-01-01'
@@ -68,7 +110,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/3
               excerpt: "is a student who has not attained the age of 24"
     versions:
       - effective_from: '1990-01-01'
@@ -87,13 +129,33 @@ rules:
           - path: versions[0].formula
             kind: definition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/2
               excerpt: "a child of the taxpayer or a descendant of such a child, or ... a brother, sister, stepbrother, or stepsister of the taxpayer or a descendant of any such relative"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
           individual_is_child_of_taxpayer_or_descendant_of_such_child
           or individual_is_sibling_stepsibling_or_descendant_of_such_relative
+
+  - name: individual_is_younger_than_taxpayer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(3)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/3
+              excerpt: "such individual is younger than the taxpayer claiming such individual as a qualifying child"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          individual_age_at_close_of_calendar_year
+          < taxpayer_age_at_close_of_calendar_year
 
   - name: age_requirements_met
     kind: derived
@@ -107,12 +169,12 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/3
               excerpt: "younger than the taxpayer ... and ... has not attained the age of 19 ... or ... is a student who has not attained the age of 24"
           - path: versions[0].formula
             kind: exception
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/3
               excerpt: "permanently and totally disabled ... at any time during such calendar year, the requirements of subparagraph (A) shall be treated as met"
     versions:
       - effective_from: '1990-01-01'
@@ -141,7 +203,7 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/1
               excerpt: "has not filed a joint return (other than only for a claim of refund) with the individual’s spouse under section 6013"
     versions:
       - effective_from: '1990-01-01'
@@ -161,7 +223,7 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/4
               excerpt: "If the parents claiming any qualifying child do not file a joint return together"
     versions:
       - effective_from: '1990-01-01'
@@ -180,7 +242,7 @@ rules:
           - path: versions[0].formula
             kind: definition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/1
               excerpt: "The term “qualifying child” means ... an individual— (A) ... relationship ... (B) ... same principal place of abode ... (C) ... age requirements ... (D) ... has not provided over one-half ... support ... and (E) ... has not filed a joint return"
     versions:
       - effective_from: '1990-01-01'
@@ -190,6 +252,444 @@ rules:
           and age_requirements_met
           and individual_own_support_fraction_provided_by_individual <= support_fraction_threshold
           and not individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
+
+  - name: qualifying_child_before_tiebreaker_without_individual_support_requirement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(1), paragraph (1)(D) omitted for an adopting provision
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/152/c/1
+              excerpt: "The term “qualifying child” means ... an individual— (A) ... (B) ... (C) ... and (E)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualifying_child_relationship
+          and individual_principal_place_of_abode_with_taxpayer_fraction > abode_fraction_threshold
+          and age_requirements_met
+          and not individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
+
+  - name: claimant_qualifying_child_relationship
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(2), other-taxpayer context
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/152/c/2
+              excerpt: "a child of the taxpayer or a descendant of such a child, or ... a brother, sister, stepbrother, or stepsister of the taxpayer or a descendant of any such relative"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_individual_is_child_of_taxpayer_or_descendant_of_such_child
+          or claimant_individual_is_sibling_stepsibling_or_descendant_of_such_relative
+
+  - name: claimant_individual_is_younger_than_claimant_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(3)(A), other-taxpayer context
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/3
+              excerpt: "such individual is younger than the taxpayer claiming such individual as a qualifying child"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_individual_age_at_close_of_calendar_year
+          < claimant_taxpayer_age_at_close_of_calendar_year
+
+  - name: claimant_age_requirements_met
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(3), other-taxpayer context
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/3
+              excerpt: "younger than the taxpayer ... and ... has not attained the age of 19 ... or ... is a student who has not attained the age of 24"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/152/c/3
+              excerpt: "permanently and totally disabled ... at any time during such calendar year, the requirements of subparagraph (A) shall be treated as met"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_individual_is_permanently_and_totally_disabled
+          or (
+              claimant_individual_is_younger_than_claimant_taxpayer
+              and (
+                  claimant_individual_age_at_close_of_calendar_year < child_age_limit
+                  or (
+                      claimant_individual_is_student
+                      and claimant_individual_age_at_close_of_calendar_year < student_age_limit
+                  )
+              )
+          )
+
+  - name: claimant_individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(1)(E), other-taxpayer context
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/1
+              excerpt: "has not filed a joint return (other than only for a claim of refund) with the individual’s spouse under section 6013"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_individual_filing_status == 1
+          and not claimant_individual_return_filed_only_for_claim_of_refund
+
+  - name: claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(1), other-taxpayer context with paragraph (1)(D) omitted
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/152/c/1
+              excerpt: "The term “qualifying child” means ... an individual— (A) ... (B) ... (C) ... and (E)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_qualifying_child_relationship
+          and claimant_individual_principal_place_of_abode_with_taxpayer_fraction > abode_fraction_threshold
+          and claimant_age_requirements_met
+          and not claimant_individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
+
+  - name: claimant_qualifying_child_before_tiebreaker
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(1), other-taxpayer context
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/152/c/1
+              excerpt: "The term “qualifying child” means ... an individual— (A) ... (B) ... (C) ... (D) ... and (E)"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+          and claimant_individual_own_support_fraction_provided_by_individual
+              <= support_fraction_threshold
+
+  - name: claimant_taxpayer_is_parent_and_claims_individual
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4), parent and actual-claim row
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the parents claiming any qualifying child"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_taxpayer_is_parent_of_individual
+          and claimant_taxpayer_claims_individual_as_qualifying_child
+
+  - name: claimant_taxpayer_is_parent_and_may_claim_individual_before_tiebreaker
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(C), parent eligibility row
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the parents of an individual may claim such individual as a qualifying child"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_taxpayer_is_parent_of_individual
+          and claimant_qualifying_child_before_tiebreaker
+
+  - name: claimant_taxpayer_is_parent_and_meets_qualifying_child_requirements_without_individual_support
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(C), parent eligibility under an adopting provision
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the parents of an individual may claim such individual as a qualifying child"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_taxpayer_is_parent_of_individual
+          and claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+
+  - name: claimant_parent_adjusted_gross_income_at_least_evaluated_taxpayer_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(C), equal-or-higher parent blocker
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "higher than the highest adjusted gross income of any parent of the individual"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_taxpayer_is_parent_of_individual
+          and claimant_adjusted_gross_income
+              >= evaluated_taxpayer_adjusted_gross_income_on_claimant_row
+
+  - name: other_claiming_eligible_taxpayer_adjusted_gross_income_at_least_evaluated_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(A)(ii), equal-or-higher claimant blocker
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the taxpayer with the highest adjusted gross income"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_qualifying_child_before_tiebreaker
+          and claimant_taxpayer_claims_individual_as_qualifying_child
+          and claimant_adjusted_gross_income
+              >= evaluated_taxpayer_adjusted_gross_income_on_claimant_row
+
+  - name: other_claiming_eligible_taxpayer_without_individual_support_adjusted_gross_income_at_least_evaluated_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(A)(ii), adopting-provision claimant blocker
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the taxpayer with the highest adjusted gross income for such taxable year"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+          and claimant_taxpayer_claims_individual_as_qualifying_child
+          and claimant_adjusted_gross_income
+              >= evaluated_taxpayer_adjusted_gross_income_on_claimant_row
+
+  - name: individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(A)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "if (but for this paragraph) an individual may be claimed as a qualifying child by 2 or more taxpayers"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          and (
+              count_where(
+                other_taxpayer_context_for_qualifying_child_tiebreaker,
+                claimant_qualifying_child_before_tiebreaker
+              ) >= 2
+              or (
+                  qualifying_child_before_tiebreaker
+                  and count_where(
+                    other_taxpayer_context_for_qualifying_child_tiebreaker,
+                    claimant_qualifying_child_before_tiebreaker
+                  ) >= 1
+              )
+          )
+
+  - name: no_parent_of_individual_is_a_claiming_taxpayer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "if clause (i) does not apply"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          and not (
+              taxpayer_is_parent_of_individual
+              and taxpayer_claims_individual_as_qualifying_child
+          )
+          and count_where(
+            other_taxpayer_context_for_qualifying_child_tiebreaker,
+            claimant_taxpayer_is_parent_and_claims_individual
+          ) == 0
+
+  - name: parents_of_individual_may_claim_individual_but_no_parent_claims
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "If the parents of an individual may claim such individual as a qualifying child but no parent so claims the individual"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+              (
+                  taxpayer_is_parent_of_individual
+                  and qualifying_child_before_tiebreaker
+              )
+              or count_where(
+                other_taxpayer_context_for_qualifying_child_tiebreaker,
+                claimant_taxpayer_is_parent_and_may_claim_individual_before_tiebreaker
+              ) > 0
+          )
+          and no_parent_of_individual_is_a_claiming_taxpayer
+
+  - name: taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "only if the adjusted gross income of such taxpayer is higher than the highest adjusted gross income of any parent of the individual"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          and not taxpayer_is_parent_of_individual
+          and count_where(
+            other_taxpayer_context_for_qualifying_child_tiebreaker,
+            claimant_taxpayer_is_parent_of_individual
+          ) > 0
+          and count_where(
+            other_taxpayer_context_for_qualifying_child_tiebreaker,
+            claimant_parent_adjusted_gross_income_at_least_evaluated_taxpayer_adjusted_gross_income
+          ) == 0
+
+  - name: taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 152(c)(4)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/152/c/4
+              excerpt: "the taxpayer with the highest adjusted gross income"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          and qualifying_child_before_tiebreaker
+          and taxpayer_claims_individual_as_qualifying_child
+          and count_where(
+            other_taxpayer_context_for_qualifying_child_tiebreaker,
+            other_claiming_eligible_taxpayer_adjusted_gross_income_at_least_evaluated_taxpayer
+          ) == 0
 
   - name: tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
     kind: derived
@@ -203,47 +703,50 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/4
               excerpt: "if (but for this paragraph) an individual may be claimed as a qualifying child by 2 or more taxpayers ... such individual shall be treated as the qualifying child of the taxpayer who is— (i) a parent ... or (ii) ... the taxpayer with the highest adjusted gross income"
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/4
               excerpt: "If the parents claiming any qualifying child do not file a joint return together, such child shall be treated as the qualifying child of— (i) the parent with whom the child resided for the longest period of time ... or (ii) ... the parent with the highest adjusted gross income"
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/4
               excerpt: "If the parents of an individual may claim such individual as a qualifying child but no parent so claims the individual, such individual may be claimed as the qualifying child of another taxpayer but only if the adjusted gross income of such taxpayer is higher than the highest adjusted gross income of any parent"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          not individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
-          or (
-              individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
-              and (
-                  (
-                      parents_of_individual_may_claim_individual_but_no_parent_claims
-                      and not taxpayer_is_parent_of_individual
-                      and taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
-                  )
-                  or (
-                      not parents_of_individual_may_claim_individual_but_no_parent_claims
-                      and parents_claiming_child_do_not_file_joint_return_together
-                      and taxpayer_is_parent_of_individual
-                      and (
-                          child_resided_with_taxpayer_parent_for_longest_period
-                          or child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          and (
+              not individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+              or (
+                  individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+                  and (
+                      (
+                          parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and not taxpayer_is_parent_of_individual
+                          and taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
                       )
-                  )
-                  or (
-                      not parents_of_individual_may_claim_individual_but_no_parent_claims
-                      and not parents_claiming_child_do_not_file_joint_return_together
-                      and (
-                          taxpayer_is_parent_of_individual
-                          or (
-                              no_parent_of_individual_is_a_claiming_taxpayer
-                              and taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers
+                      or (
+                          not parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and parents_claiming_child_do_not_file_joint_return_together
+                          and taxpayer_is_parent_of_individual
+                          and (
+                              child_resided_with_taxpayer_parent_for_longest_period
+                              or child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
+                          )
+                      )
+                      or (
+                          not parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and not parents_claiming_child_do_not_file_joint_return_together
+                          and (
+                              taxpayer_is_parent_of_individual
+                              or (
+                                  no_parent_of_individual_is_a_claiming_taxpayer
+                                  and taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers
+                              )
                           )
                       )
                   )
@@ -262,12 +765,12 @@ rules:
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/1
               excerpt: "The term “qualifying child” means ... an individual ... [meeting paragraph (1)]"
           - path: versions[0].formula
             kind: formula
             source:
-              corpus_citation_path: us/statute/26/152
+              corpus_citation_path: us/statute/26/152/c/4
               excerpt: "Special rule relating to 2 or more who can claim the same qualifying child"
     versions:
       - effective_from: '1990-01-01'

--- a/us/statutes/26/152/c.yaml
+++ b/us/statutes/26/152/c.yaml
@@ -21,15 +21,23 @@ module:
         taxpayer and must include every other potential qualifying-child
         claimant, every actual claimant, and every parent, including a parent
         who does not independently satisfy paragraph (1). The caller attests
-        that rows are complete and unique and that each row's copied evaluated-
-        taxpayer AGI is consistent. This closed-world contract makes empty and
-        multiple-parent cases explicit.
+        that rows are complete and unique, that duplicated facts about the
+        individual are consistent across contexts, and that each row's copied
+        evaluated-taxpayer AGI is consistent. This closed-world contract makes
+        empty and multiple-parent cases explicit.
 
         The pinned engine has no relation maximum and does not portably compare
         a related entity's scalar with the current entity's scalar. AGI maxima
         are therefore expressed as the absence of an equal-or-higher row, with
         the evaluated taxpayer's reported AGI copied onto each comparison row.
         Equality fails both strict-higher and unique-highest tests.
+
+        The assigned highest-AGI output is expressly named as a comparison
+        among claiming taxpayers. It therefore ranks actual claimants who meet
+        the applicable before-tiebreaker qualifying-child definition; an
+        eligible taxpayer who does not claim the individual is not an AGI
+        blocker. Candidate counting remains based on who may claim, regardless
+        of whether that taxpayer files the claim.
 
         Section 32(c)(3)(A) adopts section 152(c) without paragraph (1)(D).
         This module exposes private before-tiebreaker components both with and
@@ -567,7 +575,7 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
           and (
               count_where(
                 other_taxpayer_context_for_qualifying_child_tiebreaker,
@@ -599,7 +607,7 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
           and not (
               taxpayer_is_parent_of_individual
               and taxpayer_claims_individual_as_qualifying_child
@@ -655,7 +663,7 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
           and not taxpayer_is_parent_of_individual
           and count_where(
             other_taxpayer_context_for_qualifying_child_tiebreaker,
@@ -683,7 +691,7 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
           and qualifying_child_before_tiebreaker
           and taxpayer_claims_individual_as_qualifying_child
           and count_where(
@@ -718,7 +726,7 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: |-
-          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_comparison_values_consistent
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
           and (
               not individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
               or (

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -5,11 +5,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -25,9 +26,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -53,29 +51,21 @@
       us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
       us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
       us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-      us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
       us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+      us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 40
       us:statutes/26/152/c#input.individual_is_student: false
       us:statutes/26/152/c#input.filing_status: 0
       us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-      us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-      us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
       us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-      us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+      us:statutes/26/152/c#input.taxpayer_claims_individual_as_qualifying_child: true
+      us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: true
       us:statutes/26/152/c#input.parents_filing_status: 1
       us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
       us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
-      us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-      us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_child_count: 1
     us:statutes/26/32#eitc_capped_child_count: 1
@@ -93,7 +83,6 @@
     us:statutes/26/32#eitc_investment_income_eligible: holds
     us:statutes/26/32#eitc_allowed: holds
     us:statutes/26/32#eitc: 3400
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
 - name: childless_person_age_predicate
   period:
     period_kind: tax_year
@@ -115,20 +104,17 @@
     us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
     us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
     us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
     us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+    us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 40
     us:statutes/26/152/c#input.individual_is_student: false
     us:statutes/26/152/c#input.filing_status: 0
     us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
     us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+    us:statutes/26/152/c#input.taxpayer_claims_individual_as_qualifying_child: true
+    us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: true
     us:statutes/26/152/c#input.parents_filing_status: 1
     us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
     us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
-    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
     us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
     us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
     us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: true
@@ -136,6 +122,57 @@
   output:
     us:statutes/26/32#eitc_qualifying_child: not_holds
     us:statutes/26/32#eitc_qualifying_child_base: holds
+
+- name: eitc_tiebreaker_disregards_support_for_current_and_parent_candidates
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
+    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+    us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 40
+    us:statutes/26/152/c#input.individual_is_student: false
+    us:statutes/26/152/c#input.individual_own_support_fraction_provided_by_individual: 0.75
+    us:statutes/26/152/c#input.filing_status: 0
+    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: false
+    us:statutes/26/152/c#input.taxpayer_claims_individual_as_qualifying_child: true
+    us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: true
+    us:statutes/26/152/c#input.parents_filing_status: 1
+    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
+    ? us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
+    : false
+    us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
+    us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
+    us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
+    us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
+    us:statutes/26/152/c#relation.other_taxpayer_context_for_qualifying_child_tiebreaker:
+      - us:statutes/26/152/c#input.claimant_individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+        us:statutes/26/152/c#input.claimant_individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+        us:statutes/26/152/c#input.claimant_individual_principal_place_of_abode_with_taxpayer_fraction: 0.75
+        us:statutes/26/152/c#input.claimant_individual_is_permanently_and_totally_disabled: false
+        us:statutes/26/152/c#input.claimant_individual_age_at_close_of_calendar_year: 8
+        us:statutes/26/152/c#input.claimant_taxpayer_age_at_close_of_calendar_year: 40
+        us:statutes/26/152/c#input.claimant_individual_is_student: false
+        us:statutes/26/152/c#input.claimant_individual_own_support_fraction_provided_by_individual: 0.75
+        us:statutes/26/152/c#input.claimant_individual_filing_status: 0
+        us:statutes/26/152/c#input.claimant_individual_return_filed_only_for_claim_of_refund: false
+        us:statutes/26/152/c#input.claimant_taxpayer_is_parent_of_individual: true
+        us:statutes/26/152/c#input.claimant_taxpayer_claims_individual_as_qualifying_child: false
+        us:statutes/26/152/c#input.claimant_adjusted_gross_income: 40000
+        us:statutes/26/152/c#input.evaluated_taxpayer_adjusted_gross_income_on_claimant_row: 50000
+  output:
+    us:statutes/26/32#eitc_qualifying_child_base: holds
+    us:statutes/26/32#eitc_qualifying_child: holds
+    us:statutes/26/32#eitc_individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: holds
+    us:statutes/26/32#eitc_parents_of_individual_may_claim_individual_but_no_parent_claims: holds
+    us:statutes/26/32#eitc_taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: holds
+    us:statutes/26/32#eitc_tiebreaker_treats_individual_as_qualifying_child_of_taxpayer: holds
+
 - name: investment_income_denies_credit
   period:
     period_kind: tax_year
@@ -143,11 +180,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -163,9 +201,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -191,31 +226,22 @@
       us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
       us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
       us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
-      us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
       us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+      us:statutes/26/152/c#input.taxpayer_age_at_close_of_calendar_year: 40
       us:statutes/26/152/c#input.individual_is_student: false
       us:statutes/26/152/c#input.filing_status: 0
       us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
-      us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
-      us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
       us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
-      us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+      us:statutes/26/152/c#input.taxpayer_claims_individual_as_qualifying_child: true
+      us:statutes/26/152/c#input.qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent: true
       us:statutes/26/152/c#input.parents_filing_status: 1
       us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
       us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
-      us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
-      us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_investment_income_eligible: not_holds
     us:statutes/26/32#eitc_allowed: not_holds
     us:statutes/26/32#eitc: 0
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -3,13 +3,16 @@ imports:
   - us:statutes/26/32/c/2
   - us:statutes/26/152/c
   - us:statutes/26/152/c#individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
+  - us:statutes/26/152/c#parents_claiming_child_do_not_file_joint_return_together
   - us:statutes/26/7703#taxpayer_married_under_general_rule
   - us:policies/irs/rev-proc-2025-32/earned-income-credit
 module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/statute/26/32
+    corpus_citation_paths:
+      - us/statute/26/32
+      - us/statute/26/32/c/3
   deferred_outputs:
     - output: us:statutes/26/32/f#eitc_table_based_credit_determination
       blocked_by:
@@ -131,6 +134,208 @@ rules:
         formula: |-
           65
 
+  - name: eitc_individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(3)(A), 152(c)(4)(A)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/32/c/3
+              excerpt: "as defined in section 152(c), determined without regard to paragraph (1)(D) thereof"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement
+              output: qualifying_child_before_tiebreaker_without_individual_support_requirement
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+              output: claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
+          and (
+              count_where(
+                other_taxpayer_context_for_qualifying_child_tiebreaker,
+                claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+              ) >= 2
+              or (
+                  qualifying_child_before_tiebreaker_without_individual_support_requirement
+                  and count_where(
+                    other_taxpayer_context_for_qualifying_child_tiebreaker,
+                    claimant_qualifying_child_before_tiebreaker_without_individual_support_requirement
+                  ) >= 1
+              )
+          )
+
+  - name: eitc_parents_of_individual_may_claim_individual_but_no_parent_claims
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(3)(A), 152(c)(4)(C)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/32/c/3
+              excerpt: "as defined in section 152(c), determined without regard to paragraph (1)(D) thereof"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement
+              output: qualifying_child_before_tiebreaker_without_individual_support_requirement
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#claimant_taxpayer_is_parent_and_meets_qualifying_child_requirements_without_individual_support
+              output: claimant_taxpayer_is_parent_and_meets_qualifying_child_requirements_without_individual_support
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer
+              output: no_parent_of_individual_is_a_claiming_taxpayer
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          (
+              (
+                  taxpayer_is_parent_of_individual
+                  and qualifying_child_before_tiebreaker_without_individual_support_requirement
+              )
+              or count_where(
+                other_taxpayer_context_for_qualifying_child_tiebreaker,
+                claimant_taxpayer_is_parent_and_meets_qualifying_child_requirements_without_individual_support
+              ) > 0
+          )
+          and no_parent_of_individual_is_a_claiming_taxpayer
+
+  - name: eitc_taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(3)(A), 152(c)(4)(A)(ii)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/32/c/3
+              excerpt: "as defined in section 152(c), determined without regard to paragraph (1)(D) thereof"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#qualifying_child_before_tiebreaker_without_individual_support_requirement
+              output: qualifying_child_before_tiebreaker_without_individual_support_requirement
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#other_claiming_eligible_taxpayer_without_individual_support_adjusted_gross_income_at_least_evaluated_taxpayer
+              output: other_claiming_eligible_taxpayer_without_individual_support_adjusted_gross_income_at_least_evaluated_taxpayer
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
+          and qualifying_child_before_tiebreaker_without_individual_support_requirement
+          and taxpayer_claims_individual_as_qualifying_child
+          and count_where(
+            other_taxpayer_context_for_qualifying_child_tiebreaker,
+            other_claiming_eligible_taxpayer_without_individual_support_adjusted_gross_income_at_least_evaluated_taxpayer
+          ) == 0
+
+  - name: eitc_tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(3)(A), 152(c)(4)
+    metadata:
+      private: true
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/32/c/3
+              excerpt: "as defined in section 152(c), determined without regard to paragraph (1)(D) thereof"
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#parents_claiming_child_do_not_file_joint_return_together
+              output: parents_claiming_child_do_not_file_joint_return_together
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
+              output: taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/152/c#no_parent_of_individual_is_a_claiming_taxpayer
+              output: no_parent_of_individual_is_a_claiming_taxpayer
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          qualifying_child_tiebreaker_other_taxpayer_contexts_are_complete_unique_and_consistent
+          and (
+              not eitc_individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+              or (
+                  eitc_individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers
+                  and (
+                      (
+                          eitc_parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and not taxpayer_is_parent_of_individual
+                          and taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income
+                      )
+                      or (
+                          not eitc_parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and parents_claiming_child_do_not_file_joint_return_together
+                          and taxpayer_is_parent_of_individual
+                          and (
+                              child_resided_with_taxpayer_parent_for_longest_period
+                              or child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income
+                          )
+                      )
+                      or (
+                          not eitc_parents_of_individual_may_claim_individual_but_no_parent_claims
+                          and not parents_claiming_child_do_not_file_joint_return_together
+                          and (
+                              taxpayer_is_parent_of_individual
+                              or (
+                                  no_parent_of_individual_is_a_claiming_taxpayer
+                                  and eitc_taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers
+                              )
+                          )
+                      )
+                  )
+              )
+          )
+
   - name: eitc_qualifying_child_base
     kind: derived
     entity: Person
@@ -145,31 +350,25 @@ rules:
             import:
               target: us:statutes/26/152/c#qualifying_child_relationship
               output: qualifying_child_relationship
-              hash: sha256:6b4df92c453619173f7c6c8b4f06e38ebb84b63521b2f53c30f49acf7d4d79bb
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
           - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/152/c#abode_fraction_threshold
               output: abode_fraction_threshold
-              hash: sha256:6b4df92c453619173f7c6c8b4f06e38ebb84b63521b2f53c30f49acf7d4d79bb
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
           - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/152/c#age_requirements_met
               output: age_requirements_met
-              hash: sha256:6b4df92c453619173f7c6c8b4f06e38ebb84b63521b2f53c30f49acf7d4d79bb
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/26/152/c#tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
-              output: tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
-              hash: sha256:6b4df92c453619173f7c6c8b4f06e38ebb84b63521b2f53c30f49acf7d4d79bb
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
           - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/152/c#individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
               output: individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
-              hash: sha256:6b4df92c453619173f7c6c8b4f06e38ebb84b63521b2f53c30f49acf7d4d79bb
+              hash: sha256:4a81deb4d21271496da6fa5503ea4708e4bc41f96f08f3de9acbb90668644d29
           - path: versions[0].formula
             kind: definition
             source:
@@ -182,7 +381,7 @@ rules:
           and individual_principal_place_of_abode_with_taxpayer_fraction > abode_fraction_threshold
           and age_requirements_met
           and not individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
-          and tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
+          and eitc_tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
 
   - name: eitc_qualifying_child
     kind: derived


### PR DESCRIPTION
EITC frontier items 10–15 — all six encoded; neither §61 nor §1402 required. 20 companion cases + §32 integration. Refs #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)