### PR TITLE
Encode post-P.L. 119-21 ABAWD exception criteria in 7 CFR 273.24

### DIFF
--- a/.axiom/encoding-manifests/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.json
@@ -1,32 +1,31 @@
 {
   "applied_files": [
     {
-      "path": "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "5914bbc9f6822e2fdc385fece397d4f6291f69f29b0836af5a828ac189d19177"
-    },
-    {
       "path": "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml",
       "sha256": "a02c74c91457ac9aff7189ff069f54d9bbad0e760a59272fa82cf5d058ffc036"
+    },
+    {
+      "path": "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml",
+      "sha256": "2ab6b4850fde01651a4e56ec62e17c5d65028904e60e6960747593ce48d31396"
     }
   ],
   "axiom_encode_git": {
-    "commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-1312-backport",
-    "version": "0.2.1201",
-    "version_commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ca:policies/cdss/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-29T09:48:44.385303+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3/sign-applied-files/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3",
+  "generated_at": "2026-08-04T12:49:04.661802+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo50vz_lo/sign-applied-files/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo50vz_lo",
   "generated_output_sha256": "a02c74c91457ac9aff7189ff069f54d9bbad0e760a59272fa82cf5d058ffc036",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,29 +33,47 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "4f50367c297ec261aa0a3fe40bdd705764acecbe8585f3df1007bcbdf639850b"
+    "value": "e70bcd8947d2450d1108c4cc96db3a1495a83b53ed6a4327f0ecb83fc262d8e5"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-29T07:45:45.496135+00:00",
+    "generated_at": "2026-08-04T12:45:04.941466+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "36e1cb99fbdbd2345d3bccd6810f63155f532d4ed83f50c8f679da2ca5ce8682",
-    "prior_signature": "726278bed11a6b2715c2defd18db4473341d4142bac9ae856a546574d5e3c0f5",
+    "manifest_sha256": "b35d0dc81471ee9877615f2479c66d2cd7b3e43623f06ad85d8103908e52cb24",
+    "prior_signature": "34ff1e97abd918213f206c2fef20df44bb5a09502c678ad016a47d7da5ab9b7b",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-28T22:21:42.156294+00:00",
+      "generated_at": "2026-07-29T09:48:44.385303+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "0b803e3e37e45cac21ba8d1802979da8a925fb03cda622fb949da49dabf192f3",
-      "prior_signature": "7dace90b8ab23d30c2a1fed99badb03a746ee87171e298c6dda6b5372c0affa1",
+      "manifest_sha256": "33bcf4928a641d8baa29cf7c2c6abe32e58c08c727a19de98914967e63976753",
+      "prior_signature": "4f50367c297ec261aa0a3fe40bdd705764acecbe8585f3df1007bcbdf639850b",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-13T01:40:08.170379+00:00",
+        "generated_at": "2026-07-29T07:45:45.496135+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "a00cd9f7260e60fcf4915f74eb7d9b193e2c5d9ea96fa0f41c19f5681a89391c",
-        "prior_signature": "3eac90c6d96dc619d20330e26bf70d8f6a88b18c0c2d6b12a09c2fde8bd656f8",
+        "manifest_sha256": "36e1cb99fbdbd2345d3bccd6810f63155f532d4ed83f50c8f679da2ca5ce8682",
+        "prior_signature": "726278bed11a6b2715c2defd18db4473341d4142bac9ae856a546574d5e3c0f5",
         "run_id": null,
+        "supersedes": {
+          "backend": "manual",
+          "generated_at": "2026-07-28T22:21:42.156294+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "0b803e3e37e45cac21ba8d1802979da8a925fb03cda622fb949da49dabf192f3",
+          "prior_signature": "7dace90b8ab23d30c2a1fed99badb03a746ee87171e298c6dda6b5372c0affa1",
+          "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-13T01:40:08.170379+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "a00cd9f7260e60fcf4915f74eb7d9b193e2c5d9ea96fa0f41c19f5681a89391c",
+            "prior_signature": "3eac90c6d96dc619d20330e26bf70d8f6a88b18c0c2d6b12a09c2fde8bd656f8",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
+          "tool": "axiom-encode sign-applied-files"
+        },
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ca/policies/cdss/snap/modified-categorical-eligibility.json
+++ b/.axiom/encoding-manifests/us-ca/policies/cdss/snap/modified-categorical-eligibility.json
@@ -2,31 +2,26 @@
   "applied_files": [
     {
       "path": "us-ca/policies/cdss/snap/modified-categorical-eligibility.test.yaml",
-      "sha256": "5e6e39057ffc08d2de98d41d4b53024fcb6d6a915689eace0cc9360f506bc30c"
-    },
-    {
-      "path": "us-ca/policies/cdss/snap/modified-categorical-eligibility.yaml",
-      "sha256": "ba01095a1d8619ece130958a128a662011c685ede2e564802f90b46e3bc628dc"
+      "sha256": "30a3acb31ed58b909a86dba991926a957b70bbfb10931b15da318e4f5322ff5d"
     }
   ],
   "axiom_encode_git": {
-    "commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-1312-backport",
-    "version": "0.2.1201",
-    "version_commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ca:policies/cdss/snap/modified-categorical-eligibility",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-29T09:48:44.387127+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3/sign-applied-files/us-ca/policies/cdss/snap/modified-categorical-eligibility.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3",
+  "generated_at": "2026-08-04T12:45:04.947331+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us-ca/policies/cdss/snap/modified-categorical-eligibility.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
   "generated_output_sha256": "ba01095a1d8619ece130958a128a662011c685ede2e564802f90b46e3bc628dc",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,22 +29,31 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ece4a8b7be6485a571ff9dcff84016d1c0d8af1b7b04f7336f9f809d1f5c2f21"
+    "value": "c52067149c9d89da6e535abb900b5eacca99607b649601bdd8ac03a11d1531fc"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-29T07:45:45.497349+00:00",
+    "generated_at": "2026-07-29T09:48:44.387127+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "3d106a81b8aeb785b3489fa6d30de79b7837fa7e79a8d2eec43f4caf0f3e07d7",
-    "prior_signature": "1032f597023e7c161a9d507e11386541b7bb4d654f74ddf984e3d8d073bee5c7",
+    "manifest_sha256": "52e18a46a5da8f2abc497845105aabc32a65c04f65d36196d8194cd955feb544",
+    "prior_signature": "ece4a8b7be6485a571ff9dcff84016d1c0d8af1b7b04f7336f9f809d1f5c2f21",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-28T22:21:42.158092+00:00",
+      "generated_at": "2026-07-29T07:45:45.497349+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "f3a9f410c793cf294d113e2f51c22d3987d5b2141b13b315617879f1333f49a6",
-      "prior_signature": "a786875e6ae0335cfbcdfb9e9037cea26687e7fd6ab8ad5419c98e7008577501",
+      "manifest_sha256": "3d106a81b8aeb785b3489fa6d30de79b7837fa7e79a8d2eec43f4caf0f3e07d7",
+      "prior_signature": "1032f597023e7c161a9d507e11386541b7bb4d654f74ddf984e3d8d073bee5c7",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-28T22:21:42.158092+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "f3a9f410c793cf294d113e2f51c22d3987d5b2141b13b315617879f1333f49a6",
+        "prior_signature": "a786875e6ae0335cfbcdfb9e9037cea26687e7fd6ab8ad5419c98e7008577501",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
     },
     "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-co/policies/cdhs/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-co/policies/cdhs/snap/fy-2026-benefit-calculation.json
@@ -1,0 +1,37 @@
+{
+  "applied_files": [
+    {
+      "path": "us-co/policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml",
+      "sha256": "be29716080fb7ca395f9afc1d722fa0389c18b6dcbea93b267d5def04a78ec59"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-co:policies/cdhs/snap/fy-2026-benefit-calculation",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-08-04T12:45:04.948750+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
+  "generated_output_sha256": "abfc6da46483e403877f0a4de737e8da20733e3961a87b6c13ac0247019943bb",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "8802622026804b2e77aab4be74b33f6c7773ae9ac787584b49fdd0ce4ea6dce4"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.json
@@ -2,31 +2,26 @@
   "applied_files": [
     {
       "path": "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "50a38c65fb073523cdc0c17e8deeafc8f1691b2eb2eaadda6cc77f3f38285f79"
-    },
-    {
-      "path": "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
-      "sha256": "a942c33104ad4acab8fd510f09cf5446c23df73f9ba9c2ae64b31c3a5faea432"
+      "sha256": "a60c295918d78fa127c72fc78952678e9acfa0b9cc567005f2a65661099ae4cf"
     }
   ],
   "axiom_encode_git": {
-    "commit": "adff58d1032d26be07644c181f5c4f6b1bf1b706",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1201",
-    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ga:policies/dfcs/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T01:40:08.607542+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9xk5npen/sign-applied-files/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp9xk5npen",
+  "generated_at": "2026-08-04T12:45:04.951756+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
   "generated_output_sha256": "a942c33104ad4acab8fd510f09cf5446c23df73f9ba9c2ae64b31c3a5faea432",
   "generation_prompt_sha256": null,
-  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,43 +29,52 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "a6e7e5bed1601c1c937265706e28cf2e7659c6bb7f3de2928c87911c44c3eafe"
+    "value": "a525deef31a2ca52471e3d2a6a26ccbeb50923cb84040681a2080416bd86e2b8"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-12T22:27:29.792204+00:00",
+    "generated_at": "2026-07-13T01:40:08.607542+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "fd31aa817d0557ff60e8a37bef67396dfd1cc9164bd11a2c7a03519361d4a62d",
-    "prior_signature": "698a98ea15b6e839d099faef93675303d92790f5c30865fb1f45610ab871337b",
+    "manifest_sha256": "52ba6803cd5f3a44b4499964181eb679a149d1de0376c24b560c3e88fd1de2d0",
+    "prior_signature": "a6e7e5bed1601c1c937265706e28cf2e7659c6bb7f3de2928c87911c44c3eafe",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-12T21:14:40.913392+00:00",
+      "generated_at": "2026-07-12T22:27:29.792204+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "78954e25155eabee2d824b17fb4b6c06f47c9bc0a09d0deb289bd0669bfcf852",
-      "prior_signature": "e18908909f42c02a0f5f82c27859a4339196a21ce7b81906d4461fff172e5d40",
+      "manifest_sha256": "fd31aa817d0557ff60e8a37bef67396dfd1cc9164bd11a2c7a03519361d4a62d",
+      "prior_signature": "698a98ea15b6e839d099faef93675303d92790f5c30865fb1f45610ab871337b",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-12T19:08:21.179427+00:00",
+        "generated_at": "2026-07-12T21:14:40.913392+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "30961e8878ae7d8f02a074e655eb427e3e3bdc1f27a0084aabba99b86bba5b86",
-        "prior_signature": "3d284429600457c341698efcb332e4bd19a391f3612e39205ff55355d635ef58",
+        "manifest_sha256": "78954e25155eabee2d824b17fb4b6c06f47c9bc0a09d0deb289bd0669bfcf852",
+        "prior_signature": "e18908909f42c02a0f5f82c27859a4339196a21ce7b81906d4461fff172e5d40",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-12T18:10:10.907077+00:00",
+          "generated_at": "2026-07-12T19:08:21.179427+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "8af41adc70fe05c103734195f97ea62dbda90b9544d2eae8d2afa972abb4b313",
-          "prior_signature": "29a1d76eb7fdcac444a90b24e902348d67520f2cc0f3f2e04217e28d2bdae816",
+          "manifest_sha256": "30961e8878ae7d8f02a074e655eb427e3e3bdc1f27a0084aabba99b86bba5b86",
+          "prior_signature": "3d284429600457c341698efcb332e4bd19a391f3612e39205ff55355d635ef58",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-12T18:09:28.742756+00:00",
+            "generated_at": "2026-07-12T18:10:10.907077+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "864dd420ffe6515fab8217139d71ba908d93415487d559ed837082504c1f3e56",
-            "prior_signature": "6ca90b8461ef28a666d9838d29096c7296d9cf7a88ccfebebb167eb6a9316fe1",
+            "manifest_sha256": "8af41adc70fe05c103734195f97ea62dbda90b9544d2eae8d2afa972abb4b313",
+            "prior_signature": "29a1d76eb7fdcac444a90b24e902348d67520f2cc0f3f2e04217e28d2bdae816",
             "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-12T18:09:28.742756+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "864dd420ffe6515fab8217139d71ba908d93415487d559ed837082504c1f3e56",
+              "prior_signature": "6ca90b8461ef28a666d9838d29096c7296d9cf7a88ccfebebb167eb6a9316fe1",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
             "tool": "axiom-encode sign-applied-files"
           },
           "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.json
@@ -2,31 +2,26 @@
   "applied_files": [
     {
       "path": "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "f276f5fdfa4e0c27223a9971fb6798f974114aef2fdaf059f2e07c8afc487092"
-    },
-    {
-      "path": "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
-      "sha256": "c090e2c1a5c4806d2f82e5a56fa6ae7b16de46169871111b950723bf938b925f"
+      "sha256": "db444ca7bb2edf24c2414d137fd3e72431aa39ec03ae65ccb06adfa077addd41"
     }
   ],
   "axiom_encode_git": {
-    "commit": "adff58d1032d26be07644c181f5c4f6b1bf1b706",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1201",
-    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-md:policies/dhs/fia/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T01:40:09.040048+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb_gx_kbl/sign-applied-files/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb_gx_kbl",
+  "generated_at": "2026-08-04T12:45:04.954245+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
   "generated_output_sha256": "c090e2c1a5c4806d2f82e5a56fa6ae7b16de46169871111b950723bf938b925f",
   "generation_prompt_sha256": null,
-  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +29,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "a8057393822d6a2dc83fdee2a4297e2322082348e854f766a92b0ae4ff82c9fb"
+    "value": "1720c954ab07040cd1c47c61c115880b62ec1fca96da52e176b71feb56742c58"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-12T22:27:30.232528+00:00",
+    "generated_at": "2026-07-13T01:40:09.040048+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "f935a67986d7e56cbd13e12b9e4f12113e2c287188d7bdc26e74bf291fe3a059",
-    "prior_signature": "95719a75242225e0d8a2ec9a1a5605890d0e2cfca4f17c6443e2bc9150cce38d",
+    "manifest_sha256": "106bf872a8f9489f4a0f76dd6e2a6b2683a39f3ce0d45152e2e91c8888b572ec",
+    "prior_signature": "a8057393822d6a2dc83fdee2a4297e2322082348e854f766a92b0ae4ff82c9fb",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-12T21:14:41.399388+00:00",
+      "generated_at": "2026-07-12T22:27:30.232528+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "ac7998da07c06f8e111ced17cfd6b18f88d57c0b9dcac68aa582cfc22c944e70",
-      "prior_signature": "a7c5ad4f57e28a77537b7301a456a5cdc12a74eaa003da98466b22fbb0f4edbd",
+      "manifest_sha256": "f935a67986d7e56cbd13e12b9e4f12113e2c287188d7bdc26e74bf291fe3a059",
+      "prior_signature": "95719a75242225e0d8a2ec9a1a5605890d0e2cfca4f17c6443e2bc9150cce38d",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-12T18:10:11.412621+00:00",
+        "generated_at": "2026-07-12T21:14:41.399388+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "0e783e45dd2b3cbb2ac554bc630a894e143ace55fa2398b23928713a9533a574",
-        "prior_signature": "008ffd7d401f61f50132317a9b5c00cc3cb6b26105f58ee5c54ec5e67d66564d",
+        "manifest_sha256": "ac7998da07c06f8e111ced17cfd6b18f88d57c0b9dcac68aa582cfc22c944e70",
+        "prior_signature": "a7c5ad4f57e28a77537b7301a456a5cdc12a74eaa003da98466b22fbb0f4edbd",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-12T18:09:29.239837+00:00",
+          "generated_at": "2026-07-12T18:10:11.412621+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "1f9f2ee86f415d5f189d9adfe8264505cc57b052414994072e3dee357323cc3b",
-          "prior_signature": "3457ea05439477d947ea0365d70ede9082943f20d798850ae4c20bc471614406",
+          "manifest_sha256": "0e783e45dd2b3cbb2ac554bc630a894e143ace55fa2398b23928713a9533a574",
+          "prior_signature": "008ffd7d401f61f50132317a9b5c00cc3cb6b26105f58ee5c54ec5e67d66564d",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-12T18:09:29.239837+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "1f9f2ee86f415d5f189d9adfe8264505cc57b052414994072e3dee357323cc3b",
+            "prior_signature": "3457ea05439477d947ea0365d70ede9082943f20d798850ae4c20bc471614406",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us-ny/policies/otda/snap/fy-2026-benefit-calculation.json
+++ b/.axiom/encoding-manifests/us-ny/policies/otda/snap/fy-2026-benefit-calculation.json
@@ -1,32 +1,31 @@
 {
   "applied_files": [
     {
-      "path": "us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml",
-      "sha256": "e168b707a7823b0b2d66e01e04899b5b22df8fdfccae153cdd5b91c3423ab53e"
-    },
-    {
       "path": "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
       "sha256": "ea73222f65e01e0ffb412b3f2cf418050ef1e39109b377b5e3f9c6896c520aa9"
+    },
+    {
+      "path": "us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml",
+      "sha256": "0439e372b91383799ca693b4cdcc6eb3e59372ad8812ba2d4010c66c0953d7dc"
     }
   ],
   "axiom_encode_git": {
-    "commit": "adff58d1032d26be07644c181f5c4f6b1bf1b706",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.1201",
-    "version_commit": "f960f1daf932cd47e5cddd1618057be1112f22a0"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us-ny:policies/otda/snap/fy-2026-benefit-calculation",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-13T02:36:32.706355+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo9firzv_/sign-applied-files/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo9firzv_",
+  "generated_at": "2026-08-04T12:49:04.671593+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo50vz_lo/sign-applied-files/us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpo50vz_lo",
   "generated_output_sha256": "ea73222f65e01e0ffb412b3f2cf418050ef1e39109b377b5e3f9c6896c520aa9",
   "generation_prompt_sha256": null,
-  "manual_exception": "#875",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +33,54 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "ce574180bfce89557364e44197d8179abf012dfd23d78367edc417defec6398a"
+    "value": "783801f4b1f03abbe0e76d060f93ca771cf78934a213a75cb56021ccd2ca7f76"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-13T02:17:21.885943+00:00",
+    "generated_at": "2026-08-04T12:45:04.956009+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "399dab4520705f67e1054befce07b673c548b72e6cbdd6e2ce129722f54737d4",
-    "prior_signature": "ebfe6f015ecc6047fc9155ae9dba5d6ff2cbc674fa3dfd677d60d88355d48122",
+    "manifest_sha256": "b6ae00c7b9e0247616e0ab0f29bc148e5bf2fd63ddf3997fe95d66c0defa241b",
+    "prior_signature": "f9083b012bb22294a1c98cb2e71c1970939e270d523c2d69878ef620faf362ff",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-13T01:40:41.194329+00:00",
+      "generated_at": "2026-07-13T02:36:32.706355+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "d2456f91b915c8af611be2c0ab83fd08de2195cf4d23b3527a4fb5b62c188153",
-      "prior_signature": "f5055702f40f55340fb2788d68cbc92157310c18bbc4357ddeaa281500bd5541",
+      "manifest_sha256": "b15e73643f56256f5830729869b690d458bee90512bced1e36aa74d62b110ec5",
+      "prior_signature": "ce574180bfce89557364e44197d8179abf012dfd23d78367edc417defec6398a",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-13T01:40:09.481674+00:00",
+        "generated_at": "2026-07-13T02:17:21.885943+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "97b324a350815aaec2155e6e7019496335d47081e966e69e76b1af28580dd580",
-        "prior_signature": "0048ac64bc5828dc5b4af1900956c8cbeb338be5358bea04c43825d7b9cff336",
+        "manifest_sha256": "399dab4520705f67e1054befce07b673c548b72e6cbdd6e2ce129722f54737d4",
+        "prior_signature": "ebfe6f015ecc6047fc9155ae9dba5d6ff2cbc674fa3dfd677d60d88355d48122",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-12T15:13:06.543377+00:00",
+          "generated_at": "2026-07-13T01:40:41.194329+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "4abacb3c753f8a27969aa68faa030e6991c69d4fa50475b18593f314cb28e3ba",
-          "prior_signature": "74e6b03a8b5d309b8dc993048418c7b2adb6646d8e5672ae4ff3a338a4e10d68",
+          "manifest_sha256": "d2456f91b915c8af611be2c0ab83fd08de2195cf4d23b3527a4fb5b62c188153",
+          "prior_signature": "f5055702f40f55340fb2788d68cbc92157310c18bbc4357ddeaa281500bd5541",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-13T01:40:09.481674+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "97b324a350815aaec2155e6e7019496335d47081e966e69e76b1af28580dd580",
+            "prior_signature": "0048ac64bc5828dc5b4af1900956c8cbeb338be5358bea04c43825d7b9cff336",
+            "run_id": null,
+            "supersedes": {
+              "backend": "manual",
+              "generated_at": "2026-07-12T15:13:06.543377+00:00",
+              "generation_prompt_sha256": null,
+              "manifest_sha256": "4abacb3c753f8a27969aa68faa030e6991c69d4fa50475b18593f314cb28e3ba",
+              "prior_signature": "74e6b03a8b5d309b8dc993048418c7b2adb6646d8e5672ae4ff3a338a4e10d68",
+              "run_id": null,
+              "tool": "axiom-encode sign-applied-files"
+            },
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us/policies/usda/snap/state-plan-composition.json
+++ b/.axiom/encoding-manifests/us/policies/usda/snap/state-plan-composition.json
@@ -2,31 +2,26 @@
   "applied_files": [
     {
       "path": "us/policies/usda/snap/state-plan-composition.test.yaml",
-      "sha256": "d211613e154c86b4c55eb7151f56af823929246505951264448870842630b4e4"
-    },
-    {
-      "path": "us/policies/usda/snap/state-plan-composition.yaml",
-      "sha256": "a69101e09fe1b0b3c4a70c5df2d7329a5dd0931c194e8df54ec560412df71695"
+      "sha256": "bb252ac61e71723b72d5a4f8c87b0035f4d24efd244ba92011b033802253993d"
     }
   ],
   "axiom_encode_git": {
-    "commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-1312-backport",
-    "version": "0.2.1201",
-    "version_commit": "7121774c254ca8b34d05009202a32d7e6f7d16d7"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1201",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us:policies/usda/snap/state-plan-composition",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-29T09:48:44.388730+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3/sign-applied-files/us/policies/usda/snap/state-plan-composition.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp4v1wsyv3",
+  "generated_at": "2026-08-04T12:45:04.957966+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/policies/usda/snap/state-plan-composition.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
   "generated_output_sha256": "a69101e09fe1b0b3c4a70c5df2d7329a5dd0931c194e8df54ec560412df71695",
   "generation_prompt_sha256": null,
-  "manual_exception": "composition",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,36 +29,45 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "30579a78b42e929dd59258597fde0e607b1084d9c7c06cd4b078f17ba39effce"
+    "value": "71b922cc79b53502051cc08fa939ad8066b0f5162d719f94f482a704da557cb3"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-13T02:36:32.293624+00:00",
+    "generated_at": "2026-07-29T09:48:44.388730+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "0a860a0142d624ebe02b76903424c833680e47ea084be5d698f970ef9cd7b5de",
-    "prior_signature": "e53b8c4b214b1e667d45d5eaed1f202363d050586e8a01e6b5d6040d728dbb93",
+    "manifest_sha256": "9cebccc1419b8d7e288b9bd30110850b59d493bacf7559aa50075cad9863bca4",
+    "prior_signature": "30579a78b42e929dd59258597fde0e607b1084d9c7c06cd4b078f17ba39effce",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-13T02:17:21.487077+00:00",
+      "generated_at": "2026-07-13T02:36:32.293624+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "92de486ef90587549c827231012eab25061e9d75ce2b27a177c8ea277a5e4c48",
-      "prior_signature": "21bc5cf405bcad662db958a0455051aaeca2ee43a43a2a15f6cefa9f036827b2",
+      "manifest_sha256": "0a860a0142d624ebe02b76903424c833680e47ea084be5d698f970ef9cd7b5de",
+      "prior_signature": "e53b8c4b214b1e667d45d5eaed1f202363d050586e8a01e6b5d6040d728dbb93",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-13T01:40:41.639509+00:00",
+        "generated_at": "2026-07-13T02:17:21.487077+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "e78e4a984965844f8b26e0d39de8dd0d8d20ab4ff9a70934c77c34869c39c48e",
-        "prior_signature": "a56ef8a1ad9e391b1e123e8d2bca3e94ecc09ae51c21045a797bb14234d265a6",
+        "manifest_sha256": "92de486ef90587549c827231012eab25061e9d75ce2b27a177c8ea277a5e4c48",
+        "prior_signature": "21bc5cf405bcad662db958a0455051aaeca2ee43a43a2a15f6cefa9f036827b2",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-13T01:40:07.289038+00:00",
+          "generated_at": "2026-07-13T01:40:41.639509+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "15ce04f84ca96c088e72a75e57314fb2add8e04c3ba701f7cf4d2a224e9686b2",
-          "prior_signature": "d28cc840361753181b78c84e0c7155b3514dda5f3edd73a9610ff3e3ee5c2deb",
+          "manifest_sha256": "e78e4a984965844f8b26e0d39de8dd0d8d20ab4ff9a70934c77c34869c39c48e",
+          "prior_signature": "a56ef8a1ad9e391b1e123e8d2bca3e94ecc09ae51c21045a797bb14234d265a6",
           "run_id": null,
+          "supersedes": {
+            "backend": "manual",
+            "generated_at": "2026-07-13T01:40:07.289038+00:00",
+            "generation_prompt_sha256": null,
+            "manifest_sha256": "15ce04f84ca96c088e72a75e57314fb2add8e04c3ba701f7cf4d2a224e9686b2",
+            "prior_signature": "d28cc840361753181b78c84e0c7155b3514dda5f3edd73a9610ff3e3ee5c2deb",
+            "run_id": null,
+            "tool": "axiom-encode sign-applied-files"
+          },
           "tool": "axiom-encode sign-applied-files"
         },
         "tool": "axiom-encode sign-applied-files"

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
@@ -1,6 +1,10 @@
 {
   "applied_files": [
     {
+      "path": "us/regulations/7-cfr/273/11/c.yaml",
+      "sha256": "6827c4cc35619aa8780e53f85ddcc79454e17813bb2a5d5294e73f07e08d9b55"
+    },
+    {
       "path": "us/regulations/7-cfr/273/11/c.test.yaml",
       "sha256": "fc6784a66a37fd3655f844d86faefcd501da02bade8c0bbe63d48b4056bbc3ad"
     }
@@ -13,34 +17,43 @@
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
   "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
+  "backend": "deterministic",
   "citation": "us:regulations/7-cfr/273/11/c",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-04T12:45:04.960215+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/11/c.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
-  "generated_output_sha256": "c8be87e1d30bccc329b53867968a7033330e425837ef2a03efbda891765a74b7",
+  "generated_at": "2026-08-04T13:06:38.839699+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1rvd7o7c/deterministic-repair/us/regulations/7-cfr/273/11/c.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1rvd7o7c",
+  "generated_output_sha256": "6827c4cc35619aa8780e53f85ddcc79454e17813bb2a5d5294e73f07e08d9b55",
   "generation_prompt_sha256": null,
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
+  "model": "proof-import-hash-v1",
+  "run_id": "deterministic-repair",
+  "runner": "deterministic-repair",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "3f18bb2adcc06a70e4f20fcc42b069f1875422a1c3935eaed3dd93ae7bb15989"
+    "value": "afdabcb6c02ef2636759914a3394fe079e40c5b8e047175d655deb58d961ed5b"
   },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-07T04:55:32.784640+00:00",
+    "generated_at": "2026-08-04T12:45:04.960215+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "5fed24423c9d0e8d768b9edcb8e47cc7c78967250fa4693b5eea2cc8fdd70c3a",
-    "prior_signature": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8",
+    "manifest_sha256": "367c9942d3aa6ee27419a15c89158cf6ed27c8ecd66d8311debfc31eb9105221",
+    "prior_signature": "3f18bb2adcc06a70e4f20fcc42b069f1875422a1c3935eaed3dd93ae7bb15989",
     "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-07-07T04:55:32.784640+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "5fed24423c9d0e8d768b9edcb8e47cc7c78967250fa4693b5eea2cc8fdd70c3a",
+      "prior_signature": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8",
+      "run_id": null,
+      "tool": "axiom-encode sign-applied-files"
+    },
     "tool": "axiom-encode sign-applied-files"
   },
-  "tool": "axiom-encode sign-applied-files",
+  "tool": "axiom-encode repair-proof-import-hashes",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
@@ -2,31 +2,26 @@
   "applied_files": [
     {
       "path": "us/regulations/7-cfr/273/11/c.test.yaml",
-      "sha256": "2c7d0338f14637c2fc5cb0bb2c1367bebbb1ac0f39a417ba7b28f5f7761c0317"
-    },
-    {
-      "path": "us/regulations/7-cfr/273/11/c.yaml",
-      "sha256": "c8be87e1d30bccc329b53867968a7033330e425837ef2a03efbda891765a74b7"
+      "sha256": "fc6784a66a37fd3655f844d86faefcd501da02bade8c0bbe63d48b4056bbc3ad"
     }
   ],
   "axiom_encode_git": {
-    "commit": "381e62ad800b7efacde65973a6f22d8f1f0f22b4",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode",
-    "version": "0.2.1184",
-    "version_commit": "381e62ad800b7efacde65973a6f22d8f1f0f22b4"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.1184",
+  "axiom_encode_version": "0.2.1200",
   "backend": "manual",
   "citation": "us:regulations/7-cfr/273/11/c",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-07T04:55:32.784640+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgg90h8js/sign-applied-files/us/regulations/7-cfr/273/11/c.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpgg90h8js",
+  "generated_at": "2026-08-04T12:45:04.960215+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/11/c.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
   "generated_output_sha256": "c8be87e1d30bccc329b53867968a7033330e425837ef2a03efbda891765a74b7",
   "generation_prompt_sha256": null,
-  "manual_exception": "#564",
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
@@ -34,7 +29,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8"
+    "value": "3f18bb2adcc06a70e4f20fcc42b069f1875422a1c3935eaed3dd93ae7bb15989"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-07-07T04:55:32.784640+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "5fed24423c9d0e8d768b9edcb8e47cc7c78967250fa4693b5eea2cc8fdd70c3a",
+    "prior_signature": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
@@ -1,37 +1,50 @@
 {
   "applied_files": [
     {
+      "path": "us/regulations/7-cfr/273/24.test.yaml",
+      "sha256": "3f700bcd0d9e6bda83cefc5f6d1cc51c4aefa5487ea26d121e8d329ed65e422d"
+    },
+    {
       "path": "us/regulations/7-cfr/273/24.yaml",
-      "sha256": "956c2c20b9311eec7bdfba8559662b5b5fe23af90fb34aa8f7d3f61e78b37501"
+      "sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec"
     }
   ],
   "axiom_encode_git": {
-    "commit": "9f37175887c14d00f16c87a6644d3ebc88763e9f",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.954",
-    "version_commit": "9f37175887c14d00f16c87a6644d3ebc88763e9f"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.954",
-  "backend": "deterministic",
-  "citation": "us:us/regulations/7-cfr/273/24",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/7-cfr/273/24",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-29T02:54:01.996017+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpyhact0vg/deterministic-repair/us/regulations/7-cfr/273/24.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpyhact0vg",
-  "generated_output_sha256": "956c2c20b9311eec7bdfba8559662b5b5fe23af90fb34aa8f7d3f61e78b37501",
+  "generated_at": "2026-08-04T12:45:04.962148+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/24.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
+  "generated_output_sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec",
   "generation_prompt_sha256": null,
-  "model": "embedded-scalar-literal-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6"
+    "value": "47bef9c7b2e312421f43ae70d6b490a644a77a758e55649f2079ed6f59f2118c"
   },
-  "tool": "axiom-encode repair-embedded-scalar-literals",
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-06-29T02:54:01.996017+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "2cd1b3cb2d7b38fb7984440f055d9463e84fdd7ca07211aa0aa97025b5542d2b",
+    "prior_signature": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6",
+    "run_id": "deterministic-repair",
+    "tool": "axiom-encode repair-embedded-scalar-literals"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "us/regulations/7-cfr/273/24.test.yaml",
-      "sha256": "3f700bcd0d9e6bda83cefc5f6d1cc51c4aefa5487ea26d121e8d329ed65e422d"
-    },
-    {
       "path": "us/regulations/7-cfr/273/24.yaml",
       "sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec"
+    },
+    {
+      "path": "us/regulations/7-cfr/273/24.test.yaml",
+      "sha256": "24711e988cabe22cac37fdb5e71adef7ace18d208ed7281cea80305bce17d9b9"
     }
   ],
   "axiom_encode_git": {
@@ -21,9 +21,9 @@
   "citation": "us:regulations/7-cfr/273/24",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-04T12:45:04.962148+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/24.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
+  "generated_at": "2026-08-04T13:37:30.005014+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6/sign-applied-files/us/regulations/7-cfr/273/24.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6",
   "generated_output_sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec",
   "generation_prompt_sha256": null,
   "model": "",
@@ -33,16 +33,34 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "47bef9c7b2e312421f43ae70d6b490a644a77a758e55649f2079ed6f59f2118c"
+    "value": "f77afc88d0826a97b45b008e2116fb950b55aae9e459967f653a7fa60e89c601"
   },
   "supersedes": {
-    "backend": "deterministic",
-    "generated_at": "2026-06-29T02:54:01.996017+00:00",
+    "backend": "manual",
+    "generated_at": "2026-08-04T13:37:02.774033+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "2cd1b3cb2d7b38fb7984440f055d9463e84fdd7ca07211aa0aa97025b5542d2b",
-    "prior_signature": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6",
-    "run_id": "deterministic-repair",
-    "tool": "axiom-encode repair-embedded-scalar-literals"
+    "manifest_sha256": "a6bc0b7bd681a63bfc4944733d29c969e497a999bff998437e7483f27ac81cf8",
+    "prior_signature": "bf5ba3d089d2ce1d79a38346dac1d5235973a2a3ef7d93034434e81d024fe585",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-08-04T12:45:04.962148+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "b177f6a3a3747fc6d161dc4d256f7224f38844aadfa8d6c1e869d45258983d36",
+      "prior_signature": "47bef9c7b2e312421f43ae70d6b490a644a77a758e55649f2079ed6f59f2118c",
+      "run_id": null,
+      "supersedes": {
+        "backend": "deterministic",
+        "generated_at": "2026-06-29T02:54:01.996017+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "2cd1b3cb2d7b38fb7984440f055d9463e84fdd7ca07211aa0aa97025b5542d2b",
+        "prior_signature": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6",
+        "run_id": "deterministic-repair",
+        "tool": "axiom-encode repair-embedded-scalar-literals"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/7.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/7.json
@@ -1,12 +1,12 @@
 {
   "applied_files": [
     {
-      "path": "us/regulations/7-cfr/273/7.test.yaml",
-      "sha256": "3a2efd3a097c30a72d5fd93a1ddc612d917cd1a588ff0dd0619c52c93cecd03d"
+      "path": "us/regulations/7-cfr/273/7.yaml",
+      "sha256": "39dc6d050ebcc8db6eb7b8c4711a082a3707e0761258e159eb516d090e72bf87"
     },
     {
-      "path": "us/regulations/7-cfr/273/7.yaml",
-      "sha256": "b5efd606db224dd933a10af621b7007b5d5e057c2d74a2bdec7703ae92cfd91e"
+      "path": "us/regulations/7-cfr/273/7.test.yaml",
+      "sha256": "3a2efd3a097c30a72d5fd93a1ddc612d917cd1a588ff0dd0619c52c93cecd03d"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us:regulations/7-cfr/273/7",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-04T12:45:04.963950+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/7.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
-  "generated_output_sha256": "b5efd606db224dd933a10af621b7007b5d5e057c2d74a2bdec7703ae92cfd91e",
+  "generated_at": "2026-08-04T13:37:30.008380+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6/sign-applied-files/us/regulations/7-cfr/273/7.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6",
+  "generated_output_sha256": "39dc6d050ebcc8db6eb7b8c4711a082a3707e0761258e159eb516d090e72bf87",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,16 +33,34 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "1a9c5251df8cf30dfe9cbf724482962a75b201c23411c3e4558f7d2ff76f10a1"
+    "value": "7950d5d9ce6c759186c9f5edad0e247b6e37304601ca95f43ee6b0394bdc49ed"
   },
   "supersedes": {
-    "backend": "deterministic",
-    "generated_at": "2026-06-29T02:53:11.056134+00:00",
+    "backend": "manual",
+    "generated_at": "2026-08-04T13:37:02.776745+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "9d409d6f9ca2c7f05c4b0e1d6305b83b5f69dbf3386a3d7329f2b168f95dbd9b",
-    "prior_signature": "4e6facd0cb94a3e55158caf318e908ac71468319292e8e1ff66df35252b6b786",
-    "run_id": "deterministic-repair",
-    "tool": "axiom-encode repair-embedded-scalar-literals"
+    "manifest_sha256": "0fb7fe92f5e5e002720daf1c5477d714cbabcffe67712acbdc5ff520f2197b05",
+    "prior_signature": "ca81bbfe6c3d010eb7f7499697cf76ffe50897d1f4586ff8440eda8221e8eef2",
+    "run_id": null,
+    "supersedes": {
+      "backend": "manual",
+      "generated_at": "2026-08-04T12:45:04.963950+00:00",
+      "generation_prompt_sha256": null,
+      "manifest_sha256": "ca65f13cfb820f7fc180d67157d687681d8a25446731fa754b9045ae593ca4c4",
+      "prior_signature": "1a9c5251df8cf30dfe9cbf724482962a75b201c23411c3e4558f7d2ff76f10a1",
+      "run_id": null,
+      "supersedes": {
+        "backend": "deterministic",
+        "generated_at": "2026-06-29T02:53:11.056134+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "9d409d6f9ca2c7f05c4b0e1d6305b83b5f69dbf3386a3d7329f2b168f95dbd9b",
+        "prior_signature": "4e6facd0cb94a3e55158caf318e908ac71468319292e8e1ff66df35252b6b786",
+        "run_id": "deterministic-repair",
+        "tool": "axiom-encode repair-embedded-scalar-literals"
+      },
+      "tool": "axiom-encode sign-applied-files"
+    },
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/7.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/7.json
@@ -1,37 +1,50 @@
 {
   "applied_files": [
     {
+      "path": "us/regulations/7-cfr/273/7.test.yaml",
+      "sha256": "3a2efd3a097c30a72d5fd93a1ddc612d917cd1a588ff0dd0619c52c93cecd03d"
+    },
+    {
       "path": "us/regulations/7-cfr/273/7.yaml",
-      "sha256": "5123ab7bfa8ccb81c4986d3c834100c3c89cb60d3dcf5f28eb16503989b81bce"
+      "sha256": "b5efd606db224dd933a10af621b7007b5d5e057c2d74a2bdec7703ae92cfd91e"
     }
   ],
   "axiom_encode_git": {
-    "commit": "9f37175887c14d00f16c87a6644d3ebc88763e9f",
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
     "dirty_tracked": false,
-    "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode",
-    "version": "0.2.954",
-    "version_commit": "9f37175887c14d00f16c87a6644d3ebc88763e9f"
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
-  "axiom_encode_version": "0.2.954",
-  "backend": "deterministic",
-  "citation": "us:us/regulations/7-cfr/273/7",
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:regulations/7-cfr/273/7",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-06-29T02:53:11.056134+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpgqat4oga/deterministic-repair/us/regulations/7-cfr/273/7.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpgqat4oga",
-  "generated_output_sha256": "5123ab7bfa8ccb81c4986d3c834100c3c89cb60d3dcf5f28eb16503989b81bce",
+  "generated_at": "2026-08-04T12:45:04.963950+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs/sign-applied-files/us/regulations/7-cfr/273/7.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpzc4bz0xs",
+  "generated_output_sha256": "b5efd606db224dd933a10af621b7007b5d5e057c2d74a2bdec7703ae92cfd91e",
   "generation_prompt_sha256": null,
-  "model": "embedded-scalar-literal-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "4e6facd0cb94a3e55158caf318e908ac71468319292e8e1ff66df35252b6b786"
+    "value": "1a9c5251df8cf30dfe9cbf724482962a75b201c23411c3e4558f7d2ff76f10a1"
   },
-  "tool": "axiom-encode repair-embedded-scalar-literals",
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-06-29T02:53:11.056134+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "9d409d6f9ca2c7f05c4b0e1d6305b83b5f69dbf3386a3d7329f2b168f95dbd9b",
+    "prior_signature": "4e6facd0cb94a3e55158caf318e908ac71468319292e8e1ff66df35252b6b786",
+    "run_id": "deterministic-repair",
+    "tool": "axiom-encode repair-embedded-scalar-literals"
+  },
+  "tool": "axiom-encode sign-applied-files",
   "trace_file": null,
   "trace_sha256": null
 }

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35932,6 +35932,24 @@
         ]
       }
     ],
+    "us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1": [
+      {
+        "module": "us/regulations/7-cfr/273/24.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4": [
+      {
+        "module": "us/regulations/7-cfr/273/24.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/policy/cms/chip-spa/al/al-24-0031-fcep-and-al-24-0031-absc/pdf/page-2": [
       {
         "module": "us-al/policies/cms/alabama-chip-eligibility.yaml",
@@ -43854,6 +43872,24 @@
       },
       {
         "module": "us/statutes/7/2015/e.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/7/2015/d/2": [
+      {
+        "module": "us/regulations/7-cfr/273/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/7/2015/o/3": [
+      {
+        "module": "us/regulations/7-cfr/273/24.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -4146,12 +4146,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml":
-    active:
-      fingerprint: "sha256:881eda4279377e626a7c2af7051aead8e4b785c286d65eaa3ae2c599bc155e1d"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/385/3.yaml":
     active:
       fingerprint: "sha256:b8d41cdb748fd44e6cfcd59d250cc9233ef9a733d34106f531bccf9e84ae22c5"
@@ -8661,12 +8655,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml":
-    pending:
-      fingerprint: "sha256:bf3fec15192a90cfa538de8ecbff84b10cf8c3c728ce58d687aaefd6a3a6785a"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-co/policies/cms/colorado-chip-eligibility.yaml":
     pending:
       fingerprint: "sha256:23944cb9c34904e01113f246b5f58cea3b42df20421464fcaa2a993674c243e1"
@@ -12687,12 +12675,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml":
-    pending:
-      fingerprint: "sha256:a963ac2c3cf5b48586954414aadb988ee5fbe87ddaf42234d188ead2c8ca0728"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ga/policies/dfcs/snap/standard-utility-allowances.yaml":
     pending:
       fingerprint: "sha256:e516ba057f68e2410e58fd4e2468204f206edbeaf460504cfc459cd4345cde14"
@@ -13854,12 +13836,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.yaml":
     pending:
       fingerprint: "sha256:9dbd467c895e84c469c85985f7602f61e3a56cdc1bff578cb6613e735e6b1cfd"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml":
-    pending:
-      fingerprint: "sha256:90a35e6eee464f18c0e7d0cd047df3ee375364f2379a065e9ba4eee9bca0c794"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -18366,12 +18342,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/regulations/7-cfr/247/9/b.yaml":
     pending:
       fingerprint: "sha256:9ab42d1759779bd7991a86f5d3c0b5653661a244ee1585ccad00c0bb04471a10"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-  "us/regulations/7-cfr/273/11/c.yaml":
-    pending:
-      fingerprint: "sha256:2a7c97c3b5cc9b7a7b2cfa0579a878c484f6825b4833deb6b2f581d37e71716e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"

--- a/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml
@@ -38,6 +38,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -108,6 +136,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -168,6 +224,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -230,6 +314,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -292,6 +404,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -327,6 +467,34 @@
     us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
     us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
     us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
     us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -385,6 +553,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -467,6 +663,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -506,6 +730,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -545,6 +797,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -628,6 +908,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -716,6 +1024,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -795,6 +1131,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -834,6 +1198,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -873,6 +1265,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -951,6 +1371,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -990,6 +1438,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -1029,6 +1505,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -1066,3 +1570,82 @@
     us-ca:policies/cdss/snap/fy-2026-benefit-calculation#calfresh_categorical_zero_benefit_denial_applies: holds
     us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible: not_holds
     us:policies/usda/snap/state-plan-composition#snap_benefit: 0
+# July 2026 post-P.L. 119-21 ABAWD regression: California inherits the federal
+# 7 CFR 273.24 module through us:policies/usda/snap/state-plan-composition, so
+# a 55-year-old with exhausted countable months and no exception must be
+# work-requirement ineligible - and therefore not snap_member_eligible - inside
+# the CalFresh composition with no California-side edit.
+- name: abawd_age_55_flows_through_california_composition_july_2026
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 55
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 55
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
+    us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
+    us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
+    us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
+    ? us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed
+    : false
+    us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
+    us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
+    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
+    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
+    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
+    us:regulations/7-cfr/273/24#snap_member_work_requirement_eligible: not_holds
+    us:regulations/7-cfr/273/24#snap_member_work_requirement_ineligible: holds
+    us:policies/usda/snap/state-plan-composition#snap_member_eligible: not_holds

--- a/us-ca/policies/cdss/snap/modified-categorical-eligibility.test.yaml
+++ b/us-ca/policies/cdss/snap/modified-categorical-eligibility.test.yaml
@@ -14,6 +14,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -46,6 +74,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -75,6 +131,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -104,6 +188,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -133,6 +245,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -162,6 +302,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -192,6 +360,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -222,6 +418,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -251,6 +475,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -280,6 +532,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -309,6 +589,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -339,6 +647,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -369,6 +705,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -399,6 +763,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -429,6 +821,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: true
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -459,6 +879,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -475,6 +923,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -508,6 +984,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -524,6 +1028,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -556,6 +1088,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: true
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -572,6 +1132,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -634,6 +1222,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -664,6 +1280,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -694,6 +1338,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -724,6 +1396,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -754,6 +1454,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -776,6 +1504,34 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -795,6 +1551,34 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -814,6 +1598,34 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: true
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -854,6 +1666,34 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: true
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -868,6 +1708,34 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: true
@@ -882,6 +1750,22 @@
     us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
     us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
     us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
     us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -918,6 +1802,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -952,6 +1864,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -972,6 +1912,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -1001,6 +1969,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: true
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -1023,6 +2019,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: true
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -1052,6 +2076,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false
@@ -1068,6 +2120,34 @@
       us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_has_drug_felony_conviction: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_ssi_recipient_in_cash_out_state: false
       us-ca:policies/cdss/snap/modified-categorical-eligibility#input.member_is_institutionalized_in_nonexempt_facility: false

--- a/us-co/policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-co/policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml
@@ -46,6 +46,33 @@
     us:statutes/7/2012/j#relation.member_of_household: &id001
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/24#input.member_age: 60
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
@@ -720,6 +747,33 @@
     us:statutes/7/2012/j#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/24#input.member_age: 60
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: true
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false

--- a/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.test.yaml
@@ -36,6 +36,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -113,6 +141,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -177,6 +233,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -241,6 +325,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -280,6 +392,34 @@
     us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
     us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
     us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
     us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -336,6 +476,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false

--- a/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.test.yaml
@@ -36,6 +36,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -112,6 +140,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -175,6 +231,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -238,6 +322,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -276,6 +388,34 @@
     us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
     us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
     us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
     us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -332,6 +472,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false

--- a/us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml
+++ b/us-ny/policies/otda/snap/fy-2026-benefit-calculation.test.yaml
@@ -33,6 +33,34 @@
     us:statutes/7/2012/j#relation.member_of_household: &id001
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -332,6 +360,34 @@
     us:statutes/7/2012/j#relation.member_of_household: &id002
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: true
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -410,6 +466,34 @@
     us:statutes/7/2012/j#relation.member_of_household: &id003
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -679,6 +763,34 @@
     us:statutes/7/2012/j#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -702,6 +814,34 @@
     us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -777,6 +917,34 @@
     us:statutes/7/2012/j#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -800,6 +968,34 @@
     us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -879,6 +1075,34 @@
     us:statutes/7/2012/j#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
@@ -902,6 +1126,34 @@
     us:policies/usda/snap/state-plan-composition#relation.member_of_household:
     - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
       us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
       us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false

--- a/us/policies/usda/snap/state-plan-composition.test.yaml
+++ b/us/policies/usda/snap/state-plan-composition.test.yaml
@@ -36,6 +36,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 60
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 60
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -84,6 +112,34 @@
     us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
     us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
     us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_age: 60
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
     us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
     us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
     us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -233,6 +289,34 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 25
+      us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+      us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+      us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+      us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+      us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+      us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+      us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+      us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+      us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+      us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+      us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+      us:regulations/7-cfr/273/24#input.member_age: 25
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
@@ -304,6 +388,22 @@
       us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
       us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
       us:regulations/7-cfr/273/7#input.member_age: 25
+      us:regulations/7-cfr/273/24#input.member_age: 25
+      us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+      us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+      us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+      us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+      us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+      us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+      us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+      us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+      us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+      us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
+      us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+      us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
       us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
       us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false

--- a/us/regulations/7-cfr/273/11/c.test.yaml
+++ b/us/regulations/7-cfr/273/11/c.test.yaml
@@ -112,12 +112,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -168,12 +167,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -224,12 +222,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -280,12 +277,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0

--- a/us/regulations/7-cfr/273/11/c.yaml
+++ b/us/regulations/7-cfr/273/11/c.yaml
@@ -102,7 +102,7 @@ rules:
             import:
               target: us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible
               output: snap_member_abawd_time_limit_eligible
-              hash: sha256:956c2c20b9311eec7bdfba8559662b5b5fe23af90fb34aa8f7d3f61e78b37501
+              hash: sha256:089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec
     versions:
       - effective_from: '2008-10-01'
         formula: |-
@@ -273,7 +273,7 @@ rules:
             import:
               target: us:regulations/7-cfr/273/10#snap_earned_income_deduction_rate_for_net_income
               output: snap_earned_income_deduction_rate_for_net_income
-              hash: sha256:c0fea2e5d8677777fdf6356f65d31e93f7722eb83335e2dc01214e6b46dc3b27
+              hash: sha256:f9b9f00101218d1d335aa9fff400f0578ae2dc314334693bae7e0dde51202dff
     versions:
       - effective_from: '2008-10-01'
         formula: |-

--- a/us/regulations/7-cfr/273/24.test.yaml
+++ b/us/regulations/7-cfr/273/24.test.yaml
@@ -39,7 +39,7 @@
     us:regulations/7-cfr/273/24#snap_member_abawd_fulfilling_work_requirement: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: holds
 - name: abawd_exception_applies_to_responsible_adult_with_child_under_fourteen
-  period: 2026-01
+  period: 2026-07
   input:
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
@@ -493,5 +493,86 @@
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
   output:
     us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: under_eighteen_excepted
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 17
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 17
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: medical_unfitness_excepted
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 40
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: true
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: pregnancy_excepted
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 40
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: true
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
     us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds

--- a/us/regulations/7-cfr/273/24.test.yaml
+++ b/us/regulations/7-cfr/273/24.test.yaml
@@ -1,10 +1,21 @@
+# Companion tests for the ABAWD time-limit module. The exception criteria
+# encode 7 U.S.C. 2015(o)(3) as replaced by P.L. 119-21 section 10102(a)
+# (effective 2025-07-04): the July 2026 cases below pin the post-enactment
+# boundaries (55/64/65/66, dependent-child 13 vs 14, Indian status, and the
+# narrow (d)(2) cross-reference that leaves ages 60-64 general-work-exempt
+# but ABAWD-subject). Age 65 holding via member_age >= 65 follows USDA's
+# operational reading (FNS OBBBA ABAWD exceptions implementation memorandum,
+# 2025-10-03); the statute's literal "over 65" is documented in the module.
 - name: abawd_work_hours_fulfill_requirement
   period: 2026-01
   input:
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/7#input.member_age: 30
     us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
     us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
@@ -18,10 +29,6 @@
     us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
     us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
     us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
-    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 20
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -31,13 +38,16 @@
   output:
     us:regulations/7-cfr/273/24#snap_member_abawd_fulfilling_work_requirement: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: holds
-- name: abawd_exception_applies_to_parent_with_child_under_eighteen
+- name: abawd_exception_applies_to_responsible_adult_with_child_under_fourteen
   period: 2026-01
   input:
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: true
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: true
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 13
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/7#input.member_age: 30
     us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
     us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
@@ -51,14 +61,49 @@
     us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
     us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
     us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
-    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
   output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_responsible_for_dependent_child_under_fourteen: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: holds
+- name: abawd_no_exception_for_dependent_child_aged_fourteen
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 30
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: true
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 14
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 30
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_responsible_for_dependent_child_under_fourteen: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
 - name: more_than_three_countable_months_exceeds_abawd_limit
   period: 2026-01
   input:
@@ -70,8 +115,11 @@
   input:
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/7#input.member_age: 30
     us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
     us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
@@ -85,10 +133,6 @@
     us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
     us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
     us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
-    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -127,12 +171,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -172,12 +215,11 @@
     us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
     us:regulations/7-cfr/273/24#input.member_age: 30
     us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
-    us:regulations/7-cfr/273/24#input.member_is_parent_of_household_member_under_age_eighteen: false
-    us:regulations/7-cfr/273/24#input.member_resides_with_household_member_under_age_eighteen: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
     us:regulations/7-cfr/273/24#input.member_is_pregnant: false
-    us:regulations/7-cfr/273/24#input.member_is_homeless: false
-    us:regulations/7-cfr/273/24#input.member_is_veteran: false
-    us:regulations/7-cfr/273/24#input.member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
     us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
     us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
     us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
@@ -192,3 +234,264 @@
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
     us:regulations/7-cfr/273/24#snap_member_work_requirement_eligible: not_holds
     us:regulations/7-cfr/273/24#snap_member_work_requirement_ineligible: holds
+- name: age_55_subject_to_time_limit_post_hr1
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 55
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 55
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/7#input.member_snap_work_requirements_waived_due_to_pending_ssi_joint_application: false
+    us:regulations/7-cfr/273/7#input.member_registered_for_work_or_registered_by_state: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_snap_et_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_participated_in_workfare_if_assigned: true
+    us:regulations/7-cfr/273/7#input.member_provided_employment_status_or_availability_information: true
+    us:regulations/7-cfr/273/7#input.member_reported_to_referred_suitable_employer_if_referred: true
+    us:regulations/7-cfr/273/7#input.member_accepted_bona_fide_suitable_employment_offer_if_offered: true
+    us:regulations/7-cfr/273/7#input.member_voluntarily_quit_or_reduced_work_below_30_hours_without_good_cause: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_fulfilling_work_requirement: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_countable_month_limit_exceeded: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_regained_or_additional_eligibility: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
+    us:regulations/7-cfr/273/7#snap_member_general_work_requirement_eligible: holds
+    us:regulations/7-cfr/273/24#snap_member_work_requirement_eligible: not_holds
+    us:regulations/7-cfr/273/24#snap_member_work_requirement_ineligible: holds
+- name: age_64_subject_despite_general_work_exemption
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 64
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 64
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/7#snap_member_general_work_requirement_exempt: holds
+    us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
+- name: age_65_excepted_under_usda_operational_reading
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 65
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 65
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: holds
+- name: age_66_excepted_under_either_reading
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 66
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 66
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: age_23_no_exception_post_hr1
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 23
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 23
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+    us:regulations/7-cfr/273/24#input.member_abawd_weekly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_abawd_monthly_work_hours: 0
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_combines_work_and_work_program_20_hours_weekly: false
+    us:regulations/7-cfr/273/24#input.member_participates_in_abawd_workfare_program: false
+    us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 4
+    us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
+    us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: not_holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible: not_holds
+- name: indian_or_urban_indian_excepted
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 40
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: true
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: california_indian_excepted
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 40
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: true
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+- name: statutory_d2_exemption_flows_into_abawd_exception
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/24#input.member_age: 40
+    us:regulations/7-cfr/273/24#input.member_medically_certified_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/24#input.member_is_parent_or_household_member_responsible_for_dependent_child: false
+    us:regulations/7-cfr/273/24#input.member_youngest_dependent_child_age: 0
+    us:regulations/7-cfr/273/24#input.member_is_pregnant: false
+    us:regulations/7-cfr/273/24#input.member_is_indian_or_urban_indian: false
+    us:regulations/7-cfr/273/24#input.member_is_california_indian: false
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: true
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+    us:regulations/7-cfr/273/24#input.member_covered_by_abawd_time_limit_waiver: false
+  output:
+    us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
+    us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds

--- a/us/regulations/7-cfr/273/24.yaml
+++ b/us/regulations/7-cfr/273/24.yaml
@@ -22,11 +22,43 @@ module:
 
     have not exceeded the countable-month limit, or have regained eligibility.
 
-    This module composes that time-limit rule with the general work
+    The exception criteria encode 7 U.S.C. 2015(o)(3) as struck and replaced
 
-    requirement in 7 CFR 273.7.'
+    by P.L. 119-21 section 10102(a) (effective July 4, 2025): age under 18 or
+
+    65 and older, medical unfitness, responsibility for a dependent child
+
+    under 14, the statutory work-registration exemptions of 7 U.S.C.
+
+    2015(d)(2), pregnancy, and Indian, Urban Indian, and California Indian
+
+    status. The still-unconformed eCFR text of 273.24(c) retains the
+
+    pre-P.L. 119-21 criteria and does not control. This module composes the
+
+    time-limit rule with the general work requirement in 7 CFR 273.7.'
   source_verification:
-    corpus_citation_path: us/regulation/7/273/24
+    corpus_citation_paths:
+    - us/regulation/7/273/24
+    - us/statute/7/2015/o/3
+    - us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1
+    - us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+      - us/statute/7/2015/o/3
+      - us/statute/7/2015/d/2
+      - us/regulation/7/273/24
+      rationale: |-
+        P.L. 119-21 section 10102(a) struck and replaced 7 U.S.C. 2015(o)(3)
+        effective July 4, 2025, and that replacement paragraph controls every
+        exception branch encoded here. The eCFR text of 7 CFR 273.24(c) has
+        not been conformed to the amendment and still carries the Fiscal
+        Responsibility Act criteria, so it cannot supply the exception list.
+        The FNS OBBBA ABAWD exceptions implementation memorandum pages are
+        cited only for what the statute text does not settle: the operational
+        reading of "under 18, or over 65" as ages 18-64 subject with 65 and
+        older excepted, and the upon-enactment July 4, 2025 effective date.
 imports:
 - us:regulations/7-cfr/273/7
 rules:
@@ -95,60 +127,114 @@ rules:
 - name: snap_member_abawd_exception_applies_scalar_limit
   kind: parameter
   dtype: Count
-  source: 7 CFR 273.24(c)
+  source: 7 U.S.C. 2015(o)(3)(A) as amended by P.L. 119-21 section 10102(a)
   metadata:
     proof:
       atoms:
       - path: versions[0].formula
         kind: parameter
         source:
-          corpus_citation_path: us/regulation/7/273/24
-          span: 7 CFR 273.24(c)
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: under 18, or over 65, years of age
   versions:
-  - effective_from: '2025-10-01'
+  - effective_from: '2025-07-04'
     formula: '18'
+# Upper age bound of the post-P.L. 119-21 exception. The enacted text reads
+# "under 18, or over 65, years of age"; read literally, "over 65" would leave
+# age exactly 65 subject. USDA operationalizes the band as ages 18-64 subject
+# and 65 and older excepted (FNS OBBBA ABAWD exceptions implementation
+# memorandum, 2025-10-03, page 1), and this encoding follows the USDA
+# operational reading: member_age >= 65 excepts. The memorandum, not the
+# statutory phrase, is the authority for the inclusive boundary.
 - name: snap_member_abawd_exception_applies_scalar_limit_2
   kind: parameter
   dtype: Count
-  source: 7 CFR 273.24(c)
+  source: 7 U.S.C. 2015(o)(3)(A) as amended by P.L. 119-21 section 10102(a) and FNS OBBBA ABAWD exceptions implementation memorandum (2025-10-03)
   metadata:
     proof:
       atoms:
       - path: versions[0].formula
         kind: parameter
         source:
-          corpus_citation_path: us/regulation/7/273/24
-          span: 7 CFR 273.24(c)
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: under 18, or over 65, years of age
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1
+          excerpt: Therefore, individuals aged 18 to 64 are now subject to the time limit, unless they meet another exception.
   versions:
-  - effective_from: '2025-10-01'
-    formula: '55'
+  - effective_from: '2025-07-04'
+    formula: '65'
+- name: snap_member_abawd_exception_dependent_child_age_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: 7 U.S.C. 2015(o)(3)(C) as amended by P.L. 119-21 section 10102(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: a parent or other member of a household with responsibility for a dependent child under 14 years of age
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '14'
+- name: snap_member_abawd_responsible_for_dependent_child_under_fourteen
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(o)(3)(C) as amended by P.L. 119-21 section 10102(a)
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'member_is_parent_or_household_member_responsible_for_dependent_child
+      and member_youngest_dependent_child_age < snap_member_abawd_exception_dependent_child_age_scalar_limit'
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/24#snap_member_abawd_exception_dependent_child_age_scalar_limit
+          output: snap_member_abawd_exception_dependent_child_age_scalar_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: a parent or other member of a household with responsibility for a dependent child under 14 years of age
+# 7 U.S.C. 2015(o)(3) as struck and replaced by P.L. 119-21 section 10102(a),
+# effective upon enactment July 4, 2025. The replacement paragraph does NOT
+# carry the Fiscal Responsibility Act's homeless, veteran, or former-foster-
+# youth exceptions, and its subparagraph (D) cross-references only the
+# statutory work-registration exemptions of subsection (d)(2) - not the
+# regulation's general-work exemption list, whose (d)(1)-derived age-60 branch
+# would wrongly except ages 60-64 from the time limit.
 - name: snap_member_abawd_exception_applies
   kind: derived
   entity: Person
   dtype: Judgment
   period: Month
-  source: 7 CFR 273.24(c)
+  source: 7 U.S.C. 2015(o)(3) as amended by P.L. 119-21 section 10102(a)
   versions:
-  - effective_from: '2025-10-01'
+  - effective_from: '2025-07-04'
     formula: 'member_age < snap_member_abawd_exception_applies_scalar_limit
 
       or member_age >= snap_member_abawd_exception_applies_scalar_limit_2
 
       or member_medically_certified_physically_or_mentally_unfit_for_employment
 
-      or member_is_parent_of_household_member_under_age_eighteen
+      or snap_member_abawd_responsible_for_dependent_child_under_fourteen
 
-      or member_resides_with_household_member_under_age_eighteen
-
-      or snap_member_general_work_requirement_exempt
+      or snap_member_statutory_work_registration_exemption_applies
 
       or member_is_pregnant
 
-      or member_is_homeless
+      or member_is_indian_or_urban_indian
 
-      or member_is_veteran
-
-      or member_age_24_or_younger_and_was_in_foster_care_on_attaining_age_18'
+      or member_is_california_indian'
   metadata:
     proof:
       atoms:
@@ -164,6 +250,41 @@ rules:
           target: us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies_scalar_limit_2
           output: snap_member_abawd_exception_applies_scalar_limit_2
           hash: sha256:local
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: "Paragraph (2) shall not apply to an individual if the individual is—"
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: medically certified as physically or mentally unfit for employment
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: otherwise exempt under subsection (d)(2)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: a pregnant woman
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: an Indian or an Urban Indian (as such terms are defined in paragraphs (13) and (28) of
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: a California Indian described in
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4
+          excerpt: These changes were effective upon enactment, July 4, 2025.
 - name: snap_member_abawd_time_limit_inapplicable
   kind: derived
   entity: Person

--- a/us/regulations/7-cfr/273/7.test.yaml
+++ b/us/regulations/7-cfr/273/7.test.yaml
@@ -94,3 +94,59 @@
   output:
     us:regulations/7-cfr/273/7#snap_member_general_work_requirement_waived: holds
     us:regulations/7-cfr/273/7#snap_member_general_work_requirement_eligible: holds
+- name: age_62_general_work_exempt_but_not_statutorily_exempt_under_d2
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/7#input.member_age: 62
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+  output:
+    us:regulations/7-cfr/273/7#snap_member_general_work_requirement_exempt: holds
+    us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: not_holds
+- name: treatment_program_participant_is_statutorily_exempt_under_d2
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: true
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 0
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+  output:
+    us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: holds
+- name: thirty_hour_worker_is_statutorily_exempt_under_d2
+  period: 2026-07
+  input:
+    us:regulations/7-cfr/273/7#input.member_age: 40
+    us:regulations/7-cfr/273/7#input.member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time: false
+    us:regulations/7-cfr/273/7#input.member_physically_or_mentally_unfit_for_employment: false
+    us:regulations/7-cfr/273/7#input.member_subject_to_and_complying_with_title_iv_work_requirement: false
+    us:regulations/7-cfr/273/7#input.member_responsible_for_dependent_child_under_six_or_incapacitated_person: false
+    us:regulations/7-cfr/273/7#input.member_receiving_or_applying_for_unemployment_compensation_and_complying: false
+    us:regulations/7-cfr/273/7#input.member_regular_participant_in_drug_or_alcohol_treatment: false
+    us:regulations/7-cfr/273/7#input.member_weekly_work_hours: 30
+    us:regulations/7-cfr/273/7#input.member_weekly_wages: 0
+    us:regulations/7-cfr/273/7#input.federal_or_state_minimum_wage: 7.25
+    us:regulations/7-cfr/273/7#input.migrant_or_seasonal_farmworker_under_contract_to_begin_employment_within_30_days: false
+    us:regulations/7-cfr/273/7#input.alaska_subsistence_hunts_or_fishes_30_hours_weekly: false
+    us:regulations/7-cfr/273/7#input.member_student_enrolled_at_least_half_time_and_student_eligible: false
+  output:
+    us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_applies: holds
+    us:regulations/7-cfr/273/7#snap_member_general_work_requirement_exempt: holds

--- a/us/regulations/7-cfr/273/7.yaml
+++ b/us/regulations/7-cfr/273/7.yaml
@@ -72,7 +72,9 @@ module:
 
     qualifying half-time students.'
   source_verification:
-    corpus_citation_path: us/regulation/7/273/7
+    corpus_citation_paths:
+    - us/regulation/7/273/7
+    - us/statute/7/2015/d/2
 rules:
 - name: snap_member_general_work_requirement_exempt_scalar_limit
   kind: parameter
@@ -173,6 +175,96 @@ rules:
           target: us:regulations/7-cfr/273/7#snap_member_general_work_requirement_exempt_scalar_limit_3
           output: snap_member_general_work_requirement_exempt_scalar_limit_3
           hash: sha256:local
+- name: snap_member_statutory_work_registration_exemption_scalar_limit
+  kind: parameter
+  dtype: Count
+  source: 7 U.S.C. 2015(d)(2)(E) and 7 CFR 273.7(b)(1)(vii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: employed a minimum of thirty hours per week or receiving weekly earnings which equal the minimum hourly rate under the Fair Labor Standards Act of 1938
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/7
+          excerpt: An employed or self-employed person working a minimum of 30 hours weekly or earning weekly wages at least equal to the Federal minimum wage multiplied by 30 hours.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '30'
+# The statutory work-registration exemption list of 7 U.S.C. 2015(d)(2) only.
+# This is deliberately NARROWER than snap_member_general_work_requirement_exempt:
+# the regulation's exemption list at 7 CFR 273.7(b)(1) also carries the
+# subsection (d)(1) age bounds (under 16, or 60 and older), which are NOT part
+# of the (d)(2) list. The post-P.L. 119-21 ABAWD exception at 7 U.S.C.
+# 2015(o)(3)(D) cross-references only "(d)(2)", so persons aged 60-64 remain
+# exempt from the general work requirements while subject to the ABAWD time
+# limit (FNS OBBBA ABAWD exceptions implementation memorandum, 2025-10-03).
+- name: snap_member_statutory_work_registration_exemption_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(d)(2)
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'member_subject_to_and_complying_with_title_iv_work_requirement
+
+      or member_receiving_or_applying_for_unemployment_compensation_and_complying
+
+      or member_responsible_for_dependent_child_under_six_or_incapacitated_person
+
+      or member_student_enrolled_at_least_half_time_and_student_eligible
+
+      or member_regular_participant_in_drug_or_alcohol_treatment
+
+      or member_weekly_work_hours >= snap_member_statutory_work_registration_exemption_scalar_limit
+
+      or member_weekly_wages >= federal_or_state_minimum_wage * snap_member_statutory_work_registration_exemption_scalar_limit
+
+      or member_age_16_or_17_is_not_household_head_or_attends_school_or_training_half_time'
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/7#snap_member_statutory_work_registration_exemption_scalar_limit
+          output: snap_member_statutory_work_registration_exemption_scalar_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: (A) currently subject to and complying with a work registration requirement under title IV of the Social Security Act
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: or the Federal-State unemployment compensation system
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: (B) a parent or other member of a household with responsibility for the care of a dependent child under age six or of an incapacitated person
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: (C) a bona fide student enrolled at least half time in any recognized school, training program, or institution of higher education
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: (D) a regular participant in a drug addiction or alcoholic treatment and rehabilitation program
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/d/2
+          excerpt: (F) a person between the ages of sixteen and eighteen who is not a head of a household or who is attending school, or enrolled in an employment training program, on at least a half-time basis
 - name: snap_member_general_work_requirement_compliant
   kind: derived
   entity: Person

--- a/us/regulations/7-cfr/273/7.yaml
+++ b/us/regulations/7-cfr/273/7.yaml
@@ -196,6 +196,11 @@ rules:
   - effective_from: '2025-07-04'
     formula: '30'
 # The statutory work-registration exemption list of 7 U.S.C. 2015(d)(2) only.
+# Operationalization note: the (d)(2)(E) earnings branch reuses this module's
+# regulation-derived federal_or_state_minimum_wage input; the statute's
+# reference is the FLSA federal minimum (29 U.S.C. 206(a)(1)), so supplying a
+# higher state wage makes the earnings test conservatively stricter than the
+# literal statutory floor.
 # This is deliberately NARROWER than snap_member_general_work_requirement_exempt:
 # the regulation's exemption list at 7 CFR 273.7(b)(1) also carries the
 # subsection (d)(1) age bounds (under 16, or 60 and older), which are NOT part


### PR DESCRIPTION
Fixes #1210.

## What this fixes

`us/regulations/7-cfr/273/24.yaml` still encoded the FRA-era ABAWD exception criteria of 7 U.S.C. §2015(o)(3). P.L. 119-21 §10102(a) (enacted 2025-07-04) struck and replaced that paragraph. Two externally reported wrong verdicts from the grounded-chat demo (Cody Storm, Code for America, 2026-07-28) reproduce directly from the stale encoding: a 55-year-old came back age-excepted, and former-foster-youth status alone produced an exception. Both are wrong under current law.

## Encoding changes

**`us/regulations/7-cfr/273/24.yaml`** — the exception surface now encodes the full replacement paragraph:

| Branch | Before | After |
|---|---|---|
| Age | `< 18 or >= 55` | `< 18 or >= 65` (see boundary note below) |
| Medical unfitness | kept | kept (re-grounded in §2015(o)(3)(B)) |
| Child in household | parent of / resides with member under 18 | responsibility for a dependent child under 14, with a real numeric boundary (new parameter 14 + derived rule) |
| General-work cross-reference | blanket `snap_member_general_work_requirement_exempt` import | narrow statutory §2015(d)(2) predicate (new rule in 273/7) |
| Pregnancy | kept | kept |
| Homeless / veteran / former foster youth | OR'd in | removed (H.R. 1 ended them) |
| Indian / Urban Indian / California Indian | absent | added (§2015(o)(3)(F)–(G)) |

**`us/regulations/7-cfr/273/7.yaml`** — adds `snap_member_statutory_work_registration_exemption_applies`, encoding exactly the §2015(d)(2) list (title IV / UC-system compliance, caretaker of child under six or incapacitated person, half-time student, treatment participant, 30-hour or minimum-wage×30 worker, the 16–17 school case), with its own proved 30-hour parameter. The regulation's exemption list at 273.7(b)(1) also carries the §2015(d)(1) age bounds (under 16, 60+), which are **not** part of (d)(2) — importing the blanket exemption would have kept ages 60–64 wrongly ABAWD-excepted after the 55→65 flip. The general-work age-60 threshold itself is untouched (FNS: "Individuals aged 60 or older remain exempt from the general work requirements" while ages 18–64 are time-limit subject).

### Age-65 boundary note

The enacted text reads "under 18, or over 65, years of age" — literally, age exactly 65 would remain subject. USDA operationalizes the band as ages 18–64 subject / 65+ excepted (FNS OBBBA ABAWD exceptions implementation memorandum, 2025-10-03, ingested as `us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo` in axiom-corpus#578). The encoding follows the USDA operational reading (`member_age >= 65`), cites the memorandum for that boundary, and documents the discrepancy in the module comment, the `upstream_source_check` rationale, and the proof atoms. The memorandum — not the statutory phrase — is the authority for inclusivity at 65.

### Effective dates

Changed rules carry `effective_from: '2025-07-04'` — the legal effective date ("These changes were effective upon enactment, July 4, 2025", memo p.4) — not the FY2026 surface convenience date. Engine semantics verified at the pinned engine ref (`DerivedVersion::applies_at`: a version applies iff `effective_from <= period.start`): July 2025 (mid-month enactment) stays unresolved rather than resolving to either regime; August 2025 onward resolves to post-H.R. 1 law; July 2026 — the reported cases — is unambiguous. No month can resolve to the repealed criteria. Unchanged rules keep their existing dates.

## Tests

New July 2026 companion matrix in `24.test.yaml` (every case assigns the full input closure):

- **age 55** — exception `not_holds`; with exhausted months, zero work, no waiver: time-limit ineligible, `snap_member_work_requirement_ineligible: holds` even though the general-work side is fully compliant (the exact demo scenario);
- **age 64** — exception `not_holds` while `snap_member_general_work_requirement_exempt: holds` and the §2015(d)(2) predicate `not_holds` (the 60–64 split pinned end to end);
- **age 65** — excepted under the USDA operational reading; **age 66** — excepted under either reading;
- **age 23, no exception** — `not_holds` (the former-foster demographic; the foster input no longer exists — its removal is the fix);
- **child 13 vs 14** — holds at 13, not on that basis at 14;
- **Indian / Urban Indian and California Indian** — positive cases; direct positives also for under-18, medical unfitness, and pregnancy;
- **treatment participant** — §2015(d)(2) flow-through into the ABAWD exception.

`7.test.yaml` adds the age-62 divergence case (general-work exempt `holds`, statutory (d)(2) exemption `not_holds`) plus (d)(2) positives. `us-ca/policies/cdss/snap/fy-2026-benefit-calculation.test.yaml` adds a July 2026 program-level regression: the 55-year-old with exhausted months is work-requirement ineligible — and `snap_member_eligible: not_holds` — inside the CalFresh composition, with no California-side edit (CA inherits the federal module through `us:policies/usda/snap/state-plan-composition`).

### Pre-existing fixtures that leaned on the defect

Companion fixtures in six files (`us/policies/usda/snap/state-plan-composition`, CA benefit calc + MCE, CO, GA, MD, NY) modeled household members as `member_age: 60` with **no other ABAWD inputs** — evaluable only because the defective `>= 55` branch short-circuited the exception. Under the corrected encoding those members are ABAWD-subject, so each member block now assigns the full post-H.R. 1 input set with `snap_abawd_countable_months_in_three_year_period: 0` (a 60-year-old who hasn't used the clock is time-limit eligible via the countable-month route). Zero expected outputs changed — every repair is input completion, not assertion rewriting. The old `24.test.yaml` never varied age off 30 and never set the foster input true, which is how the stale criteria survived; the new matrix closes that hole.

## Gates run locally (pinned toolchain: encode 3869d66d / 0.2.1200, engine ffd8213, corpus at the #578 ingest tip)

- `validate --skip-reviewers` on 273/24 + 273/7: ✓ PASSED
- `proof-validate`: 19 + 15 atoms, ✓ PASSED (all excerpts verbatim from `us/statute/7/2015/o/3`, `us/statute/7/2015/d/2`, `us/regulation/7/273/7`, and the memo pages)
- Companion battery, full repo: every SNAP file green (13 CA composition cases, 18 module-24 cases, 8 module-7 cases); the only failing file repo-wide is `us/statutes/26/32.test.yaml`, which fails identically at `origin/main` (pre-existing, untouched here)
- `oracle-coverage-pending check` (classifier ref ee2fb3ea, CI's default): "Declared: 3219 applied: 3219 stale: 0 — Pending ratchet passed" (no ledger change needed)
- `oracle-coverage --fail-on-unmapped --fail-on-untested-comparable`: exit 0
- `tools/build_program_artifacts.py --check`: built 34/34 programs (includes `us-ca-snap` FY2026 with the corrected federal module)
- `guard-generated` vs origin/main: "All changed RuleSpec files have encoder apply manifests" (10 signed manual attestations; the CA/NY manifests attest module+test so the drift test keeps whole-pair coverage)
- Reverse index regenerated; repository pytest: 66 passed (includes the manifest-drift and reverse-index suites)

## Provenance and sequencing

- Corpus feedstock: TheAxiomFoundation/axiom-corpus#578 (FNS memo ingest, signed manifest, merge-commit).
- This PR's new citations (`us/statute/7/2015/o/3`, `us/statute/7/2015/d/2`, memo pages) resolve at the corpus ref this branch validates against; the dedicated toolchain PR bumping `axiom_corpus_ref` to the #578 merge commit must land first (rule 1: no toolchain changes in a feature PR). New citation paths widen the pending US release cut — expected, flagging per the provenance regime.
- All changed RuleSpec files carry signed `manual-attestation` apply manifests (backend recorded honestly as `manual`).

## Cross-family review

A sol correctness/completeness audit of this branch passed all seven substantive areas — statutory fidelity of the exception formula, the §2015(d)(2) predicate (including confirmation that the (d)(1) age bounds are excluded and the age-60 general-work rule is untouched), effective-date semantics against the pinned engine's `DerivedVersion::applies_at`, the test matrix, the input-only fixture repairs (verified: zero expected-output changes across all seven files), the five waiver decrements, and character-for-character verbatim verification of all 20 new proof excerpts.

Its one flagged item was an acceptance-criterion mismatch, not an artifact defect: the audit prompt demanded `manual`/`manual-attestation` on every changed-file manifest, but `.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json` records backend `deterministic` / runner `deterministic-repair` — because that change *was* made by `axiom-encode repair-proof-import-hashes`, whose manifest-writing path the guard treats as first-class ("the guard verifies the signature and file hashes either way"). Recording it as manual would be less accurate provenance, so the deterministic-repair manifest stands. The audit's three nits are addressed in the final commit: the child-under-14 positive now runs at 2026-07 like the rest of the matrix, direct positives exist for the under-18 / medical-unfitness / pregnancy branches (18 module-24 cases total), and the (d)(2)(E) earnings-branch operationalization note documents that the shared `federal_or_state_minimum_wage` input is conservatively stricter than the statute's FLSA federal floor when a state wage is higher.

## Out of scope, tracked separately

- `us-ca/regulations/mpp/63-410/321.yaml` still timelessly encodes the pre-2023 "50 years of age or over" text; it is outside the FY2026 program scope and did not cause the reported verdicts (see #1210) — separate cleanup.
- axiom-oracles behavioral matrix at the statute boundaries (supplementing the structural warning in axiom-oracles#400) — oracle-repo follow-up.
- `us/statutes/26/32.test.yaml` pre-existing failures on main (unrelated EITC surface).

After merge: new `program-artifacts` release → `finbot-snap-demo` `artifacts.lock.json` bump → Modal + Vercel redeploy → replay both July 2026 demo scenarios before telling anyone the demo is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
