### PR TITLE
Remove now-compiling specs from the program-artifacts allowlist

### DIFF
--- a/tools/known-broken-specs.txt
+++ b/tools/known-broken-specs.txt
@@ -1,5 +1,2 @@
 # Specs that do not currently compile through axiom-compose + axiom-rules-engine.
 # Each entry suppresses the CI build gate for that spec. Fixes tracked in #562.
-programs/us-az/tanf/fy-2026.yaml
-programs/us-ct/tanf/fy-2026.yaml
-programs/us-fl/tca/fy-2026.yaml


### PR DESCRIPTION
Removes the three remaining entries from `tools/known-broken-specs.txt` — the program-artifacts gate reports all three specs as compiling now, so their entries only suppress a gate that should be strict again:

- `programs/us-az/tanf/fy-2026.yaml` (was: compose `TransformationError` on a `conditional_value` condition)
- `programs/us-ct/tanf/fy-2026.yaml` (was: eligibility-coverage gate on `ct_tfa_resources_eligible`)
- `programs/us-fl/tca/fy-2026.yaml` (was: eligibility-coverage gate on `fl_tca_gross_income_eligible`)

The failure modes listed are from #562's inventory; whatever fixed them landed since. With this change the allowlist is empty — every `programs/` spec must compile, and any regression in these three fails PR CI instead of being silently tolerated.

## Verification

Local run of `tools/build_program_artifacts.py` at `09d8d50a9` (this branch's base — the allowlist is consulted for reporting only, so the edit cannot change what compiles) with the workflow's exact toolchain pins:

- engine `ffd8213271947b0189a9dd61a055c1e0e78908a0` (AXIOM_RULES_ENGINE_REF), built from a clean checkout
- axiom-compose `fabe0b3b3fd6e90d3e8f075516f9b668f524f711` (AXIOM_COMPOSE_REF), install commit verified via `direct_url.json`

Output: `built 34/34 programs`, with the gate's own removal instruction naming exactly these three entries:

```
NOTE: allowlisted specs now compile — remove from known-broken-specs.txt: programs/us-az/tanf/fy-2026.yaml, programs/us-ct/tanf/fy-2026.yaml, programs/us-fl/tca/fy-2026.yaml
built 34/34 programs
```

Removing the entries does not change what compiles — the allowlist is only consulted for reporting — so the gate on this PR re-verifies the strict result.

## Scope

Allowlist-only. No RuleSpec content, no encoding manifests (none required — no encoded content changes), no toolchain/workflow-pin/CODEOWNERS changes (.github#39 rules 1 and 3). Shrinks the suppression set per the decrement-only waiver principle (#39 rule 2). Tracking: #562 (its us-az/us-ct/us-fl rows are now resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
