### PR TITLE
Encode §32 eligibility predicates (EITC frontier)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,8 +2,9 @@
 
 ## State
 
-In progress on branch `closure/w3-eitc-32-eligibility` from `origin/main`.
-Assigned EITC frontier items: 1, 2, 5, 6, and 7.
+Implementation and targeted validation complete on branch
+`closure/w3-eitc-32-eligibility` from `origin/main`. Assigned EITC frontier
+items: 1, 2, 5, 6, and 7.
 
 ## Done
 
@@ -32,9 +33,27 @@ Assigned EITC frontier items: 1, 2, 5, 6, and 7.
   output deferred: section 151 exports no per-child entitlement result, while
   the section 152 parent and its subsection (e) adjusted bases are
   entity/schema unsupported.
+- Aligned the child marriage input with the repository's point-in-time
+  `married_at_close` fact convention; the §32(c)(3)(B) text does not invoke
+  section 7703's taxpayer filing-status classification.
+- Updated the section 24(d) proof import hash for the changed section 32
+  module.
+- Validation completed:
+  - section 32 proof validation: 50 atoms, no issues;
+  - section 24(d) proof validation: 17 atoms, no issues;
+  - section 24(d) execution: 4 of 4 cases passed;
+  - section 32 execution: all 21 newly added cases passed; the two pre-existing
+    section 32(c)(2) fixtures still emit their same four stale-reference
+    diagnostics;
+  - repository layout: 9 tests passed;
+  - section 24(d) non-reviewer validation passed.
 
 ## Next
 
-- Run final targeted, proof, schema, and repository validation.
-- Record final validation in this ledger, push, and open the requested draft
-  PR.
+- Push and open the requested draft PR.
+- A key holder must refresh the signed applied-rule manifests for sections 32
+  and 24(d). The repository signing command was attempted, but this workspace
+  does not provide `AXIOM_ENCODE_APPLY_SIGNING_KEY`; no signature was forged or
+  bypassed.
+- Separately repair the pre-existing stale section 32(c)(2) test references;
+  they are outside this assignment.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -18,11 +18,16 @@ Assigned EITC frontier items: 1, 2, 5, 6, and 7.
   aggregate over the existing Person age predicate.
 - Added six aggregate tests covering ages 24, 25, 64, and 65 plus both
   either-spouse branches, and migrated the importing section 24(d) fixtures.
+- Encoded the section 32(k)(1) ten-year fraud and two-year
+  reckless-or-intentional-disregard windows, including the excluded
+  determination year and inclusive last years.
+- Encoded the section 32(k)(2) indefinite prior-deficiency gate and its
+  current-claim required-information exception.
+- Added ten disallowance-window cases and three prior-deficiency cases, and
+  migrated all affected section 32 and section 24(d) fixtures.
 
 ## Next
 
-- Encode the section 32(k)(1) disallowance windows and section 32(k)(2)
-  prior-deficiency information gate with statutory-boundary tests.
 - Encode the section 32(c)(3)(B) marital gate and declare the exact upstream
   section 151/152(e) entitlement wall.
 - Validate, document any genuine upstream-law wall, push, and open the

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,12 +11,19 @@ Assigned EITC frontier items: 1, 2, 5, 6, and 7.
 - Created an isolated worktree. The requested sibling-directory path was
   blocked by the filesystem sandbox, so the worktree lives at
   `.git/codex-worktrees/w3-eitc-32-eligibility`.
+- Read the five assigned frontier rows, the EITC program/grid context, the
+  required sibling encodings, and the governing corpus records resolved by
+  exact `citation_path` across every inventory record.
+- Encoded the section 32(c)(1)(A)(ii)(II) taxpayer-or-spouse childless-age
+  aggregate over the existing Person age predicate.
+- Added six aggregate tests covering ages 24, 25, 64, and 65 plus both
+  either-spouse branches, and migrated the importing section 24(d) fixtures.
 
 ## Next
 
-- Read the assigned frontier rows and authoritative corpus records by
-  `citation_path`.
-- Inspect the EITC program/grid context and repository conventions.
-- Encode each unblocked predicate with statutory-boundary tests.
+- Encode the section 32(k)(1) disallowance windows and section 32(k)(2)
+  prior-deficiency information gate with statutory-boundary tests.
+- Encode the section 32(c)(3)(B) marital gate and declare the exact upstream
+  section 151/152(e) entitlement wall.
 - Validate, document any genuine upstream-law wall, push, and open the
   requested draft PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,10 +25,16 @@ Assigned EITC frontier items: 1, 2, 5, 6, and 7.
   current-claim required-information exception.
 - Added ten disallowance-window cases and three prior-deficiency cases, and
   migrated all affected section 32 and section 24(d) fixtures.
+- Encoded the section 32(c)(3)(B) year-end marital-status gate and exercised
+  the unmarried, married-without-entitlement, and married-with-entitlement
+  branches.
+- Declared the composite section 151 entitlement / but-for-section-152(e)
+  output deferred: section 151 exports no per-child entitlement result, while
+  the section 152 parent and its subsection (e) adjusted bases are
+  entity/schema unsupported.
 
 ## Next
 
-- Encode the section 32(c)(3)(B) marital gate and declare the exact upstream
-  section 151/152(e) entitlement wall.
-- Validate, document any genuine upstream-law wall, push, and open the
-  requested draft PR.
+- Run final targeted, proof, schema, and repository validation.
+- Record final validation in this ledger, push, and open the requested draft
+  PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,22 @@
+# Progress
+
+## State
+
+In progress on branch `closure/w3-eitc-32-eligibility` from `origin/main`.
+Assigned EITC frontier items: 1, 2, 5, 6, and 7.
+
+## Done
+
+- Read the closure-sprint encoder preamble and root `CLAUDE.md`.
+- Created an isolated worktree. The requested sibling-directory path was
+  blocked by the filesystem sandbox, so the worktree lives at
+  `.git/codex-worktrees/w3-eitc-32-eligibility`.
+
+## Next
+
+- Read the assigned frontier rows and authoritative corpus records by
+  `citation_path`.
+- Inspect the EITC program/grid context and repository conventions.
+- Encode each unblocked predicate with statutory-boundary tests.
+- Validate, document any genuine upstream-law wall, push, and open the
+  requested draft PR.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,9 +2,10 @@
 
 ## State
 
-Implementation and targeted validation complete on branch
-`closure/w3-eitc-32-eligibility` from `origin/main`. Assigned EITC frontier
-items: 1, 2, 5, 6, and 7.
+Implementation, targeted validation, and independent review are complete on
+branch `closure/w3-eitc-32-eligibility` from `origin/main`. Assigned EITC
+frontier items: 1, 2, 5, 6, and 7. Remote delivery is blocked by this
+workspace's network and signing-key constraints.
 
 ## Done
 
@@ -47,13 +48,20 @@ items: 1, 2, 5, 6, and 7.
     diagnostics;
   - repository layout: 9 tests passed;
   - section 24(d) non-reviewer validation passed.
+- Independent final review found no substantive statutory or RuleSpec defect
+  and approved the changes for a draft PR, subject to signed manifests.
+- A normal push was attempted and failed because the sandbox could not resolve
+  `github.com`; the connected GitHub write was cancelled, so no remote branch
+  or PR state is claimed.
 
 ## Next
 
-- Push and open the requested draft PR.
 - A key holder must refresh the signed applied-rule manifests for sections 32
   and 24(d). The repository signing command was attempted, but this workspace
   does not provide `AXIOM_ENCODE_APPLY_SIGNING_KEY`; no signature was forged or
   bypassed.
+- Push the branch and open the draft PR titled
+  `Encode §32 eligibility predicates (EITC frontier)`, referencing
+  `rulespec-us#1135`.
 - Separately repair the pre-existing stale section 32(c)(2) test references;
   they are outside this assignment.

--- a/us/statutes/26/24/d.test.yaml
+++ b/us/statutes/26/24/d.test.yaml
@@ -36,6 +36,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
@@ -114,6 +115,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
@@ -188,6 +190,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
@@ -257,6 +260,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false

--- a/us/statutes/26/24/d.test.yaml
+++ b/us/statutes/26/24/d.test.yaml
@@ -36,7 +36,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false
@@ -110,7 +110,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false
@@ -180,7 +180,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false
@@ -245,7 +245,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 0
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false

--- a/us/statutes/26/24/d.test.yaml
+++ b/us/statutes/26/24/d.test.yaml
@@ -47,8 +47,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: false
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit: []
@@ -121,8 +125,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: false
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit: []
@@ -191,8 +199,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: false
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit: []
@@ -256,8 +268,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: false
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit: []

--- a/us/statutes/26/24/d.yaml
+++ b/us/statutes/26/24/d.yaml
@@ -185,7 +185,7 @@ rules:
             import:
               target: us:statutes/26/32#eitc
               output: eitc
-              hash: sha256:979e101eb20ac9f43fd37884e7241f3afc1abb7f3eea5abc93cc1b67067d8179
+              hash: sha256:c332d818fc2922ea76be0e053d62932c8da5cc18e20c29ce950bb8677d1784f2
     versions:
       - effective_from: '2026-01-01'
         formula: |-

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -31,7 +31,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false
@@ -105,6 +105,68 @@
     us:statutes/26/32#eitc_childless_minimum_age: 25
     us:statutes/26/32#eitc_childless_age_ceiling_exclusive: 65
     us:statutes/26/32#eitc_childless_age_eligible: holds
+- name: childless_age_aggregate_below_minimum
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 24
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: not_holds
+- name: childless_age_aggregate_at_minimum
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 25
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: holds
+- name: childless_age_aggregate_below_ceiling
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 64
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: holds
+- name: childless_age_aggregate_at_ceiling
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 65
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: not_holds
+- name: childless_age_aggregate_either_spouse_eligible
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 24
+    - us:statutes/26/32#input.age: 25
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: holds
+- name: childless_age_aggregate_neither_spouse_eligible
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit:
+    - us:statutes/26/32#input.age: 24
+    - us:statutes/26/32#input.age: 65
+  output:
+    us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: not_holds
 - name: qualifying_child_married_exception
   period:
     period_kind: tax_year
@@ -169,7 +231,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
-    us:statutes/26/32#input.childless_taxpayer_or_spouse_age_eligible_for_eitc: false
+    us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_claims_section_911_benefits: false

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -31,6 +31,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
@@ -73,7 +74,7 @@
       us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-      us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
+      us:statutes/26/32#input.individual_married_as_of_close_of_taxpayer_taxable_year: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
     us:statutes/26/164/f#input.taxpayer_is_individual: true
     us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
@@ -349,7 +350,7 @@
     us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
     us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
     us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: true
+    us:statutes/26/32#input.individual_married_as_of_close_of_taxpayer_taxable_year: true
     us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
   output:
     us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: holds
@@ -361,7 +362,7 @@
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
+    us:statutes/26/32#input.individual_married_as_of_close_of_taxpayer_taxable_year: false
   output:
     us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: not_holds
 - name: qualifying_child_married_with_section_151_entitlement
@@ -390,7 +391,7 @@
     us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
     us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
     us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: true
+    us:statutes/26/32#input.individual_married_as_of_close_of_taxpayer_taxable_year: true
     us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: true
   output:
     us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: holds
@@ -429,6 +430,7 @@
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
+    us:statutes/26/32#input.age: 0
     us:statutes/26/32#relation.eitc_taxpayer_or_spouse_of_tax_unit: []
     us:statutes/26/32#input.taxpayer_is_dependent_for_section_151_to_another_taxpayer: false
     us:statutes/26/32#input.taxpayer_is_qualifying_child_of_another_taxpayer: false
@@ -471,7 +473,7 @@
       us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-      us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
+      us:statutes/26/32#input.individual_married_as_of_close_of_taxpayer_taxable_year: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
     us:statutes/26/164/f#input.taxpayer_is_individual: true
     us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -44,8 +44,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: true
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit:
@@ -167,6 +171,158 @@
     - us:statutes/26/32#input.age: 65
   output:
     us:statutes/26/32#childless_taxpayer_or_spouse_age_eligible_for_eitc: not_holds
+- name: no_final_determination_has_no_eitc_disallowance_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_fraud_disallowance_taxable_years: 10
+    us:statutes/26/32#eitc_reckless_or_intentional_disregard_disallowance_taxable_years: 2
+    us:statutes/26/32#eitc_disallowance_period_applies: not_holds
+- name: fraud_determination_taxable_year_is_before_disallowance_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: not_holds
+- name: fraud_disallowance_period_first_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 1
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: holds
+- name: fraud_disallowance_period_tenth_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 10
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: holds
+- name: fraud_disallowance_period_expired_after_tenth_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 11
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: not_holds
+- name: reckless_determination_taxable_year_is_before_disallowance_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: not_holds
+- name: reckless_disallowance_period_first_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 1
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: holds
+- name: reckless_disallowance_period_second_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 2
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: holds
+- name: reckless_disallowance_period_expired_after_second_taxable_year
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 3
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: not_holds
+- name: active_fraud_period_not_masked_by_expired_reckless_period
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 10
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: true
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 3
+  output:
+    us:statutes/26/32#eitc_disallowance_period_applies: holds
+- name: no_prior_deficiency_denial_has_no_information_bar
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: false
+  output:
+    us:statutes/26/32#prior_deficiency_denial_without_required_eligibility_information: not_holds
+- name: prior_deficiency_denial_without_information_bars_eitc
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: true
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: false
+  output:
+    us:statutes/26/32#prior_deficiency_denial_without_required_eligibility_information: holds
+- name: required_information_cures_prior_deficiency_denial_bar
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: true
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
+  output:
+    us:statutes/26/32#prior_deficiency_denial_without_required_eligibility_information: not_holds
 - name: qualifying_child_married_exception
   period:
     period_kind: tax_year
@@ -244,8 +400,12 @@
     us:statutes/26/32#input.satisfies_eitc_separated_spouse_rules: false
     us:statutes/26/32#input.taxable_year_is_full_12_months: true
     us:statutes/26/32#input.taxable_year_closed_by_reason_of_taxpayer_death: false
-    us:statutes/26/32#input.eitc_disallowance_period_applies: false
-    us:statutes/26/32#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud: 0
+    us:statutes/26/32#input.taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: false
+    us:statutes/26/32#input.taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud: 0
+    us:statutes/26/32#input.taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63: false
+    us:statutes/26/32#input.taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year: true
     us:statutes/26/32#input.taxpayer_includes_required_social_security_number_on_return: true
     us:statutes/26/32#input.spouse_includes_required_social_security_number_on_return: false
     us:statutes/26/32#relation.qualifying_child_of_tax_unit:

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -73,7 +73,7 @@
       us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-      us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
+      us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
     us:statutes/26/164/f#input.taxpayer_is_individual: true
     us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
@@ -336,7 +336,7 @@
     us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
     us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
     us:statutes/26/152/c#input.individual_is_student: false
-    us:statutes/26/152/c#input.filing_status: 0
+    us:statutes/26/152/c#input.filing_status: 2
     us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
     us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
     us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
@@ -349,10 +349,52 @@
     us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
     us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
     us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-    us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: true
+    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: true
     us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
   output:
+    us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: holds
     us:statutes/26/32#eitc_qualifying_child: not_holds
+    us:statutes/26/32#eitc_qualifying_child_base: holds
+- name: unmarried_child_does_not_require_section_151_entitlement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
+  output:
+    us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: not_holds
+- name: qualifying_child_married_with_section_151_entitlement
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
+    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
+    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+    us:statutes/26/152/c#input.individual_is_student: false
+    us:statutes/26/152/c#input.filing_status: 2
+    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
+    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
+    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
+    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+    us:statutes/26/152/c#input.parents_filing_status: 1
+    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
+    us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
+    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
+    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
+    us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
+    us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: true
+    us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: true
+  output:
+    us:statutes/26/32#qualifying_child_marital_status_requires_section_151_entitlement: holds
+    us:statutes/26/32#eitc_qualifying_child: holds
     us:statutes/26/32#eitc_qualifying_child_base: holds
 - name: investment_income_denies_credit
   period:
@@ -429,7 +471,7 @@
       us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
       us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
-      us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
+      us:statutes/26/32#input.individual_is_married_as_of_close_of_taxpayer_taxable_year: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
     us:statutes/26/164/f#input.taxpayer_is_individual: true
     us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -13,6 +13,8 @@ module:
     corpus_citation_paths:
       - us/statute/26/32
       - us/statute/26/32/c/1
+      - us/statute/26/32/k/1
+      - us/statute/26/32/k/2
   deferred_outputs:
     - output: us:statutes/26/32/f#eitc_table_based_credit_determination
       blocked_by:
@@ -142,6 +144,40 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           65
+
+  - name: eitc_fraud_disallowance_taxable_years
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 32(k)(1)(B)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/32/k/1
+              text: "the period of 10 taxable years after the most recent taxable year for which there was a final determination that the taxpayer’s claim of credit under this section was due to fraud"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          10
+
+  - name: eitc_reckless_or_intentional_disregard_disallowance_taxable_years
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 32(k)(1)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/32/k/1
+              text: "the period of 2 taxable years after the most recent taxable year for which there was a final determination that the taxpayer’s claim of credit under this section was due to reckless or intentional disregard of rules and regulations (but not due to fraud)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2
 
   - name: eitc_qualifying_child_base
     kind: derived
@@ -559,6 +595,64 @@ rules:
               eitc_taxpayer_or_spouse_of_tax_unit,
               eitc_childless_age_eligible
           ) > 0
+
+  - name: eitc_disallowance_period_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(k)(1)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/k/1
+              text: "No credit shall be allowed under this section for any taxable year in the disallowance period."
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/k/1
+              text: "the period of 10 taxable years after the most recent taxable year for which there was a final determination that the taxpayer’s claim of credit under this section was due to fraud"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/k/1
+              text: "the period of 2 taxable years after the most recent taxable year for which there was a final determination that the taxpayer’s claim of credit under this section was due to reckless or intentional disregard of rules and regulations (but not due to fraud)"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          (
+              taxpayer_has_final_eitc_claim_determination_due_to_fraud
+              and taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud >= 1
+              and taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_fraud <= eitc_fraud_disallowance_taxable_years
+          )
+          or (
+              taxpayer_has_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud
+              and taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud >= 1
+              and taxable_years_after_most_recent_taxable_year_with_final_eitc_claim_determination_due_to_reckless_or_intentional_disregard_but_not_fraud <= eitc_reckless_or_intentional_disregard_disallowance_taxable_years
+          )
+
+  - name: prior_deficiency_denial_without_required_eligibility_information
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(k)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/k/2
+              text: "no credit shall be allowed under this section for any subsequent taxable year unless the taxpayer provides such information as the Secretary may require to demonstrate eligibility for such credit"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          taxpayer_was_denied_eitc_for_any_prior_taxable_year_as_result_of_deficiency_procedures_under_subchapter_b_of_chapter_63
+          and not taxpayer_provided_all_information_secretary_requires_to_demonstrate_eitc_eligibility_for_current_taxable_year
 
   - name: eitc_demographic_eligible
     kind: derived

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -13,9 +13,25 @@ module:
     corpus_citation_paths:
       - us/statute/26/32
       - us/statute/26/32/c/1
+      - us/statute/26/32/c/3
       - us/statute/26/32/k/1
       - us/statute/26/32/k/2
   deferred_outputs:
+    - output: us:statutes/26/32#taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e
+      blocked_by:
+        - us:statutes/26/151/c#dependent_exemption_entitlement
+        - us:statutes/26/152#dependent_parent_schema_context
+        - us:statutes/26/152/e#divorced_parent_dependent_special_rule
+      reason: >-
+        Section 32(c)(3)(B) requires both a per-child section 151 entitlement
+        conclusion and a counterfactual entitlement conclusion with section
+        152(e) disregarded. Section 151 exposes no per-child entitlement
+        output, and the section 152 parent is entity/schema unsupported and
+        expressly defers its dependent composition and subsection (e)
+        adjusted bases. The section 32 qualifying-child base cannot substitute
+        because it deliberately disregards section 152(c)(1)(D) as well as
+        section 152(e), and the zero 2026 exemption amount does not negate
+        entitlement under section 151(d)(5)(B).
     - output: us:statutes/26/32/f#eitc_table_based_credit_determination
       blocked_by:
         - us:policies/irs/rev-proc-2025-32/earned-income-credit#eitc_maximum_credit_amounts
@@ -221,7 +237,7 @@ rules:
           - path: versions[0].formula
             kind: definition
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/3
               text: "qualifying child ... as defined in section 152(c), determined without regard to paragraph (1)(D) thereof and section 152(e)"
     versions:
       - effective_from: '2026-01-01'
@@ -231,6 +247,25 @@ rules:
           and age_requirements_met
           and not individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund
           and tiebreaker_treats_individual_as_qualifying_child_of_taxpayer
+
+  - name: qualifying_child_marital_status_requires_section_151_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(3)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/c/3
+              text: "The term “qualifying child” shall not include an individual who is married as of the close of the taxpayer’s taxable year unless"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          individual_is_married_as_of_close_of_taxpayer_taxable_year
 
   - name: eitc_qualifying_child
     kind: derived
@@ -244,17 +279,17 @@ rules:
           - path: versions[0].formula
             kind: definition
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/3
               text: "The term “qualifying child” means a qualifying child of the taxpayer (as defined in section 152(c), determined without regard to paragraph (1)(D) thereof and section 152(e))."
           - path: versions[0].formula
             kind: exception
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/3
               text: "The term “qualifying child” shall not include an individual who is married as of the close of the taxpayer’s taxable year unless the taxpayer is entitled to a deduction under section 151 for such taxable year with respect to such individual (or would be so entitled but for section 152(e))."
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/3
               text: "A qualifying child shall not be taken into account under subsection (b) unless the taxpayer includes the name, age, and TIN of the qualifying child on the return of tax for the taxable year."
     versions:
       - effective_from: '2026-01-01'

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -10,6 +10,9 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/26/32
+    corpus_citation_paths:
+      - us/statute/26/32
+      - us/statute/26/32/c/1
   deferred_outputs:
     - output: us:statutes/26/32/f#eitc_table_based_credit_determination
       blocked_by:
@@ -42,6 +45,15 @@ rules:
     kind: data_relation
     data_relation:
       predicate: qualifying_child_of_tax_unit
+      arity: 2
+      arguments:
+        - TaxUnit
+        - Person
+
+  - name: eitc_taxpayer_or_spouse_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: eitc_taxpayer_or_spouse_of_tax_unit
       arity: 2
       arguments:
         - TaxUnit
@@ -107,7 +119,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/1
               text: "has attained age 25 but not attained age 65 before the close of the taxable year"
     versions:
       - effective_from: '2026-01-01'
@@ -124,7 +136,7 @@ rules:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/1
               text: "has attained age 25 but not attained age 65 before the close of the taxable year"
     versions:
       - effective_from: '2026-01-01'
@@ -518,13 +530,35 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/c/1
               text: "has attained age 25 but not attained age 65 before the close of the taxable year"
     versions:
       - effective_from: '2026-01-01'
         formula: |-
           age >= eitc_childless_minimum_age
           and age < eitc_childless_age_ceiling_exclusive
+
+  - name: childless_taxpayer_or_spouse_age_eligible_for_eitc
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 32(c)(1)(A)(ii)(II)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/32/c/1
+              text: "such individual (or, if the individual is married, either the individual or the individual’s spouse) has attained age 25 but not attained age 65 before the close of the taxable year"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          count_where(
+              eitc_taxpayer_or_spouse_of_tax_unit,
+              eitc_childless_age_eligible
+          ) > 0
 
   - name: eitc_demographic_eligible
     kind: derived

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -265,7 +265,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          individual_is_married_as_of_close_of_taxpayer_taxable_year
+          individual_married_as_of_close_of_taxpayer_taxable_year
 
   - name: eitc_qualifying_child
     kind: derived


### PR DESCRIPTION
Items 1/2/5/6 encoded (childless age incl. 24/25/64/65 boundaries; §32(k) disallowance; prior deficiency; married-child gate). Item 7 honestly deferred at the §151/152(e) wall with a named deferred_outputs entry. Refs #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)