### PR TITLE
Pin Idaho corpus successor

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,8 +5,8 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-# NC TY2026 temporal successor merged by axiom-corpus PR #539.
-axiom_corpus_ref = "b403bf49e3c9cf31f26f239f1e188683be1b9e65"
+# Idaho income-tax statute successor merged by axiom-corpus PR #554.
+axiom_corpus_ref = "2ccb67efa41f60b5a80cb736c0272e68d5591389"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

Advance the validation corpus pin to axiom-corpus merge commit `2ccb67efa41f60b5a80cb736c0272e68d5591389` from PR #554.

That commit adds the signed immutable Idaho Title 63 Chapter 30 successor scope and an expression-date-aware native Idaho parser. It replaces the malformed bodyless/navigation recovery records without mutating the released historical scope, and selects only the 2026-effective rendition where official pages also contain future 2027 text.

## Review and validation

- independent pin review: CLEAN
- only `.axiom/toolchain.toml` changes
- TOML parsing and exact SHA assertion passed
- axiom-corpus main verified at the pinned SHA
- signed ingest manifest, 7/7 complete scope, 13 applied files, and named release verified present at that commit

This pin change intentionally triggers full RuleSpec-US repository revalidation. No RuleSpec policy module changes in this PR.