### PR TITLE
Point the NY income-tax program spec at the current pilot outputs

### DIFF
--- a/programs/us-ny/income-tax/fy-2026.yaml
+++ b/programs/us-ny/income-tax/fy-2026.yaml
@@ -6,10 +6,9 @@ program: us-ny/income-tax
 period: 2026-01
 outputs:
   - ny_pit_pilot_taxable_income
-  - ny_pit_pilot_main_tax
-  - ny_pit_pilot_income_tax_liability
+  - ny_pit_pilot_main_income_tax
 acknowledged_incomplete:
-  - ny_pit_pilot_income_tax_liability
+  - ny_pit_pilot_main_income_tax
 scope:
   state:
     - policies/income_tax/pilot_liability_pipeline


### PR DESCRIPTION
The `fb41b32fc` rewrite of the NY PIT pilot ended the pipeline at `ny_pit_pilot_main_income_tax`, but `programs/us-ny/income-tax/fy-2026.yaml` still certified the pre-rewrite output names (`ny_pit_pilot_main_tax`, `ny_pit_pilot_income_tax_liability`), which no longer exist among the module's derived rules. The program-artifacts build compiles fine (it doesn't cross-check certified names), but any consumer that asserts certified outputs — e.g. the finbot-snap-demo smoke suite during a release pin bump — fails on the phantom names, which is how this surfaced (blocking the ABAWD-fix demo redeploy, #1210 follow-through).

Certifies the two outputs the pipeline actually derives and carries the pilot-scope `acknowledged_incomplete` marker on the terminal main-income-tax output (the pre-rewrite spec's intent, transposed).

Spec-only change; the program-artifacts workflow rebuilds and gates on this PR by path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
