### PR TITLE
Add signed encoding manifest for us/regulation/42/435/561

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/561.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/561.json
@@ -1,86 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us/regulations/42-cfr/435/561.test.yaml",
-      "sha256": "fe43d9d56acf75a25b58198de6ff01295ef0f51b3bde968c9873fa98d95cc654"
+      "path": "us/regulations/42-cfr/435/561.yaml",
+      "sha256": "56ab4acd53142dd02f06ce49c82a8216cb4e9f90f27bd6fff85b338310b8fc7c"
     },
     {
-      "path": "us/regulations/42-cfr/435/561.yaml",
-      "sha256": "cce35508c6ebc7a2eaf8c5fb6d24382463d7ba70b076390b8b89b95b80544d43"
+      "path": "us/regulations/42-cfr/435/561.test.yaml",
+      "sha256": "53bceb682b6e1271a0708fa4db82c4e6169c107459287e2739982cf8ec48e6bc"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
     "dirty_tracked": false,
-    "root": "/private/tmp/axiom-encode-3869d66d",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1428",
+    "version_commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us:regulations/42-cfr/435/561",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-20T17:29:04.472250+00:00",
-  "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/regulations/42-cfr/435/561.yaml",
-  "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
-  "generated_output_sha256": "cce35508c6ebc7a2eaf8c5fb6d24382463d7ba70b076390b8b89b95b80544d43",
-  "generation_prompt_sha256": null,
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1428",
+  "backend": "openai",
+  "citation": "us/regulation/42/435/561",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-regulation-42-435-561/workspace/context-manifest.json",
+  "context_manifest_sha256": "e62ba0da5d6cdc14f4c77db92fdf00469b84a8296b6eb45e144731c4fbda5101",
+  "generated_at": "2026-08-03T17:06:42.713430+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/regulations/42-cfr/435/561.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "56ab4acd53142dd02f06ce49c82a8216cb4e9f90f27bd6fff85b338310b8fc7c",
+  "generation_prompt_sha256": "f9ac1ff6515ea0cb7f762c134845664082109aa4feeefd5c0c95b75faebf3b11",
+  "model": "gpt-5.6-terra",
+  "run_id": "2e93f757",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "aceb0a2351d728680a24d05f2811778bc23fd08a9ebfdac71f7d8b6feda6e31d"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "XjJHzrlrMXQrfJtmcZ2GX/1N+I6n6xuOonrFkGTdMiqnxzZvGTUBq49YhvOcs0/7O/dUGntd6wAgxKHUvkytAA=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-20T17:25:29.325514+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "6f87014976678660f1a8e65a861d168cfc93977b3f29c2149fee55320d1c416d",
-    "prior_signature": "8729b8ad7d60c63bca239b88ca9e5874f790149515b5ef5ce7ebaac73c4db7c6",
-    "run_id": null,
-    "supersedes": {
-      "backend": "manual",
-      "generated_at": "2026-07-20T17:24:35.409206+00:00",
-      "generation_prompt_sha256": null,
-      "manifest_sha256": "4b2052521868fee14d1c3f60722557b32879dc127776351217f70efab51cc14e",
-      "prior_signature": "f11569501f516b954a532e3db216f0cfbc3d428c58b9ed4ffbc74a788cd4bb2f",
-      "run_id": null,
-      "supersedes": {
-        "backend": "manual",
-        "generated_at": "2026-07-20T17:22:55.214505+00:00",
-        "generation_prompt_sha256": null,
-        "manifest_sha256": "51d3641f51c7365eebdd612f2501c25713ece0f212c1425aa3f66aac10b08897",
-        "prior_signature": "035fe1f446a0fdde577d3ece43db3f93853774f17cfa530e31c50b0813fa3611",
-        "run_id": null,
-        "supersedes": {
-          "backend": "manual",
-          "generated_at": "2026-07-20T17:21:52.085202+00:00",
-          "generation_prompt_sha256": null,
-          "manifest_sha256": "1a6b2667ae7e8a9749714f4eb2e1e70ad3eb2fc40878abcd6aa4e5dccccaf959",
-          "prior_signature": "325033f1fd83c78f4f28e2f1a631e84c42df2d84398d3dd3c8a016b9a6a98a08",
-          "run_id": null,
-          "supersedes": {
-            "backend": "manual",
-            "generated_at": "2026-07-20T17:18:52.868143+00:00",
-            "generation_prompt_sha256": null,
-            "manifest_sha256": "bdd65edd072c4334521dd03e26b709698e1a546f99962dfde8212b8e3b2fba4c",
-            "prior_signature": "1e462c30035417c8e0f24f6b905f42ce0981acf93147ae40b97cb45f1f09db3c",
-            "run_id": null,
-            "tool": "axiom-encode sign-applied-files"
-          },
-          "tool": "axiom-encode sign-applied-files"
-        },
-        "tool": "axiom-encode sign-applied-files"
-      },
-      "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-24-snap-cms-pit-union",
+    "corpus_release_content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "corpus_release_selector_sha256": "ff442cae483bca2fe0d94ec0724c02b5157fae0cb2339ebf955d4df1fdf4a3d9",
+    "corpus_source": "local",
+    "expression_date": "2026-07-31",
+    "generation_input_sha256": "052a6e15ed2964ae32a8a850d0e9b740ff0187e0412618d06fb34d00e9cfe7cf",
+    "provision_file": "data/corpus/provisions/us/regulation/2026-06-29-cms-2454-ifc-42-cfr-435-community-engagement-corrected-r2026-07-24-self-contained.jsonl",
+    "provision_file_sha256": "ef36b03266e212fa35f0b3bca33beb09774d083bd17988156e12192fdf720bea",
+    "requested_corpus_citation_path": "us/regulation/42/435/561",
+    "resolved_corpus_citation_path": "us/regulation/42/435/561",
+    "resolved_text_sha256": "052a6e15ed2964ae32a8a850d0e9b740ff0187e0412618d06fb34d00e9cfe7cf",
+    "row": {
+      "body_sha256": "052a6e15ed2964ae32a8a850d0e9b740ff0187e0412618d06fb34d00e9cfe7cf",
+      "citation_path": "us/regulation/42/435/561",
+      "document_class": "regulation",
+      "expression_date": "2026-07-31",
+      "jurisdiction": "us",
+      "line_number": 10,
+      "provision_file": "data/corpus/provisions/us/regulation/2026-06-29-cms-2454-ifc-42-cfr-435-community-engagement-corrected-r2026-07-24-self-contained.jsonl",
+      "provision_file_sha256": "ef36b03266e212fa35f0b3bca33beb09774d083bd17988156e12192fdf720bea",
+      "record_id": "be2d5065-4393-531a-ae94-9e220723a1a2",
+      "source_as_of": "2026-06-03",
+      "source_path": "sources/us/regulation/2026-06-29-cms-2454-ifc-42-cfr-435-community-engagement-corrected-r2026-07-24-self-contained/official-documents/release-scope-us-regulation-2026-06-03-cms-2454-ifc-42-cfr-435-community-engagement-r2026-07-15-self-contained-r2026-07-15-cascade-contained-r2026-07-15-self-contained-r2026-07-17-dedup",
+      "version": "2026-06-29-cms-2454-ifc-42-cfr-435-community-engagement-corrected-r2026-07-24-self-contained"
     },
-    "tool": "axiom-encode sign-applied-files"
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-03",
+    "source_sha256": "052a6e15ed2964ae32a8a850d0e9b740ff0187e0412618d06fb34d00e9cfe7cf"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-regulation-42-435-561.json",
+  "trace_sha256": "215feac4d6b49487f6d28f72cba77173b632d100135c77a19a1bb75de5f68027",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ddfce38dae9d998480f466a65e13acf7ef0bc59",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1428"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "15631ee8916f704b0b176670268082fa71937a82633cb334dbe3c978cb47e7e2",
+      "pre_apply_file_count": 1504,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "290b4297e789ab7f054f2e47bc447e8ad4c64244a11af81a3e7e688554c84c3f",
+      "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
 }

--- a/us/regulations/42-cfr/435/561.test.yaml
+++ b/us/regulations/42-cfr/435/561.test.yaml
@@ -1,19 +1,36 @@
-- name: state-plan-enrollee-must-receive-outreach
+- name: state-plan-enrollee-receives-complete-outreach
   period: 2027-01
   input:
     us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: true
     us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project: false
     us:regulations/42-cfr/435/561#input.demonstration_project_coverage_is_minimum_essential_coverage_equivalent: false
-    us:regulations/42-cfr/435/561#input.individual_age: 18
+    us:regulations/42-cfr/435/561#input.individual_age: 30
     us:regulations/42-cfr/435/561#input.individual_is_pregnant: false
     us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
     us:regulations/42-cfr/435/561#input.months_specified_by_state_under_section_435_556_a_1: 2
+    us:regulations/42-cfr/435/561#input.individual_is_determined_or_redetermined_eligible_at_application_renewal_or_change: true
+    us:regulations/42-cfr/435/561#input.state_elects_short_term_hardship_exception: false
+    us:regulations/42-cfr/435/561#input.short_term_hardship_event_becomes_available_or_is_effectuated: false
+    ? us:regulations/42-cfr/435/561#input.state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
+    : false
+    us:regulations/42-cfr/435/561#input.cms_requests_increased_outreach_due_to_monitoring_or_compliance_information: false
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_all_qualifying_status_changes: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: true
   output:
+    us:regulations/42-cfr/435/561#demonstration_project_outreach_population: not_holds
     us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: holds
     us:regulations/42-cfr/435/561#initial_outreach_lead_months: 5
-- name: demonstration-project-population-qualifies-for-outreach
+    us:regulations/42-cfr/435/561#periodic_outreach_notice_required: holds
+    us:regulations/42-cfr/435/561#outreach_notice_content_complete: holds
+    us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete: holds
+    us:regulations/42-cfr/435/561#outreach_notice_complete: holds
+- name: qualifying-demonstration-project-individual-requires-outreach
   period: 2027-01
   input:
     us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: false
@@ -24,10 +41,26 @@
     us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/561#input.months_specified_by_state_under_section_435_556_a_1: 1
+    us:regulations/42-cfr/435/561#input.individual_is_determined_or_redetermined_eligible_at_application_renewal_or_change: false
+    us:regulations/42-cfr/435/561#input.state_elects_short_term_hardship_exception: false
+    us:regulations/42-cfr/435/561#input.short_term_hardship_event_becomes_available_or_is_effectuated: false
+    ? us:regulations/42-cfr/435/561#input.state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
+    : false
+    us:regulations/42-cfr/435/561#input.cms_requests_increased_outreach_due_to_monitoring_or_compliance_information: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_all_qualifying_status_changes: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
+    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: true
   output:
     us:regulations/42-cfr/435/561#demonstration_project_outreach_population: holds
     us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: holds
-- name: demonstration-project-person-pregnant-not-in-outreach-population
+    us:regulations/42-cfr/435/561#initial_outreach_lead_months: 4
+    us:regulations/42-cfr/435/561#periodic_outreach_notice_required: holds
+    us:regulations/42-cfr/435/561#outreach_notice_complete: holds
+- name: pregnancy-and-missing-additional-modality-block-respective-results
   period: 2027-01
   input:
     us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: false
@@ -38,64 +71,23 @@
     us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
     us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
-  output:
-    us:regulations/42-cfr/435/561#demonstration_project_outreach_population: not_holds
-    us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: not_holds
-- name: periodic-outreach-triggered-by-cms-request
-  period: 2027-01
-  input:
+    us:regulations/42-cfr/435/561#input.months_specified_by_state_under_section_435_556_a_1: 2
     us:regulations/42-cfr/435/561#input.individual_is_determined_or_redetermined_eligible_at_application_renewal_or_change: false
     us:regulations/42-cfr/435/561#input.state_elects_short_term_hardship_exception: false
     us:regulations/42-cfr/435/561#input.short_term_hardship_event_becomes_available_or_is_effectuated: false
     ? us:regulations/42-cfr/435/561#input.state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
     : false
-    us:regulations/42-cfr/435/561#input.cms_requests_increased_outreach_due_to_monitoring_or_compliance_information: true
-  output:
-    us:regulations/42-cfr/435/561#periodic_outreach_notice_required: holds
-- name: required_outreach_notice_incomplete_without_additional_modality
-  period: 2027-01
-  input:
-    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: true
-    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project: false
-    us:regulations/42-cfr/435/561#input.demonstration_project_coverage_is_minimum_essential_coverage_equivalent: false
-    us:regulations/42-cfr/435/561#input.individual_age: 18
-    us:regulations/42-cfr/435/561#input.individual_is_pregnant: false
-    us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
-    us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
-    us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
+    us:regulations/42-cfr/435/561#input.cms_requests_increased_outreach_due_to_monitoring_or_compliance_information: false
     us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
-    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement
-    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement: true
     us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
-    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
-    : true
+    us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_all_qualifying_status_changes: true
     us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
     us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: false
   output:
-    us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: holds
+    us:regulations/42-cfr/435/561#demonstration_project_outreach_population: not_holds
+    us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required: not_holds
+    us:regulations/42-cfr/435/561#periodic_outreach_notice_required: not_holds
     us:regulations/42-cfr/435/561#outreach_notice_content_complete: holds
     us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete: not_holds
     us:regulations/42-cfr/435/561#outreach_notice_complete: not_holds
-- name: required_outreach_notice_complete_with_content_and_modalities
-  period: 2027-01
-  input:
-    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_under_section_435_119: true
-    us:regulations/42-cfr/435/561#input.eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project: false
-    us:regulations/42-cfr/435/561#input.demonstration_project_coverage_is_minimum_essential_coverage_equivalent: false
-    us:regulations/42-cfr/435/561#input.individual_age: 18
-    us:regulations/42-cfr/435/561#input.individual_is_pregnant: false
-    us:regulations/42-cfr/435/561#input.individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits: false
-    us:regulations/42-cfr/435/561#input.individual_is_enrolled_for_title_xviii_part_b_benefits: false
-    us:regulations/42-cfr/435/561#input.individual_is_otherwise_eligible_to_enroll_under_state_plan: false
-    us:regulations/42-cfr/435/561#input.outreach_notice_provided_consistent_with_section_435_905_b: true
-    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_comply_with_community_engagement_requirement
-    : true
-    us:regulations/42-cfr/435/561#input.outreach_notice_explains_consequences_of_noncompliance: true
-    ? us:regulations/42-cfr/435/561#input.outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
-    : true
-    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_regular_mail_or_elected_electronic_format: true
-    us:regulations/42-cfr/435/561#input.outreach_notice_provided_by_at_least_one_additional_modality: true
-  output:
-    us:regulations/42-cfr/435/561#outreach_notice_content_complete: holds
-    us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete: holds
-    us:regulations/42-cfr/435/561#outreach_notice_complete: holds

--- a/us/regulations/42-cfr/435/561.yaml
+++ b/us/regulations/42-cfr/435/561.yaml
@@ -4,245 +4,230 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/regulation/42/435/561
-  summary: |-
-    The agency must provide notice of the requirement to demonstrate community engagement to individuals eligible to enroll or enrolled under Sec. 435.119, and to certain individuals in qualifying section 1115(a)(2) demonstration projects who are at least 19 and under 65, not pregnant, not enrolled in Medicare Parts A or B, and not otherwise eligible under the State plan. Initial outreach must occur three months plus the State-specified months before implementation or expansion, with additional notices at enrollment, eligibility events, hardship-event points, advance notices for reductions, and upon CMS request.
+    source_sha256: 052a6e15ed2964ae32a8a850d0e9b740ff0187e0412618d06fb34d00e9cfe7cf
+  summary: '"The agency must provide notice, in a manner and frequency described in
+    this section, of the requirement to demonstrate community engagement under this
+    subpart" and "[t]he notice required under paragraph (a) of this section must be
+    provided in a manner consistent with Sec. 435.905(b) and include information on--"'
 rules:
-  - name: demonstration_project_outreach_minimum_age
-    kind: parameter
-    dtype: Integer
-    source: 42 CFR 435.561(a)(2)(i)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "At least 19 and under 65 years of age"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          19
+- name: demonstration_project_outreach_minimum_age
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.561(a)(2)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: At least 19 and under 65 years of age
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '19'
+- name: demonstration_project_outreach_maximum_age_exclusive
+  kind: parameter
+  dtype: Integer
+  source: 42 CFR 435.561(a)(2)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: At least 19 and under 65 years of age
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '65'
+- name: initial_outreach_base_lead_months
+  kind: parameter
+  dtype: Count
+  source: 42 CFR 435.561(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: Three months plus the number of months specified by the State
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '3'
+- name: demonstration_project_outreach_population
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(a)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: Otherwise eligible to enroll or are enrolled in a demonstration
+            project under section 1115(a)(2) of the Act that provides coverage equivalent
+            to minimum essential coverage requirements as defined under Sec. 435.4
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: and are--
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project
 
-  - name: demonstration_project_outreach_maximum_age_exclusive
-    kind: parameter
-    dtype: Integer
-    source: 42 CFR 435.561(a)(2)(i)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "At least 19 and under 65 years of age"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          65
+      and demonstration_project_coverage_is_minimum_essential_coverage_equivalent
 
-  - name: initial_outreach_base_lead_months
-    kind: parameter
-    dtype: Count
-    source: 42 CFR 435.561(b)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "Three months plus the number of months specified by the State"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          3
+      and individual_age >= demonstration_project_outreach_minimum_age
 
-  - name: demonstration_project_outreach_population
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(a)(2)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: predicate
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#demonstration_project_outreach_minimum_age
-              output: demonstration_project_outreach_minimum_age
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#demonstration_project_outreach_maximum_age_exclusive
-              output: demonstration_project_outreach_maximum_age_exclusive
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          eligible_to_enroll_or_enrolled_in_section_1115_demonstration_project
-          and demonstration_project_coverage_is_minimum_essential_coverage_equivalent
-          and individual_age >= demonstration_project_outreach_minimum_age
-          and individual_age < demonstration_project_outreach_maximum_age_exclusive
-          and not individual_is_pregnant
-          and not individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits
-          and not individual_is_enrolled_for_title_xviii_part_b_benefits
-          and not individual_is_otherwise_eligible_to_enroll_under_state_plan
+      and individual_age < demonstration_project_outreach_maximum_age_exclusive
 
-  - name: community_engagement_outreach_notice_required
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(a)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: predicate
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#demonstration_project_outreach_population
-              output: demonstration_project_outreach_population
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          eligible_to_enroll_or_enrolled_under_section_435_119
-          or demonstration_project_outreach_population
+      and not individual_is_pregnant
 
-  - name: initial_outreach_lead_months
-    kind: derived
-    entity: Person
-    dtype: Count
-    period: Month
-    source: 42 CFR 435.561(b)(1)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "Three months plus the number of months specified by the State"
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#initial_outreach_base_lead_months
-              output: initial_outreach_base_lead_months
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          initial_outreach_base_lead_months + months_specified_by_state_under_section_435_556_a_1
+      and not individual_is_entitled_to_or_enrolled_for_title_xviii_part_a_benefits
 
-  - name: periodic_outreach_notice_required
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(b)(3)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: predicate
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          individual_is_determined_or_redetermined_eligible_at_application_renewal_or_change
-          or state_elects_short_term_hardship_exception
-          or short_term_hardship_event_becomes_available_or_is_effectuated
-          or state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
-          or cms_requests_increased_outreach_due_to_monitoring_or_compliance_information
+      and not individual_is_enrolled_for_title_xviii_part_b_benefits
 
-  - name: outreach_notice_content_complete
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(c)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "The notice required under paragraph \n(a) of this section must be provided in a manner consistent with Sec.  \n435.905(b) and include information on"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          outreach_notice_provided_consistent_with_section_435_905_b
-          and outreach_notice_explains_how_to_comply_with_community_engagement_requirement
-          and outreach_notice_explains_consequences_of_noncompliance
-          and outreach_notice_explains_how_to_report_change_in_specified_excluded_individual_status
+      and not individual_is_otherwise_eligible_to_enroll_under_state_plan'
+- name: community_engagement_outreach_notice_required
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: The agency must provide notice, in a manner and frequency described
+            in this section, of the requirement to demonstrate community engagement
+            under this subpart to individuals who are--
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'eligible_to_enroll_or_enrolled_under_section_435_119
 
-  - name: outreach_notice_delivery_modalities_complete
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(d)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: condition
-            source:
-              corpus_citation_path: us/regulation/42/435/561
-              excerpt: "The notice must be \nprovided to the individual--\n    (1) By regular mail, or, if elected by the individual, in an \nelectronic format consistent with Sec.  435.918; and\n    (2) In one or more of the following additional modalities"
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          outreach_notice_provided_by_regular_mail_or_elected_electronic_format
-          and outreach_notice_provided_by_at_least_one_additional_modality
+      or demonstration_project_outreach_population'
+- name: initial_outreach_lead_months
+  kind: derived
+  entity: Person
+  dtype: Count
+  period: Month
+  source: 42 CFR 435.561(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: Three months plus the number of months specified by the State
+  versions:
+  - effective_from: '0001-01-01'
+    formula: initial_outreach_base_lead_months + months_specified_by_state_under_section_435_556_a_1
+- name: periodic_outreach_notice_required
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(b)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: Periodically as follows--
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'individual_is_determined_or_redetermined_eligible_at_application_renewal_or_change
 
-  - name: outreach_notice_complete
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 42 CFR 435.561(c), (d)
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#community_engagement_outreach_notice_required
-              output: community_engagement_outreach_notice_required
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#outreach_notice_content_complete
-              output: outreach_notice_content_complete
-              hash: sha256:local
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:regulations/42-cfr/435/561#outreach_notice_delivery_modalities_complete
-              output: outreach_notice_delivery_modalities_complete
-              hash: sha256:local
-    versions:
-      - effective_from: '0001-01-01'
-        formula: |-
-          (
-            not community_engagement_outreach_notice_required
-          )
-          or (
-            outreach_notice_content_complete
-            and outreach_notice_delivery_modalities_complete
-          )
+      or state_elects_short_term_hardship_exception
+
+      or short_term_hardship_event_becomes_available_or_is_effectuated
+
+      or state_sends_advance_notice_for_reduction_due_to_hardship_deselection_expiration_or_loss_of_excluded_status
+
+      or cms_requests_increased_outreach_due_to_monitoring_or_compliance_information'
+- name: outreach_notice_content_complete
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(c)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: The notice required under paragraph (a) of this section must be
+            provided in a manner consistent with Sec. 435.905(b) and include information
+            on--
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'outreach_notice_provided_consistent_with_section_435_905_b
+
+      and outreach_notice_explains_how_to_comply_with_community_engagement_requirement
+
+      and outreach_notice_explains_consequences_of_noncompliance
+
+      and outreach_notice_explains_how_to_report_all_qualifying_status_changes'
+- name: outreach_notice_delivery_modalities_complete
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: By regular mail, or, if elected by the individual, in an electronic
+            format consistent with Sec. 435.918
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: In one or more of the following additional modalities
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'outreach_notice_provided_by_regular_mail_or_elected_electronic_format
+
+      and outreach_notice_provided_by_at_least_one_additional_modality'
+- name: outreach_notice_complete
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.561(c)-(d)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: The notice required under paragraph (a) of this section must be
+            provided in a manner consistent with Sec. 435.905(b)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/561
+          excerpt: The notice must be provided to the individual--
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'outreach_notice_content_complete
+
+      and outreach_notice_delivery_modalities_complete'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/regulation/42/435/561`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Base commit: `251d8d66dabdebcb763d9e7c9b8322a281440c36`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30834675671

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.