### PR TITLE
Encode §32(i) threshold gate; defer the aggregate honestly (EITC frontier)

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/32.json
+++ b/.axiom/encoding-manifests/statutes/26/32.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/32.yaml",
-      "sha256": "0de46b091a656526cc93e7580751e9671f478851e4297c5db1a33f626dda1d89"
+      "sha256": "c3c63a2d9f026c1b79d3215987c21f4fd49dbcaecec073424e57d7d22b4e9015"
     },
     {
       "path": "statutes/26/32.test.yaml",

--- a/.axiom/encoding-manifests/statutes/26/32.json
+++ b/.axiom/encoding-manifests/statutes/26/32.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/32.yaml",
-      "sha256": "979e101eb20ac9f43fd37884e7241f3afc1abb7f3eea5abc93cc1b67067d8179"
+      "sha256": "d369a2ca8fe8abfb89a9d5e7decab32b4f7acc698e611acafb6df7a95b198851"
     },
     {
       "path": "statutes/26/32.test.yaml",

--- a/.axiom/encoding-manifests/statutes/26/32.json
+++ b/.axiom/encoding-manifests/statutes/26/32.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "statutes/26/32.test.yaml",
-      "sha256": "b308b99c1044e3ae0de1e250b6275e17430b3dbfad113018dbe06639fa8812ca"
+      "sha256": "5719f6e1444be573e455cd4b62b4433e03d611bb05afc0f6ecc5f9cfc2deb0a0"
     }
   ],
   "axiom_encode_git": {

--- a/.axiom/encoding-manifests/statutes/26/32.json
+++ b/.axiom/encoding-manifests/statutes/26/32.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "statutes/26/32.test.yaml",
-      "sha256": "2a550ae576e2a905e9ee09db52920503e3f94e248a1dda7354be0e8ae393e475"
+      "sha256": "b308b99c1044e3ae0de1e250b6275e17430b3dbfad113018dbe06639fa8812ca"
     }
   ],
   "axiom_encode_git": {

--- a/.axiom/encoding-manifests/statutes/26/32.json
+++ b/.axiom/encoding-manifests/statutes/26/32.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/32.yaml",
-      "sha256": "d369a2ca8fe8abfb89a9d5e7decab32b4f7acc698e611acafb6df7a95b198851"
+      "sha256": "0de46b091a656526cc93e7580751e9671f478851e4297c5db1a33f626dda1d89"
     },
     {
       "path": "statutes/26/32.test.yaml",

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -39357,6 +39357,7 @@
       {
         "module": "us/statutes/26/32.yaml",
         "via": [
+          "module",
           "proof_atom"
         ]
       }

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -39353,6 +39353,14 @@
         ]
       }
     ],
+    "us/statute/26/32/i/1": [
+      {
+        "module": "us/statutes/26/32.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/3201": [
       {
         "module": "us/statutes/26/3201.yaml",

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -39362,6 +39362,14 @@
         ]
       }
     ],
+    "us/statute/26/32/i/2": [
+      {
+        "module": "us/statutes/26/32.yaml",
+        "via": [
+          "module"
+        ]
+      }
+    ],
     "us/statute/26/3201": [
       {
         "module": "us/statutes/26/3201.yaml",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,10 +2,12 @@
 
 ## State
 
-Ready for review. The full §32(i)(2) disqualified-income aggregate is
-explicitly deferred on upstream-law walls. The independently supported
-§32(i)(1) threshold rule is verified against its exact corpus path and tested
-at the 2026 equality and first-disqualifying boundaries.
+Implementation and validation are complete. The full §32(i)(2)
+disqualified-income aggregate is explicitly deferred on upstream-law walls.
+The independently supported §32(i)(1) threshold rule is verified against its
+exact corpus path and tested at the 2026 equality and first-disqualifying
+boundaries. Remote delivery is blocked because the sandbox cannot resolve
+`github.com`; the connected GitHub write fallback was not authorized.
 
 The requested external worktree path was not writable in the execution
 sandbox. The branch is attached instead beneath the repository at
@@ -49,11 +51,16 @@ sandbox. The branch is attached instead beneath the repository at
   manifest-sync warning.
 - Confirmed the reverse index is current: 4,241 provisions, 5,080 edges, and
   4,486 modules.
+- Attempted to push `closure/w4-eitc-32i-invest`; Git failed with
+  `Could not resolve host: github.com`. No remote branch or pull request was
+  created.
 
 ## Next
 
-- Push `closure/w4-eitc-32i-invest`.
-- Open the required draft pull request referencing `rulespec-us#1135`.
+- When GitHub access is available, push `closure/w4-eitc-32i-invest`.
+- Open a draft pull request titled
+  `Encode §32(i) investment income disqualification (EITC frontier)` and
+  reference `rulespec-us#1135`.
 - Human review should preserve the §32(i)(2) deferral until the category-
   specific §61 inclusion/exclusion surface, §469 passive-activity definition,
   and §1402(a) net-earnings output are encoded.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,9 @@
 
 ## State
 
-In progress on `closure/w4-eitc-32i-invest`, based on `origin/main`.
+Corpus review complete. The full §32(i)(2) disqualified-income aggregate is
+deferred on upstream-law walls; the independently supported §32(i)(1)
+threshold rule remains in scope for exact-boundary tests.
 
 The requested external worktree path was not writable in the execution
 sandbox. The branch is attached instead beneath the repository at
@@ -13,13 +15,28 @@ sandbox. The branch is attached instead beneath the repository at
 - Read the closure-sprint encoder preamble.
 - Read the repository agent notes in `CLAUDE.md`.
 - Created the required topic branch and an isolated worktree.
+- Read the frontier-classification row for
+  `eitc_relevant_investment_income`.
+- Resolved the governing provisions by `citation_path` across the pinned
+  `axiom-corpus` inventory and read their bodies.
+- Confirmed that §1222 capital gain net income is encoded, but the aggregate
+  still depends on:
+  - category-specific §61 inclusion and exclusion mechanics for interest,
+    dividends, rents, and royalties;
+  - §469 passive-activity classification, which is absent from the pinned
+    corpus and has no RuleSpec module; and
+  - the §32(c)(2) overlap exclusion, whose self-employment branch reaches the
+    expressly deferred §1402(a) net-earnings output.
+- Confirmed that §32(i)(1) disqualifies only when the aggregate strictly
+  exceeds the inflation-adjusted threshold; equality remains eligible.
+- Inspected the `closure/eitc-2026` program and diagnostic grid without
+  modifying the frozen program.
 
 ## Next
 
-- Read item 3's frontier-classification row.
-- Resolve every governing provision by `citation_path` across the corpus
-  inventory and read the authoritative text.
-- Inspect the `closure/eitc-2026` program/grid and sibling RuleSpec conventions.
-- Determine whether any component hits the section 61 or section 1402 wall.
-- Encode the supported §32(i) definition and threshold boundary with companion
-  tests.
+- Add an exact `deferred_outputs` entry for the §32(i)(2) aggregate.
+- Tighten the threshold proof citation to §32(i)(1).
+- Add 2026 tests at $12,200 and $12,201.
+- Repair only the stale mechanical input names needed to execute the existing
+  section 32 companion fixture.
+- Run focused RuleSpec validation and repository checks.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,9 +2,10 @@
 
 ## State
 
-Corpus review complete. The full §32(i)(2) disqualified-income aggregate is
-deferred on upstream-law walls; the independently supported §32(i)(1)
-threshold rule remains in scope for exact-boundary tests.
+Ready for review. The full §32(i)(2) disqualified-income aggregate is
+explicitly deferred on upstream-law walls. The independently supported
+§32(i)(1) threshold rule is verified against its exact corpus path and tested
+at the 2026 equality and first-disqualifying boundaries.
 
 The requested external worktree path was not writable in the execution
 sandbox. The branch is attached instead beneath the repository at
@@ -31,12 +32,28 @@ sandbox. The branch is attached instead beneath the repository at
   exceeds the inflation-adjusted threshold; equality remains eligible.
 - Inspected the `closure/eitc-2026` program and diagnostic grid without
   modifying the frozen program.
+- Added a `deferred_outputs` entry for
+  `us:statutes/26/32/i/2#eitc_relevant_investment_income` naming the exact
+  §61, §469, and §1402(a) blockers.
+- Added `us/statute/26/32/i/1` and `us/statute/26/32/i/2` to the module's
+  verified corpus sources and regenerated the reverse citation index.
+- Added threshold cases proving that $12,200 remains eligible and $12,201 is
+  ineligible for tax year 2026.
+- Mechanically refreshed the two pre-existing comprehensive fixtures to the
+  current §32(c)(2) input contract and added the missing positive
+  qualifying-child Judgment case required by the repository validator.
+- Refreshed the section 32 encoding-manifest hashes.
+- Passed focused RuleSpec execution: 1 file, 7 cases.
+- Passed focused RuleSpec CI validation and proof validation (42 atoms).
+- Passed the full repository test suite: 65 tests, with one non-failing
+  manifest-sync warning.
+- Confirmed the reverse index is current: 4,241 provisions, 5,080 edges, and
+  4,486 modules.
 
 ## Next
 
-- Add an exact `deferred_outputs` entry for the §32(i)(2) aggregate.
-- Tighten the threshold proof citation to §32(i)(1).
-- Add 2026 tests at $12,200 and $12,201.
-- Repair only the stale mechanical input names needed to execute the existing
-  section 32 companion fixture.
-- Run focused RuleSpec validation and repository checks.
+- Push `closure/w4-eitc-32i-invest`.
+- Open the required draft pull request referencing `rulespec-us#1135`.
+- Human review should preserve the §32(i)(2) deferral until the category-
+  specific §61 inclusion/exclusion surface, §469 passive-activity definition,
+  and §1402(a) net-earnings output are encoded.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,25 @@
+# Progress — §32(i) investment income disqualification
+
+## State
+
+In progress on `closure/w4-eitc-32i-invest`, based on `origin/main`.
+
+The requested external worktree path was not writable in the execution
+sandbox. The branch is attached instead beneath the repository at
+`.worktrees/w4-eitc-32i-invest`.
+
+## Done
+
+- Read the closure-sprint encoder preamble.
+- Read the repository agent notes in `CLAUDE.md`.
+- Created the required topic branch and an isolated worktree.
+
+## Next
+
+- Read item 3's frontier-classification row.
+- Resolve every governing provision by `citation_path` across the corpus
+  inventory and read the authoritative text.
+- Inspect the `closure/eitc-2026` program/grid and sibling RuleSpec conventions.
+- Determine whether any component hits the section 61 or section 1402 wall.
+- Encode the supported §32(i) definition and threshold boundary with companion
+  tests.

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -5,11 +5,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -25,9 +26,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -71,11 +69,6 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_child_count: 1
     us:statutes/26/32#eitc_capped_child_count: 1
@@ -93,7 +86,6 @@
     us:statutes/26/32#eitc_investment_income_eligible: holds
     us:statutes/26/32#eitc_allowed: holds
     us:statutes/26/32#eitc: 3400
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
 - name: childless_person_age_predicate
   period:
     period_kind: tax_year
@@ -143,11 +135,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -163,9 +156,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -209,13 +199,25 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_investment_income_eligible: not_holds
     us:statutes/26/32#eitc_allowed: not_holds
     us:statutes/26/32#eitc: 0
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+- name: investment_income_equal_to_2026_threshold_remains_eligible
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.eitc_relevant_investment_income: 12200
+  output:
+    us:statutes/26/32#eitc_investment_income_eligible: holds
+- name: investment_income_one_dollar_above_2026_threshold_is_ineligible
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/32#input.eitc_relevant_investment_income: 12201
+  output:
+    us:statutes/26/32#eitc_investment_income_eligible: not_holds

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -128,6 +128,37 @@
   output:
     us:statutes/26/32#eitc_qualifying_child: not_holds
     us:statutes/26/32#eitc_qualifying_child_base: holds
+- name: qualifying_child_married_exception_when_dependency_entitlement_exists
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
+    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
+    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+    us:statutes/26/152/c#input.individual_is_student: false
+    us:statutes/26/152/c#input.filing_status: 0
+    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
+    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
+    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
+    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+    us:statutes/26/152/c#input.parents_filing_status: 1
+    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
+    us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
+    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
+    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
+    us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
+    us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: true
+    us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: true
+  output:
+    us:statutes/26/32#eitc_qualifying_child: holds
+    us:statutes/26/32#eitc_qualifying_child_base: holds
 - name: investment_income_denies_credit
   period:
     period_kind: tax_year

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -9,7 +9,9 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/statute/26/32
+    corpus_citation_paths:
+      - us/statute/26/32
+      - us/statute/26/32/i/1
   deferred_outputs:
     - output: us:statutes/26/32/i/2#eitc_relevant_investment_income
       blocked_by:

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -11,6 +11,25 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/32
   deferred_outputs:
+    - output: us:statutes/26/32/i/2#eitc_relevant_investment_income
+      blocked_by:
+        - us:statutes/26/61#category_specific_interest_dividend_rent_and_royalty_gross_income
+        - us:statutes/26/469#passive_activity_income_and_losses
+        - us:statutes/26/1402/a#net_earnings_from_self_employment
+      reason: >-
+        Paragraph (i)(2)(A) and (C) require category-specific determinations
+        of interest, dividends, rents, and royalties includible in gross
+        income after the subtitle's inclusions and exclusions. The existing
+        section 61 module only exposes a broad gross-income total whose
+        exclusion amount is itself an input. Paragraph (i)(2)(E) also requires
+        income and losses from every passive activity as defined by section
+        469, excluding amounts included in section 32(c)(2) and the preceding
+        subparagraphs. Section 469 is absent from the pinned corpus and has no
+        RuleSpec module, while the section 32(c)(2) overlap reaches the
+        expressly deferred section 1402(a) net-earnings output. Accepting
+        already classified category totals as new inputs would replace this
+        derived frontier item with several unresolved legal conclusions rather
+        than encode the full enumerated definition.
     - output: us:statutes/26/32/f#eitc_table_based_credit_determination
       blocked_by:
         - us:policies/irs/rev-proc-2025-32/earned-income-credit#eitc_maximum_credit_amounts
@@ -629,7 +648,7 @@ rules:
     entity: TaxUnit
     dtype: Judgment
     period: Year
-    source: 26 USC 32(i), 32(j)
+    source: 26 USC 32(i)(1), 32(j)
     metadata:
       proof:
         atoms:
@@ -642,7 +661,7 @@ rules:
           - path: versions[0].formula
             kind: condition
             source:
-              corpus_citation_path: us/statute/26/32
+              corpus_citation_path: us/statute/26/32/i/1
               excerpt: "No credit shall be allowed under subsection (a) for the taxable year"
               text: "No credit shall be allowed under subsection (a) for the taxable year if the aggregate amount of disqualified income of the taxpayer for the taxable year exceeds $10,000."
     versions:

--- a/us/statutes/26/32.yaml
+++ b/us/statutes/26/32.yaml
@@ -12,6 +12,7 @@ module:
     corpus_citation_paths:
       - us/statute/26/32
       - us/statute/26/32/i/1
+      - us/statute/26/32/i/2
   deferred_outputs:
     - output: us:statutes/26/32/i/2#eitc_relevant_investment_income
       blocked_by:


### PR DESCRIPTION
The $12,200/$12,201 threshold gate encoded and boundary-tested ('exceeds' = equality eligible). The disqualified-income AGGREGATE is deferred: category-specific §61 inclusion law, §469 passive, §1402(a) — accepting preclassified totals would merely relocate the frontier. Refs #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)