### PR TITLE
Pin tariff T0 corpus successor

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,8 +5,9 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-# Idaho income-tax statute successor merged by axiom-corpus PR #554.
-axiom_corpus_ref = "2ccb67efa41f60b5a80cb736c0272e68d5591389"
+# US tariff T0 authority set (Title 19 spine, HTS 2026 Rev 3/4/12/14
+# snapshots, Rev14 notes, FR instruments) merged by axiom-corpus PR #557.
+axiom_corpus_ref = "3a0acc4169006e33ee9c1c07fdf37f33cd7737c3"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

- Bump `axiom_corpus_ref` to `3a0acc4169006e33ee9c1c07fdf37f33cd7737c3`, the
  merge commit of axiom-corpus#557 (US tariff T0 authority set: Title 19
  spine, USITC HTS 2026 Revision 3/4/12/14 snapshots, Rev14 GN3 + Chapter 99
  notes, Federal Register instruments for the 2026-02-24 and 2026-07-24
  regime boundaries).
- Only the corpus pin moves; encoder/engine/canonical-target pins unchanged.
- Follows the dedicated-pin-PR convention (#1188 Idaho, #1108 NC).

Prerequisite for the `us/statutes/19/...` tariff encodings in the T0 lane
(rulespec-us#1190; oracle program axiom-oracles#444). The corpus commit's new
citation paths (`us/statute/hts/...`, `us/statute/19/...`, five
`us/rulemaking/...` scopes) widen the pending `us` release cut.

## Test plan

- [ ] CI green (full-repository revalidation triggers on toolchain.toml
  changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
