### PR TITLE
Pin validator with current PR 911 waiver bootstrap

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -75,7 +75,7 @@ jobs:
 
   validate:
     needs: [legacy-rulespec-freeze, workflow-toolchain]
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@d78569d1ba0810338da7d06d41c42531cb742e06
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@df2a6d1a9cf25d4963f127d26d61281c188febeb
     secrets: inherit
     with:
       axiom-encode-ref: ${{ needs.workflow-toolchain.outputs.axiom_encode_ref }}

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -113,7 +113,7 @@ def test_required_workflow_runs_freeze_before_validation() -> None:
 
     assert "legacy-rulespec-freeze:" in workflow
     assert "needs: [legacy-rulespec-freeze, workflow-toolchain]" in workflow
-    assert "d78569d1ba0810338da7d06d41c42531cb742e06" in workflow
+    assert "df2a6d1a9cf25d4963f127d26d61281c188febeb" in workflow
     assert (
         "retired-schema-bootstrap-sha256: >-\n"
         "        ${{ ((github.event_name == 'pull_request'"


### PR DESCRIPTION
Pins repository checks to the reviewed organization validator merge that authenticates RuleSpec PR #911 head 251d8d66 and waiver SHA-256 73b126ca. No policy or waiver content changes. Focused check: 21 legacy-freeze tests pass.