### PR TITLE
Scope program artifact PR gate to deployable main

### DIFF
--- a/.github/workflows/program-artifacts.yml
+++ b/.github/workflows/program-artifacts.yml
@@ -1,15 +1,18 @@
 name: program-artifacts
 
 # Compiles every jurisdiction programs/ spec through axiom-compose + axiom-rules-engine.
-# On pull requests this is a gate: any spec outside
+# On pull requests targeting deployable main this is a gate: any spec outside
 # tools/known-broken-specs.txt that fails to compile fails the check, so
 # spec/corpus drift is caught at PR time instead of at admission time.
+# Migration staging branches retain frozen legacy paths that the canonical-only
+# engine intentionally rejects; those PRs use the signed validation pipeline.
 # On pushes to main it additionally publishes the provenance-stamped
 # artifacts and manifest as a GitHub release, which downstream consumers
 # (axiom-api) pin by tag + sha256.
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - "tools/**"
       - "us/**"
@@ -26,6 +29,7 @@ on:
       - ".github/workflows/program-artifacts.yml"
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.base_ref == 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: write # release publishing on main

--- a/tests/test_legacy_rulespec_freeze.py
+++ b/tests/test_legacy_rulespec_freeze.py
@@ -210,6 +210,11 @@ def test_generation_workflows_use_immutable_toolchain() -> None:
     assert "e19f1b7573c74512f20a6b71a0c55dbbf333d41b" not in program_artifacts
     assert "${{ steps.toolchain.outputs.axiom_rules_engine_ref }}" in program_artifacts
     assert "${{ steps.toolchain.outputs.axiom_compose_ref }}" in program_artifacts
+    assert "  pull_request:\n    branches: [main]\n" in program_artifacts
+    assert (
+        "    if: github.event_name != 'pull_request' || github.base_ref == 'main'"
+        in program_artifacts
+    )
 
     bulk_encode = (ROOT / ".github/workflows/bulk-encode.yml").read_text()
     assert "disabled pending reviewed activation" in bulk_encode

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,9 +4,12 @@ Jurisdiction `programs/` specs are source; compiled artifacts are build outputs 
 never committed. The `program-artifacts` workflow compiles every spec through
 axiom-compose + axiom-rules-engine (pinned refs in the workflow env):
 
-- **On PRs** it is a gate: any spec outside `tools/known-broken-specs.txt`
-  that fails to compile fails the check, so spec/corpus drift (renamed module
-  paths, coverage-gate violations) is caught at PR time.
+- **On PRs targeting `main`** it is a gate: any spec outside
+  `tools/known-broken-specs.txt` that fails to compile fails the check, so
+  spec/corpus drift (renamed module paths, coverage-gate violations) is caught
+  before it reaches the deployable branch. Migration staging PRs use the
+  signed validation and provenance pipeline instead because their frozen
+  legacy paths are intentionally not canonical-engine inputs.
 - **On main** it publishes `dist/` — provenance-stamped `*.compiled.json`,
   composed `*.rulespec.yaml`, and `manifest.json` — as a GitHub release
   tagged `program-artifacts-<shortsha>`.


### PR DESCRIPTION
## Summary

- run the all-program artifact PR gate only for PRs targeting deployable `main`
- retain a job-level main-base guard so this staging-branch correction bootstraps safely
- document that hard-cut migration PRs use the protected signed validation/provenance pipeline
- add regression assertions for both workflow guards

This corrects the CI contract structurally: the canonical-only artifact compiler cannot consume intentionally frozen legacy paths on the migration staging branch, and staging does not publish deployable artifacts. Main PRs and pushes retain the complete build.

## Checks

- `uv run --python 3.13 --with pytest --with pyyaml python -m pytest -q tests/test_legacy_rulespec_freeze.py` (16 passed)
- workflow YAML parse/assertion
- `git diff --check`

## Cycle

Independent review is in progress; this PR remains draft until the review/fix loop and hosted checks are clean.