### PR TITLE
Pin corpus successor carrying the FNS OBBBA ABAWD memo

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -5,13 +5,16 @@
 axiom_encode_version = "0.2.1200"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
 axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
-# US tariff parity feedstock: lane A (47 FR tariff instruments, 44 HTS
-# revision snapshots for 2025 Basic-R32 and 2026 Basic-R13, 47 GN3 and
-# chapter 99 notes versions; axiom-corpus PRs #560-#569) plus lane E
-# witness-line sources (4 HTS witness-line versions for beer/solar
-# lines, Proclamation 10339 pages, Section 338 alcohol annex text
-# renditions; axiom-corpus PR #572).
-axiom_corpus_ref = "ed7d4e4f0ba519dc46d4727527331e02b5a547e9"
+# US tariff parity feedstock (axiom-corpus PRs #560-#569, #572) plus
+# the FNS OBBBA ABAWD exceptions implementation memorandum (2025-10-03,
+# us/guidance scope 2026-08-03-snap-obbb-abawd-exceptions-implementation-memo;
+# axiom-corpus PR #578) - operational-authority feedstock for the
+# post-P.L. 119-21 correction of us/regulations/7-cfr/273/24
+# (rulespec-us issue #1210). Successor of ed7d4e4f; also carries the
+# wave-6 UK council CTR ingest and uk-rulespec-2026-08-04 cut that
+# landed on corpus main in between (UK-scoped, no us/* provision
+# changes).
+axiom_corpus_ref = "1e8bfc0a52d2d5fa38ce7cf4ab2577b0536d971e"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Dedicated toolchain PR (provenance rule 1: pins move only in gated, single-purpose PRs).

Bumps `axiom_corpus_ref` `ed7d4e4f` → `1e8bfc0a` — the merge commit of TheAxiomFoundation/axiom-corpus#578, which ingests the FNS **OBBBA ABAWD exceptions implementation memorandum** (2025-10-03) as signed us/guidance scope `2026-08-03-snap-obbb-abawd-exceptions-implementation-memo`.

This is the prerequisite for the 7 CFR 273.24 post-P.L. 119-21 correction (#1210): the memorandum is the operational authority for the 18–64 / 65+ age band, the July 4, 2025 effective date, and the ages-60–64 general-work-exempt-but-ABAWD-subject split. The follow-up content PR cites its page provisions alongside `us/statute/7/2015/o/3`.

Between the old and new pin, corpus main additionally carries the wave-6 UK council CTR ingest (#577) and the `uk-rulespec-2026-08-04` release cut (#579) — UK-scoped, no `us/*` provision changes — plus release-object registration (#576). US citation resolution is additive-only across this range.

Full-repository revalidation runs on this PR by construction (toolchain change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
