### PR TITLE
Add signed encoding manifest for us-la/statute/47:297.4

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/4.yaml",
-      "sha256": "0378e2542807861692231da972a1039f23109669e4c2406d2795587aef2b3176"
+      "sha256": "7d9bb7bef221929135a95f4cc46654f258766b15911fc0e92c5c4d07f28f6b88"
     },
     {
       "path": "us-la/statutes/47/297/4.test.yaml",
-      "sha256": "f4eb0f0d883a3d4054f369f75b2c49a7b94250919c51647ebcf0bea744af26f2"
+      "sha256": "8f9f13968735379671189471e7921a80e2d1cc8904d50262de2e15ca02b086f5"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "70baa25d4eb2929c0817a6ff58c0908dba286ee2",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1626",
+    "version_commit": "70baa25d4eb2929c0817a6ff58c0908dba286ee2"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1626",
   "backend": "openai",
   "citation": "us-la/statute/47:297.4",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.4/workspace/context-manifest.json",
-  "context_manifest_sha256": "862d61a1c08c2c50c935b36b5469c2fb3d78479534b72705d0c45aacf031ca92",
-  "generated_at": "2026-07-19T02:00:20.840179+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/297/4.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "0378e2542807861692231da972a1039f23109669e4c2406d2795587aef2b3176",
-  "generation_prompt_sha256": "cc2b0456884ba5bb1de5f23997f906f6c3835c95a6780b7f293a0f8ea8985397",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.4/workspace/context-manifest.json",
+  "context_manifest_sha256": "a02963807365a6fa8f1892b74064bfb3a991b6b793d23dc56b2a99bf75776535",
+  "generated_at": "2026-08-07T18:41:45.039483+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/297/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "7d9bb7bef221929135a95f4cc46654f258766b15911fc0e92c5c4d07f28f6b88",
+  "generation_prompt_sha256": "7e16e30ebbe2ff439ebd6115121be9aafccb27936a048f72f56b651847f87cf2",
   "model": "gpt-5.6-terra",
-  "run_id": "a0c984fe",
+  "run_id": "5c2a9dbc",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "xCHDmDZ/Sd7wY+aZYSCKKYkLyv/2WhUt/0bpwJTAMfefGe6/jlPAmUmzHseyraEr6oNiDZ6GacZ40cneTcAADQ=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "mGbWA7CNc8lKa2fJPkGQ7fnMG1dEKBpLOERkAip9JJi+BZFl4QDcPUrz23BxX5BhCjhtOARfp1d8aTvSBaQPAg=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "5f048ba93b612ae65531fc78ff293d7cbbf1813fcfe2dfbb29f63ddbf3c0dc89",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:297.4",
     "resolved_corpus_citation_path": "us-la/statute/47:297.4",
-    "resolved_text_sha256": "5f048ba93b612ae65531fc78ff293d7cbbf1813fcfe2dfbb29f63ddbf3c0dc89",
+    "resolved_text_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528",
     "row": {
-      "body_sha256": "5f048ba93b612ae65531fc78ff293d7cbbf1813fcfe2dfbb29f63ddbf3c0dc89",
+      "body_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528",
       "citation_path": "us-la/statute/47:297.4",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 3,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 376,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "6f00533d-61b7-50b0-b2c0-86d158f146fb",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-297.4",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101769.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "5f048ba93b612ae65531fc78ff293d7cbbf1813fcfe2dfbb29f63ddbf3c0dc89"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-297.4.json",
-  "trace_sha256": "1002c96e70abf5890aef946fbd5ac8ad568254efc8e876a710fe7ad165b421dc",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-297.4.json",
+  "trace_sha256": "00d83af2c1be3175899ea0b7e54b581578a6abd821974882da92e42e9588336d",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "70baa25d4eb2929c0817a6ff58c0908dba286ee2",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1626"
     },
     "axiom_rules_engine": {
-      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "a5803f1fead8dc416e2de2d738953e5ebf35a2433bcd5a3cc1e0ae1d57cc184e",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "8e5fbf3dbcdfa99086654e757b0b05556df6cf4ef69194b38fd310d3ea458cd2",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/297/4.test.yaml
+++ b/us-la/statutes/47/297/4.test.yaml
@@ -1,4 +1,4 @@
-- name: initial_low_income_rate_applies_in_2006
+- name: low_income_rate_in_2006
   period:
     period_kind: tax_year
     start: '2006-01-01'
@@ -8,29 +8,38 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 300
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 250
     us-la:statutes/47/297/4#child_care_expense_credit: 250
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 150
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-- name: later_low_income_rate_applies_in_2007
+- name: agi_25000_low_income_current_rate
   period:
     period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
+    start: '2024-01-01'
+    end: '2024-12-31'
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 300
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 200
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-- name: middle_income_excess_carries_forward
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: agi_25001_middle_income
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -38,15 +47,23 @@
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 30000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 180
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 80
-- name: upper_middle_income_credit_is_ten_percent
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
+- name: low_income_no_excess_has_no_refund
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -54,15 +71,56 @@
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 50000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit: 500
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: middle_income_no_excess_has_no_carryforward
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 180
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit: 180
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: middle_income_boundary_35000
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-- name: high_income_credit_is_capped
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 180
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 80
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
+- name: upper_middle_income_boundary_35001
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -70,27 +128,95 @@
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 70000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
+    us-la:statutes/47/297/4#child_care_expense_credit: 60
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: upper_middle_income_boundary_60000
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 60
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: high_income_boundary_60001
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
     us-la:statutes/47/297/4#child_care_expense_credit: 25
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 15
-- name: ineligible_individual_has_no_credit
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
+- name: nonresident_is_ineligible
   period:
     period_kind: tax_year
     start: '2024-01-01'
     end: '2024-12-31'
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: false
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: federal_section_21_ineligibility_blocks_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0

--- a/us-la/statutes/47/297/4.yaml
+++ b/us-la/statutes/47/297/4.yaml
@@ -4,7 +4,7 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:297.4
-    source_sha256: 5f048ba93b612ae65531fc78ff293d7cbbf1813fcfe2dfbb29f63ddbf3c0dc89
+    source_sha256: 34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528
   summary: '"There shall be a credit from the tax imposed by this Part for child care
     expenses for which a resident individual is eligible pursuant to the federal income
     tax credit provided by Internal Revenue Code Section 21 for the same taxable year."'
@@ -14,7 +14,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(1)(a)
+  source: La. R.S. 47:297.4(A)(1)(a)
   metadata:
     proof:
       atoms:
@@ -31,7 +31,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(2)
+  source: La. R.S. 47:297.4(A)(2)
   metadata:
     proof:
       atoms:
@@ -48,7 +48,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(2)
+  source: La. R.S. 47:297.4(A)(2)
   metadata:
     proof:
       atoms:
@@ -65,7 +65,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(3)
+  source: La. R.S. 47:297.4(A)(3)
   metadata:
     proof:
       atoms:
@@ -82,7 +82,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(3)
+  source: La. R.S. 47:297.4(A)(3)
   metadata:
     proof:
       atoms:
@@ -99,7 +99,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(4)
+  source: La. R.S. 47:297.4(A)(4)
   metadata:
     proof:
       atoms:
@@ -114,31 +114,33 @@ rules:
 - name: low_income_unreduced_federal_credit_percentage
   kind: parameter
   dtype: Rate
-  source: R.S. 47:297.4(A)(1)(a)(i)-(ii)
+  source: La. R.S. 47:297.4(A)(1)(a)(i)-(ii)
   metadata:
     proof:
       atoms:
-      - path: versions[0].formula
-        kind: effective_period
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: For tax years beginning after December 31, 2005 and ending before
-            January 1, 2007
       - path: versions[0].formula
         kind: parameter
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: twenty-five percent of the unreduced federal credit
-      - path: versions[1].formula
+      - path: versions[0].formula
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: For tax years beginning after December 31, 2006
+          excerpt: beginning after December 31
+          2005 and ending before January 1: null
+          2007: null
       - path: versions[1].formula
         kind: parameter
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: fifty percent of the unreduced federal credit
+      - path: versions[1].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: beginning after December 31
+          2006: null
   versions:
   - effective_from: '2006-01-01'
     formula: '0.25'
@@ -147,7 +149,7 @@ rules:
 - name: middle_income_claimed_federal_credit_percentage
   kind: parameter
   dtype: Rate
-  source: R.S. 47:297.4(A)(2)
+  source: La. R.S. 47:297.4(A)(2)
   metadata:
     proof:
       atoms:
@@ -162,7 +164,7 @@ rules:
 - name: upper_income_claimed_federal_credit_percentage
   kind: parameter
   dtype: Rate
-  source: R.S. 47:297.4(A)(3)-(4)
+  source: La. R.S. 47:297.4(A)(3)-(4)
   metadata:
     proof:
       atoms:
@@ -179,7 +181,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(A)(4)
+  source: La. R.S. 47:297.4(A)(4)
   metadata:
     proof:
       atoms:
@@ -195,7 +197,7 @@ rules:
   kind: parameter
   dtype: Count
   period: Year
-  source: R.S. 47:297.4(B)(2)
+  source: La. R.S. 47:297.4(B)(2)
   metadata:
     proof:
       atoms:
@@ -203,17 +205,16 @@ rules:
         kind: parameter
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: for a period not exceeding five years
+          excerpt: period not exceeding five years
   versions:
   - effective_from: '2006-01-01'
     formula: '5'
-- name: child_care_expense_credit
+- name: child_care_expense_credit_eligibility
   kind: derived
   entity: Person
-  dtype: Money
-  unit: USD
+  dtype: Judgment
   period: Year
-  source: R.S. 47:297.4(A)
+  source: La. R.S. 47:297.4(A)
   metadata:
     proof:
       atoms:
@@ -223,87 +224,227 @@ rules:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: resident individual is eligible pursuant to the federal income
             tax credit provided by Internal Revenue Code Section 21
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'individual_is_resident
+
+      and eligible_for_federal_child_care_credit_under_section_21'
+- name: low_income_credit_allowed_without_federal_claim
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.4(A)(1)(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: Louisiana credit shall be allowed without regard to whether they
+            claimed such federal credit
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'child_care_expense_credit_eligibility
+
+      and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit'
+- name: low_income_child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:297.4(A)(1)(a)(i)-(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: credit shall be calculated based on the federal tax credit before
+            it is reduced by the amount of the individual's federal income tax
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: twenty-five percent of the unreduced federal credit
+  versions:
+  - effective_from: '2006-01-01'
+    formula: "if child_care_expense_credit_eligibility and federal_adjusted_gross_income\
+      \ <= low_income_federal_adjusted_gross_income_limit:\n  low_income_unreduced_federal_credit_percentage\
+      \ * max(0, unreduced_federal_child_care_credit)\nelse: 0"
+- name: middle_income_child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:297.4(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: credit shall be equal to thirty percent of the federal credit for
+            child care expenses claimed on the resident individual's federal tax return
+  versions:
+  - effective_from: '2006-01-01'
+    formula: "if child_care_expense_credit_eligibility and federal_adjusted_gross_income\
+      \ > middle_income_federal_adjusted_gross_income_lower_bound and federal_adjusted_gross_income\
+      \ <= middle_income_federal_adjusted_gross_income_limit:\n  middle_income_claimed_federal_credit_percentage\
+      \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
+- name: upper_middle_income_child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:297.4(A)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: (3) If the resident individual's federal adjusted gross income
+            is greater than thirty-five thousand and less than or equal to sixty thousand
+            dollars, the credit shall be equal to ten percent of the federal credit
+            for child care expenses claimed on the resident individual's federal tax
+            return.
+  versions:
+  - effective_from: '2006-01-01'
+    formula: "if child_care_expense_credit_eligibility and federal_adjusted_gross_income\
+      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound and federal_adjusted_gross_income\
+      \ <= upper_middle_income_federal_adjusted_gross_income_limit:\n  upper_income_claimed_federal_credit_percentage\
+      \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
+- name: high_income_child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:297.4(A)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: credit shall be equal to the lesser of twenty-five dollars or ten
+            percent of the federal credit for child care expenses claimed on the resident
+            individual's federal tax return
+  versions:
+  - effective_from: '2006-01-01'
+    formula: "if child_care_expense_credit_eligibility and federal_adjusted_gross_income\
+      \ > high_income_federal_adjusted_gross_income_lower_bound:\n  min(high_income_credit_cap,\
+      \ upper_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return))\n\
+      else: 0"
+- name: child_care_expense_credit
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:297.4(A)(1)-(4)
+  metadata:
+    proof:
+      atoms:
       - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: The credit shall be calculated using the following percentages
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: Louisiana credit shall be allowed without regard to whether they
-            claimed such federal credit
-      - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: lesser of twenty-five dollars or ten percent
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident and eligible_for_federal_child_care_credit_under_section_21:\n\
-      \  if federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:\n\
-      \    low_income_unreduced_federal_credit_percentage * max(0, unreduced_federal_child_care_credit)\n\
-      \  else:\n    if federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound\
-      \ and federal_adjusted_gross_income <= middle_income_federal_adjusted_gross_income_limit:\n\
-      \      middle_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return)\n\
-      \    else:\n      if federal_adjusted_gross_income > upper_middle_income_federal_adjusted_gross_income_lower_bound\
-      \ and federal_adjusted_gross_income <= upper_middle_income_federal_adjusted_gross_income_limit:\n\
-      \        upper_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return)\n\
-      \      else:\n        if federal_adjusted_gross_income > high_income_federal_adjusted_gross_income_lower_bound:\n\
-      \          min(high_income_credit_cap, upper_income_claimed_federal_credit_percentage\
-      \ * max(0, federal_child_care_credit_claimed_on_federal_return))\n        else:\
-      \ 0\nelse: 0"
+    formula: 'low_income_child_care_expense_credit
+
+      + middle_income_child_care_expense_credit
+
+      + upper_middle_income_child_care_expense_credit
+
+      + high_income_child_care_expense_credit'
 - name: child_care_expense_credit_refundable_overpayment
   kind: derived
   entity: Person
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(B)(1)
+  source: La. R.S. 47:297.4(B)(1)
   metadata:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: resident individuals whose federal adjusted gross income is equal
-            to or less than twenty-five thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit shall constitute an overpayment
+          excerpt: If the credit against Louisiana income tax for resident individuals
+            whose federal adjusted gross income is equal to or less than twenty-five
+            thousand dollars exceeds the amount of such individual's tax liability
   versions:
   - effective_from: '2006-01-01'
     formula: "if individual_is_resident and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:\n\
       \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
       \ 0"
+- name: child_care_credit_refund_exempt_from_overpayment_requirements
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.4(B)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: The right to a refund of any such overpayment shall not be subject
+            to the requirements of R.S. 47:1621(B)
+  versions:
+  - effective_from: '2006-01-01'
+    formula: child_care_expense_credit_refundable_overpayment > 0
 - name: child_care_expense_credit_carryforward
   kind: derived
   entity: Person
   dtype: Money
   unit: USD
   period: Year
-  source: R.S. 47:297.4(B)(2)
+  source: La. R.S. 47:297.4(B)(2)
   metadata:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: resident individuals whose federal adjusted gross income is greater
-            than twenty-five thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward as a credit against
-            any subsequent tax liability
+          excerpt: excess tax credit may be carried forward as a credit against any
+            subsequent tax liability
   versions:
   - effective_from: '2006-01-01'
     formula: "if individual_is_resident and federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound:\n\
       \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
       \ 0"
+- name: child_care_expense_credit_carryforward_years
+  kind: derived
+  entity: Person
+  dtype: Count
+  period: Year
+  source: La. R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: for a period not exceeding five years
+  versions:
+  - effective_from: '2006-01-01'
+    formula: "if child_care_expense_credit_carryforward > 0:\n  excess_credit_carryforward_year_limit\n\
+      else: 0"


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:297.4`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `31206695601`
Base commit: `38ddc92d4160a0d39af13bfe232a446b554a15c5`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31207629399

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.