### PR TITLE
Add signed encoding manifest for us-nc/statute/105/105-153.7

### DIFF
--- a/.axiom/encoding-manifests/us-nc/policies/income_tax/pilot_liability_pipeline.json
+++ b/.axiom/encoding-manifests/us-nc/policies/income_tax/pilot_liability_pipeline.json
@@ -1,77 +1,95 @@
 {
   "applied_files": [
     {
-      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml",
-      "sha256": "0a89076b9a12be7cc540decc4997840e219bc9fc7368c9b8a8d69366ea3a3320"
+      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
+      "sha256": "0ef7f4c4f64ec99718a32eeac8380ad973d544ce948f27f3620dc8102f9fcc21"
     },
     {
-      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
-      "sha256": "ab2eff5ec5986ce9e4f8b5c7fddee21fe93f5a672b157b7154268b91c4362dc2"
+      "path": "us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml",
+      "sha256": "b3d0a0e63725f7c40df22fc1298f1b74333d28d70b0076d4778cfa8e74e7b0ca"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "9ea1f44ea1fba0985e630e87eafeb6abeafd7083",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1428",
+    "version_commit": "9ea1f44ea1fba0985e630e87eafeb6abeafd7083"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-nc:policies/income_tax/pilot_liability_pipeline",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-26T12:39:32.244523+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfj3e9jy2/sign-applied-files/us-nc/policies/income_tax/pilot_liability_pipeline.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpfj3e9jy2",
-  "generated_output_sha256": "ab2eff5ec5986ce9e4f8b5c7fddee21fe93f5a672b157b7154268b91c4362dc2",
-  "generation_prompt_sha256": null,
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1428",
+  "backend": "openai",
+  "citation": "us-nc/statute/105/105-153.7",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-nc-statute-105-105-153.7/workspace/context-manifest.json",
+  "context_manifest_sha256": "1afb9f1f10fc407a694d28a054e2a5ac25b04f89d7af3d69aae220cc0d1e6ed7",
+  "generated_at": "2026-08-03T17:31:05.150062+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/policies/income_tax/pilot_liability_pipeline.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "0ef7f4c4f64ec99718a32eeac8380ad973d544ce948f27f3620dc8102f9fcc21",
+  "generation_prompt_sha256": "fdff6c741a90d2bf14b27c8be888ebc360fcb41ec4333adf4ff21febd81c971d",
+  "model": "gpt-5.6-terra",
+  "run_id": "129a11fc",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "f13221ae98f8b9eac13892e5c5bb982a274a60d83ed82beb58d9a0f68fef80ed"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "LJdUIF0OJNZu23yCoA97gEHIFmee0MUNYXshxccKaygq+6CksibuocQ4RPjt9nfGA8OCoOIyDexIvRRwH8vmAA=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-26T12:36:04.988414+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "d0d5e59c33e77a72686368dfc299153dc7892e9f1aa9f7cf44d3f0d0780aa1e6",
-    "prior_signature": "d0dc6b8f782cb84e992a08ae9be1c4ef39e7407330b47f8e0df6deb1dda1a922",
-    "run_id": null,
-    "supersedes": {
-      "backend": "manual",
-      "generated_at": "2026-07-26T12:13:34.022339+00:00",
-      "generation_prompt_sha256": null,
-      "manifest_sha256": "178a790b957bd164535a8f3145089e89529b0864cfaaf0cb5d50133487e7e026",
-      "prior_signature": "fdf9cb0b3eb9b2cb0a60156290afbbca83d4ead112580b4ed2af21fdb46f5406",
-      "run_id": null,
-      "supersedes": {
-        "backend": "manual",
-        "generated_at": "2026-07-21T21:19:50.568065+00:00",
-        "generation_prompt_sha256": null,
-        "manifest_sha256": "e8be57c87b3f6193cf76b1f34e57034cf4984a2967c28f4527f6f8706a39bcb3",
-        "prior_signature": "d14b5eec8738e35f58b27730a9fb6a938beed00bb186fc0e95a686c253f460eb",
-        "run_id": null,
-        "supersedes": {
-          "backend": "manual",
-          "generated_at": "2026-07-21T21:03:48.365239+00:00",
-          "generation_prompt_sha256": null,
-          "manifest_sha256": "00951f237951138cde3e8ab4bb0f00f1f3a7f37681400e0c1749f01ffd3dcfab",
-          "prior_signature": "8c88219fd07d94670929ca9e25fda5374db7223785b98147572f485c336d9192",
-          "run_id": null,
-          "tool": "axiom-encode sign-applied-files"
-        },
-        "tool": "axiom-encode sign-applied-files"
-      },
-      "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-07-24-snap-cms-pit-union",
+    "corpus_release_content_sha256": "cb275c76c4f07f8ad37470a32296bb1763e5db853d152697524ab07021b6d544",
+    "corpus_release_selector_sha256": "ff442cae483bca2fe0d94ec0724c02b5157fae0cb2339ebf955d4df1fdf4a3d9",
+    "corpus_source": "local",
+    "expression_date": "2026-07-13",
+    "generation_input_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+    "provision_file": "data/corpus/provisions/us-nc/statute/2026-07-13-recovery.jsonl",
+    "provision_file_sha256": "671d105b274dc6d7bd7faeadceecf6aa2f5850444d2785c5e752e6e5604c1bb7",
+    "requested_corpus_citation_path": "us-nc/statute/105/105-153.7",
+    "resolved_corpus_citation_path": "us-nc/statute/105/105-153.7",
+    "resolved_text_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+    "row": {
+      "body_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6",
+      "citation_path": "us-nc/statute/105/105-153.7",
+      "document_class": "statute",
+      "expression_date": "2026-07-13",
+      "jurisdiction": "us-nc",
+      "line_number": 53,
+      "provision_file": "data/corpus/provisions/us-nc/statute/2026-07-13-recovery.jsonl",
+      "provision_file_sha256": "671d105b274dc6d7bd7faeadceecf6aa2f5850444d2785c5e752e6e5604c1bb7",
+      "record_id": "87e8f1e6-2622-55a3-8c79-7b0bd039d804",
+      "source_as_of": "2026-07-13",
+      "source_path": "sources/us-nc/statute/2026-07-13-recovery/official-documents/us-nc-code-105",
+      "version": "2026-07-13-recovery"
     },
-    "tool": "axiom-encode sign-applied-files"
+    "rulespec_root": "rulespec-us/us-nc",
+    "source_as_of": "2026-07-13",
+    "source_sha256": "e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-nc-statute-105-105-153.7.json",
+  "trace_sha256": "f34c805f8c4e82f71681af4d3197ed6dc1387167cf07a4608dafe76867cbf0dd",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "9ea1f44ea1fba0985e630e87eafeb6abeafd7083",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1428"
+    },
+    "axiom_rules_engine": {
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "3f4e92112ba10ef1ea81dab0354d042399cae1c9ddeb166a69ff3f3d28df68c9",
+      "pre_apply_file_count": 1015,
+      "rulespec_root": "rulespec-us/us-nc",
+      "toolchain_contract_sha256": "290b4297e789ab7f054f2e47bc447e8ad4c64244a11af81a3e7e688554c84c3f",
+      "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
+    },
+    "rulespec_dependencies": [],
+    "schema": "axiom-encode/apply-validation-execution/v1"
+  },
+  "validation_waiver_set_sha256": "73b126caeeef96d7064137103f7d430aa203dffcf4ca359b3ab22fd6b2197e7c"
 }

--- a/us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml
+++ b/us-nc/policies/income_tax/pilot_liability_pipeline.test.yaml
@@ -1,73 +1,41 @@
-# Fixtures are hand-computed for tax year 2026. North Carolina liability before
-# credits is 3.99 per cent of the supplied completed-return North Carolina
-# taxable-income boundary under N.C. Gen. Stat. 105-153.7(a).
-- name: zero taxable income
+- name: zero north carolina taxable income produces zero pilot liability
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.north_carolina_taxable_income: 0
   output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '0'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '0'
-- name: negative taxable income is floored
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_nonnegative_north_carolina_taxable_income: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_individual_income_tax_liability: 0
+- name: negative north carolina taxable income is floored before pilot liability
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: -1000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.north_carolina_taxable_income: -1000
   output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '0'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '0'
-- name: taxable income 30000
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_nonnegative_north_carolina_taxable_income: 0
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_individual_income_tax_liability: 0
+- name: tax year 2026 pilot liability uses the 3.99 percent rate
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 30000
+    us-nc:policies/income_tax/pilot_liability_pipeline#input.north_carolina_taxable_income: 100000
   output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '30000'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '1197'
-- name: taxable income 60000
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_nonnegative_north_carolina_taxable_income: 100000
+    us-nc:policies/income_tax/pilot_liability_pipeline#pilot_individual_income_tax_liability: 3990
+- name: withholding tables do not apply to qualifying short period return
   period:
     period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
+    start: '2024-01-01'
+    end: '2024-12-31'
   input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 60000
+    us-nc:statutes/105/105-153/7#input.secretary_has_provided_withholding_tables: true
+    us-nc:statutes/105/105-153/7#input.files_return_under_code_section_443_a_1_due_to_change_in_annual_accounting_period: true
+    us-nc:statutes/105/105-153/7#input.taxable_period_months: 11
   output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '60000'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '2394'
-- name: completed-return taxable income matches the statute module fixture
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 100000
-  output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '100000'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '3990'
-- name: taxable income 120000
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 120000
-  output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '120000'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '4788'
-- name: taxable income 300000
-  period:
-    period_kind: tax_year
-    start: '2026-01-01'
-    end: '2026-12-31'
-  input:
-    us-nc:policies/income_tax/pilot_liability_pipeline#input.nc_pit_pilot_state_taxable_income: 300000
-  output:
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_taxable_income: '300000'
-    us-nc:policies/income_tax/pilot_liability_pipeline#nc_pit_pilot_income_tax_liability: '11970'
+    us-nc:statutes/105/105-153/7#withholding_tables_apply_to_individual: not_holds

--- a/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
+++ b/us-nc/policies/income_tax/pilot_liability_pipeline.yaml
@@ -4,74 +4,57 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-nc/statute/105/105-153.7
-    upstream_source_check:
-      status: composed_from_supplied_current_authority
-      checked_paths:
-        - us-nc/statute/105/105-153.7
-      rationale: |-
-        The current statute, as amended by the enacted 2026 overlay, expressly
-        sets the tax-year-2026 individual income-tax rate at 3.99 percent. This
-        narrow pilot retains its completed-return taxable-income boundary and
-        makes no claim about the upstream deduction or credit calculation.
-  summary: |-
-    Composed North Carolina individual income-tax pipeline for the 2026
-    before-credit target. It accepts one TaxUnit-level completed-return North
-    Carolina taxable-income boundary, floors it at zero, and applies the rate
-    imported from the encoded section 105-153.7 module. It deliberately excludes
-    all credits and makes no independent claim about the upstream federal and
-    state adjustment chain. The imported rate is policy-bearing; zero is only
-    the nonnegative taxable-income floor. The enacted schedule changes after
-    2026 and subsection (a1) can alter still-later rates, so both rules remain
-    bounded to tax year 2026. This narrow boundary is suitable for comparison
-    with PolicyEngine's
-    nc_taxable_income feeding nc_income_tax_before_credits for full-year
-    resident tax units.
+    source_sha256: e174d86f3f866609e4ea700ca6ffde8204b1aee6213713507209c7001cd311a6
+  summary: '"A tax is imposed for each taxable year on the North Carolina taxable
+    income of every individual." For taxable years after 2025, the enacted rate is
+    "3.99%"; withholding tables do not apply to a qualifying short-period Code section
+    443(a)(1) return.'
 imports:
-  - us-nc:statutes/105/105-153/7#individual_income_tax_rate
+- us-nc:statutes/105/105-153/7#individual_income_tax_rate
 rules:
-  - name: nc_pit_pilot_taxable_income
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: N.C. Gen. Stat. 105-153.7, supplied completed-return state taxable income floored at zero
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "A tax is imposed for each taxable year on the North Carolina taxable income of every individual"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          max(0, nc_pit_pilot_state_taxable_income)
-  - name: nc_pit_pilot_income_tax_liability
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: N.C. Gen. Stat. 105-153.7(a), the 3.99 per cent flat tax on North Carolina taxable income before credits
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
-              output: individual_income_tax_rate
-              hash: sha256:a647150d3f279d01c8716d9ac36fbcdf04ffc98f60cde57aecba78d1247e4224
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-nc/statute/105/105-153.7
-              excerpt: "the tax is a percentage of the taxpayer's North Carolina taxable income computed as follows"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          nc_pit_pilot_taxable_income * individual_income_tax_rate
+- name: pilot_nonnegative_north_carolina_taxable_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: N.C. Gen. Stat. § 105-153.7(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: A tax is imposed for each taxable year on the North Carolina taxable
+            income of every individual.
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: max(0, north_carolina_taxable_income)
+- name: pilot_individual_income_tax_liability
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: N.C. Gen. Stat. § 105-153.7(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-nc/statute/105/105-153.7
+          excerpt: the tax is a percentage of the taxpayer's North Carolina taxable
+            income
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-nc:statutes/105/105-153/7#individual_income_tax_rate
+          output: individual_income_tax_rate
+          hash: sha256:a647150d3f279d01c8716d9ac36fbcdf04ffc98f60cde57aecba78d1247e4224
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: pilot_nonnegative_north_carolina_taxable_income * individual_income_tax_rate


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-nc/statute/105/105-153.7`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Base commit: `68cca4a6fa806b63f95277c129575d88d2ac07f1`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/30836768345

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.