### PR TITLE
Authorize reviewed canonical-layout migration

### DIFF
--- a/.axiom/reviewed-migrations.json
+++ b/.axiom/reviewed-migrations.json
@@ -3,7 +3,7 @@
   "migrations": [
     {
       "pull_request": 911,
-      "head": "aa760622eb4297a0fd300bf2b816867ec4385916",
+      "head": "b9b46dd845c61a49091146b3a3510fa3b8204ee7",
       "retired_schema_bootstrap_sha256": "0d960eaf2830a9657108ffcba72bf965dd10ddeb0fc5fcc1b28a6039a21e5c0b",
       "validation_waiver_bootstrap_sha256": "827c551bf7d8dc562ae74c8d6f02a3862afeaf0ad656a203b4fe35b79f5f8aac"
     }

--- a/.axiom/reviewed-migrations.json
+++ b/.axiom/reviewed-migrations.json
@@ -3,7 +3,7 @@
   "migrations": [
     {
       "pull_request": 911,
-      "head": "b9b46dd845c61a49091146b3a3510fa3b8204ee7",
+      "head": "f95effd52a10fa98a456777379eb2339172a422e",
       "retired_schema_bootstrap_sha256": "0d960eaf2830a9657108ffcba72bf965dd10ddeb0fc5fcc1b28a6039a21e5c0b",
       "validation_waiver_bootstrap_sha256": "827c551bf7d8dc562ae74c8d6f02a3862afeaf0ad656a203b4fe35b79f5f8aac"
     }

--- a/.axiom/reviewed-migrations.json
+++ b/.axiom/reviewed-migrations.json
@@ -1,0 +1,11 @@
+{
+  "format": "axiom/reviewed-migrations/v1",
+  "migrations": [
+    {
+      "pull_request": 911,
+      "head": "aa760622eb4297a0fd300bf2b816867ec4385916",
+      "retired_schema_bootstrap_sha256": "0d960eaf2830a9657108ffcba72bf965dd10ddeb0fc5fcc1b28a6039a21e5c0b",
+      "validation_waiver_bootstrap_sha256": "827c551bf7d8dc562ae74c8d6f02a3862afeaf0ad656a203b4fe35b79f5f8aac"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- authorize RuleSpec PR #911 at exact reviewed head `f95effd52a10fa98a456777379eb2339172a422e`
- bind the existing retired-schema and validation-waiver bootstrap hashes
- make no RuleSpec content or workflow changes

## Checks
- strict JSON parse
- exact PR number and head assertion
- `git diff --check`

This protected-base record is intentionally separate from PR #911 so the migration workflow cannot self-authorize.