### PR TITLE
ci: pin Montana 2026 shared workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@629e8e5882ae317d4ed9f469d4e7eeb6b08d14de # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@608e11e01c26339b3b1bf36b7f543e8ce042de1e # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- advance the legacy reusable validation workflow caller from `.github` merge `629e8e5882ae317d4ed9f469d4e7eeb6b08d14de` to exact Montana shared-workflow merge `608e11e01c26339b3b1bf36b7f543e8ce042de1e`
- keep the change pin-only; RuleSpec, fixtures, manifests, and `oracle-coverage-pending.yaml` are unchanged
- the shared commit pins oracle coverage to exact encoder postmerge `f6bd0baef34bb34104733a25170c0ac8e7ed62d9`

Both upstream merges have green postmerge checks.

## Validation

- `python tests/generate_reverse_index.py --check` — current (4240 provisions, 5079 edges, 4486 modules)
- `pytest -q tests/test_reverse_index.py tests/test_repository_layout.py` — 15 passed
- workflow YAML parse and exact pin-count assertion — passed
- `git diff --check` — passed

## Review cycle

Independent review of exact commit `6194a8adc929932a0a0aae5f5b1fdf1821bb44de` returned CLEAN with no actionable findings.
