### PR TITLE
Pin Arkansas 2026 encoder in RuleSpec validation

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@608e11e01c26339b3b1bf36b7f543e8ce042de1e # temporary v5 migration bridge
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec-legacy-pending-safe.yml@b380085c2e3b810f2c6b55d71a65fec8e3765fb0 # temporary v5 migration bridge
     secrets: inherit
     with:
       validate-roots: auto


### PR DESCRIPTION
## Summary

- advance the repository-checks caller from shared-workflow merge `608e11e01c26339b3b1bf36b7f543e8ce042de1e` to Arkansas shared-workflow merge `b380085c2e3b810f2c6b55d71a65fec8e3765fb0`
- preserve the exact reusable workflow path, inherited secrets, validation roots, permissions, triggers, and every RuleSpec byte
- transitively select exact Arkansas encoder merge `ee2fb3ea43a7a159eaea0e500b982ce9e0af9873` only for the workflow's oracle-coverage classifier

## Validation

- YAML safe-load parse — passed
- exact-count assertion — old SHA absent; new SHA occurs exactly once
- hidden-tree search — only `.github/workflows/repository-checks.yml` contains the new caller pin
- `git diff --check` — passed
- exact diff scope — one file, one line changed; no RuleSpec or fixture changes
- referenced shared merge postmerge `Test shared workflows` run `30336000314` — green
- referenced shared workflow exists at the pinned immutable SHA, declares `workflow_call`, and defaults oracle coverage to exact Arkansas encoder merge `ee2fb3ea43a7a159eaea0e500b982ce9e0af9873`

## Review cycle

Independent read-only review of exact commit `4f980ad8989c2a46c241254ca111a312cabbbcbe` returned CLEAN with no actionable findings. The reviewer independently verified the one-file/one-line scope, immutable signed shared merge, exact nested encoder default, YAML/counts/diff checks, clean tree, and successful shared postmerge run.
