### PR TITLE
Make the compat contract express the dimension that actually gates

### DIFF
--- a/tools/build_program_artifacts.py
+++ b/tools/build_program_artifacts.py
@@ -350,6 +350,22 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # Cross-check before building anything: an engine that can report its own
+    # loader contract must agree with what this builder expects to stamp.
+    # Engines predating `capabilities` return None and the emitted artifacts
+    # remain the sole authority (artifact_schema_of, below).
+    caps = engine_capabilities(engine_bin)
+    if caps is not None:
+        reported = caps.get("artifact_format_version")
+        if reported != EXPECTED_ARTIFACT_SCHEMA_VERSION:
+            print(
+                f"engine reports artifact_format_version {reported}, builder expects "
+                f"{EXPECTED_ARTIFACT_SCHEMA_VERSION} — refusing to publish artifacts whose "
+                f"compat contract would be wrong",
+                file=sys.stderr,
+            )
+            return 2
+
     manifest_programs = []
     unexpected_failures: list[str] = []
     unexpected_successes: list[str] = []

--- a/tools/build_program_artifacts.py
+++ b/tools/build_program_artifacts.py
@@ -38,9 +38,12 @@ from pathlib import Path
 import yaml
 
 MANIFEST_FORMAT_VERSION = 1
-# The compiled-artifact format generation. Bumped only on a
-# breaking artifact-format change; the engine negotiates against it on load.
-ARTIFACT_SCHEMA_VERSION = 2
+# The compiled-artifact format generation this builder is known to work with.
+# It is an EXPECTATION, not the stamped value: what lands in the manifest is
+# read back from the artifact the engine emitted (artifact_schema_of), and a
+# mismatch fails the build. Bumping the engine across a format boundary without
+# bumping this is therefore a hard error, not a silently mislabeled release.
+EXPECTED_ARTIFACT_SCHEMA_VERSION = 2
 # The fixed, tested lower bound an artifact requires of the engine. A floor, not
 # the building engine's version — any engine >= this that supports the artifact
 # schema can load it. Raise only when an emitted feature demands a newer engine.
@@ -169,21 +172,66 @@ def engine_build_sha(engine_bin: str) -> str:
     return ""
 
 
-def build_compat(engine_version: str, engine_sha: str) -> dict:
+def build_compat(engine_version: str, engine_sha: str, artifact_schema: int) -> dict:
     """The four-field compatibility contract carried by every artifact.
 
-    - artifact_schema: the compiled-artifact format generation (gating).
+    - artifact_schema: the compiled-artifact format generation, READ BACK from
+      the artifact the engine actually emitted — never a hardcoded claim.
     - built_by_engine: pure provenance (version + real build sha) — never gates.
-    - requires_engine: the negotiation floor. min_version is a FIXED tested
-      lower bound (not the building engine's version): every engine >= this that
-      still supports artifact_schema can load the artifact. Raise it only when an
-      emitted feature actually requires a newer engine.
+    - requires_engine: the negotiation floor. It carries BOTH dimensions,
+      because they move independently and only one of them gates:
+
+      * min_version is a FIXED tested semver lower bound (not the building
+        engine's version). It does not gate loading.
+      * artifact_format_version is what the loader matches EXACTLY. An engine
+        reporting a different number rejects this artifact however new its
+        semver is.
+
+      Emitting only min_version is what let engine v0.1.0 (format 1) and these
+      artifacts (format 2) both advertise "0.1.0" and read as compatible while
+      every load failed. Released v0.2.0 widens the same false pass: a consumer
+      compares 0.2.0 >= 0.1.0, concludes compatible, and is refused at load.
+      Compare `axiom-rules-engine capabilities`.artifact_format_version against
+      requires_engine.artifact_format_version; treat semver as advisory.
     """
     return {
-        "artifact_schema": ARTIFACT_SCHEMA_VERSION,
+        "artifact_schema": artifact_schema,
         "built_by_engine": {"version": engine_version, "git_sha": engine_sha},
-        "requires_engine": {"min_version": MIN_ENGINE_VERSION, "capabilities": []},
+        "requires_engine": {
+            "min_version": MIN_ENGINE_VERSION,
+            "artifact_format_version": artifact_schema,
+            "capabilities": [],
+        },
     }
+
+
+def artifact_schema_of(artifact: Path) -> int:
+    """The format generation the engine actually stamped into this artifact.
+
+    Ground truth, not a declaration: the loader compares this exact number, so
+    the manifest must report what was emitted rather than what the builder
+    believes. Any engine produces it; no new engine feature is required.
+    """
+    found = json.loads(artifact.read_text()).get("artifact_format_version")
+    if not isinstance(found, int):
+        raise RuntimeError(
+            f"{artifact.name}: artifact_format_version is {found!r}, expected an int"
+        )
+    return found
+
+
+def engine_capabilities(engine_bin: str) -> dict | None:
+    """What the binary says it can load, or None on engines predating the
+    `capabilities` subcommand. Used only to cross-check the emitted artifacts."""
+    try:
+        out = subprocess.run(
+            [engine_bin, "capabilities"], capture_output=True, text=True, timeout=60
+        )
+        if out.returncode != 0:
+            return None
+        return json.loads(out.stdout)
+    except (OSError, json.JSONDecodeError, subprocess.SubprocessError):
+        return None
 
 
 def assemble_manifest(
@@ -193,6 +241,7 @@ def assemble_manifest(
     engine_version: str,
     engine_sha: str,
     toolchain: dict,
+    artifact_schema: int,
 ) -> dict:
     """Assemble the top-level manifest. Pure function so it is directly testable
     with real inputs (the fields below must come from here, not a test's copy)."""
@@ -215,7 +264,8 @@ def assemble_manifest(
         # a release name may be stamped only when an axiom-corpus release
         # manifest's provenance commit exactly equals that pin.
         "corpus_release": None,
-        "artifact_schema": ARTIFACT_SCHEMA_VERSION,
+        # Observed from the emitted artifacts, not declared. See build_compat.
+        "artifact_schema": artifact_schema,
         "programs": programs,
     }
 
@@ -303,6 +353,7 @@ def main() -> int:
     manifest_programs = []
     unexpected_failures: list[str] = []
     unexpected_successes: list[str] = []
+    artifact_schemas: set[int] = set()
     engine_version = "unknown"
 
     # Compose and compile in a neutral temp directory OUTSIDE the repo: the
@@ -334,7 +385,19 @@ def main() -> int:
 
         # The four-field compatibility contract, self-describing inside each
         # artifact so a consumer can negotiate with the engine before loading.
-        compat = build_compat(engine_version, engine_sha)
+        schema = artifact_schema_of(artifact_path)
+        if schema != EXPECTED_ARTIFACT_SCHEMA_VERSION:
+            print(
+                f"FAIL {spec_rel}: engine emitted artifact_format_version {schema}, "
+                f"builder expects {EXPECTED_ARTIFACT_SCHEMA_VERSION}. The engine pin moved "
+                f"across a format boundary; bump EXPECTED_ARTIFACT_SCHEMA_VERSION "
+                f"deliberately and re-cut the engine release.",
+                file=sys.stderr,
+            )
+            unexpected_failures.append(spec_rel)
+            continue
+        artifact_schemas.add(schema)
+        compat = build_compat(engine_version, engine_sha, schema)
         provenance = {
             "corpus": corpus,
             "spec_path": spec_rel,
@@ -372,8 +435,21 @@ def main() -> int:
             f"({manifest_programs[-1]['counts']['derived']}d)"
         )
 
+    if len(artifact_schemas) > 1:
+        print(
+            f"artifacts disagree on artifact_format_version {sorted(artifact_schemas)} — "
+            f"a single manifest cannot describe them",
+            file=sys.stderr,
+        )
+        return 1
     manifest = assemble_manifest(
-        manifest_programs, corpus, composer, engine_version, engine_sha, toolchain
+        manifest_programs,
+        corpus,
+        composer,
+        engine_version,
+        engine_sha,
+        toolchain,
+        artifact_schemas.pop() if artifact_schemas else EXPECTED_ARTIFACT_SCHEMA_VERSION,
     )
     (dist / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
 

--- a/tools/build_program_artifacts.py
+++ b/tools/build_program_artifacts.py
@@ -222,16 +222,31 @@ def artifact_schema_of(artifact: Path) -> int:
 
 def engine_capabilities(engine_bin: str) -> dict | None:
     """What the binary says it can load, or None on engines predating the
-    `capabilities` subcommand. Used only to cross-check the emitted artifacts."""
+    `capabilities` subcommand.
+
+    Only a nonzero exit (unknown subcommand) or a missing binary reads as
+    "legacy engine". An engine that CLAIMS the subcommand — exits zero — and
+    then emits something unparseable is broken, not old, and must fail the
+    build rather than masquerade as legacy and bypass the cross-check. Same
+    for a hang: a 60s timeout on printing two fields is not a legacy engine.
+    """
     try:
         out = subprocess.run(
             [engine_bin, "capabilities"], capture_output=True, text=True, timeout=60
         )
-        if out.returncode != 0:
-            return None
-        return json.loads(out.stdout)
-    except (OSError, json.JSONDecodeError, subprocess.SubprocessError):
+    except (OSError, FileNotFoundError):
+        return None  # missing/unrunnable binary; the first compile will say so
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"{engine_bin}: `capabilities` hung; broken engine, not a legacy one")
+    if out.returncode != 0:
         return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        raise RuntimeError(
+            f"{engine_bin}: `capabilities` exited 0 but emitted non-JSON; "
+            f"refusing to treat a broken engine as a legacy one"
+        )
 
 
 def assemble_manifest(

--- a/tools/tests/test_manifest_provenance.py
+++ b/tools/tests/test_manifest_provenance.py
@@ -6,6 +6,8 @@ fails the test (they do not recreate dicts by hand)."""
 import json
 import subprocess
 import sys
+
+import pytest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -61,7 +63,7 @@ def test_engine_build_sha_unknown_returns_empty(tmp_path, monkeypatch):
 
 
 def test_build_compat_contract_shape_and_floor():
-    compat = bpa.build_compat(engine_version="0.1.0", engine_sha="e19f1b75cafe")
+    compat = bpa.build_compat(engine_version="0.1.0", engine_sha="e19f1b75cafe", artifact_schema=2)
     assert compat["artifact_schema"] == 2
     # Provenance carries the real build sha; gating carries the FIXED floor,
     # not the building version. Artifact readers separately require the exact
@@ -70,18 +72,19 @@ def test_build_compat_contract_shape_and_floor():
     assert compat["requires_engine"]["min_version"] == bpa.MIN_ENGINE_VERSION == "0.1.0"
     assert compat["requires_engine"]["capabilities"] == []
     # A newer building engine still stamps the fixed floor, not its own version.
-    assert bpa.build_compat("0.9.0", "abc")["requires_engine"]["min_version"] == "0.1.0"
+    assert bpa.build_compat("0.9.0", "abc", 2)["requires_engine"]["min_version"] == "0.1.0"
 
 
 def test_assemble_manifest_stamps_real_engine_sha_not_stale():
     toolchain = {"axiom_rules_engine_ref": "e19f1b75", "axiom_corpus_ref": "7661f3c9"}
     m = bpa.assemble_manifest(
-        programs=[{"program_id": "co-snap", "compat": bpa.build_compat("0.1.0", "cafef00dbabe")}],
+        programs=[{"program_id": "co-snap", "compat": bpa.build_compat("0.1.0", "cafef00dbabe", 2)}],
         corpus={"repo": "rulespec-us", "sha": "733d1a17", "dirty": False},
         composer="0.1.0",
         engine_version="0.1.0",
         engine_sha="cafef00dbabe",
         toolchain=toolchain,
+        artifact_schema=2,
     )
     # The BOM's key assertion: engine identity is a real sha, not the "0.1.0" string.
     assert m["engine"]["git_sha"] == "cafef00dbabe"
@@ -100,8 +103,43 @@ def test_assemble_manifest_stamps_real_engine_sha_not_stale():
 def test_manifest_and_program_compat_cannot_disagree():
     # Both the artifact provenance and the per-program manifest entry take the
     # SAME compat object; prove equality holds for a shared instance.
-    compat = bpa.build_compat("0.1.0", "cafef00d")
+    compat = bpa.build_compat("0.1.0", "cafef00d", 2)
     program_entry = {"program_id": "co-snap", "compat": compat}
-    m = bpa.assemble_manifest([program_entry], {}, "0.1.0", "0.1.0", "cafef00d", {})
+    m = bpa.assemble_manifest([program_entry], {}, "0.1.0", "0.1.0", "cafef00d", {}, 2)
     assert m["programs"][0]["compat"] is compat
     assert m["programs"][0]["compat"]["built_by_engine"]["git_sha"] == "cafef00d"
+
+
+def test_requires_engine_carries_the_gating_schema_not_only_semver():
+    """Regression: v0.1.0 (format 1) and format-2 artifacts both advertised
+    "0.1.0", so a third party comparing `--version` against
+    requires_engine.min_version concluded compatible while every load failed.
+    Released v0.2.0 widens the same gap. The floor must carry the dimension the
+    loader actually matches."""
+    requires = bpa.build_compat("0.1.0", "ffd8213", artifact_schema=2)["requires_engine"]
+    assert requires["artifact_format_version"] == 2
+    # An engine reporting format 1 must be rejectable from the contract ALONE,
+    # without downloading or attempting to load the artifact.
+    engine_reports = {"engine_version": "0.2.0", "artifact_format_version": 1}
+    assert engine_reports["engine_version"] >= requires["min_version"]  # semver says yes
+    assert (
+        engine_reports["artifact_format_version"] != requires["artifact_format_version"]
+    ), "the schema dimension is what must say no"
+
+
+def test_compat_schema_follows_the_emitted_artifact_not_the_constant():
+    """The stamped generation is observed, never asserted: if the engine pin
+    moves across a format boundary the manifest must not keep claiming the old
+    number."""
+    compat = bpa.build_compat("0.1.0", "abc", artifact_schema=3)
+    assert compat["artifact_schema"] == 3
+    assert compat["requires_engine"]["artifact_format_version"] == 3
+
+
+def test_artifact_schema_of_reads_the_emitted_value(tmp_path):
+    artifact = tmp_path / "x.compiled.json"
+    artifact.write_text(json.dumps({"artifact_format_version": 2, "program": {}}))
+    assert bpa.artifact_schema_of(artifact) == 2
+    artifact.write_text(json.dumps({"program": {}}))
+    with pytest.raises(RuntimeError):
+        bpa.artifact_schema_of(artifact)

--- a/tools/tests/test_manifest_provenance.py
+++ b/tools/tests/test_manifest_provenance.py
@@ -167,4 +167,10 @@ def test_engine_capabilities_is_none_on_engines_without_the_subcommand(tmp_path)
     # builder must fall back to the emitted artifacts, not crash or invent.
     assert bpa.engine_capabilities(_fake_engine(tmp_path, "exit 1")) is None
     assert bpa.engine_capabilities(str(tmp_path / "missing")) is None
-    assert bpa.engine_capabilities(_fake_engine(tmp_path, "echo not-json")) is None
+
+
+def test_engine_capabilities_fails_closed_on_a_broken_self_report(tmp_path):
+    # Exit 0 with unparseable output is a BROKEN engine, not a legacy one:
+    # treating it as legacy would silently bypass the pre-build cross-check.
+    with pytest.raises(RuntimeError):
+        bpa.engine_capabilities(_fake_engine(tmp_path, "echo not-json"))

--- a/tools/tests/test_manifest_provenance.py
+++ b/tools/tests/test_manifest_provenance.py
@@ -143,3 +143,28 @@ def test_artifact_schema_of_reads_the_emitted_value(tmp_path):
     artifact.write_text(json.dumps({"program": {}}))
     with pytest.raises(RuntimeError):
         bpa.artifact_schema_of(artifact)
+
+
+def _fake_engine(tmp_path, body: str):
+    bin_path = tmp_path / "axiom-rules-engine"
+    bin_path.write_text(f"#!/bin/sh\n{body}\n")
+    bin_path.chmod(0o755)
+    return str(bin_path)
+
+
+def test_engine_capabilities_reads_the_self_report(tmp_path):
+    bin_path = _fake_engine(
+        tmp_path, 'echo \'{"engine_version": "0.2.1", "artifact_format_version": 2}\''
+    )
+    assert bpa.engine_capabilities(bin_path) == {
+        "engine_version": "0.2.1",
+        "artifact_format_version": 2,
+    }
+
+
+def test_engine_capabilities_is_none_on_engines_without_the_subcommand(tmp_path):
+    # Engines predating `capabilities` exit nonzero on the unknown command; the
+    # builder must fall back to the emitted artifacts, not crash or invent.
+    assert bpa.engine_capabilities(_fake_engine(tmp_path, "exit 1")) is None
+    assert bpa.engine_capabilities(str(tmp_path / "missing")) is None
+    assert bpa.engine_capabilities(_fake_engine(tmp_path, "echo not-json")) is None


### PR DESCRIPTION
## The false pass

Every published manifest carries:

```json
"requires_engine": {"min_version": "0.1.0", "capabilities": []}
```

A third party reads it, runs `axiom-rules-engine --version`, sees `0.2.0`, compares `0.2.0 >= 0.1.0`, and concludes compatible. They are wrong — released v0.2.0 refuses every one of these artifacts at load:

```
compiled artefact `us-co-snap.compiled.json` violates the v2 contract:
program.extends was removed; compose before compilation
```

This was already true when the released engine was v0.1.0 and both sides advertised `"0.1.0"`. v0.2.0 widened it: the version gap now *looks* reassuring while the incompatibility is unchanged. **Semver is not the dimension the loader compares.** Artifact format version is, and it moves independently of the package version.

## The change

`requires_engine` carries `artifact_format_version` alongside `min_version`, so incompatibility is decidable from the published contract alone — before downloading an artifact or attempting a load.

The stamped generation is also no longer a hardcoded constant. `artifact_schema_of()` reads it back from the artifact the engine actually emitted, so the manifest reports **what was built, not what the builder believed**. `ARTIFACT_SCHEMA_VERSION` becomes `EXPECTED_ARTIFACT_SCHEMA_VERSION`: an expectation the build checks against reality and fails on. Moving the engine pin across a format boundary is now a hard error rather than a silently mislabeled release. Artifacts disagreeing among themselves fails too — one manifest cannot honestly describe them.

## Scope

`tools/` only — two files. No toolchain pin, workflow, waiver, or encoding manifest, per `.github#39`.

Pairs with [axiom-rules-engine#156](https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/156), which adds the `capabilities` subcommand a consumer compares against. Independently useful: the floor is correct whether or not the engine can self-report yet, and the builder degrades gracefully on engines without it.

11 tests pass, including a regression asserting the semver comparison says yes while the schema comparison says no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)