### PR TITLE
Add signed encoding manifest for us-la/statute/47:294

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/294.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/294.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/294.yaml",
-      "sha256": "19b42bbc7bef3dd1b9f2300d443005f6079f899c04cf012466a0b0bf4a6d16a7"
+      "sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97"
     },
     {
       "path": "us-la/statutes/47/294.test.yaml",
-      "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+      "sha256": "4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1565",
+    "version_commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1565",
   "backend": "openai",
   "citation": "us-la/statute/47:294",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-294/workspace/context-manifest.json",
-  "context_manifest_sha256": "a1c68b62dc40728f55d1276954dde5f5cb385f9a1649456515c1d26d0027a9b1",
-  "generated_at": "2026-07-19T00:20:57.209247+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/294.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "19b42bbc7bef3dd1b9f2300d443005f6079f899c04cf012466a0b0bf4a6d16a7",
-  "generation_prompt_sha256": "eec22d14bb75043ad08376c0d97f613d9449cf589943855e110159f393ad9e7c",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-294/workspace/context-manifest.json",
+  "context_manifest_sha256": "c58145b6cbe3e010cf28da0359b6f05b3807ab27dc5e78120b5e1ded7d77c21d",
+  "generated_at": "2026-08-05T21:19:16.008462+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/294.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97",
+  "generation_prompt_sha256": "a91cdd30ebe54b35d2f6fa78aa00553521c376604a3d2dd0601ff2acb1e992f1",
   "model": "gpt-5.6-terra",
-  "run_id": "da233be3",
+  "run_id": "5126c68d",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "ACC1/G3bOcEY/iWLrMffR4jnVpwwKwTxDAEvbXWYP3+HfGfNzb6wFsId54FbKASYjNJr3QpI43T2Z27j4TlEAA=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "g81jJ6957cxgruXAxFtLdprIKSu4RioFrWnF7LSztmbse01U0XS4VlfMIurZIcVJZhUZT2NBNbCKhZ/Q7nTBAA=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "305be359c89fd6608590e432a3cddd707cd1828e652dad8d8ef6dce3cc2d6a9c",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:294",
     "resolved_corpus_citation_path": "us-la/statute/47:294",
-    "resolved_text_sha256": "305be359c89fd6608590e432a3cddd707cd1828e652dad8d8ef6dce3cc2d6a9c",
+    "resolved_text_sha256": "2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b",
     "row": {
-      "body_sha256": "305be359c89fd6608590e432a3cddd707cd1828e652dad8d8ef6dce3cc2d6a9c",
+      "body_sha256": "2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b",
       "citation_path": "us-la/statute/47:294",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 1,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 366,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "b21d68ab-0797-5cbe-bb24-bf9b483c478a",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-294",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101761.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "305be359c89fd6608590e432a3cddd707cd1828e652dad8d8ef6dce3cc2d6a9c"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-294.json",
-  "trace_sha256": "1e20a6d677ec8186a387c70c0cd9255614d5c4142cb34772b5d1d55ac98cb27d",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-294.json",
+  "trace_sha256": "171231e115570152432c61fcc3d57124fcc4d17d81d0be916eb6a6b63d843438",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1565"
     },
     "axiom_rules_engine": {
-      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "8ae33fc1e3cdb6daadb049ece098db76e894b9d56d8e115a97175783f6e158f5",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "6e88ec73d78075712862bfe7cb959262ef88c9989d86c10c1f25941378f7c73c",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/294.test.yaml
+++ b/us-la/statutes/47/294.test.yaml
@@ -1,1 +1,20 @@
-[]
+- name: joint surviving spouse and head of household standard deduction for tax year
+    2025
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input: {}
+  output:
+    us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household: 25000
+- name: annual standard deduction adjustment beginning in 2026
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
+  output:
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 500
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000

--- a/us-la/statutes/47/294.yaml
+++ b/us-la/statutes/47/294.yaml
@@ -4,21 +4,23 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:294
-    source_sha256: 305be359c89fd6608590e432a3cddd707cd1828e652dad8d8ef6dce3cc2d6a9c
-  summary: '"For tax year 2025" the standard deduction is "$12,500.00" for "Single
-    Individual and Married-Separate"; "Married-Joint Return, a Qualified Surviving
-    Spouse, and Head of Household" receive "200% of the dollar amount" provided for
-    Single Individuals. Beginning January 1, 2026, the deduction is adjusted annually
-    using the CPI-U percentage increase for the previous calendar year.'
+    source_sha256: 2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b
+  summary: '"For tax year 2025" the standard deduction for "Single Individual and
+
+    Married-Separate" is "$12,500.00"; specified joint-return statuses receive
+
+    "200% of the dollar amount." "Beginning January 1, 2026" the deduction is
+
+    adjusted annually using the CPI-U percentage increase for the previous
+
+    calendar year.'
   deferred_outputs:
   - output: us-la:statutes/47/294#standard_deduction
-    reason: Taxpayer-specific standard deduction determination requires the federally
-      determined filing status, for which no executable upstream filing-status RuleSpec
-      export is supplied. The post-2025 annual adjustment also requires a period-indexed
-      prior-year deduction and CPI-U percentage increase mechanism not supplied in
-      executable context.
+    reason: Determining the taxpayer-specific standard deduction requires the federally
+      derived filing status used on the federal income tax return, and no executable
+      upstream filing-status RuleSpec export is supplied.
 rules:
-- name: standard_deduction_single_individual_married_separate_2025
+- name: standard_deduction_single_individual_married_separate
   kind: parameter
   dtype: Money
   unit: USD
@@ -32,8 +34,19 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:294
           excerpt: Single Individual and Married-Separate $12,500.00
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
+      - path: versions[0].effective_to
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
   versions:
   - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
     formula: '12500'
 - name: standard_deduction_joint_surviving_spouse_head_of_household_multiplier
   kind: parameter
@@ -48,11 +61,23 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:294
           excerpt: 200% of the dollar amount
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
+      - path: versions[0].effective_to
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
   versions:
   - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
     formula: '2.00'
-- name: standard_deduction_joint_surviving_spouse_head_of_household_2025
-  kind: parameter
+- name: standard_deduction_joint_surviving_spouse_head_of_household
+  kind: derived
+  entity: TaxUnit
   dtype: Money
   unit: USD
   period: Year
@@ -68,8 +93,8 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
-          target: us-la:statutes/47/294#standard_deduction_single_individual_married_separate_2025
-          output: standard_deduction_single_individual_married_separate_2025
+          target: us-la:statutes/47/294#standard_deduction_single_individual_married_separate
+          output: standard_deduction_single_individual_married_separate
           hash: sha256:local
       - path: versions[0].formula
         kind: import
@@ -77,6 +102,65 @@ rules:
           target: us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household_multiplier
           output: standard_deduction_joint_surviving_spouse_head_of_household_multiplier
           hash: sha256:local
+      - path: versions[0].effective_to
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
   versions:
   - effective_from: '2025-01-01'
-    formula: standard_deduction_single_individual_married_separate_2025 * standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+    effective_to: '2025-12-31'
+    formula: standard_deduction_single_individual_married_separate * standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+- name: standard_deduction_annual_adjustment_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: multiplying the amount of the prior year's standard deduction by
+            the percentage increase
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026
+  versions:
+  - effective_from: '2026-01-01'
+    formula: prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
+- name: standard_deduction_after_annual_adjustment
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: shall be adjusted annually by an amount
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_annual_adjustment_amount
+          output: standard_deduction_annual_adjustment_amount
+          hash: sha256:local
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026
+  versions:
+  - effective_from: '2026-01-01'
+    formula: prior_year_standard_deduction + standard_deduction_annual_adjustment_amount


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:294`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `6535019ce780d9e78f10509f2fe7a2607fb2bdc4`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31047850869

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.