### PR TITLE
Add signed encoding manifest for us-la/statute/47:295

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/295.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/295.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/295.yaml",
-      "sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43"
+      "sha256": "4053b9b510dd86854daa5548684a20625b29773a1cf01ed16fba94ce2e54719f"
     },
     {
       "path": "us-la/statutes/47/295.test.yaml",
-      "sha256": "e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3"
+      "sha256": "9113783450c4718f042380cea2526c3db3c3c3b2e08f3f28cc6b5f01b7888851"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:295",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
-  "context_manifest_sha256": "a46538f2df21ad37301111b54a0c3f87465beeeaf69fe728628b1d27b2c1e891",
-  "generated_at": "2026-07-19T01:15:42.847716+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/295.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43",
-  "generation_prompt_sha256": "517ba3adc79ac2e317a6706e0d3902b6f6a37acdcd8cd939bc2e0cda568b877d",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
+  "context_manifest_sha256": "cb1966105fa7c3b82f538dda79429332927d6b76c8f18ff36b92a13f60d08f48",
+  "generated_at": "2026-08-08T00:10:28.524612+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/295.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "4053b9b510dd86854daa5548684a20625b29773a1cf01ed16fba94ce2e54719f",
+  "generation_prompt_sha256": "fb6b5557d963e3dfb19d847a57a3261bd4f579102cac8c985bdccb872a340b1a",
   "model": "gpt-5.6-terra",
-  "run_id": "ee4501d0",
+  "run_id": "a3adb79e",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "jPgfkJVUkRtpmv3/Cck7a+eE6Kyj3T48LEmFi3puX2dCA1ufJMV3M8rlkVV4cKosXolGHxo17MpK+sBzc+ppDg=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "BKqnUpY9IZUTljDVi0/8Flgw1GYM/LpEIrSFL9j34iHu3euyO2KeGx41n1lGC3RfwhFKQWCmKpocSr2asvNvDw=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:295",
     "resolved_corpus_citation_path": "us-la/statute/47:295",
-    "resolved_text_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+    "resolved_text_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
     "row": {
-      "body_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+      "body_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
       "citation_path": "us-la/statute/47:295",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 2,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 367,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "bf28763e-16ac-5832-9fd4-133ce0ec0099",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-295",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101762.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
-  "trace_sha256": "21744ad6c860a433dfb8ab2fd794b7d129c5da23066f262741188cd30c7169e3",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
+  "trace_sha256": "37755760fee39915bcc2d5f30e62da85fcb0c65a279a14520d7e8a8a4735dcd6",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
-      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
+      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "5af1d5c04b8754c1d1c3383068de3c7d1f3a18e07ce8b224b66b7a1792a2c422",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "b79478a25f93aa622ad742dbc28d5130c99d453f47eb025953ae2645159f75e2",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/295.test.yaml
+++ b/us-la/statutes/47/295.test.yaml
@@ -1,3 +1,23 @@
+- name: resident individual is subject to Louisiana income tax before 2016
+  period:
+    period_kind: tax_year
+    start: '2015-01-01'
+    end: '2015-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: true
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#individual_subject_to_louisiana_income_tax: holds
+- name: nonresident individual is subject to Louisiana income tax before 2016
+  period:
+    period_kind: tax_year
+    start: '2015-01-01'
+    end: '2015-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: false
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: true
+  output:
+    us-la:statutes/47/295#individual_subject_to_louisiana_income_tax: holds
 - name: penalty waiver above threshold requires oversight
   period:
     period_kind: custom
@@ -31,3 +51,78 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
+- name: complete and partial federal return filings are required and incorporated
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_income_tax_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_income_tax_return_part: true
+    us-la:statutes/47/295#input.complete_federal_income_tax_return_copy_is_filed: true
+    us-la:statutes/47/295#input.federal_income_tax_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_income_tax_return_copy_must_be_filed_when_required: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_must_be_filed_when_required: holds
+    us-la:statutes/47/295#complete_federal_income_tax_return_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_becomes_part_of_louisiana_return: holds
+- name: complete federal return filing requirement is absent when not required
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_income_tax_return_copy: false
+    us-la:statutes/47/295#input.secretary_requires_federal_income_tax_return_part: true
+    us-la:statutes/47/295#input.complete_federal_income_tax_return_copy_is_filed: true
+    us-la:statutes/47/295#input.federal_income_tax_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_income_tax_return_copy_must_be_filed_when_required: not_holds
+    us-la:statutes/47/295#federal_income_tax_return_part_must_be_filed_when_required: holds
+    us-la:statutes/47/295#complete_federal_income_tax_return_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_becomes_part_of_louisiana_return: holds
+- name: federal return part filing requirement is absent when not required
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_income_tax_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_income_tax_return_part: false
+    us-la:statutes/47/295#input.complete_federal_income_tax_return_copy_is_filed: true
+    us-la:statutes/47/295#input.federal_income_tax_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_income_tax_return_copy_must_be_filed_when_required: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_must_be_filed_when_required: not_holds
+    us-la:statutes/47/295#complete_federal_income_tax_return_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_becomes_part_of_louisiana_return: holds
+- name: complete federal return is not incorporated when not filed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_income_tax_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_income_tax_return_part: true
+    us-la:statutes/47/295#input.complete_federal_income_tax_return_copy_is_filed: false
+    us-la:statutes/47/295#input.federal_income_tax_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_income_tax_return_copy_must_be_filed_when_required: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_must_be_filed_when_required: holds
+    us-la:statutes/47/295#complete_federal_income_tax_return_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#federal_income_tax_return_part_becomes_part_of_louisiana_return: holds
+- name: federal return part is not incorporated when not filed
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_income_tax_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_income_tax_return_part: true
+    us-la:statutes/47/295#input.complete_federal_income_tax_return_copy_is_filed: true
+    us-la:statutes/47/295#input.federal_income_tax_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_income_tax_return_copy_must_be_filed_when_required: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_must_be_filed_when_required: holds
+    us-la:statutes/47/295#complete_federal_income_tax_return_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#federal_income_tax_return_part_becomes_part_of_louisiana_return: not_holds

--- a/us-la/statutes/47/295.yaml
+++ b/us-la/statutes/47/295.yaml
@@ -4,16 +4,47 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:295
-    source_sha256: eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06
-  summary: '"Beginning January 1, 2016, waivers of all penalties exceeding twenty-five
-    thousand dollars shall be subject to oversight by the House Committee on Ways
-    and Means and the Senate Committee on Revenue and Fiscal Affairs."'
+    source_sha256: 4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959
+  summary: '"There is imposed an income tax for each taxable year upon the Louisiana
+    income
+
+    of every individual, whether resident or nonresident." Beginning January 1,
+
+    2016, penalty waivers exceeding twenty-five thousand dollars are subject to
+
+    committee oversight, subject to the voluntary-disclosure-program exception.'
   deferred_outputs:
-  - output: us-la:statutes/47/295#individual_louisiana_income_tax_amount
-    reason: The source imposes the tax but provides that its amount is determined
-      in accordance with R.S. 47:32, whose executable computation is not supplied
-      in this prompt.
+  - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+    reason: us-la/statute/47:295(a) requires the individual Louisiana income tax amount
+      to be determined in accordance with R.S. 47:32, but the available R.S. 47:32
+      RuleSpec exports only the individual income tax rate and lacks an executable
+      tax-amount computation accepting the applicable Louisiana income or net-income
+      tax base.
 rules:
+- name: individual_subject_to_louisiana_income_tax
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: every individual, whether resident or nonresident
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: There is imposed an income tax for each taxable year
+  versions:
+  - effective_from: '1980-01-01'
+    formula: 'individual_is_louisiana_resident
+
+      or individual_is_louisiana_nonresident'
 - name: penalty_waiver_oversight_threshold
   kind: parameter
   dtype: Money
@@ -28,6 +59,11 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: penalties exceeding twenty-five thousand dollars
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: beginning January 1, 2016
   versions:
   - effective_from: '2016-01-01'
     formula: '25000'
@@ -41,19 +77,24 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:295
-          excerpt: shall not apply to any penalty the secretary remits or waives in
-            accordance with rules and regulations promulgated pursuant to the Administrative
-            Procedure Act regarding the remittance or waiver of penalties under the
-            department's voluntary disclosure program.
-      - path: versions[0].formula
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: waivers of all penalties exceeding twenty-five thousand dollars
             shall be subject to oversight
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: 'This provision shall not apply to any
+
+            penalty the secretary remits or waives in accordance with rules and regulations
+            promulgated
+
+            pursuant to the Administrative Procedure Act regarding the remittance
+            or waiver of penalties
+
+            under the department''s voluntary disclosure program.'
       - path: versions[0].formula
         kind: import
         import:
@@ -65,3 +106,100 @@ rules:
     formula: 'penalty_amount > penalty_waiver_oversight_threshold
 
       and not penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations'
+- name: complete_federal_income_tax_return_copy_must_be_filed_when_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: 'C. The secretary may require that a complete copy of the taxpayer''s
+            federal income
+
+            tax return, or any part thereof, be filed. When the return is filed, the
+            federal income tax
+
+            return, or part thereof, shall constitute and become part of the return
+            required to be filed
+
+            under this Part.'
+  versions:
+  - effective_from: '1980-01-01'
+    formula: secretary_requires_complete_federal_income_tax_return_copy
+- name: federal_income_tax_return_part_must_be_filed_when_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: 'C. The secretary may require that a complete copy of the taxpayer''s
+            federal income
+
+            tax return, or any part thereof, be filed. When the return is filed, the
+            federal income tax
+
+            return, or part thereof, shall constitute and become part of the return
+            required to be filed
+
+            under this Part.'
+  versions:
+  - effective_from: '1980-01-01'
+    formula: secretary_requires_federal_income_tax_return_part
+- name: complete_federal_income_tax_return_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: 'C. The secretary may require that a complete copy of the taxpayer''s
+            federal income
+
+            tax return, or any part thereof, be filed. When the return is filed, the
+            federal income tax
+
+            return, or part thereof, shall constitute and become part of the return
+            required to be filed
+
+            under this Part.'
+  versions:
+  - effective_from: '1980-01-01'
+    formula: complete_federal_income_tax_return_copy_is_filed
+- name: federal_income_tax_return_part_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed, the federal income tax return, or part
+            thereof, shall constitute and become part of the return required to be
+            filed under this Part.
+  versions:
+  - effective_from: '1980-01-01'
+    formula: federal_income_tax_return_part_is_filed


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:295`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `ef9dd5f72d529ebc70f539c42144361e536d7563`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31229148263

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.