### PR TITLE
Bump axiom-corpus pin to 10142cb0 (federal tax spine sections)

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "db12795577c5809009168982cf8a72fb58440620"
+axiom_corpus_ref = "10142cb0f07403c2de4599c76bec01e96640fda9"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Pin-only PR (#1134/#1140 pattern): bumps `axiom_corpus_ref` to the axiom-corpus#551 merge commit, which includes **#550** (§63 provenance repair — the inventory previously pointed at §45A's bytes — plus §165, 163 rows) and **#551** (§§27, 57–59, 901, 903, 904 + a §902 repeal-status atom, 552 rows). Both merged today after blind review with byte-level official-source verification.

Unblocks: spine Atomic PR 0 (§63(c)(6) extraction + §67(h)), then Chunk 1 (SALT + itemized deductions), and the AMT/FTC atomic encodes (SPINE-PLAN.md §9).

No other changes; toolchain edit authorized as a dedicated pin-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)