### PR TITLE
Reconcile the section 32 companion with the restructured 32(c)(2) surface

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/26/32.json
+++ b/.axiom/encoding-manifests/us/statutes/26/32.json
@@ -1,0 +1,38 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/26/32.test.yaml",
+      "sha256": "ea5c5d53dd01fddd303b23fd1a1acedc1bb0c9e56628a72957b7cfdd43860843"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/_axiom-worktrees/fix-2632-companion/rulespec-us/_axiom/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us:statutes/26/32",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-08-05T14:06:00.843284+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb2x2twqa/sign-applied-files/us/statutes/26/32.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpb2x2twqa",
+  "generated_output_sha256": "979e101eb20ac9f43fd37884e7241f3afc1abb7f3eea5abc93cc1b67067d8179",
+  "generation_prompt_sha256": null,
+  "manual_exception": "repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "742af33e99635ab876742ebd7e943b1eeb50dc763f829e417c0e0ab4c412ae22"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -1348,12 +1348,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us/statutes/26/32.yaml":
-    active:
-      fingerprint: "sha256:aaf9b762c1faa0d4c80929e91a09116b01a991b1445236e6f442071467c4e62b"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us/statutes/26/3232.yaml":
     active:
       fingerprint: "sha256:1fb0ea431d931ef2c5a2562888c60b68917c33664b9d885813fe2b21b541aad1"

--- a/us/statutes/26/32.test.yaml
+++ b/us/statutes/26/32.test.yaml
@@ -5,11 +5,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -25,9 +26,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 0
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -71,11 +69,6 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_child_count: 1
     us:statutes/26/32#eitc_capped_child_count: 1
@@ -93,7 +86,7 @@
     us:statutes/26/32#eitc_investment_income_eligible: holds
     us:statutes/26/32#eitc_allowed: holds
     us:statutes/26/32#eitc: 3400
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+    us:statutes/26/32/c/2#earned_income_before_section_112_election: 10000
 - name: childless_person_age_predicate
   period:
     period_kind: tax_year
@@ -136,6 +129,37 @@
   output:
     us:statutes/26/32#eitc_qualifying_child: not_holds
     us:statutes/26/32#eitc_qualifying_child_base: holds
+- name: qualifying_child_unmarried_allowed
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/152/c#input.individual_is_child_of_taxpayer_or_descendant_of_such_child: true
+    us:statutes/26/152/c#input.individual_is_sibling_stepsibling_or_descendant_of_such_relative: false
+    us:statutes/26/152/c#input.individual_principal_place_of_abode_with_taxpayer_fraction: 1
+    us:statutes/26/152/c#input.individual_is_permanently_and_totally_disabled: false
+    us:statutes/26/152/c#input.individual_is_younger_than_taxpayer: true
+    us:statutes/26/152/c#input.individual_age_at_close_of_calendar_year: 8
+    us:statutes/26/152/c#input.individual_is_student: false
+    us:statutes/26/152/c#input.filing_status: 0
+    us:statutes/26/152/c#input.return_filed_only_for_claim_of_refund: false
+    us:statutes/26/152/c#input.individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers: false
+    us:statutes/26/152/c#input.parents_of_individual_may_claim_individual_but_no_parent_claims: false
+    us:statutes/26/152/c#input.taxpayer_is_parent_of_individual: true
+    us:statutes/26/152/c#input.taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income: false
+    us:statutes/26/152/c#input.parents_filing_status: 1
+    us:statutes/26/152/c#input.child_resided_with_taxpayer_parent_for_longest_period: false
+    us:statutes/26/152/c#input.child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income: false
+    us:statutes/26/152/c#input.no_parent_of_individual_is_a_claiming_taxpayer: false
+    us:statutes/26/152/c#input.taxpayer_has_highest_adjusted_gross_income_among_claiming_taxpayers: false
+    us:statutes/26/32#input.qualifying_child_principal_place_of_abode_is_in_united_states: true
+    us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
+    us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
+    us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
+  output:
+    us:statutes/26/32#eitc_qualifying_child: holds
+    us:statutes/26/32#eitc_qualifying_child_base: holds
 - name: investment_income_denies_credit
   period:
     period_kind: tax_year
@@ -143,11 +167,12 @@
     end: '2026-12-31'
   input:
     us:statutes/26/32#input.filing_status: 0
-    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 10000
-    us:statutes/26/32/c/2#input.pension_or_annuity_amounts_received: 0
-    us:statutes/26/32/c/2#input.amounts_to_which_section_871_a_applies: 0
-    us:statutes/26/32/c/2#input.amounts_received_for_services_while_inmate_at_penal_institution: 0
-    us:statutes/26/32/c/2#input.subsidized_state_work_activity_amounts_received: 0
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 10000
+    us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0
+    us:statutes/26/32/c/2#input.pension_or_annuity_amount: 0
+    us:statutes/26/32/c/2#input.nonresident_alien_income_not_connected_with_united_states_business: 0
+    us:statutes/26/32/c/2#input.penal_institution_service_compensation: 0
+    us:statutes/26/32/c/2#input.subsidized_state_work_activity_service_compensation: 0
     us:statutes/26/32/c/2#input.taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income: false
     us:statutes/26/112#input.member_below_grade_of_commissioned_officer_in_armed_forces: false
     us:statutes/26/112#input.served_in_combat_zone_during_month: false
@@ -163,9 +188,6 @@
     us:statutes/26/112#input.armed_forces_missing_status_active_service_compensation: 0
     us:statutes/26/112#input.civilian_employee_in_missing_status_during_vietnam_conflict_as_result_of_conflict: false
     us:statutes/26/112#input.civilian_employee_missing_status_active_service_compensation: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
-    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 0
-    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
     us:statutes/26/32#input.adjusted_gross_income: 10000
     us:statutes/26/32#input.eitc_relevant_investment_income: 13000
     us:statutes/26/32#input.childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year: false
@@ -209,13 +231,8 @@
       us:statutes/26/32#input.qualifying_child_name_age_and_tin_included_on_return: true
       us:statutes/26/32#input.qualifying_child_marital_status_requires_section_151_entitlement: false
       us:statutes/26/32#input.taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e: false
-    us:statutes/26/164/f#input.taxpayer_is_individual: true
-    us:statutes/26/1401#input.international_social_security_agreement_under_section_233_in_effect: false
-    us:statutes/26/1401#input.filing_status: 0
-    us:statutes/26/1401#input.self_employment_income: 0
-    us:statutes/26/1401#input.wages_taken_into_account_for_additional_medicare_tax: 0
   output:
     us:statutes/26/32#eitc_investment_income_eligible: not_holds
     us:statutes/26/32#eitc_allowed: not_holds
     us:statutes/26/32#eitc: 0
-    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+    us:statutes/26/32/c/2#earned_income_before_section_112_election: 10000


### PR DESCRIPTION
## Problem

`us/statutes/26/32.test.yaml` fails the full companion battery (`axiom-encode test .`) on main — pre-existing, verified identical at dbf09f44 (2026-08-04) and at this branch's base 09d8d50a9, both with the repo's pinned toolchain:

```
- 32.test.yaml :: one_child_phase_in_and_allowed :: unknown executable output us:statutes/26/32/c/2#self_employment_earned_income_component
- 32.test.yaml :: one_child_phase_in_and_allowed :: dataset input `us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income` must use an absolute legal RuleSpec reference that resolves to an input slot, derived rule, or parameter in the compiled program
- 32.test.yaml :: investment_income_denies_credit :: (same two failures)
```

Root cause: #488 ("Encode Medicaid methodology conditions") restructured `us/statutes/26/32/c/2.yaml` — renamed its input slots, replaced the derived §1402(a)/§164(f) self-employment chain with a direct `net_earnings_from_self_employment_after_self_employment_tax_deduction` input, and dropped the `self_employment_earned_income_component` output — without updating this parent companion. CI never catches it: scoped PR validation only selects changed files, and on full runs the module's `known-validation-gaps.yaml` entry skips both validate and companion execution for `us/statutes/26/32.yaml` (#782). Only the raw full battery exposes it.

A repo-wide sweep confirms this file was the sole carrier of the stale c/2 surface (`us/statutes/26/24/d.*` already uses the current one).

## Fix

1. **Reference reconciliation** in the two earned-income cases (input amounts unchanged, so every downstream EITC assertion holds as before):

| old (removed by #488) | current surface |
|---|---|
| `#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income` | `#input.employee_compensation_includible_in_gross_income` |
| — (derived via 26/1402/a + 26/164/f) | `#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0` |
| `#input.pension_or_annuity_amounts_received` | `#input.pension_or_annuity_amount` |
| `#input.amounts_to_which_section_871_a_applies` | `#input.nonresident_alien_income_not_connected_with_united_states_business` |
| `#input.amounts_received_for_services_while_inmate_at_penal_institution` | `#input.penal_institution_service_compensation` |
| `#input.subsidized_state_work_activity_amounts_received` | `#input.subsidized_state_work_activity_service_compensation` |
| output `#self_employment_earned_income_component: 0` | output `#earned_income_before_section_112_election: 10000` |
| `26/1402/a`, `26/164/f`, `26/1401` input assignments | removed (no longer in the compiled closure) |

2. **Positive judgment coverage**: adds `qualifying_child_unmarried_allowed`, the positive twin of `qualifying_child_married_exception` (flips `qualifying_child_marital_status_requires_section_151_entitlement` to `false` → `eitc_qualifying_child: holds`). This clears the module's only `validate` failure — "Judgment rule missing positive companion output coverage: `us:statutes/26/32#eitc_qualifying_child`" — which is exactly what its waiver entry records.

## Provenance (per TheAxiomFoundation/.github#39)

- The deterministic repairers were tried first: `repair-companion-test-references` self-rolled-back (its rewrite left the renamed numeric inputs unassigned → non-numeric comparison), and `repair-judgment-positive-tests` reported no repair for this judgment. The change is therefore a reviewed manual repair attested via `sign-applied-files` with `manual_exception=repair`: `.axiom/encoding-manifests/us/statutes/26/32.json` (hmac-sha256, key `axiom-encode-apply-v1`, encode 0.2.1200), sha-pinned to the final file bytes.
- `guard-generated --base-ref origin/main --head-ref HEAD --roots us` → "All changed RuleSpec files have encoder apply manifests."
- No toolchain, workflow-pin, CODEOWNERS, or `known-validation-gaps.yaml` changes (rules 1–2). No new citations, so no widening of the pending `us-rulespec-2026-07-13` release cut (rule 7).

## Verification (pinned toolchain: encode 0.2.1200 @ 3869d66d, engine ffd8213, corpus 1e8bfc0a, canonical targets 0dac590f)

- `axiom-encode test` — module pair: **2 files, 9 cases passed**
- `axiom-encode test` — whole `us/statutes/26` subtree: **388 files, 1360 cases passed**
- `axiom-encode validate --skip-reviewers` — `32.yaml` ✓, `32/c/2.yaml` ✓ (was: 32.yaml ✗ on the waived judgment-coverage failure)
- `axiom-encode proof-validate` — `32.yaml` (42 atoms) ✓, `32/c/2.yaml` (9 atoms) ✓

## Waiver removal (added after cross-family review)

The module now fully passes validate, so this PR also deletes the stale `us/statutes/26/32.yaml` active entry from `known-validation-gaps.yaml` (#782 burn-down, −1). The first revision deferred this to a "waiver-only follow-up PR" — that reading of the waiver-change-guard was wrong, as the second reviewer (sol, adversarial pass) flagged: the guard's `approval_growth` check iterates only head entries, so **growth** must be waiver-only but a pure deletion rides along with the repair (same combined shape #1223 merged with today). With the waiver gone, this PR's own CI validates + executes + proof-validates the repaired module instead of skipping it under the waiver.

Sol's review otherwise confirmed independently: renamed surface and $10,000 economics correct, historical output assertions byte-identical, the 92-rule compiled closure excludes §§1402(a)/164(f)/1401, stale-name sweep clean, the new positive case agrees with §32(c)(3)(B), manifest hash + HMAC verify, both deterministic-repair failures reproduce, and all gates pass.

## Follow-ups

- **Frontier drafts** #1158/#1159/#1160 carry an equivalent reconciliation of this file inside larger feature work (their §112 input renames belong to #1160's own 112 restructure and are intentionally not taken here — main's §112 surface is unchanged). They rebase cleanly over this minimal repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
