### PR TITLE
Pin lane A tariff-parity corpus successor

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,9 +5,10 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-# US tariff T0 authority set (Title 19 spine, HTS 2026 Rev 3/4/12/14
-# snapshots, Rev14 notes, FR instruments) merged by axiom-corpus PR #557.
-axiom_corpus_ref = "3a0acc4169006e33ee9c1c07fdf37f33cd7737c3"
+# US tariff parity lane A feedstock (47 FR tariff instruments, 44 HTS
+# revision snapshots for 2025 Basic-R32 and 2026 Basic-R13, 47 GN3 and
+# chapter 99 notes versions) merged by axiom-corpus PRs #560-#569.
+axiom_corpus_ref = "05ce3d3dd21b0ced76f9af40c2ecc02c1c57d9c6"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

Dedicated toolchain-pin PR (T0 #1191 pattern): bump `axiom_corpus_ref` from the T0 authority set (axiom-corpus#557, `3a0acc41`) to the current axiom-corpus main tip `05ce3d3d` (merge of axiom-corpus#569), which carries the full parity lane A feedstock merged 2026-08-01/02:

- 47 `extract-federal-register` tariff instrument versions (axiom-corpus#560–#563: §232, §301 incl. forced labor, IEEPA + frameworks, §201 + §338)
- 44 USITC HTS revision snapshot versions covering the parity window (axiom-corpus#564–#567: 2025 Basic + R1–R32, 2026 Basic + R1, R2, R5–R11, R13)
- 47 GN3 + chapter 99 notes versions (axiom-corpus#568 + the R3/R4/R12 gap close #569)

All versions carry signed Ed25519 ingest manifests (key-id `axiom-corpus-ingest-v1`) and merged with merge commits.

This is the resolution prerequisite for the P4 authority-overlay encoding PRs (forced-labor §301 tier schedule, IEEPA reciprocal country rates, IEEPA fentanyl CA/MX, §232 Russia aluminum) that will cite the newly ingested instruments. Part of the parity campaign on #1190; harness counterpart is axiom-oracles#444.

## Release-cut note

The overlay PRs stacked on this pin will introduce new corpus citations against these versions; every such citation widens the pending `us` release cut on the corresponding citation roots (as flagged on #1190). This PR itself changes no encodings — it only re-pins the corpus checkout used for validation.

## Verification

- Only `.axiom/toolchain.toml` changes (dedicated pin PR; no feature content).
- Target SHA is the axiom-corpus `origin/main` tip (merge commit of #569), verified locally by `git rev-parse origin/main` after fetch.
