### PR TITLE
Assert the five senior-case zero bridge outputs in the taxable-income companion

### DIFF
--- a/.axiom/encoding-manifests/us/policies/income_tax/taxable_income_pipeline.json
+++ b/.axiom/encoding-manifests/us/policies/income_tax/taxable_income_pipeline.json
@@ -2,11 +2,7 @@
   "applied_files": [
     {
       "path": "us/policies/income_tax/taxable_income_pipeline.test.yaml",
-      "sha256": "68d295be047d7d743890bf40987aedeae0b11256f8d2cca27c65d65d3685abd8"
-    },
-    {
-      "path": "us/policies/income_tax/taxable_income_pipeline.yaml",
-      "sha256": "812f15410e4266a6118b9929399dbe4ae3f654eb77ad0e7bb77b15ee8c50de8f"
+      "sha256": "a6d9044aa5de705c0807ad5083437af415a0de25a5b46c2b2c4d020a78b878ee"
     }
   ],
   "axiom_encode_git": {
@@ -21,9 +17,9 @@
   "citation": "us:policies/income_tax/taxable_income_pipeline",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-30T03:37:10.364194+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqlxlyz_a/sign-applied-files/us/policies/income_tax/taxable_income_pipeline.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpqlxlyz_a",
+  "generated_at": "2026-07-30T04:31:57.670926+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpk7bt4m96/sign-applied-files/us/policies/income_tax/taxable_income_pipeline.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpk7bt4m96",
   "generated_output_sha256": "812f15410e4266a6118b9929399dbe4ae3f654eb77ad0e7bb77b15ee8c50de8f",
   "generation_prompt_sha256": null,
   "manual_exception": "composition",
@@ -34,15 +30,24 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "b15e5c9dba54448eb3e378b4b8cddabf5c4c1459d86ac1a092edce06eb20dab4"
+    "value": "eb39873091e8cf9c7f895212deb388e4cabf1f63e74d6dc09a263f74b09bdc2e"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-30T02:42:45.695030+00:00",
+    "generated_at": "2026-07-30T03:37:10.364194+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "66a938c7f46dbe1e813411a9c43669b572bb65badc7244f2f6fdcd9fbeba7358",
-    "prior_signature": "8220c20a0c3c8a3f5fd76853e2fd3044ffffb9aea1447de30a18f97e9fa1e291",
+    "manifest_sha256": "8c963557c47f1790403219bfc673a9cfae1e53bbaafbb19e4dbf725c3238c32f",
+    "prior_signature": "b15e5c9dba54448eb3e378b4b8cddabf5c4c1459d86ac1a092edce06eb20dab4",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-30T02:42:45.695030+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "66a938c7f46dbe1e813411a9c43669b572bb65badc7244f2f6fdcd9fbeba7358",
+      "prior_signature": "8220c20a0c3c8a3f5fd76853e2fd3044ffffb9aea1447de30a18f97e9fa1e291",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2149
+ceiling: 2152
 entries:
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax
   source: manual
@@ -3557,6 +3557,15 @@ entries:
 - legal_id: us:policies/income_tax/self_employment_tax_pipeline#self_employment_tax_pipeline_person_is_included
   source: manual
   since: '2026-07-23'
+- legal_id: us:policies/income_tax/taxable_income_pipeline#federal_taxable_income
+  source: manual
+  since: '2026-07-29'
+- legal_id: us:policies/income_tax/taxable_income_pipeline#federal_taxable_income_deductions
+  source: manual
+  since: '2026-07-29'
+- legal_id: us:policies/income_tax/taxable_income_pipeline#taxable_income_pipeline_verified_domain_applies
+  source: manual
+  since: '2026-07-29'
 - legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
   source: manual
   since: '2026-07-27'

--- a/oracle-coverage-pending.yaml
+++ b/oracle-coverage-pending.yaml
@@ -6,7 +6,7 @@
 # an entry that is no longer unmapped must be removed.
 # Maintained by: axiom-encode oracle-coverage-pending sync.
 version: 1
-ceiling: 2152
+ceiling: 2149
 entries:
 - legal_id: us-hi:policies/income_tax/pilot_liability_pipeline#hi_pit_pilot_alternative_regular_tax
   source: manual
@@ -3557,15 +3557,6 @@ entries:
 - legal_id: us:policies/income_tax/self_employment_tax_pipeline#self_employment_tax_pipeline_person_is_included
   source: manual
   since: '2026-07-23'
-- legal_id: us:policies/income_tax/taxable_income_pipeline#federal_taxable_income
-  source: manual
-  since: '2026-07-29'
-- legal_id: us:policies/income_tax/taxable_income_pipeline#federal_taxable_income_deductions
-  source: manual
-  since: '2026-07-29'
-- legal_id: us:policies/income_tax/taxable_income_pipeline#taxable_income_pipeline_verified_domain_applies
-  source: manual
-  since: '2026-07-29'
 - legal_id: us:policies/irs/notice-2025-67/savers-credit#savers_credit_10_percent_agi_limit_all_other
   source: manual
   since: '2026-07-27'

--- a/us/policies/income_tax/taxable_income_pipeline.test.yaml
+++ b/us/policies/income_tax/taxable_income_pipeline.test.yaml
@@ -474,6 +474,7 @@
     us:statutes/26/224#qualified_tips_deduction: '0'
     us:statutes/26/225#qualified_overtime_deduction: '0'
     us:statutes/26/163/h/4/C/ii/I#qualified_passenger_vehicle_loan_interest_deduction_after_modified_adjusted_gross_income_limit: '0'
+    us:policies/income_tax/itemized_taxable_income_deductions_pipeline#federal_itemized_taxable_income_deductions: '0'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income_deductions: '24150'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income: '50850'
 
@@ -506,6 +507,9 @@
     us:statutes/26/151#senior_deduction_amount_per_qualified_individual: '5999.94'
     us:statutes/26/151#senior_deduction: '5999.94'
     us:statutes/26/151#section_151_exemption_deduction: '0'
+    us:policies/income_tax/itemized_taxable_income_deductions_pipeline#federal_itemized_taxable_income_deductions: '0'
+    us:policies/income_tax/qualified_business_income_deduction_pipeline#federal_qualified_business_income_deduction: '0'
+    us:statutes/26/170/p#nonitemizer_charitable_deduction: '0'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income_deductions: '24149.94'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income: '50851.06'
 
@@ -560,6 +564,7 @@
     us:statutes/26/224#qualified_tips_deduction: '0'
     us:statutes/26/225#qualified_overtime_deduction: '0'
     us:statutes/26/163/h/4/C/ii/I#qualified_passenger_vehicle_loan_interest_deduction_after_modified_adjusted_gross_income_limit: '0'
+    us:policies/income_tax/itemized_taxable_income_deductions_pipeline#federal_itemized_taxable_income_deductions: '0'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income_deductions: '47500'
     us:policies/income_tax/taxable_income_pipeline#federal_taxable_income: '102500'
 


### PR DESCRIPTION
Companion-only follow-up to #1179, required by the **axiom-oracles#430** review: the oracle grid's five senior-case zero bridge values (itemized ×3, QBI ×1, nonitemizer-charity ×1) lived in an oracle-side supplemental fixture, violating the never-hand-entered bridge-provenance contract. The engine asserts all five (28/28 green), making the pinned companion the sole bridge provenance; the oracle PR deletes the supplemental fixture and re-pins here.

Manifest re-signed (composition). No module change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)