### PR TITLE
Add signed encoding manifest for us-sc/manual/dss/snap-policy-manual/page-163

### DIFF
--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-159.json
@@ -1,51 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-159.test.yaml",
-      "sha256": "3ef05ee9d0c4b35499275be9b29201f058df888715f405068b2e898a123e3a9b"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-159.yaml",
+      "sha256": "0f0b1fc2e9e041d30695035fda43e8da097505c90a96f82b2b5628f1d2cd55f4"
     },
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-159.yaml",
-      "sha256": "ac0c3cb1712f9f3688cba7ce1a411f948aad69303bf437ff8eeb06a78be7ad08"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-159.test.yaml",
+      "sha256": "44d9636d719545eb6b62b908427f2c99353ce09d6cc5a716f2bcef9629c31294"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1428",
+    "version_commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-sc:policies/dss/snap-policy-manual/page-159",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T18:23:11.665705+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-159.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
-  "generated_output_sha256": "ac0c3cb1712f9f3688cba7ce1a411f948aad69303bf437ff8eeb06a78be7ad08",
-  "generation_prompt_sha256": null,
-  "manual_exception": "composition",
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1428",
+  "backend": "openai",
+  "citation": "us-sc/manual/dss/snap-policy-manual/page-159",
+  "context_manifest_file": "/home/runner/work/_temp/generated/dependent-2/_eval_workspaces/openai-gpt-5.6-sol/us-sc-manual-dss-snap-policy-manual-page-159/workspace/context-manifest.json",
+  "context_manifest_sha256": "666803bcc299474c0eaa061f734acf71b5b644ccd87904528e67dcc3f877abda",
+  "generated_at": "2026-08-03T16:46:56.104162+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/dependent-2/openai-gpt-5.6-sol/policies/dss/snap-policy-manual/page-159.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/dependent-2",
+  "generated_output_sha256": "0f0b1fc2e9e041d30695035fda43e8da097505c90a96f82b2b5628f1d2cd55f4",
+  "generation_prompt_sha256": "412caf495de9c0fa0a37fc955fd323695bd68542425b25b0b4f22b2a75c76833",
+  "model": "gpt-5.6-sol",
+  "run_id": "840fa26d",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "cfed54519f85a8471ec711434f0fec5669cbbb0637845aa699c22c5c8805ae5e"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "fqbv9h0fpKLzslz8ctCOgOKnD2WrfMYYgs1LxK360pAqx3zKN2pem+wyh5v7obTsGy3HzpUqiVDcIaNyNPH/Ag=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-27T17:15:54.006399+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "fbd6db0ab974ff94b7b50958d0178b13b987255bebae54564a21be2b9e060fde",
-    "prior_signature": "f6f9a77da3cf9609cb5f9b6d4d42d197f90e4a7a27c685f2effb3e151ed4fdc9",
-    "run_id": null,
-    "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-24-snap-cms-pit-union",
+    "corpus_release_content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "corpus_release_selector_sha256": "ff442cae483bca2fe0d94ec0724c02b5157fae0cb2339ebf955d4df1fdf4a3d9",
+    "corpus_source": "local",
+    "expression_date": "2026-01-01",
+    "generation_input_sha256": "631906fbd4b55efa5e9839d73a331782460c4755b0b05bd943ca55e49f56f52f",
+    "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+    "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+    "requested_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-159",
+    "resolved_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-159",
+    "resolved_text_sha256": "631906fbd4b55efa5e9839d73a331782460c4755b0b05bd943ca55e49f56f52f",
+    "row": {
+      "body_sha256": "631906fbd4b55efa5e9839d73a331782460c4755b0b05bd943ca55e49f56f52f",
+      "citation_path": "us-sc/manual/dss/snap-policy-manual/page-159",
+      "document_class": "manual",
+      "expression_date": "2026-01-01",
+      "jurisdiction": "us-sc",
+      "line_number": 160,
+      "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+      "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+      "record_id": "54428e77-42da-5f45-90c5-4289d4479e0d",
+      "source_as_of": "2025-12-30",
+      "source_path": "sources/us-sc/manual/2026-05-27-sc-snap-manual/official-documents/sc-dss-snap-policy-manual-vol-69.pdf",
+      "version": "2026-05-27-sc-snap-manual"
+    },
+    "rulespec_root": "rulespec-us/us-sc",
+    "source_as_of": "2025-12-30",
+    "source_sha256": "631906fbd4b55efa5e9839d73a331782460c4755b0b05bd943ca55e49f56f52f"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/dependent-2/traces/openai-gpt-5.6-sol/us-sc-manual-dss-snap-policy-manual-page-159.json",
+  "trace_sha256": "a7ed3e735c6bf6771a6fd2c219eac15b9fe913c33f90970f2f3dd170d313f055",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1428"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "55a68923d17074a0b38197e4e3584d145f86f6286157c626578b97662e71bce9",
+      "pre_apply_file_count": 749,
+      "rulespec_root": "rulespec-us/us-sc",
+      "toolchain_contract_sha256": "290b4297e789ab7f054f2e47bc447e8ad4c64244a11af81a3e7e688554c84c3f",
+      "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
 }

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-163.json
@@ -1,51 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-163.test.yaml",
-      "sha256": "80d986299f5eefd7f87679533fb04066e0df54fcb7937824977d1ae85a62bc6a"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.yaml",
+      "sha256": "02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318"
     },
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-163.yaml",
-      "sha256": "c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-163.test.yaml",
+      "sha256": "881f2507d064c66a8de9e10e02e798039a9f5c3c6528a3193f281933114438c4"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1428",
+    "version_commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-sc:policies/dss/snap-policy-manual/page-163",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T18:23:11.666800+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-163.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
-  "generated_output_sha256": "c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29",
-  "generation_prompt_sha256": null,
-  "manual_exception": "composition",
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1428",
+  "backend": "openai",
+  "citation": "us-sc/manual/dss/snap-policy-manual/page-163",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-sc-manual-dss-snap-policy-manual-page-163/workspace/context-manifest.json",
+  "context_manifest_sha256": "19365021dee2976cc00b89dc45dd5156a12223661c41c8efdcc296373cc0e76f",
+  "generated_at": "2026-08-03T16:32:58.004727+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/policies/dss/snap-policy-manual/page-163.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318",
+  "generation_prompt_sha256": "0bfd6405a6f1d104810fccce7c680347f6005ead0bb2bcad3616004ad0334930",
+  "model": "gpt-5.6-sol",
+  "run_id": "b7f1d481",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "5f03c4ded6893dc197e3901b73efde78971cfa53d8d63c45597dacff44d565b1"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "b3HaPNVhhZJzlxdwFY11KWlX1Zsf0sS+PsxlQa/SuoKYMJFaPXIo4s6PC9qlCamUVktpL1WLa0N1df6v20w2Dw=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-27T17:15:54.012616+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "2167974aa281aa8d6bad1694ea126468da6b03ca7f60307b82b10f9457fd0c1d",
-    "prior_signature": "cf9a1ff88a3b4ef5b3665cca582ffe5b4ab3770c298a430b00f87ae5dc55c676",
-    "run_id": null,
-    "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-24-snap-cms-pit-union",
+    "corpus_release_content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "corpus_release_selector_sha256": "ff442cae483bca2fe0d94ec0724c02b5157fae0cb2339ebf955d4df1fdf4a3d9",
+    "corpus_source": "local",
+    "expression_date": "2026-01-01",
+    "generation_input_sha256": "eb3408ac6f1bdfc79468280396b35cd0e7c8c30bb8750d18915214beb5a465ab",
+    "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+    "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+    "requested_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-163",
+    "resolved_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-163",
+    "resolved_text_sha256": "eb3408ac6f1bdfc79468280396b35cd0e7c8c30bb8750d18915214beb5a465ab",
+    "row": {
+      "body_sha256": "eb3408ac6f1bdfc79468280396b35cd0e7c8c30bb8750d18915214beb5a465ab",
+      "citation_path": "us-sc/manual/dss/snap-policy-manual/page-163",
+      "document_class": "manual",
+      "expression_date": "2026-01-01",
+      "jurisdiction": "us-sc",
+      "line_number": 164,
+      "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+      "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+      "record_id": "e5dac343-0f44-56f2-951f-3d6a8d806e9f",
+      "source_as_of": "2025-12-30",
+      "source_path": "sources/us-sc/manual/2026-05-27-sc-snap-manual/official-documents/sc-dss-snap-policy-manual-vol-69.pdf",
+      "version": "2026-05-27-sc-snap-manual"
+    },
+    "rulespec_root": "rulespec-us/us-sc",
+    "source_as_of": "2025-12-30",
+    "source_sha256": "eb3408ac6f1bdfc79468280396b35cd0e7c8c30bb8750d18915214beb5a465ab"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-sc-manual-dss-snap-policy-manual-page-163.json",
+  "trace_sha256": "80d11d7627b06bfc080df2b11197a134acbf1156b286f183102e3ff4859b4d68",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1428"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "02a5240e3f7d0739e085192ff348770dc6fb82ae24c860df2ab3bfaf8504052c",
+      "pre_apply_file_count": 749,
+      "rulespec_root": "rulespec-us/us-sc",
+      "toolchain_contract_sha256": "290b4297e789ab7f054f2e47bc447e8ad4c64244a11af81a3e7e688554c84c3f",
+      "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
 }

--- a/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
+++ b/.axiom/encoding-manifests/us-sc/policies/dss/snap-policy-manual/page-165.json
@@ -1,51 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-165.test.yaml",
-      "sha256": "d7079aeece02315ad0ba61533072e4e65bcc1f0a0833f41db8cb4758eb131924"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.yaml",
+      "sha256": "b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5"
     },
     {
-      "path": "us-sc/policies/dss/snap-policy-manual/page-165.yaml",
-      "sha256": "072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e"
+      "path": "us-sc/policies/dss/snap-policy-manual/page-165.test.yaml",
+      "sha256": "8e11ccbedb5c32ce0cab5cfbca727bd024160f4ef639d458a5d89e3b9fb78914"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-782-pinned",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1428",
+    "version_commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-sc:policies/dss/snap-policy-manual/page-165",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-27T18:23:11.667306+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj/sign-applied-files/us-sc/policies/dss/snap-policy-manual/page-165.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmplelq9lpj",
-  "generated_output_sha256": "072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e",
-  "generation_prompt_sha256": null,
-  "manual_exception": "composition",
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1428",
+  "backend": "openai",
+  "citation": "us-sc/manual/dss/snap-policy-manual/page-165",
+  "context_manifest_file": "/home/runner/work/_temp/generated/dependent/_eval_workspaces/openai-gpt-5.6-terra/us-sc-manual-dss-snap-policy-manual-page-165/workspace/context-manifest.json",
+  "context_manifest_sha256": "6b9bd5fb935f49a850567146bceec9182027d6b445c4fe431186f3ac43a304b8",
+  "generated_at": "2026-08-03T16:35:34.994779+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/dependent/openai-gpt-5.6-terra/policies/dss/snap-policy-manual/page-165.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/dependent",
+  "generated_output_sha256": "b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5",
+  "generation_prompt_sha256": "c70b631f8e421646a9e789bdc3506037d02f86e1e2e3d913e444a9aa8d621413",
+  "model": "gpt-5.6-terra",
+  "run_id": "b8b6adee",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "edbe1515b4ab641a1462ccc916073d91f36d6accfd59ee7cf9b062ebabaf6b0a"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "nrpKWkdqJZ0N5atSi/IHhEtoF9KL0MK/PQgs8b32tC8nk8gDY2p/Oir1eEGvadPdhoeqqeJ2rm9LIH/1ar1JDw=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-27T17:15:54.013666+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "988b4315af775eff35141ac4e7c66dded62e47a4a0ee673bd52a4d07207f71bc",
-    "prior_signature": "4b42eaa4f2150c94ee01c1ff4b28a5011e1b1cde7bd861830ecee1f79c38d145",
-    "run_id": null,
-    "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-24-snap-cms-pit-union",
+    "corpus_release_content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "corpus_release_selector_sha256": "ff442cae483bca2fe0d94ec0724c02b5157fae0cb2339ebf955d4df1fdf4a3d9",
+    "corpus_source": "local",
+    "expression_date": "2026-01-01",
+    "generation_input_sha256": "cd1ac04bf8956dd17aac5420ac0e99fb1fb89ebffd8e12e59afddb296c06d8be",
+    "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+    "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+    "requested_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-165",
+    "resolved_corpus_citation_path": "us-sc/manual/dss/snap-policy-manual/page-165",
+    "resolved_text_sha256": "cd1ac04bf8956dd17aac5420ac0e99fb1fb89ebffd8e12e59afddb296c06d8be",
+    "row": {
+      "body_sha256": "cd1ac04bf8956dd17aac5420ac0e99fb1fb89ebffd8e12e59afddb296c06d8be",
+      "citation_path": "us-sc/manual/dss/snap-policy-manual/page-165",
+      "document_class": "manual",
+      "expression_date": "2026-01-01",
+      "jurisdiction": "us-sc",
+      "line_number": 166,
+      "provision_file": "data/corpus/provisions/us-sc/manual/2026-05-27-sc-snap-manual.jsonl",
+      "provision_file_sha256": "c21539d472ea105695da5e007b24839b5f4e8cea9f4e6066a933e6d3817a8e13",
+      "record_id": "6661957c-9fd7-5334-8850-b85fcd9e1c3e",
+      "source_as_of": "2025-12-30",
+      "source_path": "sources/us-sc/manual/2026-05-27-sc-snap-manual/official-documents/sc-dss-snap-policy-manual-vol-69.pdf",
+      "version": "2026-05-27-sc-snap-manual"
+    },
+    "rulespec_root": "rulespec-us/us-sc",
+    "source_as_of": "2025-12-30",
+    "source_sha256": "cd1ac04bf8956dd17aac5420ac0e99fb1fb89ebffd8e12e59afddb296c06d8be"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/dependent/traces/openai-gpt-5.6-terra/us-sc-manual-dss-snap-policy-manual-page-165.json",
+  "trace_sha256": "246baf6c69c4c41e65d2b9ac52d8cce6c3e6da0b2ac21279de795c0c5dea99aa",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1428"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "1c4d8478382256620d9662a0ceb7ee7553b673c04a7b3ed1be8466a8a37cb8e1",
+      "pre_apply_file_count": 749,
+      "rulespec_root": "rulespec-us/us-sc",
+      "toolchain_contract_sha256": "290b4297e789ab7f054f2e47bc447e8ad4c64244a11af81a3e7e688554c84c3f",
+      "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
 }

--- a/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.test.yaml
@@ -1,380 +1,256 @@
-- name: current_monthly_utility_allowance_amounts
-  period: 2026-01
-  input: {}
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-159#mandatory_utility_allowance_amount: 388
-    us-sc:policies/dss/snap-policy-manual/page-159#basic_utility_allowance_amount: 265
-    us-sc:policies/dss/snap-policy-manual/page-159#telephone_allowance_amount: 27
-
-- name: heating_cost_household_receives_mua
+- name: mandatory_utility_allowance_selected
   period: 2026-01
   input:
-    <<: &constant_inputs
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : true
   output:
-    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
-
-- name: two_non_heating_utilities_receive_bua
+- name: basic_utility_allowance_selected
   period: 2026-01
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 265
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 265
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 265
-
-- name: coherent_telephone_only_household_receives_telephone_allowance
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
-    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 27
     us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 27
-
-- name: shared_residence_disagreement_blocks_mua_assignment
+- name: telephone_only_allowance_selected
   period: 2026-01
   input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: shared_residence_disagreement_blocks_bua_assignment
-  period: 2026-01
-  input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: shared_residence_disagreement_blocks_actual_and_telephone_assignment
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: household_without_qualifying_utility_cost_receives_no_allowance
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-369#snap_individual_utility_allowance_state_value: 33
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: mua_wins_when_mua_and_bua_raw_prerequisites_overlap
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27
+- name: no_utility_allowance_selected
   period: 2026-01
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
-
-- name: bua_without_submitted_verification_receives_no_allowance
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: bua_raw_prerequisites_with_utilities_in_rent_receive_no_allowance
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: telephone_only_without_verified_actual_cost_receives_no_allowance
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
-
-- name: state_energy_assistance_basis_receives_mua
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 388
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 388
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 388
-
-- name: supplemental_heating_source_without_liheap_receives_no_mua
-  period: 2026-01
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value: 0
-    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 0
-    us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value: 0
+    us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value: 27
+    us-sc:policies/dss/snap-policy-manual/page-159#local_snap_utility_allowance_for_shelter_costs: 27

--- a/us-sc/policies/dss/snap-policy-manual/page-159.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-159.yaml
@@ -4,272 +4,247 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
-    upstream_source_check:
-      status: delegated_parameter_source
-      checked_paths:
-        - us:regulations/7-cfr/273/9
-        - us:regulations/7-cfr/273/9/d/6/iii
-      rationale: |-
-        7 CFR 273.9(d)(6)(iii) delegates utility standards to state agencies
-        and supplies the federal standard, limited, and individual allowance
-        hooks. South Carolina SNAP Manual page 159 is the current state source
-        for the MUA, BUA, and telephone amounts.
-  summary: |-
-    South Carolina's current monthly SNAP utility standards are $388 for the
-    Mandatory Utility Allowance, $265 for the Basic Utility Allowance, and $27
-    for the telephone allowance. The household receives at most one: MUA,
-    otherwise verified BUA, otherwise the verified telephone-only standard.
-    The current setters supersede page 369's historical September 2009
-    utility-standard setters when both pages are composed.
+    source_sha256: 631906fbd4b55efa5e9839d73a331782460c4755b0b05bd943ca55e49f56f52f
+  summary: '“$388 Mandatory utility allowance (MUA)”; “$265 Basic utility allowance
+
+    (BUA)”; and “$27 Telephone allowance.” Required verification must be
+
+    provided before a deduction can be given.'
 imports:
-  - us:regulations/7-cfr/273/9
-  - us-sc:policies/dss/snap-policy-manual/page-163
-  - us-sc:policies/dss/snap-policy-manual/page-165
-  - us-sc:policies/dss/snap-policy-manual/page-369
+- us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+- us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+- us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
+- us:regulations/7-cfr/273/9
 rules:
-  - name: sets_sc_current_snap_standard_utility_allowance
-    kind: source_relation
-    source: SNAP Manual page 159, mandatory utility allowance
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-      authority: state
-      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_sc_current_snap_standard_utility_allowance
+  kind: source_relation
+  source: SNAP Manual page 159, Section 12.1(D)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    authority: state
+    value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_sc_current_snap_limited_utility_allowance
+  kind: source_relation
+  source: SNAP Manual page 159, Section 12.1(E)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
+    authority: state
+    value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: sets_sc_current_snap_individual_utility_allowance
+  kind: source_relation
+  source: SNAP Manual page 159, Section 12.1(F)
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+    authority: state
+    value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: mandatory_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $388 Mandatory utility allowance (MUA)
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '388'
+- name: basic_utility_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $265 Basic utility allowance (BUA)
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '265'
+- name: telephone_allowance_amount
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $27 Telephone allowance
+  versions:
+  - effective_from: '2026-01-01'
+    formula: '27'
+- name: sc_current_snap_standard_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $388 Mandatory utility allowance (MUA)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#mandatory_utility_allowance_amount
+          output: mandatory_utility_allowance_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+          output: multiple_utility_allowance_entitlement
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if multiple_utility_allowance_entitlement: mandatory_utility_allowance_amount
+      else: 0'
+- name: sc_current_snap_limited_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $265 Basic utility allowance (BUA)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#basic_utility_allowance_amount
+          output: basic_utility_allowance_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+          output: basic_utility_allowance_entitlement
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+          output: multiple_utility_allowance_entitlement
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+  versions:
+  - effective_from: '2026-01-01'
+    formula: "if multiple_utility_allowance_entitlement:\n  0\nelse:\n  if basic_utility_allowance_entitlement:\n\
+      \    basic_utility_allowance_amount\n  else:\n    0"
+- name: sc_current_snap_individual_utility_allowance_state_value
+  kind: derived
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Section 12.1(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+          excerpt: $27 Telephone allowance
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#telephone_allowance_amount
+          output: telephone_allowance_amount
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
+          output: multiple_utility_allowance_entitlement
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
+          output: basic_utility_allowance_entitlement
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
+          output: household_entitled_to_telephone_only_standard
+          hash: sha256:b1164cfb6bae482711b4ae77d9a3c568ad2dc567a950b0005b55e06e01d851c5
+  versions:
+  - effective_from: '2026-01-01'
+    formula: "if multiple_utility_allowance_entitlement:\n  0\nelse:\n  if basic_utility_allowance_entitlement:\n\
+      \    0\n  else:\n    if household_entitled_to_telephone_only_standard:\n   \
+      \   telephone_allowance_amount\n    else:\n      0"
+- name: local_snap_utility_allowance_for_shelter_costs
+  kind: derived
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual page 159, Sections 12.1(D)-(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
+          output: sc_current_snap_standard_utility_allowance_state_value
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
+          output: sc_current_snap_limited_utility_allowance_state_value
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
+          output: sc_current_snap_individual_utility_allowance_state_value
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'sc_current_snap_standard_utility_allowance_state_value
 
-  - name: sets_sc_current_snap_limited_utility_allowance
-    kind: source_relation
-    source: SNAP Manual page 159, basic utility allowance
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option
-      authority: state
-      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+      + sc_current_snap_limited_utility_allowance_state_value
 
-  - name: sets_sc_current_snap_individual_utility_allowance
-    kind: source_relation
-    source: SNAP Manual page 159, telephone allowance
-    source_relation:
-      type: sets
-      target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
-      authority: state
-      value: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
-      basis:
-        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-
-  - name: mandatory_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(D)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
-              excerpt: "$388 Mandatory utility allowance (MUA)"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          388
-
-  - name: basic_utility_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(E)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
-              excerpt: "$265 Basic utility allowance (BUA)"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          265
-
-  - name: telephone_allowance_amount
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(F)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-159
-              excerpt: "$27 Telephone allowance"
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          27
-
-  - name: sc_current_snap_standard_utility_allowance_state_value
-    kind: derived
-    entity: Household
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(D)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#mandatory_utility_allowance_amount
-              output: mandatory_utility_allowance_amount
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
-              output: multiple_utility_allowance_entitlement
-              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          if multiple_utility_allowance_entitlement:
-            mandatory_utility_allowance_amount
-          else:
-            0
-
-  - name: sc_current_snap_limited_utility_allowance_state_value
-    kind: derived
-    entity: Household
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(E)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#basic_utility_allowance_amount
-              output: basic_utility_allowance_amount
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
-              output: basic_utility_allowance_entitlement
-              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed
-              output: household_basic_utility_allowance_deduction_allowed
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          if (
-            not household_entitled_to_mandatory_utility_allowance
-            and basic_utility_allowance_entitlement
-            and household_basic_utility_allowance_deduction_allowed
-          ):
-            basic_utility_allowance_amount
-          else:
-            0
-
-  - name: sc_current_snap_individual_utility_allowance_state_value
-    kind: derived
-    entity: Household
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Section 12.1(F)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#telephone_allowance_amount
-              output: telephone_allowance_amount
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
-              output: basic_utility_allowance_entitlement
-              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard
-              output: household_entitled_to_telephone_only_standard
-              hash: sha256:072ff5be167fe30d2ae6e4c762281fa39a8974150bc3f5e91e65ecb7423dd30e
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          if (
-            not household_entitled_to_mandatory_utility_allowance
-            and not basic_utility_allowance_entitlement
-            and household_entitled_to_telephone_only_standard
-          ):
-            telephone_allowance_amount
-          else:
-            0
-
-  - name: local_snap_utility_allowance_for_shelter_costs
-    kind: derived
-    entity: Household
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual page 159, Sections 12.1(D)-(F)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_standard_utility_allowance_state_value
-              output: sc_current_snap_standard_utility_allowance_state_value
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_limited_utility_allowance_state_value
-              output: sc_current_snap_limited_utility_allowance_state_value
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-159#sc_current_snap_individual_utility_allowance_state_value
-              output: sc_current_snap_individual_utility_allowance_state_value
-              hash: sha256:local
-    versions:
-      - effective_from: '2026-01-01'
-        formula: |-
-          sc_current_snap_standard_utility_allowance_state_value
-          + sc_current_snap_limited_utility_allowance_state_value
-          + sc_current_snap_individual_utility_allowance_state_value
+      + sc_current_snap_individual_utility_allowance_state_value'

--- a/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.test.yaml
@@ -1,312 +1,234 @@
-- name: heating_cost_entitles_household_to_mua
+- name: separately_billed_heating_cost_assigns_mua
   period: 2026-05
   input:
-    <<: &constant_inputs
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
-
-- name: liheap_payment_over_threshold_entitles_household_to_mua
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_mandatory_utility_allowance_assigned: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_utility_allowance_change_permitted: holds
+- name: liheap_payment_over_threshold_assigns_mua
   period: 2026-05
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 24
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 12
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : true
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua: 20
     us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
-
-- name: page_164_bua_prerequisite_and_verification_allow_bua_deduction
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_mandatory_utility_allowance_assigned: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_utility_allowance_change_permitted: holds
+- name: verified_bua_is_assigned_and_allowed
   period: 2026-05
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : true
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
-
-- name: actual_verified_cost_applies_only_without_mua_or_bua
+    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_basic_utility_allowance_assigned: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_actual_utility_cost_allowance_assigned: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_no_utility_deduction_assigned: not_holds
+- name: verified_actual_cost_is_assigned_when_no_mua_or_bua
   period: 2026-05
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: holds
     us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
-
-- name: mua_precedence_blocks_simultaneous_bua_and_actual_allowances
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_actual_utility_cost_allowance_assigned: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_no_utility_deduction_assigned: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_utility_allowance_change_permitted: holds
+- name: missing_verification_results_in_no_utility_deduction
   period: 2026-05
   input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_basic_utility_allowance_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
-
-- name: state_energy_assistance_basis_entitles_household_to_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
-
-- name: supplemental_heating_source_does_not_establish_mua_without_liheap
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: true
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
-    us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
-
-- name: actual_cost_signal_without_submitted_verification_is_not_allowed
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
-
-- name: next_season_heating_cost_separate_from_rent_entitles_household_to_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-
-- name: cooling_cost_incurred_during_year_separate_from_rent_entitles_household_to_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-
-- name: next_season_cooling_cost_separate_from_rent_entitles_household_to_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: holds
-
-- name: stale_incurred_heating_cost_outside_year_does_not_establish_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
-
-- name: next_season_heating_cost_included_in_rent_does_not_establish_mua
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: true
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
   output:
-    us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_actual_utility_cost_allowance_assigned: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_initial_no_utility_deduction_assigned: holds
+    us-sc:policies/dss/snap-policy-manual/page-163#household_utility_allowance_change_permitted: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-163.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-163.yaml
@@ -4,239 +4,428 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-    upstream_source_check:
-      status: checked_higher_authority
-      checked_paths:
-        - us:regulations/7-cfr/273/9
-        - us:regulations/7-cfr/273/9/d/6/iii
-      rationale: |-
-        7 CFR 273.9(d)(6)(iii) permits state utility standards, requires at
-        least two utilities for a limited allowance, and prevents overlapping
-        standards for the same expense. This page supplies South Carolina's
-        one-allowance assignment and MUA prerequisites under that authority.
-  summary: |-
-    At initial certification, a household is assigned one utility allowance:
-    actual verified utility cost only if it is not entitled to MUA or BUA,
-    MUA if entitled, BUA if entitled, or no utility deduction. MUA applies
-    when, separately from rent or mortgage, the household incurs and is billed
-    during the year for, or expects to incur during the next season, heating
-    or cooling costs; or when it received a LIHEAP payment greater than $20 in
-    the prior 12 months. Page 164's additional state
-    energy-assistance, rental, and public-housing bases and its MUA exclusions
-    also govern the final entitlement. Actual costs and BUA deductions require
-    submitted verification.
+    source_sha256: eb3408ac6f1bdfc79468280396b35cd0e7c8c30bb8750d18915214beb5a465ab
+  summary: 'At initial certification, a household will be assigned actual verified
+
+    utility cost if not entitled to MUA or BUA, MUA if entitled, BUA if
+
+    entitled, or no utility deduction. An allowance may change at
+
+    recertification, when the household moves, or at the 12-month interim
+
+    contact for a 24-month certification. Actual costs and BUA require
+
+    submitted verification. MUA requires separately incurred and billed or
+
+    expected heating or cooling costs, or a LIHEAP payment greater than $20
+
+    within the past 12 months.'
 imports:
-  - us-sc:policies/dss/snap-policy-manual/page-164
+- us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua
+- us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap
+- us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
 rules:
-  - name: liheap_payment_threshold_for_mua
-    kind: parameter
-    dtype: Money
-    unit: USD
-    period: Month
-    source: SNAP Manual 12.5(2)(B)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-              excerpt: "LIHEAP payment greater than $20 within the past 12 months"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          20
+- name: liheap_payment_threshold_for_mua
+  kind: parameter
+  dtype: Money
+  unit: USD
+  period: Month
+  source: SNAP Manual 12.5(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: '(2) Mandatory Utility Allowance (MUA) To be entitled to the MUA,
+            the following criteria must be met: (A) During the year, separately from
+            their rent or mortgage, the households must incur and be billed for, or
+            expect to incur during the next heating or cooling season: • Heating cost
+            • Cooling cost (air conditioning) or (B) The household must have received
+            a Low-Income Home Energy Assistance Program (LIHEAP) payment greater than
+            $20 within the past 12 months, regardless of whether or'
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '20'
+- name: long_certification_period_months
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Manual 12.5(1), allowance changes
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: 24-month certification period
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '24'
+- name: long_certification_interim_contact_month
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Manual 12.5(1), allowance changes
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: 12- month interim contact
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '12'
+- name: household_has_mua_heating_or_cooling_cost
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: separately from their rent or mortgage
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: incur and be billed for, or expect to incur
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage\n\
+      and (\n  (\n    household_incurred_heating_or_cooling_cost_during_year\n   \
+      \ and (\n      household_incurred_and_billed_separately_for_heating_cost\n \
+      \     or household_incurred_and_billed_separately_for_cooling_cost\n    )\n\
+      \  )\n  or household_expects_to_incur_heating_cost_next_heating_or_cooling_season\n\
+      \  or household_expects_to_incur_cooling_cost_next_heating_or_cooling_season\n\
+      )"
+- name: household_received_mua_qualifying_liheap_payment
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: within the past 12 months
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua
+          output: liheap_payment_threshold_for_mua
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_received_liheap_payment_within_past_12_months
 
-  - name: household_has_mua_heating_or_cooling_cost
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(2)(A)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-              excerpt: "During the year, separately from their rent or mortgage, the households must incur and be billed for, or expect to incur during the next heating or cooling season:"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage
-          and (
-            (
-              household_incurred_heating_or_cooling_cost_during_year
-              and (
-                household_incurred_and_billed_separately_for_heating_cost
-                or household_incurred_and_billed_separately_for_cooling_cost
-              )
-            )
-            or household_expects_to_incur_heating_cost_next_heating_or_cooling_season
-            or household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
-          )
+      and household_liheap_payment_amount > liheap_payment_threshold_for_mua'
+- name: household_entitled_to_mandatory_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: To be entitled to the MUA, the following criteria must be met
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost
+          output: household_has_mua_heating_or_cooling_cost
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment
+          output: household_received_mua_qualifying_liheap_payment
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua
+          output: household_may_receive_mua
+          hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap
+          output: household_barred_from_mua_unless_liheap
+          hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "household_received_mua_qualifying_liheap_payment\nor (\n  (\n    household_has_mua_heating_or_cooling_cost\n\
+      \    or household_may_receive_mua\n  )\n  and not household_barred_from_mua_unless_liheap\n\
+      )"
+- name: household_entitled_to_basic_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: Basic utility allowance (BUA) if entitled
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
+          output: household_may_receive_bua
+          hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_may_receive_bua
 
-  - name: household_received_mua_qualifying_liheap_payment
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(2)(B)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-              excerpt: "LIHEAP payment greater than $20 within the past 12 months"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#liheap_payment_threshold_for_mua
-              output: liheap_payment_threshold_for_mua
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_received_liheap_payment_within_past_12_months
-          and household_liheap_payment_amount > liheap_payment_threshold_for_mua
+      and not household_entitled_to_mandatory_utility_allowance'
+- name: household_actual_verified_utility_cost_allowance_applies
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(A) and verification note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: Actual verified utility cost, if not entitled to the MUA or BUA
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: verification is not submitted, the deduction cannot be allowed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_has_actual_utility_cost
 
-  - name: household_entitled_to_mandatory_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_has_mua_heating_or_cooling_cost
-              output: household_has_mua_heating_or_cooling_cost
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_received_mua_qualifying_liheap_payment
-              output: household_received_mua_qualifying_liheap_payment
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_mua
-              output: household_may_receive_mua
-              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-164#household_barred_from_mua_unless_liheap
-              output: household_barred_from_mua_unless_liheap
-              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_received_mua_qualifying_liheap_payment
-          or (
-            (
-              household_has_mua_heating_or_cooling_cost
-              or household_may_receive_mua
-            )
-            and not household_barred_from_mua_unless_liheap
-          )
+      and household_submitted_utility_verification
 
-  - name: household_entitled_to_basic_utility_allowance
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(1), 12.5(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-164#household_may_receive_bua
-              output: household_may_receive_bua
-              hash: sha256:2819a796f6eca5befc1a254032f5cd7f7aba9097e4356026f4c1928bdb129a70
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_may_receive_bua
-          and not household_entitled_to_mandatory_utility_allowance
+      and not household_entitled_to_mandatory_utility_allowance
 
-  - name: household_actual_verified_utility_cost_allowance_applies
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(1)(A)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
-              output: household_entitled_to_basic_utility_allowance
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_has_actual_verified_utility_cost
-          and household_submitted_utility_verification
-          and not household_entitled_to_mandatory_utility_allowance
-          and not household_entitled_to_basic_utility_allowance
+      and not household_entitled_to_basic_utility_allowance'
+- name: household_basic_utility_allowance_deduction_allowed
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1), verification note
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: If actual utility costs or the BUA is assigned
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: verification is not submitted, the deduction cannot be allowed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_entitled_to_basic_utility_allowance
 
-  - name: household_basic_utility_allowance_deduction_allowed
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual 12.5(1), Note
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
-              output: household_entitled_to_basic_utility_allowance
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_entitled_to_basic_utility_allowance
-          and household_submitted_utility_verification
+      and household_submitted_utility_verification'
+- name: household_initial_mandatory_utility_allowance_assigned
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: Mandatory utility allowance (MUA) if entitled
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_is_at_initial_certification
+
+      and household_entitled_to_mandatory_utility_allowance'
+- name: household_initial_basic_utility_allowance_assigned
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: Basic utility allowance (BUA) if entitled
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_is_at_initial_certification
+
+      and household_entitled_to_basic_utility_allowance'
+- name: household_initial_actual_utility_cost_allowance_assigned
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: Actual verified utility cost, if not entitled to the MUA or BUA
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies
+          output: household_actual_verified_utility_cost_allowance_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_is_at_initial_certification
+
+      and household_actual_verified_utility_cost_allowance_applies'
+- name: household_initial_no_utility_deduction_assigned
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: default
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: No utility deduction
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies
+          output: household_actual_verified_utility_cost_allowance_applies
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_is_at_initial_certification
+
+      and not household_entitled_to_mandatory_utility_allowance
+
+      and not household_entitled_to_basic_utility_allowance
+
+      and not household_actual_verified_utility_cost_allowance_applies'
+- name: household_utility_allowance_change_permitted
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual 12.5(1), allowance changes
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: changed at recertification or when the household moves
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-163
+          excerpt: 24-month certification period at the 12- month interim contact
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#long_certification_period_months
+          output: long_certification_period_months
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#long_certification_interim_contact_month
+          output: long_certification_interim_contact_month
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "household_is_at_recertification\nor household_has_moved\nor (\n  household_certification_period_months\
+      \ == long_certification_period_months\n  and household_interim_contact_month\
+      \ == long_certification_interim_contact_month\n)"

--- a/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.test.yaml
@@ -1,222 +1,312 @@
-- name: two_non_heating_utilities_receive_bua_and_block_actual_costs
+- name: actual_telephone_standard_allowed_when_no_mua_or_bua_entitlement
   period: 2026-05
   input:
-    <<: &constant_inputs
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season: false
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
-      us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage: false
-      us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
-      us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
-
-- name: coherent_telephone_only_household_receives_telephone_standard
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
     us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
     us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: holds
-
-- name: telephone_charge_must_be_anticipated_to_continue
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
+- name: bua_entitlement_with_covered_costs_and_agreement
   period: 2026-05
   input:
-    <<: *constant_inputs
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
     us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-
-- name: mua_precedence_blocks_bua_actual_and_telephone_allowances
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 25
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : true
     us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: true
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
     us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : true
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
+- name: bua_prohibited_when_utility_costs_are_included_in_rent
+  period: 2026-05
+  input:
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
     us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: not_holds
+- name: same_residence_without_agreement_blocks_allowances
+  period: 2026-05
+  input:
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_sewerage_expense: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_garbage_or_trash_collection_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_well_or_septic_tank_installation_or_maintenance_expense: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+    : true
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_heating_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_cooking_fuel: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_sewerage: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_electricity: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_garbage_or_trash_collection: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_utility_installation_fee: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-165#input.all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+    : false
+  output:
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_covered_cost_exists: holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
+    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: not_holds
+- name: auto_positive_multiple_utility_allowance_entitlement
+  period:
+    period_kind: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_heating_or_cooling_cost_is_separate_from_rent_or_mortgage: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_heating_or_cooling_cost_during_year: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_cooling_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_heating_cost_next_heating_or_cooling_season
+    : false
+    ? us-sc:policies/dss/snap-policy-manual/page-163#input.household_expects_to_incur_cooling_cost_next_heating_or_cooling_season
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_received_liheap_within_previous_12_months: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_hud_utility_payment_or_fmha_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurs_heating_or_cooling_costs_exceeding_utility_payment: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_in_private_rental_housing: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_by_landlord_based_on_individual_usage: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_flat_utility_rate_separately_from_rent: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_other_than_liheap_excluded_as_income
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_expense_exceeds_energy_assistance_amount: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_receives_energy_assistance_counted_as_income: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_resides_in_public_housing_unit_with_central_utility_meters: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_charged_only_for_excess_heating_or_cooling_costs: false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_no_utility_expenses: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_primary_heating_or_cooling_cost_included_in_rent_or_mortgage
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_uses_only_supplemental_heating_source_for_utility_cost: false
+    ? us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost
+    : false
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_utility_cost: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_initial_certification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_is_at_recertification: true
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_moved: false
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_certification_period_months: 6
+    us-sc:policies/dss/snap-policy-manual/page-163#input.household_interim_contact_month: 0
+    us-sc:policies/dss/snap-policy-manual/page-164#input.household_has_occupied_home_and_unoccupied_home: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual: false
+    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
   output:
     us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-
-- name: utilities_in_rent_receive_no_allowance_and_shared_cost_rules_remain
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: true
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#mua_or_bua_not_prorated: holds
-
-- name: telephone_only_household_without_verified_actual_cost_gets_no_standard
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds
-
-- name: utility_in_rent_does_not_block_separate_verified_actual_water_cost
-  period: 2026-05
-  input:
-    <<: *constant_inputs
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_incurred_and_billed_separately_for_heating_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_received_liheap_payment_within_past_12_months: false
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_liheap_payment_amount: 0
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_has_actual_verified_utility_cost: true
-    us-sc:policies/dss/snap-policy-manual/page-163#input.household_submitted_utility_verification: true
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_billed_for_some_utilities_but_not_incurring_heating_or_cooling_cost: false
-    us-sc:policies/dss/snap-policy-manual/page-164#input.household_incurred_and_billed_for_at_least_two_bua_utilities: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_water_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_telephone_expense: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_has_one_or_no_utility_expenses: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_utility_costs_included_in_rent_payment: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_water: true
-    us-sc:policies/dss/snap-policy-manual/page-165#input.claimed_utility_is_state_standard_for_telephone: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.multiple_households_live_in_same_residence: false
-    us-sc:policies/dss/snap-policy-manual/page-165#input.household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household: false
-  output:
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement: not_holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed: holds
-    us-sc:policies/dss/snap-policy-manual/page-165#household_entitled_to_telephone_only_standard: not_holds

--- a/us-sc/policies/dss/snap-policy-manual/page-165.yaml
+++ b/us-sc/policies/dss/snap-policy-manual/page-165.yaml
@@ -4,275 +4,288 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-    upstream_source_check:
-      status: checked_higher_authority
-      checked_paths:
-        - us:regulations/7-cfr/273/9
-        - us:regulations/7-cfr/273/9/d/6/iii
-      rationale: |-
-        7 CFR 273.9(d)(6)(ii)(C) recognizes recurring telephone service as
-        an allowable utility cost, while paragraph (d)(6)(iii) controls state
-        standards and prevents overlapping standards. This page supplies South
-        Carolina's BUA exclusions and actual/telephone verification rules.
-  summary: |-
-    BUA is not given to households with one or no utility expenses or whose
-    utility costs are included in rent, and these exclusions govern the final
-    BUA entitlement. Actual utility costs are deductible only when the
-    household is not entitled to MUA or BUA, submitted verification supports
-    an actual cost, and claimed charges are reasonably anticipated to continue
-    during the certification period. A telephone-only household may receive
-    South Carolina's telephone standard on that verified actual-cost path.
-    Shared-residence households must agree on the allowance type, and MUA or
-    BUA is not prorated in the listed shared-cost circumstances.
+    source_sha256: cd1ac04bf8956dd17aac5420ac0e99fb1fb89ebffd8e12e59afddb296c06d8be
+  summary: '"The BUA must not be given" to households with one or no utility expenses
+    or
+
+    whose utility costs are included in rent. "Actual utility costs are only
+
+    allowed for households not entitled to the MUA or BUA." Multiple households
+
+    in the same residence "must agree on the type of utility allowance."'
 imports:
-  - us-sc:policies/dss/snap-policy-manual/page-163
+- us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+- us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
 rules:
-  - name: basic_utility_allowance_covered_cost_exists
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, BUA utility expenses
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_has_water_expense
-          or household_has_sewerage_expense
-          or household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
-          or household_has_garbage_or_trash_collection_expense
-          or household_has_well_or_septic_tank_installation_or_maintenance_expense
-          or household_has_telephone_expense
+- name: basic_utility_allowance_covered_cost_exists
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, BUA utility expenses
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: Water • Sewerage • Electricity (for purposes other than heating
+            or cooling) • Garbage and/or trash collection • Well and septic tank installation
+            and maintenance • Telephone
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_has_water_expense
 
-  - name: basic_utility_allowance_prohibited
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, BUA households excluded
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: exception
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_has_one_or_no_utility_expenses
-          or household_utility_costs_included_in_rent_payment
+      or household_has_sewerage_expense
 
-  - name: basic_utility_allowance_entitlement
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, BUA entitlement and exclusions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
-              output: household_entitled_to_basic_utility_allowance
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited
-              output: basic_utility_allowance_prohibited
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
-              output: same_residence_utility_allowance_agreement_requirement_satisfied
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_entitled_to_basic_utility_allowance
-          and not basic_utility_allowance_prohibited
-          and same_residence_utility_allowance_agreement_requirement_satisfied
+      or household_has_electricity_expense_for_purposes_other_than_heating_or_cooling
 
-  - name: multiple_utility_allowance_entitlement
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, MUA entitlement
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
-              output: household_entitled_to_mandatory_utility_allowance
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
-              output: same_residence_utility_allowance_agreement_requirement_satisfied
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_entitled_to_mandatory_utility_allowance
-          and same_residence_utility_allowance_agreement_requirement_satisfied
+      or household_has_garbage_or_trash_collection_expense
 
-  - name: actual_utility_costs_allowed
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, actual utility costs allowed
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-              excerpt: "Actual utility costs are only allowed for households not entitled to the MUA or BUA."
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#multiple_utility_allowance_entitlement
-              output: multiple_utility_allowance_entitlement
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_entitlement
-              output: basic_utility_allowance_entitlement
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
-              output: same_residence_utility_allowance_agreement_requirement_satisfied
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          not multiple_utility_allowance_entitlement
-          and not basic_utility_allowance_entitlement
-          and same_residence_utility_allowance_agreement_requirement_satisfied
+      or household_has_well_or_septic_tank_installation_or_maintenance_expense
 
-  - name: actual_utility_cost_deduction_allowed
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, actual utility cost deduction categories
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed
-              output: actual_utility_costs_allowed
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-163#household_actual_verified_utility_cost_allowance_applies
-              output: household_actual_verified_utility_cost_allowance_applies
-              hash: sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          actual_utility_costs_allowed
-          and household_actual_verified_utility_cost_allowance_applies
-          and agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
-          and (
-            claimed_utility_is_heating_fuel
-            or claimed_utility_is_cooking_fuel
-            or claimed_utility_is_water
-            or claimed_utility_is_sewerage
-            or claimed_utility_is_electricity
-            or claimed_utility_is_garbage_or_trash_collection
-            or claimed_utility_is_utility_installation_fee
-            or claimed_utility_is_state_standard_for_telephone
-          )
+      or household_has_telephone_expense'
+- name: basic_utility_allowance_prohibited
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, BUA exclusions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: 'The BUA must not be given to the following households: (A) Households
+            with one or no utility expenses. (B) Households whose utility costs are
+            included in the rent payment.'
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_has_one_or_no_utility_expenses
 
-  - name: household_entitled_to_telephone_only_standard
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, actual utility costs and telephone standard
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_cost_deduction_allowed
-              output: actual_utility_cost_deduction_allowed
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_has_one_or_no_utility_expenses
-          and household_has_telephone_expense
-          and actual_utility_cost_deduction_allowed
-          and claimed_utility_is_state_standard_for_telephone
+      or household_utility_costs_included_in_rent_payment'
+- name: same_residence_utility_allowance_agreement_requirement_satisfied
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, multiple households/multiple residences
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: Multiple households living in the same residence must agree on
+            the type of utility allowance, either MUA, BUA or actual.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'not multiple_households_live_in_same_residence
 
-  - name: same_residence_utility_allowance_agreement_requirement_satisfied
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, multiple households same residence
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-              excerpt: "Multiple households living in the same residence must agree on the type of utility allowance, either MUA, BUA or actual."
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          not multiple_households_live_in_same_residence
-          or multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual
+      or multiple_households_agree_on_utility_allowance_type_mua_bua_or_actual'
+- name: basic_utility_allowance_entitlement
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, BUA entitlement and exclusions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: The BUA must not be given to the following households
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#basic_utility_allowance_prohibited
+          output: basic_utility_allowance_prohibited
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+          output: same_residence_utility_allowance_agreement_requirement_satisfied
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_entitled_to_basic_utility_allowance
 
-  - name: mua_or_bua_not_prorated
-    kind: derived
-    entity: Household
-    dtype: Judgment
-    period: Month
-    source: SNAP Manual p. 165, MUA or BUA proration
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
-          or all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible
+      and not basic_utility_allowance_prohibited
+
+      and same_residence_utility_allowance_agreement_requirement_satisfied'
+- name: multiple_utility_allowance_entitlement
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, MUA entitlement
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: Entitlement to the MUA is based on either heating or cooling costs,
+            receipt of LIHEAP, or energy assistance under state law.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+          output: same_residence_utility_allowance_agreement_requirement_satisfied
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_entitled_to_mandatory_utility_allowance
+
+      and same_residence_utility_allowance_agreement_requirement_satisfied'
+- name: actual_utility_costs_allowed
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, actual utility costs
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: Actual utility costs are only allowed for households not entitled
+            to the MUA or BUA.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_basic_utility_allowance
+          output: household_entitled_to_basic_utility_allowance
+          hash: sha256:02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-163#household_entitled_to_mandatory_utility_allowance
+          output: household_entitled_to_mandatory_utility_allowance
+          hash: sha256:02fa5417273fd447e308d6e8710e4a986a6d864a7f057dd291c15be687fbf318
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#same_residence_utility_allowance_agreement_requirement_satisfied
+          output: same_residence_utility_allowance_agreement_requirement_satisfied
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'not household_entitled_to_mandatory_utility_allowance
+
+      and not household_entitled_to_basic_utility_allowance
+
+      and same_residence_utility_allowance_agreement_requirement_satisfied'
+- name: actual_utility_cost_deduction_allowed
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, actual utility cost deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: 'If eligible for actual costs, deductions are allowed for: • Heating
+            fuel • Cooking fuel • Water • Sewerage • Electricity • Garbage and/or
+            trash collection • Fees charged for utility installation • State standard
+            for telephone'
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: The Agency must reasonably anticipate that the charges for claimed
+            utilities will continue throughout the certification period.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed
+          output: actual_utility_costs_allowed
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: "actual_utility_costs_allowed\nand agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period\n\
+      and (\n  claimed_utility_is_heating_fuel\n  or claimed_utility_is_cooking_fuel\n\
+      \  or claimed_utility_is_water\n  or claimed_utility_is_sewerage\n  or claimed_utility_is_electricity\n\
+      \  or claimed_utility_is_garbage_or_trash_collection\n  or claimed_utility_is_utility_installation_fee\n\
+      \  or claimed_utility_is_state_standard_for_telephone\n)"
+- name: household_entitled_to_telephone_only_standard
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, actual utility costs
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: State standard for telephone
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-sc:policies/dss/snap-policy-manual/page-165#actual_utility_costs_allowed
+          output: actual_utility_costs_allowed
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'actual_utility_costs_allowed
+
+      and agency_reasonably_anticipates_claimed_utility_charges_continue_throughout_certification_period
+
+      and claimed_utility_is_state_standard_for_telephone'
+- name: mua_or_bua_not_prorated
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: SNAP Manual p. 165, multiple households/multiple residences
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: If a household lives with and shares heating or cooling expenses
+            with another individual, another household, or both, the Agency will not
+            prorate the MUA or BUA
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-165
+          excerpt: The Agency will not prorate the MUA or BUA if all the individuals
+            who share utility expenses but are not in the SNAP household are excluded
+            from the household only because they are ineligible.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'household_lives_with_and_shares_heating_or_cooling_expenses_with_another_individual_or_household
+
+      or all_individuals_sharing_utility_expenses_outside_snap_household_excluded_only_because_ineligible'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-sc/manual/dss/snap-policy-manual/page-163`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `us-sc/manual/dss/snap-policy-manual/page-165`
Second direct dependent: `us-sc/manual/dss/snap-policy-manual/page-159`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Base commit: `251d8d66dabdebcb763d9e7c9b8322a281440c36`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30831706351

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.