### PR TITLE
Remove now-compiling AZ/CT/FL specs from the known-broken allowlist

### DIFF
--- a/tools/known-broken-specs.txt
+++ b/tools/known-broken-specs.txt
@@ -1,5 +1,2 @@
 # Specs that do not currently compile through axiom-compose + axiom-rules-engine.
 # Each entry suppresses the CI build gate for that spec. Fixes tracked in #562.
-programs/us-az/tanf/fy-2026.yaml
-programs/us-ct/tanf/fy-2026.yaml
-programs/us-fl/tca/fy-2026.yaml


### PR DESCRIPTION
Removes the three remaining entries from `tools/known-broken-specs.txt` — all three specs now compile, so their allowlist suppressions are stale. The allowlist is now empty (header comment kept; `load_allowlist` handles an entry-less file).

`tools/build_program_artifacts.py` has been reporting on main:

```
NOTE: allowlisted specs now compile — remove from known-broken-specs.txt: programs/us-az/tanf/fy-2026.yaml, programs/us-ct/tanf/fy-2026.yaml, programs/us-fl/tca/fy-2026.yaml
```

## Verification at the pinned toolchain

Base `52e9bc64c` (origin/main), axiom-compose @ `fabe0b3b` (the program-artifacts workflow pin), engine @ `ffd8213` (toolchain pin, clean checkout), encoder 0.2.1200 @ `3869d66d`.

- **Before** (main): every spec builds — `built 34/34 programs`, with the NOTE above naming all three allowlisted specs as unexpected successes (each composed and engine-compiled cleanly).
- **After** (this branch): `built 34/34 programs`, exit 0, no NOTE, no KNOWN-BROKEN lines.
- **guard-generated vs origin/main** (protected-base encoder 0.2.1200 @ `3869d66d`, CI's auto-derived 52-root set): pass — "All changed RuleSpec files have encoder apply manifests."

## Provenance

No RuleSpec YAML changes — the diff is one non-RuleSpec text file under `tools/`, so no encoding manifest is involved. No citations added, no toolchain/pin/CODEOWNERS changes.

Refs #562: this resolves the last of its compile-failure entries (`us-ma/snap` was fixed earlier). Its stranded ex-axiom-programs half is untouched, so the issue stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
