### PR TITLE
Bump axiom-corpus pin to 8af59216 (California BBCE authority)

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,7 +5,7 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-axiom_corpus_ref = "10142cb0f07403c2de4599c76bec01e96640fda9"
+axiom_corpus_ref = "8af592162231e9de748ba6b98792b426ad4fe8b7"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Pin-only PR (#1134/#1140/#1173 pattern): brings in **axiom-corpus#552** — WIC §§18901.5/18901.3 and six CDSS ACLs (14-56, 14-56E, 15-42, 14-63, 14-100, 13-32), the complete CalFresh BBCE authority with the seven-gate federal/state MCE map, byte-deterministic under both PyMuPDF versions, three review rounds.

Unblocks the rulespec-us#1098 BBCE encode (the 243 axiom-attributed `us-pe:snap` cases burn down against it).

No other changes; toolchain edit authorized as a dedicated pin-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)