### PR TITLE
Pin lane E witness-line corpus successor

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,10 +5,13 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-# US tariff parity lane A feedstock (47 FR tariff instruments, 44 HTS
+# US tariff parity feedstock: lane A (47 FR tariff instruments, 44 HTS
 # revision snapshots for 2025 Basic-R32 and 2026 Basic-R13, 47 GN3 and
-# chapter 99 notes versions) merged by axiom-corpus PRs #560-#569.
-axiom_corpus_ref = "05ce3d3dd21b0ced76f9af40c2ecc02c1c57d9c6"
+# chapter 99 notes versions; axiom-corpus PRs #560-#569) plus lane E
+# witness-line sources (4 HTS witness-line versions for beer/solar
+# lines, Proclamation 10339 pages, Section 338 alcohol annex text
+# renditions; axiom-corpus PR #572).
+axiom_corpus_ref = "ed7d4e4f0ba519dc46d4727527331e02b5a547e9"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
## Summary

Dedicated toolchain-pin PR (#1191/#1193 pattern): bump `axiom_corpus_ref` from the lane A tip `05ce3d3d` (merge of axiom-corpus#569) to the current axiom-corpus main tip `ed7d4e4f` (merge of axiom-corpus#572), which adds the lane E witness-line source feedstock merged 2026-08-03:

- 4 `2026-08-02` USITC HTS witness-line versions (revs 3/4/12/14) carrying the beer 2203.00.00(.30/.60/.90) and solar 8541.42.00(.10/.80)/8541.43.00(.10/.80) line rows with exact rates, units, and footnote lifecycle
- `2026-08-02-tariff-201-solar-proclamation-10339-pages` — page-level text of Proclamation 10339 (87 FR 7357, staged-rate table and note 18 amendments)
- `2026-08-02-tariff-338-alcohol-annex-text-renditions` — page-level text of the Proclamation 11046 Annex I/II White House text renditions (note 51, 9903.03.12/.15/.16), which the Federal Register prints as graphics only

All six versions carry signed Ed25519 ingest manifests (key-id `axiom-corpus-ingest-v1`) and merged with a merge commit after independent review.

This is the resolution prerequisite for the lane E witness-line encoding PR (beer/solar entry lines, §201 staged-rate expiry, §338 alcohol, beer §232-derivative flip, §301 list-3 membership). Part of the parity campaign on #1190; harness counterpart is axiom-oracles#444.

## Release-cut note

The encoding PR stacked on this pin will introduce new corpus citations against these versions; every such citation widens the pending `us` release cut on the corresponding citation roots (as flagged on #1190). This PR itself changes no encodings — it only re-pins the corpus checkout used for validation.

## Verification

- Only `.axiom/toolchain.toml` changes (dedicated pin PR; no feature content).
- Target SHA is the axiom-corpus `origin/main` tip (merge commit of #572), verified locally by `git rev-parse origin/main` after fetch.