### PR TITLE
Encode §112 combat-zone month rules; defer on missing federal law (EITC frontier)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -37843,6 +37843,60 @@
         ]
       }
     ],
+    "us/statute/26/112/a": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/112/a/2": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/112/b": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/112/b/2": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/112/c/2": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/112/c/3": [
+      {
+        "module": "us/statutes/26/112.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/26/1211": [
       {
         "module": "us/statutes/26/1211.yaml",
@@ -40764,6 +40818,15 @@
     "us/statute/26/7701": [
       {
         "module": "us/statutes/26/7701.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/26/7701/a/24": [
+      {
+        "module": "us/statutes/26/112.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/FINAL_REPORT.md
+++ b/FINAL_REPORT.md
@@ -1,0 +1,104 @@
+# Final report — §112 combat-zone month rules
+
+## Delivery status
+
+- Branch: `closure/w5-eitc-112-combat`
+- Base: `origin/main` at `ecb057ef3`
+- Worktree: `/Users/maxghenis/TheAxiomFoundation/rulespec-us/.git/codex-worktrees/w5-eitc-112-combat`
+- The requested sibling worktree path was outside the writable sandbox. The
+  exact requested `git worktree add` created the branch but could not create
+  that directory, so work continued in the repository-internal worktree above
+  on the required branch.
+- The requested output file
+  `/Users/maxghenis/TheAxiomFoundation/_closure-sprint/out/w5-eitc-112-combat.result.md`
+  is also outside the writable sandbox. The attempted write was rejected;
+  this committed report is the complete handoff.
+- Push attempted: failed with `Could not resolve host: github.com`.
+- Draft PR: not created because the branch could not be pushed. Intended title:
+  `Encode §112 combat-zone month rules (EITC frontier)`; intended issue
+  reference: `rulespec-us#1135`.
+
+## Per-item disposition
+
+| Item | Disposition | Governing text and corpus paths | Focused tests | Result / blocker |
+|---|---|---|---:|---|
+| 19 — civilian missing-status month | Deferred | 26 USC 112(d)(2)-(3): `us/statute/26/112/d/2`, `us/statute/26/112/d/3` | 0 | Added an explicit `deferred_outputs` entry. The pinned corpus has no 5 USC 5561 record defining “active service,” “employee,” and “missing status,” and no retained Executive Order record for the President-designated Vietnam termination date. The existing aggregate missing-status regression remains. |
+| 20 — hospitalization composition | Encoded | 26 USC 112(a)(2), (b)(2), (c)(2)-(3): `us/statute/26/112/a/2`, `/b/2`, `/c/2`, `/c/3` | 4 | Added a Judgment requiring hospitalization in the compensation month, medical causation, and incurrence during recorded combat-zone service. One positive case and one negative case for each required conjunct pass. |
+| 21 — maximum enlisted amount | Deferred | 26 USC 112(c)(5): `us/statute/26/112/c/5` | 0 | Added an explicit `deferred_outputs` entry. Computing the amount requires the absent 37 USC 203 monthly basic-pay table plus absent 37 USC 310 and 351 special-pay rules. The existing commissioned-officer cap regression remains. |
+| 22 — post-termination months | Deferred upstream computation; consumer boundary encoded | 26 USC 112(a)(2), (b)(2), (c)(3): `us/statute/26/112/a/2`, `/b/2`, `/c/3`; calendar-unit support at 26 USC 7701(a)(24): `us/statute/26/7701/a/24` | 2 | Added an explicit deferral for computing elapsed months because the corpus retains no controlling zone-specific Presidential termination designations. Corrected the consumer comparison so month 24 is included and month 25 is excluded. |
+| 23 — Vietnam January 1978 transition | Encoded | Final sentences of 26 USC 112(a) and (b): `us/statute/26/112/a`, `us/statute/26/112/b` | 5 | January 1978 remains eligible; February 1978 and later Vietnam hospitalization months are barred. Tests also prove the rule does not apply to non-Vietnam hospitalization or direct combat-zone service. |
+
+Focused counts overlap where a boundary test proves more than one provision.
+The §112 companion now has 13 cases total, up from 4. The four affected
+companion files have 25 cases total: 13 in §112 and 4 each in §32(c)(2),
+§24(d), and root §32.
+
+## Changes
+
+- Extended `us/statutes/26/112.yaml` and its companion test.
+- Rebound dependent §32(c)(2), §24(d), and root §32 fixtures to primitive §112
+  facts; refreshed the exact §112 import-proof hashes in §32(c)(2) and §24(d).
+- Refreshed `.axiom/index/provisions_to_rules.json`.
+- Maintained committed `PROGRESS.md` throughout.
+- Did not touch any `programs/us-*/snap/` path, toolchain file, CI workflow, or
+  CODEOWNERS.
+
+## Judgment calls
+
+1. “Items 19–23” was interpreted as ordinals among the 23 `must_encode`
+   entries, corresponding to classification rows 29, 30, 31, 32, and 34.
+2. Hospitalization eligibility is a three-part conjunction: hospitalization,
+   causation by the identified wound/disease/injury, and incurrence while
+   serving in a legally recorded combat zone. The combat-zone/service
+   definitions remain primitive where their Executive Orders are absent.
+3. “More than 2 years” was applied to the existing whole-month elapsed input
+   as an inclusive 24-month boundary. The retained 12-month accounting-period
+   text at §7701(a)(24) supplies transparent calendar-unit support only; it is
+   not treated as a substantive §112 eligibility rule.
+4. The January 1978 sentence exists only at the parent `/a` and `/b` corpus
+   paths, so those are cited rather than inventing unavailable leaf paths.
+   The exception is a composable date-and-zone Judgment and is applied only
+   to paragraph (2) hospitalization, not paragraph (1) direct service.
+5. The transition rules use `1976-10-20`, the enactment date in the
+   authoritative XML source credit for Pub. L. 94-569.
+6. Raw corpus notes mention historical zone dates but do not retain normalized
+   governing Executive Order citation paths. No dates were guessed; affected
+   upstream classifications remain explicitly deferred.
+
+## Validation
+
+- Pinned corpus commit:
+  `bf97b17baebfdf12601f7c23697524bf5adcdaed`.
+- Pinned `axiom-encode` 0.2.1200 was loaded from the repository toolchain ref
+  because the current checkout's environment contains a newer incompatible
+  source tree.
+- `axiom-encode validate --skip-reviewers` on §112, §32(c)(2), and §24(d):
+  all 3 passed.
+- Reviewer-enabled `axiom-encode validate` reached `CI: ✓` for all 3 modules
+  but the four optional reviewers could not run because their CLI reported
+  `Not logged in · Please run /login`.
+- `axiom-encode proof-validate .../112.yaml`: passed, 20 atoms checked.
+- `axiom-encode test` on §112, §32(c)(2), §24(d), and root §32: passed,
+  4 files / 25 cases.
+- `python tests/generate_reverse_index.py --check`: passed, 4,246 provisions /
+  5,085 edges / 4,486 modules.
+- `python -m pytest -q tests`: 64 passed, 1 failed, 1 warning. The sole failure
+  is `test_encoded_modules_match_their_manifests` for the three intentionally
+  changed modules: §112, §24(d), and §32(c)(2).
+- Official signer dry-run with `--manual-exception '#1135'`: 4 manifests for
+  7 changed RuleSpec files.
+- Official signing attempt: blocked because
+  `AXIOM_ENCODE_APPLY_SIGNING_KEY` is unavailable.
+- `axiom-encode guard-generated`: consequently reports those same 7 files as
+  lacking refreshed matching manifests. Existing signed manifests were left
+  untouched; a maintainer with the signing key must run the signer and rerun
+  the repository suite before merge.
+
+## Commits
+
+- `815a06ad6` — initialize progress ledger
+- `fe2c7156b` — record source findings
+- `97f742617` — encode §112 combat-zone month rules
+- `63d7f173f` — refresh §112 reverse index
+- `b7514d9af` — refresh top-level EITC fixture inputs
+- `ca616e55f` — record validation results

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,7 +5,8 @@
 - Branch: `closure/w5-eitc-112-combat`
 - Checkout: `.git/codex-worktrees/w5-eitc-112-combat` (the requested sibling worktree path is outside the writable sandbox)
 - Scope: EITC frontier items 19–23, the 26 U.S.C. §112 combat-zone and missing-status month rules
-- Status: source research complete; implementation in progress
+- Status: implementation and focused validation complete; generated
+  provenance/index refresh in progress
 
 ## Done
 
@@ -29,12 +30,39 @@
   - defer post-termination month computation on absent controlling
     Presidential termination designations.
 - Identified an existing unit mismatch: the consumer compares a count named
-  in months to a parameter encoded as 2 years. The implementation will use
-  the exact 24-month boundary and test months 24 and 25.
+  in months to a parameter encoded as 2 years. The implementation now
+  multiplies the source-stated 2-year limit by the 12-month calendar-unit
+  factor retained at 26 U.S.C. §7701(a)(24), and tests months 24 and 25.
+- Checked both inventory records for `us/statute/26/7701/a/24` at the corpus
+  pin (the original and deduplicated Title 26 inventories); their bodies and
+  identifiers agree.
+- Added executable Judgment outputs for:
+  - the hospitalization/service/medical-causation composition; and
+  - the Vietnam hospitalization month boundary after January 1978.
+- Added honest `deferred_outputs` entries for:
+  - civilian missing status (absent 5 U.S.C. §5561 definitions and retained
+    Vietnam termination designation);
+  - maximum enlisted amount (absent 37 U.S.C. pay table, §310, and §351);
+  - post-termination month computation (absent retained zone-specific
+    Presidential termination designations).
+- Rebound the §112, §32(c)(2), §32, and §24(d) fixtures from the two former
+  implicit frontier inputs to their new primitive facts, and refreshed the
+  exact §112 import hashes in §32(c)(2) and §24(d).
+- Added 13 §112 cases covering every hospitalization conjunct, months 24/25,
+  January/February 1978, non-Vietnam service, the hospitalization exclusion,
+  and the unaffected direct-service branch.
+- Focused validation with pinned `axiom-encode` 0.2.1200:
+  - `validate --skip-reviewers` passes for §112, §32(c)(2), and §24(d);
+  - §112 proof validation passes with 20 atoms;
+  - 21 cases across §112, §32(c)(2), and §24(d) pass.
+- Confirmed the four-case root §32 companion has the same four unrelated
+  stale-symbol failures on unmodified `origin/main`; this change does not
+  introduce them.
 
 ## Next
 
-1. Add the two derived rules, three exact deferrals, and granular proof atoms.
-2. Update all affected companion tests and add statutory boundary cases.
-3. Refresh generated provenance/index artifacts and commit each coherent step.
-4. Run focused and repository validation, update this ledger, push, and open the required draft PR if network access permits.
+1. Commit the validated module, companion fixtures, and proof-hash cascade.
+2. Refresh generated reverse-index/provenance artifacts.
+3. Run repository checks and record any signing-key limitation.
+4. Write the final report, push, and open the required draft PR if network
+   access permits.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress — §112 combat-zone month rules
+
+## State
+
+- Branch: `closure/w5-eitc-112-combat`
+- Checkout: `.git/codex-worktrees/w5-eitc-112-combat` (the requested sibling worktree path is outside the writable sandbox)
+- Scope: EITC frontier items 19–23, the 26 U.S.C. §112 combat-zone and missing-status month rules
+- Status: source and encoding research in progress
+
+## Done
+
+- Read the encoder preamble and repository agent rules.
+- Created the requested branch from `origin/main`.
+- Created this committed progress ledger at the start of work.
+
+## Next
+
+1. Read classification rows 19–23 and resolve every governing corpus record by `citation_path`.
+2. Inspect `closure/eitc-2026` context and sibling statute encodings/tests.
+3. Encode each independent provision or declare an exact upstream-law deferral.
+4. Run focused and repository validation, update this ledger, push, and open the required draft PR if network access permits.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,8 +5,8 @@
 - Branch: `closure/w5-eitc-112-combat`
 - Checkout: `.git/codex-worktrees/w5-eitc-112-combat` (the requested sibling worktree path is outside the writable sandbox)
 - Scope: EITC frontier items 19–23, the 26 U.S.C. §112 combat-zone and missing-status month rules
-- Status: implementation and focused validation complete; generated
-  provenance/index refresh in progress
+- Status: implementation, provenance refresh, and validation complete;
+  manifest signing is blocked only by the unavailable maintainer signing key
 
 ## Done
 
@@ -54,15 +54,23 @@
 - Focused validation with pinned `axiom-encode` 0.2.1200:
   - `validate --skip-reviewers` passes for §112, §32(c)(2), and §24(d);
   - §112 proof validation passes with 20 atoms;
-  - 21 cases across §112, §32(c)(2), and §24(d) pass.
-- Confirmed the four-case root §32 companion has the same four unrelated
-  stale-symbol failures on unmodified `origin/main`; this change does not
-  introduce them.
+  - all 25 cases across §112, §32(c)(2), §24(d), and root §32 pass.
+- Refreshed the stale root §32 companion inputs and output assertion to the
+  current §32(c)(2) interface; this removed four baseline fixture failures.
+- Regenerated and checked `.axiom/index/provisions_to_rules.json` (4,246
+  provisions, 5,085 edges, 4,486 modules).
+- Ran the repository suite: 64 tests pass; the sole failure is the signed
+  manifest drift check for the three intentionally changed modules.
+- Ran the official signing workflow:
+  - dry-run identifies four manifests covering seven changed RuleSpec files;
+  - signing cannot proceed because `AXIOM_ENCODE_APPLY_SIGNING_KEY` is absent;
+  - `guard-generated` consequently reports those same seven files.
+- Left all existing signed manifests untouched for a maintainer with the
+  signing key to refresh.
 
 ## Next
 
-1. Commit the validated module, companion fixtures, and proof-hash cascade.
-2. Refresh generated reverse-index/provenance artifacts.
-3. Run repository checks and record any signing-key limitation.
-4. Write the final report, push, and open the required draft PR if network
-   access permits.
+1. Write and commit the final report.
+2. Copy the report to the requested closure-sprint output path if sandbox
+   permissions allow.
+3. Push and open the required draft PR if network access permits.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,17 +5,36 @@
 - Branch: `closure/w5-eitc-112-combat`
 - Checkout: `.git/codex-worktrees/w5-eitc-112-combat` (the requested sibling worktree path is outside the writable sandbox)
 - Scope: EITC frontier items 19–23, the 26 U.S.C. §112 combat-zone and missing-status month rules
-- Status: source and encoding research in progress
+- Status: source research complete; implementation in progress
 
 ## Done
 
 - Read the encoder preamble and repository agent rules.
 - Created the requested branch from `origin/main`.
 - Created this committed progress ledger at the start of work.
+- Resolved the assignment numbering: items 19–23 among the 23
+  must-encode entries are classification rows 29, 30, 31, 32, and 34.
+- Scanned every statute inventory at corpus pin
+  `bf97b17baebfdf12601f7c23697524bf5adcdaed`. The relevant §112 paths occur
+  only in the 2026-07-13 recovery inventory; Title 5 §5561 and the required
+  Title 37 pay provisions do not occur in any inventory.
+- Read the bodies at 26 U.S.C. §112(a), (a)(2), (b), (b)(2), (c)(2),
+  (c)(3), (c)(5), (d)(2), and (d)(3), each with expression date 2026-07-13.
+- Chosen disposition:
+  - encode the hospitalization/service/causation composition in
+    §112(a)(2), (b)(2), and (c)(2)–(3);
+  - encode the final-sentence January 1978 boundary in §112(a) and (b);
+  - defer the civilian missing-status output on absent 5 U.S.C. §5561(4)–(5);
+  - defer the maximum enlisted amount on absent Title 37 pay provisions;
+  - defer post-termination month computation on absent controlling
+    Presidential termination designations.
+- Identified an existing unit mismatch: the consumer compares a count named
+  in months to a parameter encoded as 2 years. The implementation will use
+  the exact 24-month boundary and test months 24 and 25.
 
 ## Next
 
-1. Read classification rows 19–23 and resolve every governing corpus record by `citation_path`.
-2. Inspect `closure/eitc-2026` context and sibling statute encodings/tests.
-3. Encode each independent provision or declare an exact upstream-law deferral.
+1. Add the two derived rules, three exact deferrals, and granular proof atoms.
+2. Update all affected companion tests and add statutory boundary cases.
+3. Refresh generated provenance/index artifacts and commit each coherent step.
 4. Run focused and repository validation, update this ledger, push, and open the required draft PR if network access permits.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,8 +5,8 @@
 - Branch: `closure/w5-eitc-112-combat`
 - Checkout: `.git/codex-worktrees/w5-eitc-112-combat` (the requested sibling worktree path is outside the writable sandbox)
 - Scope: EITC frontier items 19–23, the 26 U.S.C. §112 combat-zone and missing-status month rules
-- Status: implementation, provenance refresh, and validation complete;
-  manifest signing is blocked only by the unavailable maintainer signing key
+- Status: complete locally; manifest signing, push, and draft PR are blocked
+  by unavailable maintainer credentials/network
 
 ## Done
 
@@ -48,9 +48,10 @@
 - Rebound the §112, §32(c)(2), §32, and §24(d) fixtures from the two former
   implicit frontier inputs to their new primitive facts, and refreshed the
   exact §112 import hashes in §32(c)(2) and §24(d).
-- Added 13 §112 cases covering every hospitalization conjunct, months 24/25,
-  January/February 1978, non-Vietnam service, the hospitalization exclusion,
-  and the unaffected direct-service branch.
+- The §112 companion now has 13 cases (up from 4), covering every
+  hospitalization conjunct, months 24/25, January/February 1978, non-Vietnam
+  service, the hospitalization exclusion, and the unaffected direct-service
+  branch.
 - Focused validation with pinned `axiom-encode` 0.2.1200:
   - `validate --skip-reviewers` passes for §112, §32(c)(2), and §24(d);
   - §112 proof validation passes with 20 atoms;
@@ -67,10 +68,18 @@
   - `guard-generated` consequently reports those same seven files.
 - Left all existing signed manifests untouched for a maintainer with the
   signing key to refresh.
+- Attempted to push `closure/w5-eitc-112-combat`; DNS resolution for
+  `github.com` failed, so no remote branch or draft PR could be created.
+- Attempted to write the requested closure-sprint output file; the sandbox
+  rejected the path because it is outside the writable workspace. Preserved
+  the complete handoff in committed `FINAL_REPORT.md`.
 
 ## Next
 
-1. Write and commit the final report.
-2. Copy the report to the requested closure-sprint output path if sandbox
-   permissions allow.
-3. Push and open the required draft PR if network access permits.
+1. With `AXIOM_ENCODE_APPLY_SIGNING_KEY`, run the official signer for the four
+   manifests covering the seven changed RuleSpec files.
+2. Rerun the repository suite and generated-change guard.
+3. Copy `FINAL_REPORT.md` to the requested closure-sprint output path.
+4. Push the branch and open the draft PR titled
+   `Encode §112 combat-zone month rules (EITC frontier)`, referencing
+   `rulespec-us#1135`.

--- a/us/statutes/26/112.test.yaml
+++ b/us/statutes/26/112.test.yaml
@@ -6,9 +6,13 @@
   input:
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
     us:statutes/26/112#input.served_in_combat_zone_during_month: true
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 5000
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -19,8 +23,8 @@
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
   output:
-    us:statutes/26/112#hospitalization_after_combat_zone_termination_limit_years: 2
     us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 5000
+
 - name: commissioned_officer_exclusion_limited_to_maximum_enlisted_amount
   period:
     period_kind: tax_year
@@ -29,9 +33,13 @@
   input:
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: true
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: true
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 9000
@@ -43,7 +51,8 @@
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
   output:
     us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 7000
-- name: hospitalization_after_two_year_limit_not_excluded
+
+- name: hospitalization_in_month_24_after_termination_remains_excluded
   period:
     period_kind: tax_year
     start: '2026-01-01'
@@ -51,9 +60,41 @@
   input:
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: true
-    us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 3
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
+    us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 24
+    us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 5000
+    us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
+    us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
+    us:statutes/26/112#input.maximum_enlisted_amount_for_commissioned_officer_months: 0
+    us:statutes/26/112#input.armed_forces_member_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.officially_absent_from_post_of_duty_without_authority: false
+    us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
+    us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
+  output:
+    us:statutes/26/112#hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: holds
+    us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 5000
+
+- name: hospitalization_in_month_25_after_termination_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
+    us:statutes/26/112#input.served_in_combat_zone_during_month: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
+    us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 25
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 5000
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -65,6 +106,7 @@
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
   output:
     us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 0
+
 - name: missing_status_exclusions_with_military_awol_exception
   period:
     period_kind: tax_year
@@ -73,9 +115,13 @@
   input:
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -87,3 +133,134 @@
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 4000
   output:
     us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 4000
+
+- name: hospitalization_requires_hospital_interval
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+  output:
+    us:statutes/26/112#hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: not_holds
+
+- name: hospitalization_requires_causal_link
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+  output:
+    us:statutes/26/112#hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: not_holds
+
+- name: hospitalization_requires_combat_zone_service_incurrence
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+  output:
+    us:statutes/26/112#hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: not_holds
+
+- name: vietnam_hospitalization_in_january_1978_remains_within_transition
+  period:
+    period_kind: tax_year
+    start: '1978-01-01'
+    end: '1978-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: true
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 1978
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
+  output:
+    us:statutes/26/112#vietnam_combat_zone_hospitalization_month_after_january_1978: not_holds
+
+- name: vietnam_hospitalization_in_february_1978_is_after_transition
+  period:
+    period_kind: tax_year
+    start: '1978-01-01'
+    end: '1978-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: true
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 1978
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 2
+  output:
+    us:statutes/26/112#vietnam_combat_zone_hospitalization_month_after_january_1978: holds
+
+- name: non_vietnam_hospitalization_not_subject_to_january_1978_transition
+  period:
+    period_kind: tax_year
+    start: '1978-01-01'
+    end: '1978-12-31'
+  input:
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 1978
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 2
+  output:
+    us:statutes/26/112#vietnam_combat_zone_hospitalization_month_after_january_1978: not_holds
+
+- name: vietnam_hospitalization_after_january_1978_not_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
+    us:statutes/26/112#input.served_in_combat_zone_during_month: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: true
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
+    us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
+    us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 5000
+    us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
+    us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
+    us:statutes/26/112#input.maximum_enlisted_amount_for_commissioned_officer_months: 0
+    us:statutes/26/112#input.armed_forces_member_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.officially_absent_from_post_of_duty_without_authority: false
+    us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
+    us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
+  output:
+    us:statutes/26/112#vietnam_combat_zone_hospitalization_month_after_january_1978: holds
+    us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 0
+
+- name: vietnam_transition_does_not_limit_direct_combat_zone_service
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
+    us:statutes/26/112#input.served_in_combat_zone_during_month: true
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: true
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: true
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: true
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
+    us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 25
+    us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 5000
+    us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
+    us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
+    us:statutes/26/112#input.maximum_enlisted_amount_for_commissioned_officer_months: 0
+    us:statutes/26/112#input.armed_forces_member_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.officially_absent_from_post_of_duty_without_authority: false
+    us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
+    us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
+    us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
+  output:
+    us:statutes/26/112#vietnam_combat_zone_hospitalization_month_after_january_1978: holds
+    us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112: 5000

--- a/us/statutes/26/112.yaml
+++ b/us/statutes/26/112.yaml
@@ -3,7 +3,41 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/statute/26/112
+    corpus_citation_paths:
+      - us/statute/26/112
+      - us/statute/26/112/a
+      - us/statute/26/112/a/2
+      - us/statute/26/112/b
+      - us/statute/26/112/b/2
+      - us/statute/26/112/c/2
+      - us/statute/26/112/c/3
+      - us/statute/26/7701/a/24
+  deferred_outputs:
+    - output: us:statutes/26/112#civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict
+      reason: >-
+        Section 112(d)(2) adopts the meanings of “active service”,
+        “employee”, and “missing status” from 5 U.S.C. §5561. Section
+        112(d)(3) supplies the conflict start and causal-service test but makes
+        the conflict end depend on the President-designated termination date.
+        No Title 5 §5561 record, including the governing definitions in
+        §5561(4)–(5), or retained Executive Order record for the Vietnam
+        termination designation exists in any inventory at the pinned corpus
+        commit, so the civilian status cannot be classified faithfully from
+        the retained §112 text alone.
+    - output: us:statutes/26/112#maximum_enlisted_amount_for_commissioned_officer_months
+      reason: >-
+        Section 112(c)(5) requires the highest monthly basic-pay rate at the
+        highest enlisted grade plus any special pay payable to the officer
+        under 37 U.S.C. §310 or §351(a)(1) or (3). The pinned corpus contains
+        no 37 U.S.C. §203 monthly basic-pay table, §310, or §351 records from
+        which those monthly amounts can be computed.
+    - output: us:statutes/26/112#months_beginning_after_combatant_activities_termination
+      reason: >-
+        Sections 112(a)(2), 112(b)(2), and 112(c)(3) require the termination
+        date designated by the President for the particular combat zone. The
+        pinned corpus contains no controlling Executive Order designation
+        records for those zone-specific termination dates, so the month count
+        cannot be computed without an unencoded legal input.
   summary: |-
     (a) Enlisted personnel Gross income does not include compensation received for active service as a member below the grade of commissioned officer in the Armed Forces of the United States for any month during any part of which such member— (1) served in a combat zone, or (2) was hospitalized as a result of wounds, disease, or injury incurred while serving in a combat zone; but this paragraph shall not apply for any month beginning more than 2 years after the date of the termination of combatant activities in such zone. With respect to service in the combat zone designated for purposes of the Vietnam conflict, paragraph (2) shall not apply to any month after January 1978.
 
@@ -16,19 +50,155 @@ rules:
   - name: hospitalization_after_combat_zone_termination_limit_years
     kind: parameter
     dtype: Integer
-    source: 26 USC 112(a), 112(b)
+    unit: years
+    source: 26 USC 112(a)(2), 26 USC 112(b)(2)
     metadata:
       proof:
         atoms:
           - path: versions[0].formula
             kind: parameter
             source:
-              corpus_citation_path: us/statute/26/112
+              corpus_citation_path: us/statute/26/112/a/2
+              excerpt: "this paragraph shall not apply for any month beginning more than 2 years after the date of the termination of combatant activities in such zone"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/112/b/2
               excerpt: "this paragraph shall not apply for any month beginning more than 2 years after the date of the termination of combatant activities in such zone"
     versions:
       - effective_from: '1990-01-01'
         formula: |-
           2
+
+  - name: months_per_year_for_section_112_elapsed_period
+    kind: parameter
+    dtype: Integer
+    unit: months
+    source: 26 USC 7701(a)(24), calendar-unit support for the section 112 elapsed-period comparison
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: unit
+            source:
+              corpus_citation_path: us/statute/26/7701/a/24
+              excerpt: "an accounting period of 12 months"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          12
+
+  - name: hospitalized_resulting_from_combat_zone_wounds_disease_or_injury
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 112(a)(2), 26 USC 112(b)(2), 26 USC 112(c)(2)-(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/112/a/2
+              excerpt: "was hospitalized as a result of wounds, disease, or injury incurred while serving in a combat zone"
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/112/b/2
+              excerpt: "was hospitalized as a result of wounds, disease, or injury incurred while serving in a combat zone"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/112/c/2
+              excerpt: "The term “combat zone” means any area which the President of the United States by Executive Order designates"
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/26/112/c/3
+              excerpt: "Service is performed in a combat zone only if performed on or after the date designated by the President"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          armed_forces_member_was_hospitalized_during_compensation_month
+          and hospitalization_resulted_from_identified_wound_disease_or_injury
+          and identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service
+
+  - name: vietnam_hospitalization_last_eligible_year
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 112(a), 26 USC 112(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/112/a
+              excerpt: "paragraph (2) shall not apply to any month after January 1978"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/112/b
+              excerpt: "paragraph (2) shall not apply to any month after January 1978"
+    versions:
+      - effective_from: '1976-10-20'
+        formula: |-
+          1978
+
+  - name: vietnam_hospitalization_last_eligible_month_number
+    kind: parameter
+    dtype: Integer
+    source: 26 USC 112(a), 26 USC 112(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/112/a
+              excerpt: "paragraph (2) shall not apply to any month after January 1978"
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/112/b
+              excerpt: "paragraph (2) shall not apply to any month after January 1978"
+    versions:
+      - effective_from: '1976-10-20'
+        formula: |-
+          1
+
+  - name: vietnam_combat_zone_hospitalization_month_after_january_1978
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 112(a), 26 USC 112(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/112/a
+              excerpt: "With respect to service in the combat zone designated for purposes of the Vietnam conflict, paragraph (2) shall not apply to any month after January 1978."
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/112/b
+              excerpt: "With respect to service in the combat zone designated for purposes of the Vietnam conflict, paragraph (2) shall not apply to any month after January 1978."
+    versions:
+      - effective_from: '1976-10-20'
+        formula: |-
+          armed_forces_member_was_hospitalized_during_compensation_month
+          and identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone
+          and (
+              hospitalization_month_beginning_year > vietnam_hospitalization_last_eligible_year
+              or (
+                  hospitalization_month_beginning_year == vietnam_hospitalization_last_eligible_year
+                  and hospitalization_month_beginning_month_number > vietnam_hospitalization_last_eligible_month_number
+              )
+          )
 
   - name: amount_excluded_from_gross_income_by_reason_of_section_112
     kind: derived
@@ -83,7 +253,9 @@ rules:
                   served_in_combat_zone_during_month
                   or (
                       hospitalized_resulting_from_combat_zone_wounds_disease_or_injury
-                      and months_beginning_after_combatant_activities_termination <= hospitalization_after_combat_zone_termination_limit_years
+                      and months_beginning_after_combatant_activities_termination
+                          <= hospitalization_after_combat_zone_termination_limit_years
+                          * months_per_year_for_section_112_elapsed_period
                       and not vietnam_combat_zone_hospitalization_month_after_january_1978
                   )
               ):
@@ -95,7 +267,9 @@ rules:
                   served_in_combat_zone_during_month
                   or (
                       hospitalized_resulting_from_combat_zone_wounds_disease_or_injury
-                      and months_beginning_after_combatant_activities_termination <= hospitalization_after_combat_zone_termination_limit_years
+                      and months_beginning_after_combatant_activities_termination
+                          <= hospitalization_after_combat_zone_termination_limit_years
+                          * months_per_year_for_section_112_elapsed_period
                       and not vietnam_combat_zone_hospitalization_month_after_january_1978
                   )
               ):

--- a/us/statutes/26/24/d.test.yaml
+++ b/us/statutes/26/24/d.test.yaml
@@ -13,9 +13,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -87,9 +91,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -157,9 +165,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
     us:statutes/26/112#input.served_in_combat_zone_during_month: true
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 3000
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -222,9 +234,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0

--- a/us/statutes/26/24/d.yaml
+++ b/us/statutes/26/24/d.yaml
@@ -95,13 +95,13 @@ rules:
             import:
               target: us:statutes/26/32/c/2#earned_income_before_section_112_election
               output: earned_income_before_section_112_election
-              hash: sha256:67e13e5e77ecd7b4a7c5c03294843763c666830aabb567f1c15a22d6890c1408
+              hash: sha256:126be13a7ffb76e2057ad0067ac772ee32eb1e5f6aed0867a80758e0b1f23bd8
           - path: versions[0].formula
             kind: import
             import:
               target: us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112
               output: amount_excluded_from_gross_income_by_reason_of_section_112
-              hash: sha256:a7549fc6774224d725eaf654655707e7e97aecfa9fcebf378918778482f67512
+              hash: sha256:d9407c7119545f6495c91ab19b399fdf7bfca5f0d4f7b4f4c5cfe0d41f63aee0
           - path: versions[0].formula
             kind: formula
             source:

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -5,11 +5,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -29,9 +30,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -75,11 +73,6 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_child_count: 1
     us:statutes/26/32#eitc_capped_child_count: 1
@@ -97,7 +90,7 @@
     us:statutes/26/32#eitc_investment_income_eligible: holds
     us:statutes/26/32#eitc_allowed: holds
     us:statutes/26/32#eitc: 3400
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+    us:statutes/26/32/c/2#earned_income_before_section_112_election: 10000
 - name: childless_person_age_predicate
   period:
     period_kind: tax_year
@@ -147,11 +140,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -171,9 +165,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -217,13 +208,8 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_investment_income_eligible: not_holds
     us:statutes/26/32#eitc_allowed: not_holds
     us:statutes/26/32#eitc: 0
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+    us:statutes/26/32/c/2#earned_income_before_section_112_election: 10000

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -13,9 +13,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -151,9 +155,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2026
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0

--- a/us/statutes/26/32/c/2.test.yaml
+++ b/us/statutes/26/32/c/2.test.yaml
@@ -13,9 +13,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2024
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -42,9 +46,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2024
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 0
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0
@@ -71,9 +79,13 @@
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: true
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: true
     us:statutes/26/112#input.served_in_combat_zone_during_month: true
-    us:statutes/26/112#input.hospitalized_resulting_from_combat_zone_wounds_disease_or_injury: false
+    us:statutes/26/112#input.armed_forces_member_was_hospitalized_during_compensation_month: false
+    us:statutes/26/112#input.hospitalization_resulted_from_identified_wound_disease_or_injury: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_during_recorded_combat_zone_service: false
+    us:statutes/26/112#input.identified_wound_disease_or_injury_incurred_in_vietnam_combat_zone: false
+    us:statutes/26/112#input.hospitalization_month_beginning_year: 2024
+    us:statutes/26/112#input.hospitalization_month_beginning_month_number: 1
     us:statutes/26/112#input.months_beginning_after_combatant_activities_termination: 0
-    us:statutes/26/112#input.vietnam_combat_zone_hospitalization_month_after_january_1978: false
     us:statutes/26/112#input.active_service_compensation_as_enlisted_member_excluding_pensions_and_retirement_pay: 6000
     us:statutes/26/112#input.commissioned_officer_in_armed_forces_excluding_commissioned_warrant_officer: false
     us:statutes/26/112#input.active_service_compensation_as_commissioned_officer_excluding_pensions_and_retirement_pay: 0

--- a/us/statutes/26/32/c/2.yaml
+++ b/us/statutes/26/32/c/2.yaml
@@ -88,7 +88,7 @@ rules:
             import:
               target: us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112
               output: amount_excluded_from_gross_income_by_reason_of_section_112
-              hash: sha256:a7549fc6774224d725eaf654655707e7e97aecfa9fcebf378918778482f67512
+              hash: sha256:d9407c7119545f6495c91ab19b399fdf7bfca5f0d4f7b4f4c5cfe0d41f63aee0
     versions:
       - effective_from: '1990-01-01'
         formula: |-


### PR DESCRIPTION
Items 20/23 encoded (hospitalization conjunction; the January-1978 transition). Items 19/21/22 deferred on genuinely missing law: 5 USC 5561 definitions, 37 USC 203/310/351, and the Vietnam termination EO date — which the worker refused to guess. Refs #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)