### PR TITLE
Add signed encoding manifest for us-la/statute/47:294

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/294.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/294.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/294.yaml",
-      "sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97"
+      "sha256": "e5c6b13e7263b83cc59930e600a8b20f7832a2b30ee6322c85a7b2d479a24f5a"
     },
     {
       "path": "us-la/statutes/47/294.test.yaml",
-      "sha256": "4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c"
+      "sha256": "0ce94bf7dd8fc04a51377e5592174dd422f54ecbc15aad81aca036849c596a01"
     }
   ],
   "axiom_encode_git": {
-    "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1565",
-    "version_commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1565",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:294",
   "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-294/workspace/context-manifest.json",
-  "context_manifest_sha256": "c58145b6cbe3e010cf28da0359b6f05b3807ab27dc5e78120b5e1ded7d77c21d",
-  "generated_at": "2026-08-05T21:19:16.008462+00:00",
+  "context_manifest_sha256": "82e69690149f46e36c8f1800d426b825b27376fabeef14f75d559e0ee27725c7",
+  "generated_at": "2026-08-07T21:10:06.972332+00:00",
   "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/294.yaml",
   "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97",
-  "generation_prompt_sha256": "a91cdd30ebe54b35d2f6fa78aa00553521c376604a3d2dd0601ff2acb1e992f1",
+  "generated_output_sha256": "e5c6b13e7263b83cc59930e600a8b20f7832a2b30ee6322c85a7b2d479a24f5a",
+  "generation_prompt_sha256": "ddc843b834de11be6e30b87204f31e512461f922d01152221050cc626ca0f378",
   "model": "gpt-5.6-terra",
-  "run_id": "5126c68d",
+  "run_id": "2d1782cd",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "g81jJ6957cxgruXAxFtLdprIKSu4RioFrWnF7LSztmbse01U0XS4VlfMIurZIcVJZhUZT2NBNbCKhZ/Q7nTBAA=="
+    "value": "RQJjYrTtw3jMSLrvYtNyIwjNgsPSuWWRMULfmv2qCw7zc+0aJ6BEYw6N1McP1WbRGzFHCP/zY7Q4jNtT7p+WBg=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -69,20 +69,20 @@
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-294.json",
-  "trace_sha256": "171231e115570152432c61fcc3d57124fcc4d17d81d0be916eb6a6b63d843438",
+  "trace_sha256": "576282fc99bebf7fbf6e0b932936857f84e7caa8fb0cfdcc7906b4a148e81944",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1565"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "6e88ec73d78075712862bfe7cb959262ef88c9989d86c10c1f25941378f7c73c",
+      "pre_apply_content_sha256": "b79478a25f93aa622ad742dbc28d5130c99d453f47eb025953ae2645159f75e2",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/295.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/295.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/295.yaml",
-      "sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43"
+      "sha256": "710b5377d7554bfeba7b067421c795099fbdc7073979b8e3a4e4f3056ffde5e7"
     },
     {
       "path": "us-la/statutes/47/295.test.yaml",
-      "sha256": "e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3"
+      "sha256": "426a6a570894b4bddbab25c5e5d5f02d8a8b0ae0419b9cd27f16520166e81dcf"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:295",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
-  "context_manifest_sha256": "a46538f2df21ad37301111b54a0c3f87465beeeaf69fe728628b1d27b2c1e891",
-  "generated_at": "2026-07-19T01:15:42.847716+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/295.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43",
-  "generation_prompt_sha256": "517ba3adc79ac2e317a6706e0d3902b6f6a37acdcd8cd939bc2e0cda568b877d",
-  "model": "gpt-5.6-terra",
-  "run_id": "ee4501d0",
-  "runner": "openai-gpt-5.6-terra",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-01/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-295/workspace/context-manifest.json",
+  "context_manifest_sha256": "db49bfab3894a2ffd315013e4575f952c9a132af6e6bb957f3e1117adaf74137",
+  "generated_at": "2026-08-07T21:12:25.397999+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-01/openai-gpt-5.6-sol/statutes/47/295.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-01",
+  "generated_output_sha256": "710b5377d7554bfeba7b067421c795099fbdc7073979b8e3a4e4f3056ffde5e7",
+  "generation_prompt_sha256": "4284786a0b6cec8c1f4c7b0c17e7ab6387770a36883dcc3fe7454e39f28dad09",
+  "model": "gpt-5.6-sol",
+  "run_id": "85590ae3",
+  "runner": "openai-gpt-5.6-sol",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "jPgfkJVUkRtpmv3/Cck7a+eE6Kyj3T48LEmFi3puX2dCA1ufJMV3M8rlkVV4cKosXolGHxo17MpK+sBzc+ppDg=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "/RfKgMsMSczySq1szCxzX8YAJLLRaS1/SkwCpDPvbheNiQ9xGrJkwnkeAwB+OfPXAQxE3zNJRokf2pGa0HuDBw=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:295",
     "resolved_corpus_citation_path": "us-la/statute/47:295",
-    "resolved_text_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+    "resolved_text_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
     "row": {
-      "body_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+      "body_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
       "citation_path": "us-la/statute/47:295",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 2,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 367,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "bf28763e-16ac-5832-9fd4-133ce0ec0099",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-295",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101762.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
-  "trace_sha256": "21744ad6c860a433dfb8ab2fd794b7d129c5da23066f262741188cd30c7169e3",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-01/traces/openai-gpt-5.6-sol/us-la-statute-47-295.json",
+  "trace_sha256": "add5abe60ece7c35f420d95e01dc95d4328b99c1a5d45ddc74e415caaa0b9b93",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "5af1d5c04b8754c1d1c3383068de3c7d1f3a18e07ce8b224b66b7a1792a2c422",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "8d145a93b8b50e3f9ce00df5227fac03475251cc28ea9bc004cac01ee6f2ec8c",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/4.yaml",
-      "sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8"
+      "sha256": "af29cd3697be8c7787efe81ead350510d34d8912bd039270d742c124b8d96222"
     },
     {
       "path": "us-la/statutes/47/297/4.test.yaml",
-      "sha256": "4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07"
+      "sha256": "a3d9a40ea1eb21e5f9444030116931f72dc0318daf5233ab8c437e917d81389b"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1628",
-    "version_commit": "1c032e53f8af8b22298d7395f9547b38df3bf151"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1628",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:297.4",
-  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.4/workspace/context-manifest.json",
-  "context_manifest_sha256": "9f067f29062029dd07ef9821a67fc057f5d575c46751559e5a9fcc99b289390f",
-  "generated_at": "2026-08-07T19:54:30.344798+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/47/297/4.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8",
-  "generation_prompt_sha256": "2aa63a053c6c7491958ede6b5863ac4bf312ca87348be64226d88a5c8d5093e2",
-  "model": "gpt-5.6-sol",
-  "run_id": "5aa3d35a",
-  "runner": "openai-gpt-5.6-sol",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-02/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.4/workspace/context-manifest.json",
+  "context_manifest_sha256": "68b9d02c70b82a370746fa75ffe81048e90db0dbaa2b5400c8c42ebc82b4f2b2",
+  "generated_at": "2026-08-07T21:16:15.150460+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-02/openai-gpt-5.6-terra/statutes/47/297/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-02",
+  "generated_output_sha256": "af29cd3697be8c7787efe81ead350510d34d8912bd039270d742c124b8d96222",
+  "generation_prompt_sha256": "dfc3145ea3f82417e4831e4fba60bfe624a57ce8e7f6c35a22e9727e1b3a9d20",
+  "model": "gpt-5.6-terra",
+  "run_id": "c5e0d849",
+  "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "1Sj7eNLEuzWudh4wIdj0bX9uEtzMJ67RSGj5msnbad2hT6pZA4iB6mH/2UUSAf0ZqOapVg9S0OEQDW2Amf3yCQ=="
+    "value": "ybHFGs37tm3S80uUK74p8ph4RRjapJJ6zyScvx+L04hKgekK3g1o6QDYwA5RaXdnY8oFViuwpOxS9kNBXweeAQ=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -68,21 +68,21 @@
     "source_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-la-statute-47-297.4.json",
-  "trace_sha256": "f0743a7721cc3f9a7ffb847554cb47f44bd2e59678730af59be9993b74067d78",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-02/traces/openai-gpt-5.6-terra/us-la-statute-47-297.4.json",
+  "trace_sha256": "13df72985ea9b682b3931ef70117686fc8dd5585cc0a8adee501e116fb05cc7e",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1628"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "8e5fbf3dbcdfa99086654e757b0b05556df6cf4ef69194b38fd310d3ea458cd2",
+      "pre_apply_content_sha256": "10dee71e0abe1fddbf9eb5599702c4bc6180082a27d3380bb4e428a1d0f735ff",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/8.yaml",
-      "sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e"
+      "sha256": "dd69d48e90c6282320928c174637fc775a91d482bd88f38092b25790da9b8465"
     },
     {
       "path": "us-la/statutes/47/297/8.test.yaml",
-      "sha256": "de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578"
+      "sha256": "739c77fcc151099b4cb384926adcbd2c12f9bd811eb0dafbfd24287dbd3761c7"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:297.8",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.8/workspace/context-manifest.json",
-  "context_manifest_sha256": "a0a1dd5de900c45973482295e4d175b147bc4fb6114eab6158f7738347eee26f",
-  "generated_at": "2026-07-19T02:06:54.880854+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-sol/statutes/47/297/8.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e",
-  "generation_prompt_sha256": "7a3002768df2698b0cc315a2a76856c72f048e940ae3215794199723273eca24",
-  "model": "gpt-5.6-sol",
-  "run_id": "e614c338",
-  "runner": "openai-gpt-5.6-sol",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-03/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.8/workspace/context-manifest.json",
+  "context_manifest_sha256": "23eeea6833569a85cae1d99a60465a21edbd5785f08832afe72c7ad6c1ffec8d",
+  "generated_at": "2026-08-07T21:18:10.228830+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-03/openai-gpt-5.6-terra/statutes/47/297/8.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-03",
+  "generated_output_sha256": "dd69d48e90c6282320928c174637fc775a91d482bd88f38092b25790da9b8465",
+  "generation_prompt_sha256": "fad999dec0d654a046643b7bfbb92dd33fca28a10c5f16d2d86a8910303bfe01",
+  "model": "gpt-5.6-terra",
+  "run_id": "79b67281",
+  "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "q0n9MgDvv1NG2xvFjJAgw07e5p1mP9rHgXLFvYioKTfFsY9cfu5p8I9u08VfIMztj7082cTZSl/d1jkQ79qdAw=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "jtBuDxvHdMv5LEC7Ayc/VgF4C1qsSX97pLq1Jem2oCdOAccmKfQH5gYMxfBEBljOwWOmeMIhy7EbkqnvlGzfDA=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:297.8",
     "resolved_corpus_citation_path": "us-la/statute/47:297.8",
-    "resolved_text_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+    "resolved_text_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
     "row": {
-      "body_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+      "body_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
       "citation_path": "us-la/statute/47:297.8",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 4,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 380,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "4dd82690-cd40-5a42-b7bd-b1c8bd7a740c",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-297.8",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/453085.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-sol/us-la-statute-47-297.8.json",
-  "trace_sha256": "64fa9b53984cfe738148bccee3bc9504df20aad56f79a4e81000b3096259def6",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-03/traces/openai-gpt-5.6-terra/us-la-statute-47-297.8.json",
+  "trace_sha256": "73095676d73ed70b2bb4976ee2cb6d06c491b2b8e63f52e39aa8694d564e4b54",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "c1842d557337d06a3bdbb4f1417acc0cdaffdc79bacaf63ef7f67d44721c8eb8",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "8544d55452a254dcb298f256a391669e31ba639466ce5dbf4bbad388fbf44821",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/294.test.yaml
+++ b/us-la/statutes/47/294.test.yaml
@@ -1,20 +1,90 @@
-- name: joint surviving spouse and head of household standard deduction for tax year
+- name: single individual or married-separate standard deduction for tax year 2025
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: true
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 12500
+- name: joint surviving spouse or head of household standard deduction for tax year
     2025
   period:
     period_kind: tax_year
     start: '2025-01-01'
     end: '2025-12-31'
-  input: {}
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: false
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: true
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
   output:
     us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household: 25000
-- name: annual standard deduction adjustment beginning in 2026
+    us-la:statutes/47/294#standard_deduction: 25000
+- name: neither filing-status group fails closed for tax year 2025
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: false
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 0
+- name: first annual adjustment for both 2025 filing-status branch amounts
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: true
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: false
     us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
     us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
   output:
     us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 500
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000
+- name: joint branch first annual adjustment and later recurrence
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: false
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: true
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
+  output:
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 1000
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 26000
+- name: later recurrence and zero CPI-U increase
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: true
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 13000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.03
+  output:
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 390
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13390
+- name: zero increase preserves prior-year adjusted deduction
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_uses_single_individual_or_married_separate_group: true
+    us-la:statutes/47/294#input.federal_return_uses_joint_surviving_spouse_or_head_of_household_group: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction: 13000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+  output:
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 0
     us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000

--- a/us-la/statutes/47/294.yaml
+++ b/us-la/statutes/47/294.yaml
@@ -5,20 +5,17 @@ module:
   source_verification:
     corpus_citation_path: us-la/statute/47:294
     source_sha256: 2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b
-  summary: '"For tax year 2025" the standard deduction for "Single Individual and
+  summary: '"For tax year 2025" the standard deduction is "$12,500.00" for
 
-    Married-Separate" is "$12,500.00"; specified joint-return statuses receive
+    "Single Individual and Married-Separate" and "200% of the dollar amount"
 
-    "200% of the dollar amount." "Beginning January 1, 2026" the deduction is
+    for a married-joint return, qualified surviving spouse, and head of
 
-    adjusted annually using the CPI-U percentage increase for the previous
+    household. "Beginning January 1, 2026, and thereafter" it is adjusted
 
-    calendar year.'
-  deferred_outputs:
-  - output: us-la:statutes/47/294#standard_deduction
-    reason: Determining the taxpayer-specific standard deduction requires the federally
-      derived filing status used on the federal income tax return, and no executable
-      upstream filing-status RuleSpec export is supplied.
+    annually by the prior year''s deduction times the prior calendar year''s
+
+    CPI-U percentage increase.'
 rules:
 - name: standard_deduction_single_individual_married_separate
   kind: parameter
@@ -74,7 +71,7 @@ rules:
   versions:
   - effective_from: '2025-01-01'
     effective_to: '2025-12-31'
-    formula: '2.00'
+    formula: '2'
 - name: standard_deduction_joint_surviving_spouse_head_of_household
   kind: derived
   entity: TaxUnit
@@ -89,7 +86,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:294
-          excerpt: 200% of the dollar amount
+          excerpt: (2) Married-Joint Return, a Qualified Surviving 200% of the dollar
+            amount
       - path: versions[0].formula
         kind: import
         import:
@@ -102,6 +100,11 @@ rules:
           target: us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household_multiplier
           output: standard_deduction_joint_surviving_spouse_head_of_household_multiplier
           hash: sha256:local
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
       - path: versions[0].effective_to
         kind: effective_period
         source:
@@ -110,7 +113,66 @@ rules:
   versions:
   - effective_from: '2025-01-01'
     effective_to: '2025-12-31'
-    formula: standard_deduction_single_individual_married_separate * standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+    formula: 'standard_deduction_single_individual_married_separate
+
+      * standard_deduction_joint_surviving_spouse_head_of_household_multiplier'
+- name: standard_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(A)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Taxpayers are required to use the same filing status on their return
+            required to be filed under this Part as they used on their federal income
+            tax return.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Single Individual and Married-Separate $12,500.00
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: (2) Married-Joint Return, a Qualified Surviving 200% of the dollar
+            amount
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_single_individual_married_separate
+          output: standard_deduction_single_individual_married_separate
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household
+          output: standard_deduction_joint_surviving_spouse_head_of_household
+          hash: sha256:local
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
+      - path: versions[0].effective_to
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: For tax year 2025
+  versions:
+  - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
+    formula: "if federal_return_uses_single_individual_or_married_separate_group:\n\
+      \  standard_deduction_single_individual_married_separate\nelse:\n  if federal_return_uses_joint_surviving_spouse_or_head_of_household_group:\n\
+      \    standard_deduction_joint_surviving_spouse_head_of_household\n  else:\n\
+      \    0"
 - name: standard_deduction_annual_adjustment_amount
   kind: derived
   entity: TaxUnit
@@ -131,10 +193,12 @@ rules:
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:294
-          excerpt: Beginning January 1, 2026
+          excerpt: Beginning January 1, 2026, and thereafter
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
+    formula: 'prior_year_standard_deduction
+
+      * previous_calendar_year_cpi_u_percentage_increase'
 - name: standard_deduction_after_annual_adjustment
   kind: derived
   entity: TaxUnit
@@ -160,7 +224,9 @@ rules:
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:294
-          excerpt: Beginning January 1, 2026
+          excerpt: Beginning January 1, 2026, and thereafter
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction + standard_deduction_annual_adjustment_amount
+    formula: 'prior_year_standard_deduction
+
+      + standard_deduction_annual_adjustment_amount'

--- a/us-la/statutes/47/295.test.yaml
+++ b/us-la/statutes/47/295.test.yaml
@@ -1,4 +1,4 @@
-- name: penalty waiver above threshold requires oversight
+- name: penalty waiver above threshold is subject to committee oversight
   period:
     period_kind: custom
     name: day
@@ -9,7 +9,7 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: holds
-- name: voluntary disclosure waiver exception blocks oversight
+- name: voluntary disclosure program waiver is not subject to committee oversight
   period:
     period_kind: custom
     name: day
@@ -20,7 +20,7 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: true
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
-- name: penalty at threshold does not require oversight
+- name: penalty at oversight threshold is not subject to committee oversight
   period:
     period_kind: custom
     name: day
@@ -31,3 +31,21 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
+- name: filed federal return becomes part of Louisiana return
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.federal_income_tax_return_or_part_is_filed: true
+  output:
+    us-la:statutes/47/295#federal_return_or_part_becomes_part_of_louisiana_return: holds
+- name: unfiled federal return does not become part of Louisiana return
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.federal_income_tax_return_or_part_is_filed: false
+  output:
+    us-la:statutes/47/295#federal_return_or_part_becomes_part_of_louisiana_return: not_holds

--- a/us-la/statutes/47/295.yaml
+++ b/us-la/statutes/47/295.yaml
@@ -4,15 +4,27 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:295
-    source_sha256: eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06
-  summary: '"Beginning January 1, 2016, waivers of all penalties exceeding twenty-five
-    thousand dollars shall be subject to oversight by the House Committee on Ways
-    and Means and the Senate Committee on Revenue and Fiscal Affairs."'
+    source_sha256: 4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959
+  summary: '"There is imposed an income tax for each taxable year upon the Louisiana
+    income
+
+    of every individual, whether resident or nonresident." "Beginning January 1,
+
+    2016, waivers of all penalties exceeding twenty-five thousand dollars shall be
+
+    subject to oversight." "When the return is filed, the federal income tax return,
+
+    or part thereof, shall constitute and become part of the return required to be
+
+    filed under this Part."'
   deferred_outputs:
-  - output: us-la:statutes/47/295#individual_louisiana_income_tax_amount
-    reason: The source imposes the tax but provides that its amount is determined
-      in accordance with R.S. 47:32, whose executable computation is not supplied
-      in this prompt.
+  - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+    reason: R.S. 47:295(A), canonically us-la/statute/47:295(a), imposes income tax
+      upon the Louisiana income of every individual, whether resident or nonresident,
+      but provides that the amount shall be determined in accordance with R.S. 47:32;
+      computation is blocked until an executable R.S. 47:32 individual income tax
+      amount computation accepting the applicable Louisiana income or net-income tax
+      base is encoded.
 rules:
 - name: penalty_waiver_oversight_threshold
   kind: parameter
@@ -28,6 +40,11 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: penalties exceeding twenty-five thousand dollars
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: beginning January 1, 2016
   versions:
   - effective_from: '2016-01-01'
     formula: '25000'
@@ -41,19 +58,19 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:295
-          excerpt: shall not apply to any penalty the secretary remits or waives in
-            accordance with rules and regulations promulgated pursuant to the Administrative
-            Procedure Act regarding the remittance or waiver of penalties under the
-            department's voluntary disclosure program.
-      - path: versions[0].formula
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: waivers of all penalties exceeding twenty-five thousand dollars
             shall be subject to oversight
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: This provision shall not apply to any penalty the secretary remits
+            or waives in accordance with rules and regulations promulgated pursuant
+            to the Administrative Procedure Act regarding the remittance or waiver
+            of penalties under the department's voluntary disclosure program.
       - path: versions[0].formula
         kind: import
         import:
@@ -65,3 +82,28 @@ rules:
     formula: 'penalty_amount > penalty_waiver_oversight_threshold
 
       and not penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations'
+- name: federal_return_or_part_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: The secretary may require that a complete copy of the taxpayer's
+            federal income tax return, or any part thereof, be filed.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed, the federal income tax return, or part
+            thereof, shall constitute and become part of the return required to be
+            filed under this Part.
+  versions:
+  - effective_from: '2016-01-01'
+    formula: federal_income_tax_return_or_part_is_filed

--- a/us-la/statutes/47/297/4.test.yaml
+++ b/us-la/statutes/47/297/4.test.yaml
@@ -1,4 +1,4 @@
-- name: low_income_zero_claimed_credit_uses_initial_rate
+- name: low_income_2006_unreduced_credit_without_federal_claim
   period:
     period_kind: tax_year
     start: '2006-01-01'
@@ -10,8 +10,9 @@
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 250
     us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
@@ -20,85 +21,10 @@
     us-la:statutes/47/297/4#child_care_expense_credit: 250
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 150
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_zero_claimed_credit_uses_later_rate
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_nonzero_claimed_credit_same_unreduced_result
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_credit_blocked_when_not_federally_eligible
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: low_income_credit_blocked_for_nonresident
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: false
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: clause_2_lower_boundary_25000
+- name: low_income_boundary_25000_post_2006
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -107,16 +33,24 @@
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 180
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
     us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_above_lower_boundary_25001
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 500
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: middle_income_boundary_25001
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -125,16 +59,24 @@
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_upper_boundary_35000
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 300
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 300
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 200
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
+- name: middle_income_upper_boundary_35000
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -144,14 +86,23 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 300
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_3_above_35000_boundary
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 300
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 200
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
+- name: upper_middle_income_boundary_35001
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -161,47 +112,22 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_2_at_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_3_above_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 100
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 100
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
 - name: upper_middle_income_boundary_60000
   period:
     period_kind: tax_year
@@ -212,17 +138,23 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 100
     us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
+    us-la:statutes/47/297/4#child_care_expense_credit: 100
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 50
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: high_income_boundary_60001
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
+- name: high_income_boundary_60001_cap_binds
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -232,85 +164,19 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_applies: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
     us-la:statutes/47/297/4#child_care_expense_credit: 25
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 15
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: low_income_credit_exceeds_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 499
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 1
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_credit_does_not_exceed_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: above_low_income_credit_exceeds_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 179
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 1
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: above_low_income_credit_does_not_exceed_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 180
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0

--- a/us-la/statutes/47/297/4.yaml
+++ b/us-la/statutes/47/297/4.yaml
@@ -5,15 +5,11 @@ module:
   source_verification:
     corpus_citation_path: us-la/statute/47:297.4
     source_sha256: 34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528
-  summary: '“There shall be a credit from the tax imposed by this Part for child care
-
-    expenses for which a resident individual is eligible pursuant to the federal
-
-    income tax credit provided by Internal Revenue Code Section 21 for the same
-
-    taxable year.” Low-income excess credit constitutes an overpayment; excess
-
-    credit above the low-income threshold may be carried forward for up to five years.'
+  summary: “There shall be a credit from the tax imposed by this Part for child care
+    expenses” for a resident individual eligible under Internal Revenue Code Section
+    21. Low-income credit is based on the unreduced federal credit and is allowed
+    without regard to a federal claim; low-income excess is refundable and other excess
+    may be carried forward for a period not exceeding five years.
 rules:
 - name: low_income_federal_adjusted_gross_income_limit
   kind: parameter
@@ -124,22 +120,11 @@ rules:
   metadata:
     proof:
       atoms:
-      - path: versions[0].effective_from
-        kind: effective_period
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: beginning after December 31, 2005 and ending before January 1,
-            2007
       - path: versions[0].formula
         kind: parameter
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: twenty-five percent of the unreduced federal credit
-      - path: versions[1].effective_from
-        kind: effective_period
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: beginning after December 31, 2006
       - path: versions[1].formula
         kind: parameter
         source:
@@ -213,7 +198,7 @@ rules:
   versions:
   - effective_from: '2006-01-01'
     formula: '5'
-- name: child_care_expense_credit_eligibility
+- name: child_care_expense_credit_applies
   kind: derived
   entity: Person
   dtype: Judgment
@@ -246,16 +231,11 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
+          excerpt: Louisiana credit shall be allowed without regard to whether they
+            claimed such federal credit
   versions:
   - effective_from: '2006-01-01'
-    formula: 'child_care_expense_credit_eligibility
+    formula: 'child_care_expense_credit_applies
 
       and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit'
 - name: low_income_child_care_expense_credit
@@ -272,12 +252,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: calculated based on the federal tax credit before it is reduced
-      - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
+          excerpt: credit shall be calculated based on the federal tax credit before
+            it is reduced by the amount of the individual's federal income tax
   versions:
   - effective_from: '2006-01-01'
     formula: "if low_income_credit_allowed_without_federal_claim:\n  low_income_unreduced_federal_credit_percentage\
@@ -293,20 +269,15 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than twenty-five thousand dollars and less than or equal
-            to thirty-five thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: thirty percent of the federal credit for child care expenses claimed
+          excerpt: credit shall be equal to thirty percent of the federal credit for
+            child care expenses claimed on the resident individual's federal tax return
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_applies\nand federal_adjusted_gross_income\
+      \ > middle_income_federal_adjusted_gross_income_lower_bound\nand federal_adjusted_gross_income\
       \ <= middle_income_federal_adjusted_gross_income_limit:\n  middle_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: upper_middle_income_child_care_expense_credit
@@ -320,20 +291,18 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than thirty-five thousand and less than or equal to sixty
-            thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: ten percent of the federal credit for child care expenses claimed
+          excerpt: (3) If the resident individual's federal adjusted gross income
+            is greater than thirty-five thousand and less than or equal to sixty thousand
+            dollars, the credit shall be equal to ten percent of the federal credit
+            for child care expenses claimed on the resident individual's federal tax
+            return.
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_applies\nand federal_adjusted_gross_income\
+      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\nand federal_adjusted_gross_income\
       \ <= upper_middle_income_federal_adjusted_gross_income_limit:\n  upper_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: high_income_child_care_expense_credit
@@ -347,19 +316,14 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than sixty thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: lesser of twenty-five dollars or ten percent of the federal credit
-            for child care expenses claimed
+          excerpt: credit shall be equal to the lesser of twenty-five dollars or ten
+            percent of the federal credit for child care expenses claimed
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_applies\nand federal_adjusted_gross_income\
       \ > high_income_federal_adjusted_gross_income_lower_bound:\n  min(high_income_credit_cap,\
       \ upper_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return))\n\
       else: 0"
@@ -369,7 +333,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: La. R.S. 47:297.4(A)(1)-(4)
+  source: La. R.S. 47:297.4(A)
   metadata:
     proof:
       atoms:
@@ -377,7 +341,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: The credit shall be calculated using the following percentages
+          excerpt: There shall be a credit from the tax imposed by this Part for child
+            care expenses
   versions:
   - effective_from: '2006-01-01'
     formula: 'low_income_child_care_expense_credit
@@ -398,26 +363,15 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: such excess tax credit shall constitute an overpayment
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
+    formula: "if child_care_expense_credit_applies\nand federal_adjusted_gross_income\
+      \ <= low_income_federal_adjusted_gross_income_limit:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: child_care_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -436,6 +390,35 @@ rules:
   versions:
   - effective_from: '2006-01-01'
     formula: child_care_expense_credit_refundable_overpayment > 0
+- name: child_care_expense_credit_carryforward_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: excess tax credit may be carried forward as a credit against any
+            subsequent tax liability
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: period not exceeding five years
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'child_care_expense_credit_applies
+
+      and federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound
+
+      and child_care_expense_credit > louisiana_income_tax_liability
+
+      and carryforward_age_years <= excess_credit_carryforward_year_limit'
 - name: child_care_expense_credit_carryforward
   kind: derived
   entity: Person
@@ -447,26 +430,15 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is greater than twenty-five thousand
-            dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
+          excerpt: such excess tax credit may be carried forward as a credit against
+            any subsequent tax liability
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
+    formula: "if child_care_expense_credit_carryforward_eligibility:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: child_care_expense_credit_carryforward_years
   kind: derived
   entity: Person
@@ -477,16 +449,11 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
+        kind: parameter
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: for a period not exceeding five years
+          excerpt: period not exceeding five years
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_carryforward > 0:\n  excess_credit_carryforward_year_limit\n\
+    formula: "if child_care_expense_credit_carryforward_eligibility:\n  excess_credit_carryforward_year_limit\n\
       else: 0"

--- a/us-la/statutes/47/297/8.test.yaml
+++ b/us-la/statutes/47/297/8.test.yaml
@@ -6,21 +6,101 @@
   input: {}
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: not_holds
-- name: first_effective_year_uses_base_rate_and_refunds_excess
+- name: first_effective_year_uses_base_rate
   period:
     period_kind: tax_year
     start: '2008-01-01'
     end: '2008-12-31'
   input:
     us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: true
-    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
-    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 15
+- name: base_rate_remains_in_effect_in_2018
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+- name: temporary_rate_begins_in_2019
+  period:
+    period_kind: tax_year
+    start: '2019-01-01'
+    end: '2019-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit_under_temporary_rate: 50
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+- name: temporary_rate_applies_through_2030
+  period:
+    period_kind: tax_year
+    start: '2030-01-01'
+    end: '2030-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit_under_temporary_rate: 50
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+- name: base_rate_resumes_in_2031
+  period:
+    period_kind: tax_year
+    start: '2031-01-01'
+    end: '2031-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+- name: zero_federal_credit_produces_zero_louisiana_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 0
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 0
+- name: resident_positive_excess_is_overpayment_with_exempt_refund
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 30
     us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
-- name: temporary_rate_applies_but_nonresident_has_no_overpayment
+- name: resident_credit_equal_to_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 50
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: resident_credit_below_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 60
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: nonresident_credit_has_no_subsection_b_overpayment
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -30,21 +110,6 @@
     us-la:statutes/47/297/8#input.individual_is_resident: false
     us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
   output:
-    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
-    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
-    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: base_rate_resumes_after_temporary_period
-  period:
-    period_kind: tax_year
-    start: '2031-01-01'
-    end: '2031-12-31'
-  input:
-    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: true
-    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 40
-  output:
-    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
-    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
     us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
     us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds

--- a/us-la/statutes/47/297/8.yaml
+++ b/us-la/statutes/47/297/8.yaml
@@ -4,13 +4,18 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:297.8
-    source_sha256: 985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb
-  summary: “there shall be a credit against the tax imposed by this Chapter for individuals”
-    equal to three and one-half percent of the federal earned income tax credit, except
-    that the rate is five percent for tax years beginning on or after January 1, 2019,
-    through December 31, 2030. For resident individuals, excess credit constitutes
-    an overpayment, and the right to its refund is not subject to R.S. 47:1621(B).
-    The enactment was effective January 1, 2008.
+    source_sha256: 8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674
+  summary: '“there shall be a credit against the tax imposed by this Chapter for individuals”
+
+    equal to three and one-half percent of the federal earned income tax credit,
+
+    except that the credit is five percent for tax years beginning on or after
+
+    January 1, 2019, through December 31, 2030. Resident individuals'' excess
+
+    credit constitutes an overpayment, and its refund is not subject to
+
+    R.S. 47:1621(B).'
 rules:
 - name: earned_income_tax_credit_enactment_indicator
   kind: parameter
@@ -34,24 +39,6 @@ rules:
     formula: '0'
   - effective_from: '2008-01-01'
     formula: '1'
-- name: earned_income_tax_credit_applies
-  kind: derived
-  entity: Person
-  dtype: Judgment
-  period: Year
-  source: Acts 2007, No. 278, §1; La. R.S. 47:297.8(A)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
-          output: earned_income_tax_credit_enactment_indicator
-          hash: sha256:local
-  versions:
-  - effective_from: '0001-01-01'
-    formula: earned_income_tax_credit_enactment_indicator == 1
 - name: earned_income_tax_credit_base_rate
   kind: parameter
   dtype: Rate
@@ -86,6 +73,7 @@ rules:
           excerpt: on or after January 1, 2019, through December 31, 2030
   versions:
   - effective_from: '2019-01-01'
+    effective_to: '2030-12-31'
     formula: '0.05'
 - name: earned_income_tax_credit_rate
   kind: parameter
@@ -110,7 +98,7 @@ rules:
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: on or after January 1, 2019, through December 31, 2030
+          excerpt: January 1, 2019, through December 31, 2030
       - path: versions[2].formula
         kind: import
         import:
@@ -124,13 +112,65 @@ rules:
     formula: earned_income_tax_credit_temporary_rate
   - effective_from: '2031-01-01'
     formula: earned_income_tax_credit_base_rate
+- name: earned_income_tax_credit_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.8(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: eff. Jan. 1, 2008
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
+          output: earned_income_tax_credit_enactment_indicator
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: earned_income_tax_credit_enactment_indicator == 1
+- name: louisiana_earned_income_tax_credit_under_temporary_rate
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  source: La. R.S. 47:297.8(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: (2) For tax years beginning on or after January 1, 2019, through
+            December 31, 2030, there shall be a credit against the tax imposed by
+            this Chapter for individuals in an amount equal to five percent of the
+            federal earned income tax credit for which the individual is eligible
+            for the taxable year under Section 32 of the Internal Revenue Code.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_temporary_rate
+          output: earned_income_tax_credit_temporary_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2019-01-01'
+    effective_to: '2030-12-31'
+    formula: earned_income_tax_credit_temporary_rate * max(0, federal_earned_income_tax_credit)
 - name: louisiana_earned_income_tax_credit
   kind: derived
   entity: Person
   dtype: Money
   period: Year
   unit: USD
-  source: La. R.S. 47:297.8(A)
+  source: La. R.S. 47:297.8(A)(1)-(2)
   metadata:
     proof:
       atoms:
@@ -165,6 +205,11 @@ rules:
           excerpt: credit against Louisiana income tax for resident individuals exceeds
             the amount of such individual's tax liability
       - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: such excess tax credit shall constitute an overpayment
+      - path: versions[0].formula
         kind: import
         import:
           target: us-la:statutes/47/297/8#louisiana_earned_income_tax_credit
@@ -172,8 +217,8 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: 'if individual_is_resident: max(0, louisiana_earned_income_tax_credit
-      - louisiana_income_tax_liability) else: 0'
+    formula: "if individual_is_resident:\n  max(0, louisiana_earned_income_tax_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: earned_income_tax_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -187,8 +232,13 @@ rules:
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: right to a refund of any such overpayment shall not be subject
-            to the requirements of R.S. 47:1621(B)
+          excerpt: If the credit against Louisiana income tax for resident individuals
+            exceeds
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: shall not be subject to the requirements of R.S. 47:1621(B)
       - path: versions[0].formula
         kind: import
         import:
@@ -197,4 +247,6 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: earned_income_tax_credit_excess_overpayment > 0
+    formula: 'individual_is_resident
+
+      and earned_income_tax_credit_excess_overpayment > 0'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:294`
Independent canonical refresh bundle: `[{"citation":"us-la/statute/47:294","review_finding":null,"rulespec_path":"us-la/statutes/47/294.yaml","rulespec_sha256":"ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97","companion_path":"us-la/statutes/47/294.test.yaml","companion_sha256":"4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/294.json","manifest_sha256":"b65610ac89991099f3cc982ab6e934476ba78ab5813bd305886068192658c291"},{"citation":"us-la/statute/47:295","review_finding":"Preserve R.S. 47:32 ownership: R.S. 47:295(A) delegates the complete individual tax amount to R.S. 47:32, while the available 47:32 module exports only a rate and not complete tax-amount mechanics. Do not synthesize that computation in 47:295. Defer it precisely until an executable R.S. 47:32 tax-amount computation accepting the applicable Louisiana income or net-income tax base is encoded. Still encode every other source-stated branch locally, including Subsection C's filing and incorporation-by-reference requirement; if its executable document-processing mechanism is unavailable, defer only that runtime gap rather than the source-stated rule.","rulespec_path":"us-la/statutes/47/295.yaml","rulespec_sha256":"68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43","companion_path":"us-la/statutes/47/295.test.yaml","companion_sha256":"e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/295.json","manifest_sha256":"ac0483384638fe14daaa83392443bee3e5c06a2367226911fbbdaffb673d25ea"},{"citation":"us-la/statute/47:297.4","review_finding":"Freshly regenerate R.S. 47:297.4; do not adopt or repair-replay any candidate from failed run 31152343675. Encode all five source formula leaves. For a resident individual eligible under IRC Section 21, A(1)(a)(i) is 25% of the unreduced federal credit for tax year 2006 and A(1)(a)(ii) is 50% after 2006 when federal AGI is at most $25,000; include the parent A(1)(a) control and A(1)(b)'s rule that Louisiana allows this low-income credit even when no federal credit was claimed. A(2) is 30% of claimed federal credit for AGI above $25,000 through $35,000; A(3) is 10% above $35,000 through $60,000; A(4) above $60,000 is the lesser of $25 or 10% of claimed federal credit. Encode B(1)'s refundable overpayment for AGI at most $25,000 and its R.S. 47:1621(B) exemption, and B(2)'s carryforward for AGI above $25,000. Implement B(2)'s five-year limit as a local exported carryforward-eligibility Judgment that the principal carryforward amount formula actually references. With positive excess held constant, require a same-period pair with identical input and output key sets that varies only carryforward age from year 5 to year 6: year 5 must assert the eligibility Judgment holds and a positive principal carryforward amount, while year 6 must assert that Judgment not_holds and principal amount zero. Tests must also include exact same-period threshold pairs at $25,000/$25,001, $35,000/$35,001, and $60,000/$60,001. Every pair must have identical input-key and output-key sets, differ only in AGI, and assert the selected leaf amount, every unselected leaf as zero, the principal Louisiana credit, and every reached local derived selector. In particular, if the source-backed resident-and-IRC-21 Judgment is named child_care_expense_credit_applies or renamed equivalently, assert it as holds in every positive branch and boundary witness; raw resident and eligibility inputs alone are not proof of that reached local dependency. For A(1)(a), use the $25,000/$25,001 pair with all non-AGI facts fixed and assert the parent/local applicability plus every affected leaf and principal output. For B(1), hold resident status, IRC-21 eligibility, AGI at or below $25,000, and credit fixed; require an identical-key pair varying only Louisiana liability between positive excess and equality, asserting refundable overpayment positive then zero and the 47:1621(B) exemption holds then not_holds. For B(2), hold resident status, IRC-21 eligibility, AGI above $25,000, credit, and carryforward age within the limit fixed; require an identical-key pair varying only Louisiana liability between positive excess and equality, asserting principal carryforward positive then zero plus the referenced carryforward-eligibility Judgment and every other reached local selector. Also require both 2006 and post-2006 low-income percentages; a low-income case with claimed federal credit zero but positive unreduced federal credit and positive Louisiana credit; A(4) below-cap and cap-binding cases; B(1) positive refund and 47:1621(B) exemption; and B(2) positive carryforward. Preserve every valid assertion across retries. Do not defer source-stated computation, leave the five-year parameter unconsumed, disconnect eligibility from the principal carryforward amount, or avoid valid multiline branch conditions.","rulespec_path":"us-la/statutes/47/297/4.yaml","rulespec_sha256":"2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8","companion_path":"us-la/statutes/47/297/4.test.yaml","companion_sha256":"4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/4.json","manifest_sha256":"d260c8236a18664a603a525ea0d4ad552f5f3f7f0220225a3f284dd6bcc46921"},{"citation":"us-la/statute/47:297.8","review_finding":"Preserve IRC Section 32 ownership: consume federal EITC eligibility and amount as an upstream input or exact executable import; do not recreate federal mechanics locally, and do not defer Louisiana's computation. Encode 3.5% from enactment in 2008 through tax year 2018, 5% for tax years beginning 2019 through 2030 inclusive, and 3.5% again from 2031. This provision has no Louisiana dollar cap or carryforward. Subsection A applies to individuals generally; residency gates only Subsection B. For residents, a strictly positive Louisiana-credit-minus-Louisiana-liability excess is a current overpayment whose refund is exempt from R.S. 47:1621(B). Equality, below-liability, and nonresident cases produce no B overpayment or exemption, although the nonresident A credit still computes. Do not defer the express 1621(B) interaction or invent broader refund administration. Require witnesses for 2007, 2008, 2018, 2019, 2030, 2031, zero federal EITC, resident positive excess, resident equality, resident below-liability, and nonresident credit without overpayment.","rulespec_path":"us-la/statutes/47/297/8.yaml","rulespec_sha256":"5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e","companion_path":"us-la/statutes/47/297/8.test.yaml","companion_sha256":"de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/8.json","manifest_sha256":"fa1ac1cf6cb785b09144ada4bcfff3bbf5735c400000b1d13816c71eaf6de593"}]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `ef9dd5f72d529ebc70f539c42144361e536d7563`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31218615664

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.