### PR TITLE
Waiver-only: restore the four surviving strict-cutover approvals

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -11193,6 +11193,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-22-627.yaml":
+    pending:
+      fingerprint: "sha256:71f243ea1d6040b013ffdb2510a02d1d152e0ac4b266123891a25f2493f353ad"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-26-102.5.yaml":
     pending:
       fingerprint: "sha256:9bb252d466f12075d658590f0f66516a93a159dc37bf1431f245ae77449768c6"
@@ -16539,6 +16545,18 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-nc/statutes/105/105-153.5/a.yaml":
+    pending:
+      fingerprint: "sha256:d0ae8cef94463ba35b124c4a26d4b97a1303858c73b96b7810db1e7cabadf145"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/statutes/105/105-153/9.yaml":
+    pending:
+      fingerprint: "sha256:06003f08fab06b8f28e125c68e71310aab6e793cd182cd831af3ef589f84bef5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nd/policies/cms/north-dakota-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:5a6253f112f090bd19ae7813b9a41db90af07de52955d570903db15ac21d0c9d"
@@ -20424,6 +20442,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/45A/f.yaml":
     pending:
       fingerprint: "sha256:2ad82aa32a9d2407c78389faaa1dc317b07c5edeaf680c26d4e51908a52d06b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/6012.yaml":
+    pending:
+      fingerprint: "sha256:ad0c18c36b80f1ada7c7f877891e95870fed17726f193cac689f34d4f4c618da"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
Waiver-only; requires #1186 (evidence) in the base first. The other five broken consumptions resolved branch-side by adopting main's module deletions. Bind sequence per #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)