### PR TITLE
Time-bound the superseded MPP 63-410.321 ABAWD age exception

### DIFF
--- a/.axiom/encoding-manifests/us-ca/regulations/mpp/63-410/321.json
+++ b/.axiom/encoding-manifests/us-ca/regulations/mpp/63-410/321.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "us-ca/regulations/mpp/63-410/321.test.yaml",
+      "sha256": "6d1279d8158d1e6a3fb799c4bdd30b93dfb887f78c65f939d170b6e13d76b771"
+    },
+    {
+      "path": "us-ca/regulations/mpp/63-410/321.yaml",
+      "sha256": "cc5583e90f19184452a41fe5e12b19d11d4233534b9a127dac6c1501293f49ad"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/private/tmp/encode-pin-3869d66d",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "manual",
+  "citation": "us-ca:regulations/mpp/63-410/321",
+  "context_manifest_file": null,
+  "context_manifest_sha256": null,
+  "generated_at": "2026-08-05T14:06:04.040063+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc6qq8ut7/sign-applied-files/us-ca/regulations/mpp/63-410/321.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc6qq8ut7",
+  "generated_output_sha256": "cc5583e90f19184452a41fe5e12b19d11d4233534b9a127dac6c1501293f49ad",
+  "generation_prompt_sha256": null,
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "bed36cf7fdba8e3e9b434ab1fbb9f57f0d99568bc8e2f50b63e416a40113deb5"
+  },
+  "tool": "axiom-encode sign-applied-files",
+  "trace_file": null,
+  "trace_sha256": null
+}

--- a/.axiom/encoding-manifests/us-ca/regulations/mpp/63-410/321.json
+++ b/.axiom/encoding-manifests/us-ca/regulations/mpp/63-410/321.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us-ca/regulations/mpp/63-410/321.test.yaml",
-      "sha256": "6d1279d8158d1e6a3fb799c4bdd30b93dfb887f78c65f939d170b6e13d76b771"
+      "sha256": "b127b0d26157b6e88a4c185a5593a36784f10ff74a9b7ec64a2fff66164f79cb"
     },
     {
       "path": "us-ca/regulations/mpp/63-410/321.yaml",
-      "sha256": "cc5583e90f19184452a41fe5e12b19d11d4233534b9a127dac6c1501293f49ad"
+      "sha256": "b1d6a7415ee7b7a20102edaeee97766dcaf1e9e367030dba76b7ba5217ab7945"
     }
   ],
   "axiom_encode_git": {
@@ -21,10 +21,10 @@
   "citation": "us-ca:regulations/mpp/63-410/321",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-05T14:06:04.040063+00:00",
-  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc6qq8ut7/sign-applied-files/us-ca/regulations/mpp/63-410/321.yaml",
-  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpc6qq8ut7",
-  "generated_output_sha256": "cc5583e90f19184452a41fe5e12b19d11d4233534b9a127dac6c1501293f49ad",
+  "generated_at": "2026-08-05T14:55:05.272023+00:00",
+  "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdvmvask0/sign-applied-files/us-ca/regulations/mpp/63-410/321.yaml",
+  "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmpdvmvask0",
+  "generated_output_sha256": "b1d6a7415ee7b7a20102edaeee97766dcaf1e9e367030dba76b7ba5217ab7945",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
@@ -33,7 +33,16 @@
   "signature": {
     "algorithm": "hmac-sha256",
     "key_id": "axiom-encode-apply-v1",
-    "value": "bed36cf7fdba8e3e9b434ab1fbb9f57f0d99568bc8e2f50b63e416a40113deb5"
+    "value": "80fd8b4e713d4b56e263ed707bf4308fce60454cbf80c8bc041624163ccb86ee"
+  },
+  "supersedes": {
+    "backend": "manual",
+    "generated_at": "2026-08-05T14:06:04.040063+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "0a55f766077241caad550a0c444c74470ac8bc53c81fd5ee4acbc67ba0c7b197",
+    "prior_signature": "bed36cf7fdba8e3e9b434ab1fbb9f57f0d99568bc8e2f50b63e416a40113deb5",
+    "run_id": null,
+    "tool": "axiom-encode sign-applied-files"
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35934,6 +35934,12 @@
     ],
     "us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1": [
       {
+        "module": "us-ca/regulations/mpp/63-410/321.yaml",
+        "via": [
+          "module"
+        ]
+      },
+      {
         "module": "us/regulations/7-cfr/273/24.yaml",
         "via": [
           "module",
@@ -35942,6 +35948,12 @@
       }
     ],
     "us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4": [
+      {
+        "module": "us-ca/regulations/mpp/63-410/321.yaml",
+        "via": [
+          "module"
+        ]
+      },
       {
         "module": "us/regulations/7-cfr/273/24.yaml",
         "via": [
@@ -43888,6 +43900,12 @@
       }
     ],
     "us/statute/7/2015/o/3": [
+      {
+        "module": "us-ca/regulations/mpp/63-410/321.yaml",
+        "via": [
+          "module"
+        ]
+      },
       {
         "module": "us/regulations/7-cfr/273/24.yaml",
         "via": [

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -3172,17 +3172,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ca/regulations/mpp/63-410/321.yaml":
-    active:
-      fingerprint: "sha256:ac58b72eb321c463f33454a3cbaee705efac27fbe609e733bb3595ed13ad16bd"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
-      fingerprint: "sha256:7db8e583207465f1e54ec0bca09cc7d291a8523156dac773f0009bb8fa8ce04c"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/322.yaml":
     active:
       fingerprint: "sha256:fb281ca41d49734fc756d4268d4afa6dab099c2d77c5f7da4ca02f8ab110483c"

--- a/us-ca/regulations/mpp/63-410/321.test.yaml
+++ b/us-ca/regulations/mpp/63-410/321.test.yaml
@@ -1,27 +1,30 @@
-# MPP 63-410.321 was superseded: P.L. 119-21 section 10102(a) struck
-# 7 U.S.C. 2015(o)(3) effective July 4, 2025, and the module's only
-# version is bounded at 2025-06-30. June 2025 is therefore the last
-# Month period the version resolves, and these cases pin the
-# historical rule there. From July 2025 onward no version applies, so
-# the engine reports a missing formula version instead of evaluating
-# the repealed criteria; the companion harness has no assertion form
-# for that state, which is why no post-supersession case appears here.
+# MPP 63-410.321 is superseded. P.L. 118-5 section 311(a)(1) struck the
+# federal age exception this manual text mirrors, applicable to
+# applications and recertifications received from September 1, 2023 (90
+# days after the June 3, 2023 enactment), and P.L. 119-21 section
+# 10102(a) later struck and replaced 7 U.S.C. 2015(o)(3) in full. The
+# module's only version is bounded at 2023-08-31, so these cases run in
+# May 2023 - wholly before the FRA's enactment. From September 2023
+# onward no version applies: the engine reports a missing formula
+# version instead of evaluating superseded criteria, and the companion
+# harness has no assertion form for that state, which is why no
+# post-supersession case appears here.
 - name: person_under_18
-  period: 2025-06
+  period: 2023-05
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: true
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: false
   output:
     us-ca:regulations/mpp/63-410/321#person_under_18_or_50_years_of_age_or_over: holds
 - name: person_50_or_over
-  period: 2025-06
+  period: 2023-05
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: false
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: true
   output:
     us-ca:regulations/mpp/63-410/321#person_under_18_or_50_years_of_age_or_over: holds
 - name: person_between_18_and_49
-  period: 2025-06
+  period: 2023-05
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: false
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: false

--- a/us-ca/regulations/mpp/63-410/321.test.yaml
+++ b/us-ca/regulations/mpp/63-410/321.test.yaml
@@ -1,19 +1,27 @@
+# MPP 63-410.321 was superseded: P.L. 119-21 section 10102(a) struck
+# 7 U.S.C. 2015(o)(3) effective July 4, 2025, and the module's only
+# version is bounded at 2025-06-30. June 2025 is therefore the last
+# Month period the version resolves, and these cases pin the
+# historical rule there. From July 2025 onward no version applies, so
+# the engine reports a missing formula version instead of evaluating
+# the repealed criteria; the companion harness has no assertion form
+# for that state, which is why no post-supersession case appears here.
 - name: person_under_18
-  period: 2026-05
+  period: 2025-06
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: true
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: false
   output:
     us-ca:regulations/mpp/63-410/321#person_under_18_or_50_years_of_age_or_over: holds
 - name: person_50_or_over
-  period: 2026-05
+  period: 2025-06
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: false
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: true
   output:
     us-ca:regulations/mpp/63-410/321#person_under_18_or_50_years_of_age_or_over: holds
 - name: person_between_18_and_49
-  period: 2026-05
+  period: 2025-06
   input:
     us-ca:regulations/mpp/63-410/321#input.person_is_under_18_years_of_age: false
     us-ca:regulations/mpp/63-410/321#input.person_is_50_years_of_age_or_over: false

--- a/us-ca/regulations/mpp/63-410/321.yaml
+++ b/us-ca/regulations/mpp/63-410/321.yaml
@@ -3,9 +3,49 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us-ca/regulation/mpp/63-410.321
+    corpus_citation_paths:
+    - us-ca/regulation/mpp/63-410.321
+    - us/statute/7/2015/o/3
+    - us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1
+    - us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+      - us/statute/7/2015/o/3
+      - us-ca/regulation/mpp/63-410.321
+      rationale: |-
+        The encoded formula grounds on the manual text of MPP 63-410.321
+        itself. The higher federal authority, 7 U.S.C. 2015(o)(3) as struck
+        and replaced by P.L. 119-21 section 10102(a), no longer contains
+        this age exception ("under 18, or over 65, years of age"), which is
+        why the version is bounded rather than extended. The FNS OBBBA
+        ABAWD exceptions implementation memorandum pages are cited only for
+        what the statute text does not settle: the effective date of the
+        strike ("These changes were effective upon enactment, July 4,
+        2025," page 4) and the pre-Fiscal Responsibility Act age band that
+        confirms this manual text mirrors the pre-2023 statute (footnote 1,
+        page 1). Neither memorandum citation supplies any encoded value;
+        the bounded version's formula remains grounded on the manual text.
   summary: |-
     Under 18 or 50 years of age or over;
+
+    Superseded. This manual provision mirrors the federal ABAWD age
+    exception as it stood before the Fiscal Responsibility Act of 2023
+    ("The Fiscal Responsibility Act of 2023 gradually increased the age
+    of those subject to the ABAWD time limit from 49 to 54 through
+    fiscal year 2030," FNS OBBBA ABAWD exceptions implementation
+    memorandum, footnote 1, page 1). P.L. 119-21 section 10102(a) then
+    struck and replaced 7 U.S.C. 2015(o)(3) in full, effective upon
+    enactment ("These changes were effective upon enactment, July 4,
+    2025," memorandum page 4); the current statute excepts an
+    individual "under 18, or over 65, years of age". The single version
+    below is bounded at 2025-06-30 so that no month from the enactment
+    month onward resolves to the repealed criteria. Current law is
+    encoded federally in us:regulations/7-cfr/273/24; California
+    inherits it through us:policies/usda/snap/state-plan-composition,
+    and this module is outside the FY2026 program scope
+    (programs/us-ca/snap/fy-2026.yaml scopes only 63-410/1 and /6) with
+    no consumers.
 rules:
   - name: person_under_18_or_50_years_of_age_or_over
     kind: derived
@@ -22,6 +62,16 @@ rules:
               corpus_citation_path: us-ca/regulation/mpp/63-410.321
               excerpt: "Under 18 or 50 years of age or over;"
     versions:
+      # Bounded at the last full month before P.L. 119-21 section
+      # 10102(a) struck 7 U.S.C. 2015(o)(3) (enacted 2025-07-04,
+      # "effective upon enactment" per the FNS memorandum, page 4).
+      # The engine applies a version iff effective_from <= period.start
+      # <= effective_to, so a 2025-07-03 bound would still resolve the
+      # July 2025 Month period (start 2025-07-01) to the repealed text;
+      # 2025-06-30 leaves July 2025 and every later month resolving to
+      # no version, matching us/regulations/7-cfr/273/24, where no
+      # month resolves to the repealed criteria either.
       - effective_from: '0001-01-01'
+        effective_to: '2025-06-30'
         formula: |-
           person_is_under_18_years_of_age or person_is_50_years_of_age_or_over

--- a/us-ca/regulations/mpp/63-410/321.yaml
+++ b/us-ca/regulations/mpp/63-410/321.yaml
@@ -15,37 +15,55 @@ module:
       - us-ca/regulation/mpp/63-410.321
       rationale: |-
         The encoded formula grounds on the manual text of MPP 63-410.321
-        itself. The higher federal authority, 7 U.S.C. 2015(o)(3) as struck
-        and replaced by P.L. 119-21 section 10102(a), no longer contains
-        this age exception ("under 18, or over 65, years of age"), which is
-        why the version is bounded rather than extended. The FNS OBBBA
-        ABAWD exceptions implementation memorandum pages are cited only for
-        what the statute text does not settle: the effective date of the
-        strike ("These changes were effective upon enactment, July 4,
-        2025," page 4) and the pre-Fiscal Responsibility Act age band that
-        confirms this manual text mirrors the pre-2023 statute (footnote 1,
-        page 1). Neither memorandum citation supplies any encoded value;
-        the bounded version's formula remains grounded on the manual text.
+        itself. The higher federal authority was checked first: current
+        7 U.S.C. 2015(o)(3), as struck and replaced by P.L. 119-21
+        section 10102(a), no longer contains any 50-year age exception -
+        its age exception now reads "under 18, or over 65, years of
+        age;" - which is why the version is bounded rather than
+        extended. The memorandum pages are cited only for what the
+        current statute text does not settle: the FRA phase-in recital
+        that fixes the pre-FRA operational upper bound (footnote 1,
+        page 1) and the P.L. 119-21 effective date ("These changes were
+        effective upon enactment, July 4, 2025." - page 4). The
+        former-text and FRA application-date quotations come from the
+        amendment notes in the ingested USLM source backing
+        us/statute/7/2015; those notes are part of the archived source
+        document, not registered provision rows. No memorandum citation
+        supplies any encoded value; the bounded version's formula
+        remains grounded on the manual text.
   summary: |-
     Under 18 or 50 years of age or over;
 
-    Superseded. This manual provision mirrors the federal ABAWD age
-    exception as it stood before the Fiscal Responsibility Act of 2023
-    ("The Fiscal Responsibility Act of 2023 gradually increased the age
-    of those subject to the ABAWD time limit from 49 to 54 through
-    fiscal year 2030," FNS OBBBA ABAWD exceptions implementation
-    memorandum, footnote 1, page 1). P.L. 119-21 section 10102(a) then
-    struck and replaced 7 U.S.C. 2015(o)(3) in full, effective upon
-    enactment ("These changes were effective upon enactment, July 4,
-    2025," memorandum page 4); the current statute excepts an
-    individual "under 18, or over 65, years of age". The single version
-    below is bounded at 2025-06-30 so that no month from the enactment
-    month onward resolves to the repealed criteria. Current law is
-    encoded federally in us:regulations/7-cfr/273/24; California
-    inherits it through us:policies/usda/snap/state-plan-composition,
-    and this module is outside the FY2026 program scope
-    (programs/us-ca/snap/fy-2026.yaml scopes only 63-410/1 and /6) with
-    no consumers.
+    Superseded. This manual text carries the pre-Fiscal Responsibility
+    Act ABAWD age exception. Former 7 U.S.C. 2015(o)(3)(A) read "under
+    18 or over 50 years of age;" until P.L. 118-5 section 311(a)(1)
+    struck it (2023 amendment note in the ingested USLM source for
+    us/statute/7/2015), and the FNS OBBBA ABAWD exceptions
+    implementation memorandum's footnote confirms the operational
+    pre-FRA upper bound: "The Fiscal Responsibility Act of 2023
+    gradually increased the age of those subject to the ABAWD time
+    limit from 49 to 54 through fiscal year 2030." (page 1) - subject
+    through 49, i.e. the 50-or-over exception this manual text prints.
+    Under the FRA's effective-date note, state agencies apply the
+    amended paragraph "to any application for initial certification or
+    recertification received starting 90 days after the date of
+    enactment" (enacted June 3, 2023), i.e. from September 1, 2023, so
+    the version below ends 2023-08-31, the last month wholly before
+    any FRA-covered application. Certifications issued before that
+    date could carry the old criteria into later months; the module
+    abstains from that certification-keyed transition rather than
+    modeling it. The FRA amendments were temporary ("shall cease to
+    have effect on October 1, 2030."), but P.L. 119-21 section
+    10102(a) then struck and replaced 7 U.S.C. 2015(o)(3) in full,
+    effective upon enactment ("These changes were effective upon
+    enactment, July 4, 2025." - memorandum page 4), leaving nothing
+    for the sunset to restore; the current paragraph excepts an
+    individual "under 18, or over 65, years of age;" and contains no
+    50-year exception. Current law is encoded federally in
+    us:regulations/7-cfr/273/24; California inherits it through
+    us:policies/usda/snap/state-plan-composition, and this module is
+    outside the FY2026 program scope (programs/us-ca/snap/fy-2026.yaml
+    scopes only 63-410/1 and /6) with no consumers.
 rules:
   - name: person_under_18_or_50_years_of_age_or_over
     kind: derived
@@ -62,16 +80,22 @@ rules:
               corpus_citation_path: us-ca/regulation/mpp/63-410.321
               excerpt: "Under 18 or 50 years of age or over;"
     versions:
-      # Bounded at the last full month before P.L. 119-21 section
-      # 10102(a) struck 7 U.S.C. 2015(o)(3) (enacted 2025-07-04,
-      # "effective upon enactment" per the FNS memorandum, page 4).
-      # The engine applies a version iff effective_from <= period.start
-      # <= effective_to, so a 2025-07-03 bound would still resolve the
-      # July 2025 Month period (start 2025-07-01) to the repealed text;
-      # 2025-06-30 leaves July 2025 and every later month resolving to
-      # no version, matching us/regulations/7-cfr/273/24, where no
-      # month resolves to the repealed criteria either.
+      # Bounded at 2023-08-31. P.L. 118-5 section 311(a)(1) struck the
+      # former age exception this manual text mirrors, and its
+      # effective-date note applies the amended paragraph "to any
+      # application for initial certification or recertification
+      # received starting 90 days after the date of enactment" (June 3,
+      # 2023), i.e. September 1, 2023; August 2023 is the last month
+      # wholly before any FRA-covered application, and the
+      # certification-keyed transition after it is abstained from, not
+      # modeled. The engine applies a version iff effective_from <=
+      # period.start <= effective_to, so August 2023 (start 2023-08-01)
+      # is the last Month period that resolves and no later month -
+      # neither the FRA phase-in band nor anything after P.L. 119-21
+      # section 10102(a)'s July 4, 2025 strike - can resolve to
+      # superseded criteria (the invariant us/regulations/7-cfr/273/24
+      # keeps on the federal side).
       - effective_from: '0001-01-01'
-        effective_to: '2025-06-30'
+        effective_to: '2023-08-31'
         formula: |-
           person_is_under_18_years_of_age or person_is_50_years_of_age_or_over


### PR DESCRIPTION
Completes the separate cleanup flagged in #1210 and carried on #1212's out-of-scope list: `us-ca/regulations/mpp/63-410/321.yaml` timelessly encoded the pre-Fiscal Responsibility Act ABAWD age exception ("Under 18 or 50 years of age or over;") — wrong as a statement of law for any current date. It is outside the FY2026 program scope (`programs/us-ca/snap/fy-2026.yaml` scopes only `63-410/1` and `/6`), has no consumers (nothing imports it; verified by repo-wide grep), and did not cause the July 2026 demo reports — this is archival honesty, not a behavior fix.

## Encoding change

The module's single version now carries `effective_to: '2023-08-31'`:

| | Before | After |
|---|---|---|
| Version window | `0001-01-01` → open | `0001-01-01` → `2023-08-31` |
| September 2023 onward | resolves to the superseded criteria | resolves to no version (explicit `MissingDerivedFormulaVersion` if queried, never a silent value) |

The formula, rule name, and the MPP proof atom are untouched — the manual text still reads what the atom quotes, and the legal-id surface is unchanged.

### Why 2023-08-31

The USLM amendment notes for 7 U.S.C. 2015 (in the ingested source backing `us/statute/7/2015` at the pinned corpus ref) supply both halves of the bound:

- P.L. 118-5 §311(a)(1) "struck out former subpar. (A) which read as follows: 'under 18 or over 50 years of age;'" — the federal text this manual provision mirrors (operationalized inclusive at 50, consistent with the FNS memo footnote's recital that the pre-FRA subject band ran through age 49);
- the FRA's effective-date note applies the amended paragraph "to any application for initial certification or recertification received starting 90 days after the date of enactment" (June 3, 2023) — i.e. from September 1, 2023.

August 2023 is therefore the last month wholly before any FRA-covered application. The transition was certification-keyed, so certifications issued before that date could carry the old criteria into later months; the module abstains from that transition (no version) rather than modeling it — abstention over assertion. The pinned engine (`ffd8213`, `DerivedVersion::applies_at`) applies a version iff `effective_from <= period.start <= effective_to`, so August 2023 (start 2023-08-01) is the last resolving Month period. The FRA amendments were temporary (sunset October 1, 2030), but P.L. 119-21 §10102(a) then struck and replaced the whole paragraph effective upon enactment (July 4, 2025, per FNS memo page 4), leaving nothing for the sunset to restore — no later month can resolve to superseded criteria under either statute, matching the invariant #1212 keeps on the federal module (CalFresh inherits current law through `us:policies/usda/snap/state-plan-composition` → `us:regulations/7-cfr/273/24`).

New module-level citations (`us/statute/7/2015/o/3`, memo pages 1 and 4) all resolve at the repo's pinned corpus ref (`1e8bfc0a`) — no new corpus scopes, no release-cut widening. The guidance citations carry the required `upstream_source_check` record (statute checked first; the memo pages supply only the FRA phase-in recital and the P.L. 119-21 effective date, no encoded values). The amendment-note quotations are attributed to the archived USLM source document itself — those notes are part of the in-corpus source artifact, not registered provision rows, and the rationale says so explicitly.

## Tests

The three companion cases move from period 2026-05 (which after this change resolves to no version) to 2023-05 — wholly before the FRA's enactment, well inside the version window. Inputs and expected outputs are otherwise byte-identical — every case still assigns both local `#input` facts including the false ones. No post-supersession case is possible: the companion harness has no assertion form for the no-applicable-version state (it surfaces as an engine error, not an outcome), which the test-file header documents.

## Waiver removal

`known-validation-gaps.yaml` loses its `us-ca/regulations/mpp/63-410/321.yaml` entry (active + pending). The entry was stale, not load-bearing: it dates to the consolidation-time census (#396/#782), before the CA MPP corpus ground landed (recovery scope 7/13, CDSS CalFresh scope 7/17). At the pinned toolchain the module now passes `validate`, `proof-validate`, and its companion — as-is on main, before this PR's edits — so under the started-passing rule the entry must go. Deletion in a content PR is authorized: the bridge's waiver-change-guard `approval_growth` fires only on added or changed entries, and the edited module is validated for real rather than skipped (`waiver_module_is_unchanged` excludes it from the skip list).

Note the CI consequence: a `known-validation-gaps.yaml` change flips this PR's validation mode to `full-waiver-migration` — every unwaived module in every shard revalidates, not just us-ca. Main's full matrix is green today (scheduled run 09:06Z and both post-merge push runs), so this costs runtime, not risk. The open red-main alarm #1155 predates that (last activity 7/28) and looks stale.

## Gates run locally (pinned toolchain: encode 3869d66d / 0.2.1200, engine ffd8213, corpus 1e8bfc0a)

All re-run at the current revision after the audit fixes:

- `validate --skip-reviewers` on 321.yaml: ✓ PASSED
- `proof-validate`: 1 atom, ✓ PASSED (excerpt verbatim from `us-ca/regulation/mpp/63-410.321`)
- Companion: 3 cases, ✓ PASSED (engine at the ffd8213 pin)
- `guard-generated` vs origin/main with signature verification: "All changed RuleSpec files have encoder apply manifests" (one signed manual attestation covering module + companion, backend recorded honestly as `manual`, re-signed after the audit fixes)
- Reverse index regenerated (`tests/generate_reverse_index.py`): +3 edges for the new citations, byte-stable across the audit-fix revision
- Repository pytest: 66 passed (manifest-drift and reverse-index suites included)
- `tools/build_program_artifacts.py --check`: built 34/34 programs, re-confirmed at this revision (the module sits outside every program scope, so no artifact consumes it). Pre-existing note surfaced by the run, untouched here: three allowlisted TANF/TCA specs now compile and could leave `known-broken-specs.txt`
- Oracle coverage: no new, removed, or renamed executable outputs (rule name and module path unchanged — verified against the diff), so the classification surface is identical to main's green full run

## Cross-family review

A sol adversarial audit (ultra effort, read-only, against the pinned corpus/engine/toolchain checkouts) returned **VERDICT: FIX** with four findings — all accepted and addressed in the second commit:

1. **The original 2025-06-30 bound was legally wrong.** My draft bounded at the P.L. 119-21 strike on the belief that no FRA ground existed at the pinned corpus ref. Sol found the USLM amendment notes (former-text and application-date, quoted above), refuting that: the old bound would have kept returning `holds` for a 50-year-old through the FRA phase-in. The bound is now FRA-dated (2023-08-31) and the companion periods moved to 2023-05.
2. **Three quotations swapped terminal periods for commas inside the quotes.** All quotations now carry their original punctuation, attribution outside the quotes.
3. **The "18–49 subject" claim over-read the memo footnote** (which fixes only the upper bound). The claim is now scoped to what the footnote supports, with the lower bound coming from the former statutory text itself.
4. **The upstream rationale misread as denying what the current statute contains.** It now states the current text ("under 18, or over 65, years of age;") and that the 50-year exception is what's gone.

Sol's passing checks at first audit: engine `applies_at` semantics and the no-silent-value error path (including the dense-compilation reject), encoder 0.2.1200 schema acceptance of `effective_to`/plural citations/`upstream_source_check`, companion input closure, provenance structure (pins/workflows/CODEOWNERS untouched, waiver change deletion-only, manifest hashes/HMAC fields), no consumers, and an exact-three-edge reverse-index diff.

The focused sol re-verify of the fixes returned **VERDICT: SHIP** — all four findings resolved, no new defect: all ten quotations verified exact against their sources (punctuation included), the sunset sentence confirmed sound as an inference from the notes, the footnote now scoped to the upper bound with the lower bound grounded in the statutory former-text note, May 2023 cases resolve while September 2023 returns missing-formula-version, and the re-signed manifest hashes match both revised files. Merge gate: green checks + this verdict (met).

## Out of scope

- Sibling MPP 63-410 modules stay as they are: `322.yaml` ("Pregnant; or") encodes an exception H.R. 1 retained, and no other sibling encodes the age criterion. Whether the rest of the waived MPP 63-410 family can now also pass and shed waivers (their corpus ground landed with the same scopes) is a separate sweep.
- The stale red-main alarm issue #1155 (green since 7/28) — flagging here rather than closing unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
