### PR TITLE
Evidence rows for the four surviving strict-cutover consumptions

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -2,8 +2,23 @@
   "evidence_type": "rulespec-validation-fingerprints/v1",
   "generated_from": {
     "divergence_note": "for 93 of 1017 updated rows the #911 branch module bytes differ from the protected-base bytes; their fingerprints correspond to the branch tree that will consume the approvals, while module_sha256 attests the protected-base bytes as required by the approvals-PR check. Paths: us-al/policies/cms/alabama-chip-eligibility.yaml, us-ar/policies/cms/arkansas-chip-eligibility.yaml, us-az/policies/cms/arizona-chip-eligibility.yaml, us-az/policies/income_tax/pilot_liability_pipeline.yaml, us-ca/policies/income_tax/pilot_liability_pipeline.yaml, us-ca/regulations/mpp/63-301/441.yaml, us-ca/regulations/mpp/63-301/531.yaml, us-ca/regulations/mpp/63-301/541.yaml, us-ca/regulations/mpp/63-301/543.yaml, us-ca/regulations/mpp/63-301/545.yaml, us-ca/regulations/mpp/63-301/547.yaml, us-ca/regulations/mpp/63-301/631.yaml, us-ca/regulations/mpp/63-301/633.yaml, us-ca/regulations/mpp/63-301/824.yaml, us-ca/regulations/mpp/63-301/825.yaml, us-ca/regulations/mpp/63-406/1.yaml, us-ca/regulations/mpp/63-407/241.yaml, us-ca/regulations/mpp/63-407/542.yaml, us-ca/regulations/mpp/63-407/811.yaml, us-ca/regulations/mpp/63-407/855.yaml, us-ca/regulations/mpp/63-408/41.yaml, us-ca/regulations/mpp/63-503/253.yaml, us-ca/regulations/mpp/63-503/431.yaml, us-ca/regulations/mpp/63-503/432.yaml, us-co/policies/cms/colorado-chip-eligibility.yaml, us-co/regulations/10-ccr-2506-1/4.206.yaml, us-co/regulations/10-ccr-2506-1/4.305.2.yaml, us-ct/policies/cms/connecticut-chip-eligibility.yaml, us-de/policies/cms/delaware-chip-eligibility.yaml, us-de/policies/income_tax/pilot_liability_pipeline.yaml, us-fl/policies/cms/florida-chip-eligibility.yaml, us-ga/policies/cms/georgia-chip-eligibility.yaml, us-hi/regulations/har/17/680/17-680-12.yaml, us-ia/policies/cms/iowa-chip-eligibility.yaml, us-id/policies/cms/idaho-chip-eligibility.yaml, us-id/policies/income_tax/pilot_liability_pipeline.yaml, us-il/policies/cms/illinois-chip-eligibility.yaml, us-in/policies/cms/indiana-chip-eligibility.yaml, us-ks/policies/cms/kansas-chip-eligibility.yaml, us-la/policies/cms/louisiana-chip-eligibility.yaml, us-ma/policies/cms/massachusetts-chip-eligibility.yaml, us-ma/policies/income_tax/pilot_liability_pipeline.yaml, us-md/policies/income_tax/pilot_liability_pipeline.yaml, us-me/policies/cms/maine-chip-eligibility.yaml, us-me/policies/income_tax/pilot_liability_pipeline.yaml, us-mn/policies/income_tax/pilot_liability_pipeline.yaml, us-mo/policies/cms/missouri-chip-eligibility.yaml, us-ms/policies/cms/mississippi-chip-eligibility.yaml, us-mt/policies/cms/montana-chip-eligibility.yaml, us-nj/policies/cms/new-jersey-chip-eligibility.yaml, us-nv/policies/cms/nevada-chip-eligibility.yaml, us-ny/policies/cms/new-york-chip-eligibility.yaml, us-ny/policies/income_tax/nyc_composed_liability_pipeline.yaml, us-ny/policies/income_tax/pilot_liability_pipeline.yaml, us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml, us-ny/regulations/18-nycrr/387/10.yaml, us-ny/regulations/18-nycrr/387/12/f/3/v/a.yaml, us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml, us-ny/regulations/18-nycrr/387/14/a/5.yaml, us-oh/policies/income_tax/pilot_liability_pipeline.yaml, us-or/policies/cms/oregon-chip-eligibility.yaml, us-pa/policies/cms/pennsylvania-chip-eligibility.yaml, us-sd/policies/cms/south-dakota-chip-eligibility.yaml, us-tn/policies/cms/tennessee-chip-eligibility.yaml, us-tx/policies/cms/texas-chip-eligibility.yaml, us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml, us-tx/policies/hhs/texas-works-handbook/c-110-tanf.yaml, us-tx/policies/hhs/texas-works-handbook/c-110-tanf/block-2.yaml, us-ut/policies/cms/utah-chip-eligibility.yaml, us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml, us-va/policies/cms/virginia-chip-eligibility.yaml, us-va/policies/income_tax/pilot_liability_pipeline.yaml, us-wa/policies/cms/washington-chip-eligibility.yaml, us-wi/policies/cms/wisconsin-chip-eligibility.yaml, us-wv/policies/cms/west-virginia-chip-eligibility.yaml, us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml, us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml, us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml, us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml, us/policies/usda/snap/fy-2024-cola/maximum-allotments.yaml, us/policies/usda/snap/fy-2026-cola/deductions.yaml, us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml, us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml, us/statutes/26/1/h.yaml, us/statutes/26/199A.yaml, us/statutes/26/24/d.yaml, us/statutes/26/55.yaml, us/statutes/26/68.yaml, us/statutes/42/402/w.yaml, us/statutes/42/415/b.yaml, us/statutes/42/416/l.yaml, us/statutes/42/426.yaml, us/statutes/42/426/e.yaml",
+    "final_four_note": "rows for the four surviving strict-cutover consumptions; fingerprints are the #911 branch's census-reconciled active values (the consumption tree); module_sha256 attests protected-base bytes per the approvals-check semantics \u2014 26/6012 diverges (branch keeps its strict-track version; main's fails strict at the round toolchain)",
     "fingerprint_tree": "rulespec-us#911 branch tree 10f7a16e (the consumption tree)",
     "fingerprints_minted_at": "axiom-encode 485cc984 (0.2.1330) / re-verified at ee5e1b9a (0.2.1335); values are partition-invariant and identical through 0.2.1337 \u2014 the 1336/1337 changes (isolated recheck) affect audit flow only. The toolchain block records the round pin the consuming audit runs.",
+    "isolated_census_artifact": "waiver-census-isolated (sha256:467fa2f8ff7d3651a6998d662e20613dc41cac3b66af9a5a75762e6a353a7172)",
+    "isolated_census_reconciliation": {
+      "approve_replacement_fingerprint": 173,
+      "coverage": 378,
+      "parallel_false_positive": 0,
+      "remove_stale_active": 205
+    },
+    "isolated_census_run": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/30134976400",
+    "isolated_census_toolchain": {
+      "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d",
+      "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
+      "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "rulespec_ref": "83cf4dbcee74a2679159782e4117823b320f3de2"
+    },
     "method": "full waiver-ledger re-execution census via axiom_encode.cli._fingerprint_validation_waiver_modules (verify-only broker: public release trust roots only); the three us-ca mpp rows carry values proven partition-invariant under axiom-encode#1240 (solo-vs-batch agreement) \u2014 the pre-#1240 shared-cache executor's census values for them were chunk-layout-tainted",
     "module_sha256_tree": "protected base (origin/main) at this PR, per the bridge check's head-bytes semantics",
     "receipts": "TheAxiomFoundation/ops -> strict-cutover/receipts/{waiver-census-0722.jsonl,waiver-census-0722.pins.json,sol-gate-8.md,sol-gate-8b.md}",
@@ -17,21 +32,7 @@
       "rulespec_us_ref": "10f7a16ecbb9053f43dc198e2b8a3554e5ba9078"
     },
     "toolchain_block_note": "the top-level toolchain block is retained byte-equal to .axiom/target-validation-passes.json per the bridge's cross-evidence equality check; it describes the v5-foundation era that minted the untouched rows. The 1,021 rows refreshed for the strict-cutover approvals were minted and verified at the pins recorded here:",
-    "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in",
-    "isolated_census_run": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/30134976400",
-    "isolated_census_artifact": "waiver-census-isolated (sha256:467fa2f8ff7d3651a6998d662e20613dc41cac3b66af9a5a75762e6a353a7172)",
-    "isolated_census_reconciliation": {
-      "remove_stale_active": 205,
-      "approve_replacement_fingerprint": 173,
-      "parallel_false_positive": 0,
-      "coverage": 378
-    },
-    "isolated_census_toolchain": {
-      "rulespec_ref": "83cf4dbcee74a2679159782e4117823b320f3de2",
-      "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
-      "axiom_rules_engine_ref": "05eac9d2f89dabe5c6673176260762cef3a58f47",
-      "axiom_corpus_ref": "0fd35bfbda98836c406ec539a492c4e661c6695d"
-    }
+    "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in"
   },
   "modules": {
     "us-ak/policies/cms/alaska-chip-eligibility.yaml": {
@@ -5864,6 +5865,11 @@
       "module_sha256": "sha256:46ae283a4e9c95af48fda887c86baefe05c41306d0d96cd08996b9544912e04e",
       "passed": false
     },
+    "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-8.yaml": {
+      "fingerprint": "sha256:76377c19ffa1080e3c713c852c1cad450270075648d3d2330c28b18fe8505032",
+      "module_sha256": "sha256:9a8e93be4a5fd91bd0d0d4793efe40322f1f6e6e762e059e98be5f1e71e30c0f",
+      "passed": false
+    },
     "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-cic-rap/page-12.yaml": {
       "fingerprint": "sha256:5bcc9881b11d4c6e68e058505600434951e0a1e320419db80e5ed28f86069c60",
       "module_sha256": "sha256:09df1ff6566cfec36b8fa3caeb722cba46317781697c3759389129e54784b038",
@@ -5984,6 +5990,11 @@
       "module_sha256": "sha256:a799be768172038c0e6480bc34ee8b5cefcb6a6a2daaf4c03eac667cab23ee3b",
       "passed": false
     },
+    "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml": {
+      "fingerprint": "sha256:b3cd4b767cf8783bd362333b2ba7dfd8878bbee370859660086e1daf546b02bf",
+      "module_sha256": "sha256:54ec0a7e9fffa44b4ef7502cf5151bfe20b53990a4e5cbadc3327989eafc5fc8",
+      "passed": false
+    },
     "us-fl/policies/dcf/ess-program-policy-manual/200-general-program-information/page-15.yaml": {
       "fingerprint": "sha256:d80a454f34b8561376d419bdfa75772e5aedbefdaff561b890cdcff7911e516d",
       "module_sha256": "sha256:2f93595a56cb83107a7fe66c039040ec6e6202dab9bccb3dc8a749259178ca7e",
@@ -6002,6 +6013,11 @@
     "us-fl/policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-9-net-income-test.yaml": {
       "fingerprint": "sha256:131209cd3a36ca97864224790aaa54881b6a976465cdf9a7760d463677e2e2eb",
       "module_sha256": "sha256:6f0e3712922aa092a48daf3f960d33b3da90fa34669fe772caf99534ad806e73",
+      "passed": false
+    },
+    "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-5-temporary-cash-assistance-income-standards/page-1.yaml": {
+      "fingerprint": "sha256:e94778664870df9506ac2618c7a4e3ea7d3cc623a8b06f78f2246e6e516b52ea",
+      "module_sha256": "sha256:3e31dfee83ec9c39b00c8fc9c79ab95a96c73c42f926807986630b6e5025981f",
       "passed": false
     },
     "us-fl/regulations/fac/65a-1/205/block-1.yaml": {
@@ -6044,6 +6060,11 @@
       "module_sha256": "sha256:1207f85bbc9c3d38b078bf447add98bd36bc779a417b3afabbcbdecd9ccc5454",
       "passed": false
     },
+    "us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml": {
+      "fingerprint": "sha256:9d380849295103fa48e2f03f75326a6628ff485f57bd489210f3241083591450",
+      "module_sha256": "sha256:a7ed76d4630e05fe0cdbc2d776a6c5825132cb4060c05b482c2f87b0c9b7d45a",
+      "passed": false
+    },
     "us-ga/policies/dfcs/snap/3210/block-2.yaml": {
       "fingerprint": "sha256:ee606dfdbcf3883aaec1e083c2025e4f4079411650c6184bc368524219a3d26e",
       "module_sha256": "sha256:3c15a5888599a1f765b3941dc018639f139feb6d4217d5eded52a7a19a9bb144",
@@ -6077,6 +6098,11 @@
     "us-ga/policies/dfcs/snap/standard-utility-allowances.yaml": {
       "fingerprint": "sha256:e516ba057f68e2410e58fd4e2468204f206edbeaf460504cfc459cd4345cde14",
       "module_sha256": "sha256:9a61a2fca229bd71e4640b5e34373a41c45d5540f04d2cc0a8d94af85d4be559",
+      "passed": false
+    },
+    "us-ga/policies/dfcs/tanf/appendix-a.yaml": {
+      "fingerprint": "sha256:c933127697b98f68792b9883a7b5695f1baa188f2f4417333947bf4af1ff8c4f",
+      "module_sha256": "sha256:5eb46e90e0b027db4ba85994be630634ce990629547c1ce2713a33a0568781f3",
       "passed": false
     },
     "us-ga/statutes/48/48-7-26.yaml": {
@@ -6429,6 +6455,11 @@
       "module_sha256": "sha256:ca4ed7c83b4a055a4023491866a52aac06825f3ab8357a3442f5f97020c95d96",
       "passed": false
     },
+    "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml": {
+      "fingerprint": "sha256:3680f94624d40bbb0a3af77d6b7d5090051eefca1b7b71447919c74a00887e69",
+      "module_sha256": "sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99",
+      "passed": false
+    },
     "us-in/statutes/12-15-32-6.yaml": {
       "fingerprint": "sha256:f497ec07044bfc3e0c8ee25c39d205319f8a0d2f6082f9cc62d8475c6394df24",
       "module_sha256": "sha256:63f966911701d9a32494d2008fecd058da1f93d14b2d2a9795565a936da6191c",
@@ -6512,6 +6543,11 @@
     "us-la/policies/cms/louisiana-chip-eligibility.yaml": {
       "fingerprint": "sha256:aa25a8f48d4bf46e067dcf3cbef4cb9f8495eaf17e5e315d846584aaf63a98c1",
       "module_sha256": "sha256:88bd443317eb985b3acbaa8a7c134a3e61dded603552cf8be1cac17a8260682d",
+      "passed": false
+    },
+    "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml": {
+      "fingerprint": "sha256:a0baa03196157ee7dd3f5d26c7fe88711386c8c7bea84675c866409895862dcf",
+      "module_sha256": "sha256:6030ecff6d5063d305d5fbe31c585b8b41f964d7a0c31ea3cb3dc0ce95371f3a",
       "passed": false
     },
     "us-la/statutes/47:294.yaml": {
@@ -7367,6 +7403,11 @@
     "us-mi/policies/income_tax/pilot_liability_pipeline.yaml": {
       "fingerprint": "sha256:3f575fbce6bd7c799fd31e6d11bdd638cb0cf4218b763a10b05cd76da68fe324",
       "module_sha256": "sha256:d971200a1690316ad7c3e9831a53757ed09741bc40666fbe04aa5d750465025d",
+      "passed": false
+    },
+    "us-mi/policies/mdhhs/rft/248.yaml": {
+      "fingerprint": "sha256:d359d4061373dc352fef16f5fecf873081087d1f8cef9ee01ef2cfc7972c2375",
+      "module_sha256": "sha256:b428e04570d5cb4d224924736d00bcd1ae8a3fb774a65b908b0480af61175a5c",
       "passed": false
     },
     "us-mi/statutes/206.30/10.yaml": {
@@ -8344,6 +8385,21 @@
       "module_sha256": "sha256:40e825622fe7ee6aca0db3d4e2014198941c46d856db46da2896eec8ed1a56cf",
       "passed": false
     },
+    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-21.yaml": {
+      "fingerprint": "sha256:95599ecfe1053130f5178e24ab412c5d9a76da6c4943969b06a60197a2c006ad",
+      "module_sha256": "sha256:f57046795ed987059331efc8b6a01183000b1b8026eedc0d6aaa47535784c0db",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml": {
+      "fingerprint": "sha256:e07ea599c08ff108181a502ec5c29843445e4731512b992ead4be7a459d45536",
+      "module_sha256": "sha256:95baf10d2b09246ae91f4498c872e867186b154258f53e43dac35574d57116a4",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml": {
+      "fingerprint": "sha256:840bcbb9f5fae93869f1337c7a25224ddfc5aa11997c0d8d62e143a2804c4ccc",
+      "module_sha256": "sha256:ee1d5df0c22b353f0bcdb18f918220ee5530fff4941fb39c4223a3a3cbe788d1",
+      "passed": false
+    },
     "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-25.yaml": {
       "fingerprint": "sha256:0e83a3d8c4f3ca9361b17fe516d790e531f095f0ee1c02cab6c3658a029c138b",
       "module_sha256": "sha256:7744148fe1fb18ac6415014c4ebd5d3a43b408a885efa04948b289d37371836e",
@@ -8534,6 +8590,11 @@
       "module_sha256": "sha256:aeae50ef216167b2843d3b12e1dbb1017a95c8d8b76bf39f0d05402774b0b0a0",
       "passed": false
     },
+    "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-9.yaml": {
+      "fingerprint": "sha256:1fb6bc10ce849113aac100031af50ab4d2402a4e4aac04a64cbe531bc9c83501",
+      "module_sha256": "sha256:efb19643b0334824fb7470a477a7675d4c431c9fb98d312b231e7febacbe7119",
+      "passed": false
+    },
     "us-nc/policies/dhhs/fns/fns-340-deductions/page-1.yaml": {
       "fingerprint": "sha256:b1a66ae9659d49418f149dd4505bcc0acf84bb6f120bec87a5612dca31781d15",
       "module_sha256": "sha256:3072105489cdccdb4cd2ca33d0548d11cea4dfe1fa139694133807e632922a37",
@@ -8652,6 +8713,11 @@
     "us-nc/policies/dhhs/fns/fns-350-whose-income-is-counted/page-5.yaml": {
       "fingerprint": "sha256:8d88862e10b50098a48254327a9e532924083bff1bb6a0da66001b4eed9e3c59",
       "module_sha256": "sha256:779f458676e813846095ccefcf0d39b705790061969d55ed84f54bed5de02da6",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml": {
+      "fingerprint": "sha256:7b6aef13d7d22b60ee668a49c69cc56890be2635b60bb6c7df65e6b01a86a06a",
+      "module_sha256": "sha256:e577eebae32adfa876401f6182973de95ef52b4dfaf4a27e226efa615bacd175",
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-390-resources/page-10.yaml": {
@@ -8827,6 +8893,11 @@
     "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-12.yaml": {
       "fingerprint": "sha256:7ea4e2c3045d77991d348782221aad7ae1ba3ccecfe3a2f3ebb8c8b48c6b143e",
       "module_sha256": "sha256:2d4c7cdf9d1c9bed9d1824874e33f5ccc0cc7832d460443c3977fe5dca6b4ce6",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml": {
+      "fingerprint": "sha256:2ddc29000eec5c43e1b4a856f40271e120233ec041cfe880cd51f85e1f807716",
+      "module_sha256": "sha256:bbde277cc315d334b4c43d3ab81c6595673cdad6abf11527bee60e4b010736dc",
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-14.yaml": {
@@ -9279,6 +9350,16 @@
       "module_sha256": "sha256:d7e6f2bb40e18d16090f54fdc66b4ed00cc5e9b59946d500a90beb87cab175b2",
       "passed": false
     },
+    "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-2.yaml": {
+      "fingerprint": "sha256:c31134f866ebc0f449307decfe7ffa19ddf9be74e4dffbf068c5c18d16d10065",
+      "module_sha256": "sha256:c4c135b390336fefc6dbb35e0fa2d638c9e007d167310203ba0a56be7074d697",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml": {
+      "fingerprint": "sha256:874550359cb45dfeca692f9dee535b8fdb09d90bd1f7302cc00034a22a9b8aac",
+      "module_sha256": "sha256:a4e0359343b8fcc14abc92b6ce6a4b5df65842ab33094fc1ab712b6d75096953",
+      "passed": false
+    },
     "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-4.yaml": {
       "fingerprint": "sha256:062268ec3d528968d42e1c79c265b9ee56cc2fb242f9918ff552e1a3b960f83e",
       "module_sha256": "sha256:f19289c04d977abdfdd31f90b8a75ce16f393c294bc43867c68c6afb35d3322b",
@@ -9347,6 +9428,11 @@
     "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-24.yaml": {
       "fingerprint": "sha256:b589e5e3343b7e9aa5d993b86c6dc38f54d975f92d79a64b18f253805e402357",
       "module_sha256": "sha256:305eb441f843dd5e131d2bf489bc19d748bfb075326074cd1e89748d76ce5010",
+      "passed": false
+    },
+    "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml": {
+      "fingerprint": "sha256:2771fc3dc86de455bb8421a565e007efec2f764e1bbbd5fc0de1744e5876e954",
+      "module_sha256": "sha256:eb583f5a40cf1308822fc9ec4039857753b9352bc06906e905ea9ee8dd062eb9",
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-3.yaml": {
@@ -9551,7 +9637,7 @@
     },
     "us-nc/statutes/105/105-153.5/a.yaml": {
       "fingerprint": "sha256:d0ae8cef94463ba35b124c4a26d4b97a1303858c73b96b7810db1e7cabadf145",
-      "module_sha256": "sha256:0fffbe4189fed9d1b224f6f0482409902be54bcf25df47b5581e66790df51492",
+      "module_sha256": "sha256:348ea8867b2972d5f990b17f0c0e5ab6f686738350eda6d8b072787d16be1ce9",
       "passed": false
     },
     "us-nc/statutes/105/105-153.5/a1.yaml": {
@@ -9571,7 +9657,7 @@
     },
     "us-nc/statutes/105/105-153/9.yaml": {
       "fingerprint": "sha256:06003f08fab06b8f28e125c68e71310aab6e793cd182cd831af3ef589f84bef5",
-      "module_sha256": "sha256:4a5dcf7d423041a23824d204fc9b442a183ec247188c12abcd23a8163fdcd2ff",
+      "module_sha256": "sha256:d84719a68489f8696945390ee23884c46091ed9b19338978cb9f65bd046d2f38",
       "passed": false
     },
     "us-nd/policies/cms/north-dakota-chip-eligibility.yaml": {
@@ -9932,6 +10018,16 @@
     "us-sc/policies/cms/south-carolina-chip-eligibility.yaml": {
       "fingerprint": "sha256:750407b0098328fa74246c70c68c1d1defcc5d982a992301c1bfd71444c6aaf3",
       "module_sha256": "sha256:fff3821ebc6baa6e9b07f33818e42065be5be1d29fb5cd0576124390ed961482",
+      "passed": false
+    },
+    "us-sc/policies/dss/snap-policy-manual/page-125.yaml": {
+      "fingerprint": "sha256:b135dc74bc279292cdd7ab5ca577e934d1f841037027cd3a629ee2660153ac24",
+      "module_sha256": "sha256:b7053a89c0f9c61eb21538914ff277a1f8c41e8508493fe3572cac3d19a9115b",
+      "passed": false
+    },
+    "us-sc/policies/dss/snap-policy-manual/page-314.yaml": {
+      "fingerprint": "sha256:8627243507046dfbdf2e2e48a0c4e0a465d0117d2e971a787e7e556c78059757",
+      "module_sha256": "sha256:bd436ce5ed172bc5dfc4f5e788ee4e17b3347ecfbd65ca31cbc5c4f2b338251f",
       "passed": false
     },
     "us-sc/regulations/114/1300/block-1.yaml": {
@@ -10517,6 +10613,11 @@
     "us-tn/regulations/1240-01/04/24/block-1.yaml": {
       "fingerprint": "sha256:7ac5caf7f2d78214a46b0583fe38edc9e272fe015a1c83eac5381532ba06b693",
       "module_sha256": "sha256:2fdd0c53898cb58abcf95d5914867af10f9a62eaa1b7814b1ad8c44d530cf598",
+      "passed": false
+    },
+    "us-tn/regulations/1240-01/04/27/block-1.yaml": {
+      "fingerprint": "sha256:5b203210fa46184bf3eb0ff59d1efccd1d3cceb8fc56e736e7df2e191515ff27",
+      "module_sha256": "sha256:244fd10ce8106799893775e4e43171cdd48e318f5357ad9babd3611b73e9d4f7",
       "passed": false
     },
     "us-tn/regulations/1240-01/08/01/block-1.yaml": {
@@ -11327,6 +11428,11 @@
     "us/statutes/26/1411.yaml": {
       "fingerprint": "sha256:02d84cbca17ed28230b28089174561b2dd68de0b6212d092daaed0cff0dade66",
       "module_sha256": "sha256:8443d708729dfbb96068f13dae059614117dffac45ee0b3e721044c40ef05bfd",
+      "passed": false
+    },
+    "us/statutes/26/151.yaml": {
+      "fingerprint": "sha256:c46ad79f1cd1d390caa77601d5ad7a4b832b1eb6c5a58b882fb266454bb91fbf",
+      "module_sha256": "sha256:28fb0e7c50d48ad764ff1ddee8b654a18006fc3dde026034b4dfb6efb90a0fb2",
       "passed": false
     },
     "us/statutes/26/152.yaml": {
@@ -12979,6 +13085,11 @@
       "module_sha256": "sha256:8598384041ed0766f16b8a168d3c9f7765a9c9dcf4a57f83e57a698836e0b796",
       "passed": false
     },
+    "us/statutes/26/6012.yaml": {
+      "fingerprint": "sha256:ad0c18c36b80f1ada7c7f877891e95870fed17726f193cac689f34d4f4c618da",
+      "module_sha256": "sha256:66eb96874daacaa4e907ef3d752f4b7d2c55fc171be732c6b4924d4ad4937ce3",
+      "passed": false
+    },
     "us/statutes/26/6013/a.yaml": {
       "fingerprint": "sha256:79775c61bfe7dae48627df10a9454d849076eb65d208c5ba6ce17e497a05bf0f",
       "module_sha256": "sha256:d5812b6ece90267068e9dcfc9e5c6cf895c25667d38e01d5c6c040082074c0de",
@@ -13422,111 +13533,6 @@
     "us/statutes/8/1641/b.yaml": {
       "fingerprint": "sha256:88474f12453834dd0969c56bac46508b50cb66d2cc27adcd817c566e0051c306",
       "module_sha256": "sha256:7a98dbc72ac610e0af2df7e37d61bb8b24bfc2b8da7219ac5cdfa1f3af8986bc",
-      "passed": false
-    },
-    "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-8.yaml": {
-      "fingerprint": "sha256:76377c19ffa1080e3c713c852c1cad450270075648d3d2330c28b18fe8505032",
-      "module_sha256": "sha256:9a8e93be4a5fd91bd0d0d4793efe40322f1f6e6e762e059e98be5f1e71e30c0f",
-      "passed": false
-    },
-    "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml": {
-      "fingerprint": "sha256:b3cd4b767cf8783bd362333b2ba7dfd8878bbee370859660086e1daf546b02bf",
-      "module_sha256": "sha256:54ec0a7e9fffa44b4ef7502cf5151bfe20b53990a4e5cbadc3327989eafc5fc8",
-      "passed": false
-    },
-    "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-5-temporary-cash-assistance-income-standards/page-1.yaml": {
-      "fingerprint": "sha256:e94778664870df9506ac2618c7a4e3ea7d3cc623a8b06f78f2246e6e516b52ea",
-      "module_sha256": "sha256:3e31dfee83ec9c39b00c8fc9c79ab95a96c73c42f926807986630b6e5025981f",
-      "passed": false
-    },
-    "us-ga/policies/decal/caps/appendix-c-reimbursement-rates.yaml": {
-      "fingerprint": "sha256:9d380849295103fa48e2f03f75326a6628ff485f57bd489210f3241083591450",
-      "module_sha256": "sha256:a7ed76d4630e05fe0cdbc2d776a6c5825132cb4060c05b482c2f87b0c9b7d45a",
-      "passed": false
-    },
-    "us-ga/policies/dfcs/tanf/appendix-a.yaml": {
-      "fingerprint": "sha256:c933127697b98f68792b9883a7b5695f1baa188f2f4417333947bf4af1ff8c4f",
-      "module_sha256": "sha256:5eb46e90e0b027db4ba85994be630634ce990629547c1ce2713a33a0568781f3",
-      "passed": false
-    },
-    "us-in/policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation.yaml": {
-      "fingerprint": "sha256:3680f94624d40bbb0a3af77d6b7d5090051eefca1b7b71447919c74a00887e69",
-      "module_sha256": "sha256:ecfcf6f27f93c99538f553054b2d630879c447d2c89f6635f11295687bde6c99",
-      "passed": false
-    },
-    "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml": {
-      "fingerprint": "sha256:a0baa03196157ee7dd3f5d26c7fe88711386c8c7bea84675c866409895862dcf",
-      "module_sha256": "sha256:6030ecff6d5063d305d5fbe31c585b8b41f964d7a0c31ea3cb3dc0ce95371f3a",
-      "passed": false
-    },
-    "us-mi/policies/mdhhs/rft/248.yaml": {
-      "fingerprint": "sha256:d359d4061373dc352fef16f5fecf873081087d1f8cef9ee01ef2cfc7972c2375",
-      "module_sha256": "sha256:b428e04570d5cb4d224924736d00bcd1ae8a3fb774a65b908b0480af61175a5c",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-21.yaml": {
-      "fingerprint": "sha256:95599ecfe1053130f5178e24ab412c5d9a76da6c4943969b06a60197a2c006ad",
-      "module_sha256": "sha256:f57046795ed987059331efc8b6a01183000b1b8026eedc0d6aaa47535784c0db",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml": {
-      "fingerprint": "sha256:e07ea599c08ff108181a502ec5c29843445e4731512b992ead4be7a459d45536",
-      "module_sha256": "sha256:95baf10d2b09246ae91f4498c872e867186b154258f53e43dac35574d57116a4",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml": {
-      "fingerprint": "sha256:840bcbb9f5fae93869f1337c7a25224ddfc5aa11997c0d8d62e143a2804c4ccc",
-      "module_sha256": "sha256:ee1d5df0c22b353f0bcdb18f918220ee5530fff4941fb39c4223a3a3cbe788d1",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-9.yaml": {
-      "fingerprint": "sha256:1fb6bc10ce849113aac100031af50ab4d2402a4e4aac04a64cbe531bc9c83501",
-      "module_sha256": "sha256:efb19643b0334824fb7470a477a7675d4c431c9fb98d312b231e7febacbe7119",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml": {
-      "fingerprint": "sha256:7b6aef13d7d22b60ee668a49c69cc56890be2635b60bb6c7df65e6b01a86a06a",
-      "module_sha256": "sha256:e577eebae32adfa876401f6182973de95ef52b4dfaf4a27e226efa615bacd175",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-425-expedited-services-processing/page-13.yaml": {
-      "fingerprint": "sha256:2ddc29000eec5c43e1b4a856f40271e120233ec041cfe880cd51f85e1f807716",
-      "module_sha256": "sha256:bbde277cc315d334b4c43d3ab81c6595673cdad6abf11527bee60e4b010736dc",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-2.yaml": {
-      "fingerprint": "sha256:c31134f866ebc0f449307decfe7ffa19ddf9be74e4dffbf068c5c18d16d10065",
-      "module_sha256": "sha256:c4c135b390336fefc6dbb35e0fa2d638c9e007d167310203ba0a56be7074d697",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml": {
-      "fingerprint": "sha256:874550359cb45dfeca692f9dee535b8fdb09d90bd1f7302cc00034a22a9b8aac",
-      "module_sha256": "sha256:a4e0359343b8fcc14abc92b6ce6a4b5df65842ab33094fc1ab712b6d75096953",
-      "passed": false
-    },
-    "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml": {
-      "fingerprint": "sha256:2771fc3dc86de455bb8421a565e007efec2f764e1bbbd5fc0de1744e5876e954",
-      "module_sha256": "sha256:eb583f5a40cf1308822fc9ec4039857753b9352bc06906e905ea9ee8dd062eb9",
-      "passed": false
-    },
-    "us-sc/policies/dss/snap-policy-manual/page-125.yaml": {
-      "fingerprint": "sha256:b135dc74bc279292cdd7ab5ca577e934d1f841037027cd3a629ee2660153ac24",
-      "module_sha256": "sha256:b7053a89c0f9c61eb21538914ff277a1f8c41e8508493fe3572cac3d19a9115b",
-      "passed": false
-    },
-    "us-sc/policies/dss/snap-policy-manual/page-314.yaml": {
-      "fingerprint": "sha256:8627243507046dfbdf2e2e48a0c4e0a465d0117d2e971a787e7e556c78059757",
-      "module_sha256": "sha256:bd436ce5ed172bc5dfc4f5e788ee4e17b3347ecfbd65ca31cbc5c4f2b338251f",
-      "passed": false
-    },
-    "us-tn/regulations/1240-01/04/27/block-1.yaml": {
-      "fingerprint": "sha256:5b203210fa46184bf3eb0ff59d1efccd1d3cceb8fc56e736e7df2e191515ff27",
-      "module_sha256": "sha256:244fd10ce8106799893775e4e43171cdd48e318f5357ad9babd3611b73e9d4f7",
-      "passed": false
-    },
-    "us/statutes/26/151.yaml": {
-      "fingerprint": "sha256:c46ad79f1cd1d390caa77601d5ad7a4b832b1eb6c5a58b882fb266454bb91fbf",
-      "module_sha256": "sha256:28fb0e7c50d48ad764ff1ddee8b654a18006fc3dde026034b4dfb6efb90a0fb2",
       "passed": false
     }
   },


### PR DESCRIPTION
Evidence-file-only; precedes the four-approval restore per the bridge's protected-base check. Details in the commit; receipts in TheAxiomFoundation/ops → strict-cutover/. Bind sequence per #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)