### PR TITLE
Add signed encoding manifest for us-la/statute/47:294

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/294.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/294.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/294.yaml",
-      "sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97"
+      "sha256": "f72fc803bff457150de93e87f5c0ca1ba4734113bc19b470153d5dd8664b1c56"
     },
     {
       "path": "us-la/statutes/47/294.test.yaml",
-      "sha256": "4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c"
+      "sha256": "ca283264244d309b5cdc69d46d3b61a61f15fdbec958950378c6fb043f94a061"
     }
   ],
   "axiom_encode_git": {
-    "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1565",
-    "version_commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1565",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:294",
   "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-294/workspace/context-manifest.json",
-  "context_manifest_sha256": "c58145b6cbe3e010cf28da0359b6f05b3807ab27dc5e78120b5e1ded7d77c21d",
-  "generated_at": "2026-08-05T21:19:16.008462+00:00",
+  "context_manifest_sha256": "317c1ae9610b7fff60c8bd65387d41d34f7c5a5193dff24ea70f983a5d6c0810",
+  "generated_at": "2026-08-08T00:26:20.228899+00:00",
   "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/294.yaml",
   "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97",
-  "generation_prompt_sha256": "a91cdd30ebe54b35d2f6fa78aa00553521c376604a3d2dd0601ff2acb1e992f1",
+  "generated_output_sha256": "f72fc803bff457150de93e87f5c0ca1ba4734113bc19b470153d5dd8664b1c56",
+  "generation_prompt_sha256": "3ec76baf34304a572213e73b936c6db506843059992ab1b440ad0ecccda867c2",
   "model": "gpt-5.6-terra",
-  "run_id": "5126c68d",
+  "run_id": "04385223",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "g81jJ6957cxgruXAxFtLdprIKSu4RioFrWnF7LSztmbse01U0XS4VlfMIurZIcVJZhUZT2NBNbCKhZ/Q7nTBAA=="
+    "value": "gWhr4NGrla4BwRotQH9N86fIciUexrT8l/MUXCgttmJtY5DkI5irZlxKnfyA5VuEVqD4uGyD+OnZF4n7Y63YDA=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -69,20 +69,20 @@
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-294.json",
-  "trace_sha256": "171231e115570152432c61fcc3d57124fcc4d17d81d0be916eb6a6b63d843438",
+  "trace_sha256": "25c0c2a011ecd00a1d1b18355a2d73545181b1127713fd19ac81e47316d32be6",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1565"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "6e88ec73d78075712862bfe7cb959262ef88c9989d86c10c1f25941378f7c73c",
+      "pre_apply_content_sha256": "b79478a25f93aa622ad742dbc28d5130c99d453f47eb025953ae2645159f75e2",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/295.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/295.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/295.yaml",
-      "sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43"
+      "sha256": "81d35cd875757ba5d919102e6b5c3e38de5610037d285776478329f1dd2f9214"
     },
     {
       "path": "us-la/statutes/47/295.test.yaml",
-      "sha256": "e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3"
+      "sha256": "9319e05565a8e57820b1f02599a9e537ba5a3d426d86c3c2fb7e0566165456ef"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:295",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
-  "context_manifest_sha256": "a46538f2df21ad37301111b54a0c3f87465beeeaf69fe728628b1d27b2c1e891",
-  "generated_at": "2026-07-19T01:15:42.847716+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/295.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43",
-  "generation_prompt_sha256": "517ba3adc79ac2e317a6706e0d3902b6f6a37acdcd8cd939bc2e0cda568b877d",
-  "model": "gpt-5.6-terra",
-  "run_id": "ee4501d0",
-  "runner": "openai-gpt-5.6-terra",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-01/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-295/workspace/context-manifest.json",
+  "context_manifest_sha256": "d19464a6a63fba12b2adf4995e763593541a30188720cc0c6392c968b26fe0b5",
+  "generated_at": "2026-08-08T00:29:53.113638+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-01/openai-gpt-5.6-sol/statutes/47/295.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-01",
+  "generated_output_sha256": "81d35cd875757ba5d919102e6b5c3e38de5610037d285776478329f1dd2f9214",
+  "generation_prompt_sha256": "076a932fc619dcc0c986bbb639566ee21ceb78ef83f015f7e0b00788d1a55df6",
+  "model": "gpt-5.6-sol",
+  "run_id": "4cc65f45",
+  "runner": "openai-gpt-5.6-sol",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "jPgfkJVUkRtpmv3/Cck7a+eE6Kyj3T48LEmFi3puX2dCA1ufJMV3M8rlkVV4cKosXolGHxo17MpK+sBzc+ppDg=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "GKNwNI0UgNi77MWHCreSH8l4JwTImRZ1aRoWQX+78OteiMToO+8fpLTMcsHj7pJjm65s71/jhNMnnDn5iHtfBQ=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:295",
     "resolved_corpus_citation_path": "us-la/statute/47:295",
-    "resolved_text_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+    "resolved_text_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
     "row": {
-      "body_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+      "body_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
       "citation_path": "us-la/statute/47:295",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 2,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 367,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "bf28763e-16ac-5832-9fd4-133ce0ec0099",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-295",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101762.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
-  "trace_sha256": "21744ad6c860a433dfb8ab2fd794b7d129c5da23066f262741188cd30c7169e3",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-01/traces/openai-gpt-5.6-sol/us-la-statute-47-295.json",
+  "trace_sha256": "7c04e67be4c83e7ba66d8546db065f196012032311c497a9ccfe2fe7de1fb3fc",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "5af1d5c04b8754c1d1c3383068de3c7d1f3a18e07ce8b224b66b7a1792a2c422",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "0cd6a5b502c3a69f139a5f8c69421ebb9a66ff2bc097bad0f3dbf73de9a283c5",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/4.yaml",
-      "sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8"
+      "sha256": "f056665dfd43e78058734061b1f4296e9b1f59f4de67b2d857b42d936ebf637f"
     },
     {
       "path": "us-la/statutes/47/297/4.test.yaml",
-      "sha256": "4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07"
+      "sha256": "f4323c996e93d15886fac25f707e3f228ec9e168d4d4f9f316f09f837ce726c3"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1628",
-    "version_commit": "1c032e53f8af8b22298d7395f9547b38df3bf151"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1628",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:297.4",
-  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.4/workspace/context-manifest.json",
-  "context_manifest_sha256": "9f067f29062029dd07ef9821a67fc057f5d575c46751559e5a9fcc99b289390f",
-  "generated_at": "2026-08-07T19:54:30.344798+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/47/297/4.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8",
-  "generation_prompt_sha256": "2aa63a053c6c7491958ede6b5863ac4bf312ca87348be64226d88a5c8d5093e2",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-02/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.4/workspace/context-manifest.json",
+  "context_manifest_sha256": "fd34f66c4627eafe629f1acd614f4e49f23929481f6df54de47a1a0b4847ba79",
+  "generated_at": "2026-08-08T00:34:17.365604+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-02/openai-gpt-5.6-sol/statutes/47/297/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-02",
+  "generated_output_sha256": "f056665dfd43e78058734061b1f4296e9b1f59f4de67b2d857b42d936ebf637f",
+  "generation_prompt_sha256": "fe70c14f5febc38eb97ecbedd01bc8578be16761a9b840a7ddf619d56b17a1aa",
   "model": "gpt-5.6-sol",
-  "run_id": "5aa3d35a",
+  "run_id": "bef07528",
   "runner": "openai-gpt-5.6-sol",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "1Sj7eNLEuzWudh4wIdj0bX9uEtzMJ67RSGj5msnbad2hT6pZA4iB6mH/2UUSAf0ZqOapVg9S0OEQDW2Amf3yCQ=="
+    "value": "EClrUZvP3nADtohw43SehvN0KHAfLhYTUYgQC7zt7+ZMRygScR3OAv1nVbVBeRfJg7mXOkveY6YPg3demjiBAQ=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -68,21 +68,21 @@
     "source_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-la-statute-47-297.4.json",
-  "trace_sha256": "f0743a7721cc3f9a7ffb847554cb47f44bd2e59678730af59be9993b74067d78",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-02/traces/openai-gpt-5.6-sol/us-la-statute-47-297.4.json",
+  "trace_sha256": "635a849456ee08c25be5cae3387dd9ba6f8d9bae05b9e0e52fb1c95ab7b25b98",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1628"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "8e5fbf3dbcdfa99086654e757b0b05556df6cf4ef69194b38fd310d3ea458cd2",
+      "pre_apply_content_sha256": "6315d2ef40c2ccaee9bba935014881e71db52186e37d5c1244339a285800f749",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/8.yaml",
-      "sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e"
+      "sha256": "f1942540687010d835bdfa6d11ae44e162b14472cf4826cc2753c2ee25933c95"
     },
     {
       "path": "us-la/statutes/47/297/8.test.yaml",
-      "sha256": "de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578"
+      "sha256": "97820eeb47d0dc6c98ce48b627518f012adbe5232c2cad6836ea8a5322a3dde1"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1630",
+    "version_commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1630",
   "backend": "openai",
   "citation": "us-la/statute/47:297.8",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.8/workspace/context-manifest.json",
-  "context_manifest_sha256": "a0a1dd5de900c45973482295e4d175b147bc4fb6114eab6158f7738347eee26f",
-  "generated_at": "2026-07-19T02:06:54.880854+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-sol/statutes/47/297/8.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e",
-  "generation_prompt_sha256": "7a3002768df2698b0cc315a2a76856c72f048e940ae3215794199723273eca24",
-  "model": "gpt-5.6-sol",
-  "run_id": "e614c338",
-  "runner": "openai-gpt-5.6-sol",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-03/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.8/workspace/context-manifest.json",
+  "context_manifest_sha256": "d8070a4609c92b6351f0f14115d6193ba1d89455a25aece7c6f123959f083ebd",
+  "generated_at": "2026-08-08T00:36:18.596671+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-03/openai-gpt-5.6-terra/statutes/47/297/8.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-03",
+  "generated_output_sha256": "f1942540687010d835bdfa6d11ae44e162b14472cf4826cc2753c2ee25933c95",
+  "generation_prompt_sha256": "368a991e1d2a1d5eea2c0a1e85fe6aa06a84615752897ab89812c45df4b61de1",
+  "model": "gpt-5.6-terra",
+  "run_id": "9acddf01",
+  "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "q0n9MgDvv1NG2xvFjJAgw07e5p1mP9rHgXLFvYioKTfFsY9cfu5p8I9u08VfIMztj7082cTZSl/d1jkQ79qdAw=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "537SCrn8Ag8gKwXLVr6YtlpRMwbrYO4FYlGk/Ok94E9Mh1E3TTODXeXzkIACvLtHeJX0UwvRfrEjkBOTKcWRCw=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:297.8",
     "resolved_corpus_citation_path": "us-la/statute/47:297.8",
-    "resolved_text_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+    "resolved_text_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
     "row": {
-      "body_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+      "body_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
       "citation_path": "us-la/statute/47:297.8",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 4,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 380,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "4dd82690-cd40-5a42-b7bd-b1c8bd7a740c",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-297.8",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/453085.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-sol/us-la-statute-47-297.8.json",
-  "trace_sha256": "64fa9b53984cfe738148bccee3bc9504df20aad56f79a4e81000b3096259def6",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-03/traces/openai-gpt-5.6-terra/us-la-statute-47-297.8.json",
+  "trace_sha256": "35538f08b079046ea98e76adbd2f78711e6c221d61968e98138d611762cc044c",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "1517c778e2a24a11917ac596b4613ed4bbfc7ca7",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1630"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "c1842d557337d06a3bdbb4f1417acc0cdaffdc79bacaf63ef7f67d44721c8eb8",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "c5a00b269a608518e345fc1c57eeb0b66b10472da023e39b3fa0af9427dd03c5",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/294.test.yaml
+++ b/us-la/statutes/47/294.test.yaml
@@ -1,20 +1,120 @@
-- name: joint surviving spouse and head of household standard deduction for tax year
-    2025
+- name: tax year 2025 single individual or married-separate standard deduction
   period:
     period_kind: tax_year
     start: '2025-01-01'
     end: '2025-12-31'
-  input: {}
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 12500
+- name: tax year 2025 joint surviving spouse or head of household standard deduction
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: true
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
   output:
     us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household: 25000
-- name: annual standard deduction adjustment beginning in 2026
+    us-la:statutes/47/294#standard_deduction: 25000
+- name: tax year 2025 unclassified filing-status group fails closed
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 0
+- name: tax year 2026 single individual or married-separate deduction with positive
+    CPI
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
     us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
   output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 12500
     us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 500
     us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000
+    us-la:statutes/47/294#standard_deduction: 13000
+- name: tax year 2026 single individual or married-separate deduction with zero CPI
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 0
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 12500
+    us-la:statutes/47/294#standard_deduction: 12500
+- name: tax year 2026 joint surviving spouse or head of household deduction with positive
+    CPI
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: true
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 25000
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 1000
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 26000
+    us-la:statutes/47/294#standard_deduction: 26000
+- name: later single individual or married-separate recurrence uses prior adjusted
+    deduction
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 13000
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 26000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.03
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 13000
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 390
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13390
+    us-la:statutes/47/294#standard_deduction: 13390
+- name: auto_zero_applicable_prior_year_standard_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 0

--- a/us-la/statutes/47/294.yaml
+++ b/us-la/statutes/47/294.yaml
@@ -5,20 +5,15 @@ module:
   source_verification:
     corpus_citation_path: us-la/statute/47:294
     source_sha256: 2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b
-  summary: '"For tax year 2025" the standard deduction for "Single Individual and
+  summary: '"For tax year 2025" the standard deduction is "$12,500.00" for
 
-    Married-Separate" is "$12,500.00"; specified joint-return statuses receive
+    "Single Individual and Married-Separate" and "200% of the dollar amount"
 
-    "200% of the dollar amount." "Beginning January 1, 2026" the deduction is
+    for the listed joint-return filing-status group. "Beginning January 1,
 
-    adjusted annually using the CPI-U percentage increase for the previous
+    2026, and thereafter" the prior year''s standard deduction is adjusted
 
-    calendar year.'
-  deferred_outputs:
-  - output: us-la:statutes/47/294#standard_deduction
-    reason: Determining the taxpayer-specific standard deduction requires the federally
-      derived filing status used on the federal income tax return, and no executable
-      upstream filing-status RuleSpec export is supplied.
+    annually by the prior calendar year''s CPI-U percentage increase.'
 rules:
 - name: standard_deduction_single_individual_married_separate
   kind: parameter
@@ -111,6 +106,38 @@ rules:
   - effective_from: '2025-01-01'
     effective_to: '2025-12-31'
     formula: standard_deduction_single_individual_married_separate * standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+- name: applicable_prior_year_standard_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Taxpayers are required to use the same filing status
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: amount of the prior year's standard deduction
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 'if federal_return_filing_status_is_single_or_married_separate and not
+      federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household:
+      prior_year_standard_deduction_single_individual_married_separate else: if federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household
+      and not federal_return_filing_status_is_single_or_married_separate: prior_year_standard_deduction_joint_surviving_spouse_head_of_household
+      else: 0'
 - name: standard_deduction_annual_adjustment_amount
   kind: derived
   entity: TaxUnit
@@ -127,6 +154,12 @@ rules:
           corpus_citation_path: us-la/statute/47:294
           excerpt: multiplying the amount of the prior year's standard deduction by
             the percentage increase
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#applicable_prior_year_standard_deduction
+          output: applicable_prior_year_standard_deduction
+          hash: sha256:local
       - path: versions[0].effective_from
         kind: effective_period
         source:
@@ -134,7 +167,7 @@ rules:
           excerpt: Beginning January 1, 2026
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
+    formula: applicable_prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
 - name: standard_deduction_after_annual_adjustment
   kind: derived
   entity: TaxUnit
@@ -153,6 +186,12 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
+          target: us-la:statutes/47/294#applicable_prior_year_standard_deduction
+          output: applicable_prior_year_standard_deduction
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
           target: us-la:statutes/47/294#standard_deduction_annual_adjustment_amount
           output: standard_deduction_annual_adjustment_amount
           hash: sha256:local
@@ -163,4 +202,51 @@ rules:
           excerpt: Beginning January 1, 2026
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction + standard_deduction_annual_adjustment_amount
+    formula: applicable_prior_year_standard_deduction + standard_deduction_annual_adjustment_amount
+- name: standard_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Taxpayers are required to use the same filing status
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Single Individual and Married-Separate $12,500.00
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household
+          output: standard_deduction_joint_surviving_spouse_head_of_household
+          hash: sha256:local
+      - path: versions[1].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026, and thereafter
+      - path: versions[1].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_after_annual_adjustment
+          output: standard_deduction_after_annual_adjustment
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
+    formula: 'if federal_return_filing_status_is_single_or_married_separate and not
+      federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household:
+      standard_deduction_single_individual_married_separate else: if federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household
+      and not federal_return_filing_status_is_single_or_married_separate: standard_deduction_joint_surviving_spouse_head_of_household
+      else: 0'
+  - effective_from: '2026-01-01'
+    formula: standard_deduction_after_annual_adjustment

--- a/us-la/statutes/47/295.test.yaml
+++ b/us-la/statutes/47/295.test.yaml
@@ -1,3 +1,36 @@
+- name: pre-2016 resident individual income tax applies
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: true
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#individual_louisiana_income_tax_applies: holds
+- name: current nonresident individual income tax applies
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: false
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: true
+  output:
+    us-la:statutes/47/295#individual_louisiana_income_tax_applies: holds
+- name: individual with neither residency status fails closed
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: false
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#individual_louisiana_income_tax_applies: not_holds
 - name: penalty waiver above threshold requires oversight
   period:
     period_kind: custom
@@ -31,3 +64,67 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
+- name: complete copy required but not filed
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: false
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: not_holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_requested_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: complete copy required and filed
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: false
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: true
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: not_holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#filed_requested_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: requested part required but not filed
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: false
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: true
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: not_holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_requested_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: requested part required and filed
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: false
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: true
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: not_holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_requested_federal_return_part_becomes_part_of_louisiana_return: holds

--- a/us-la/statutes/47/295.yaml
+++ b/us-la/statutes/47/295.yaml
@@ -4,16 +4,53 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:295
-    source_sha256: eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06
-  summary: '"Beginning January 1, 2016, waivers of all penalties exceeding twenty-five
-    thousand dollars shall be subject to oversight by the House Committee on Ways
-    and Means and the Senate Committee on Revenue and Fiscal Affairs."'
+    source_sha256: 4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959
+  summary: '“There is imposed an income tax for each taxable year upon the Louisiana
+    income
+
+    of every individual, whether resident or nonresident.” The secretary administers
+
+    and enforces this Part and may issue implementing rules and waive, reduce, or
+
+    compromise covered amounts. Beginning January 1, 2016, qualifying penalty waivers
+
+    exceeding twenty-five thousand dollars are subject to committee oversight. The
+
+    secretary may require a complete federal return copy or a requested part to be
+
+    filed, and filed material becomes part of the Louisiana return.'
   deferred_outputs:
-  - output: us-la:statutes/47/295#individual_louisiana_income_tax_amount
-    reason: The source imposes the tax but provides that its amount is determined
-      in accordance with R.S. 47:32, whose executable computation is not supplied
-      in this prompt.
+  - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+    reason: us-la/statute/47:295(a) provides that the tax amount is determined in
+      accordance with R.S. 47:32. The amount cannot be computed until an executable
+      R.S. 47:32 complete individual tax-amount computation accepting the applicable
+      Louisiana-income or net-income tax base is encoded; the available R.S. 47:32
+      module exports only the individual income tax rate.
 rules:
+- name: individual_louisiana_income_tax_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: every individual, whether resident or nonresident
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: There is imposed an income tax
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'individual_is_louisiana_resident
+
+      or individual_is_louisiana_nonresident'
 - name: penalty_waiver_oversight_threshold
   kind: parameter
   dtype: Money
@@ -28,6 +65,11 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: penalties exceeding twenty-five thousand dollars
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: beginning January 1, 2016
   versions:
   - effective_from: '2016-01-01'
     formula: '25000'
@@ -41,19 +83,19 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:295
-          excerpt: shall not apply to any penalty the secretary remits or waives in
-            accordance with rules and regulations promulgated pursuant to the Administrative
-            Procedure Act regarding the remittance or waiver of penalties under the
-            department's voluntary disclosure program.
-      - path: versions[0].formula
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: waivers of all penalties exceeding twenty-five thousand dollars
             shall be subject to oversight
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: This provision shall not apply to any penalty the secretary remits
+            or waives in accordance with rules and regulations promulgated pursuant
+            to the Administrative Procedure Act regarding the remittance or waiver
+            of penalties under the department's voluntary disclosure program.
       - path: versions[0].formula
         kind: import
         import:
@@ -65,3 +107,78 @@ rules:
     formula: 'penalty_amount > penalty_waiver_oversight_threshold
 
       and not penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations'
+- name: complete_federal_return_copy_filing_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: require that a complete copy of the taxpayer's federal income tax
+            return
+  versions:
+  - effective_from: '0001-01-01'
+    formula: secretary_requires_complete_federal_return_copy
+- name: requested_federal_return_part_filing_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: or any part thereof, be filed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: secretary_requires_federal_return_part
+- name: filed_complete_federal_return_copy_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed, the federal income tax return, or part
+            thereof, shall constitute and become part of the return
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'secretary_requires_complete_federal_return_copy
+
+      and complete_federal_return_copy_is_filed'
+- name: filed_requested_federal_return_part_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed, the federal income tax return, or part
+            thereof, shall constitute and become part of the return
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'secretary_requires_federal_return_part
+
+      and requested_federal_return_part_is_filed'

--- a/us-la/statutes/47/297/4.test.yaml
+++ b/us-la/statutes/47/297/4.test.yaml
@@ -1,4 +1,34 @@
-- name: low_income_zero_claimed_credit_uses_initial_rate
+- name: applicability_resident_and_federally_eligible
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+- name: applicability_blocked_for_nonresident
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: false
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
+- name: applicability_blocked_without_federal_eligibility
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
+- name: threshold_25000_selects_2006_low_income_leaf
   period:
     period_kind: tax_year
     start: '2006-01-01'
@@ -8,8 +38,7 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
@@ -18,68 +47,184 @@
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 250
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 150
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_zero_claimed_credit_uses_later_rate
+- name: threshold_25001_selects_middle_income_leaf
   period:
     period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
+    start: '2006-01-01'
+    end: '2006-12-31'
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_nonzero_claimed_credit_same_unreduced_result
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_credit_blocked_when_not_federally_eligible
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 30
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 30
+- name: threshold_35000_selects_middle_income_leaf
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 300
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 300
+- name: threshold_35001_selects_upper_middle_income_leaf
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 100
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 100
+- name: threshold_60000_selects_upper_middle_income_leaf
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+- name: threshold_60001_selects_high_income_leaf_below_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+- name: post_2006_low_income_credit_allowed_without_federal_claim
+  period:
+    period_kind: tax_year
+    start: '2007-01-01'
+    end: '2007-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 500
+- name: high_income_cap_binding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
+    us-la:statutes/47/297/4#child_care_expense_credit: 25
+- name: low_income_refundable_overpayment_positive
+  period:
+    period_kind: tax_year
+    start: '2007-01-01'
+    end: '2007-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 500
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+- name: low_income_refundable_overpayment_equality
+  period:
+    period_kind: tax_year
+    start: '2007-01-01'
+    end: '2007-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 500
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: low_income_credit_blocked_for_nonresident
+- name: low_income_refund_blocked_for_nonresident
   period:
     period_kind: tax_year
     start: '2007-01-01'
@@ -95,10 +240,13 @@
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: clause_2_lower_boundary_25000
+- name: carryforward_positive_excess
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -106,123 +254,45 @@
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_above_lower_boundary_25001
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_upper_boundary_35000
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 300
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_3_above_35000_boundary
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_2_at_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_3_above_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
-- name: upper_middle_income_boundary_60000
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
     us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 50
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: high_income_boundary_60001
+    us-la:statutes/47/297/4#child_care_expense_credit: 300
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 200
+- name: carryforward_equality_has_no_excess
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 300
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 300
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 300
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: carryforward_age_five_is_eligible
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -232,17 +302,20 @@
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
-    us-la:statutes/47/297/4#child_care_expense_credit: 25
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 15
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: low_income_credit_exceeds_liability
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 10
+- name: carryforward_age_six_is_ineligible
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -250,67 +323,18 @@
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 499
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 6
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 1
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_credit_does_not_exceed_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: above_low_income_credit_exceeds_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 179
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 1
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: above_low_income_credit_does_not_exceed_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 180
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0

--- a/us-la/statutes/47/297/4.yaml
+++ b/us-la/statutes/47/297/4.yaml
@@ -9,11 +9,15 @@ module:
 
     expenses for which a resident individual is eligible pursuant to the federal
 
-    income tax credit provided by Internal Revenue Code Section 21 for the same
+    income tax credit provided by Internal Revenue Code Section 21.” For federal
 
-    taxable year.” Low-income excess credit constitutes an overpayment; excess
+    adjusted gross income not exceeding twenty-five thousand dollars, the credit
 
-    credit above the low-income threshold may be carried forward for up to five years.'
+    uses the unreduced federal credit and is allowed without regard to whether the
+
+    federal credit was claimed. Excess low-income credit is an overpayment; excess
+
+    credit above that threshold may be carried forward for no more than five years.'
 rules:
 - name: low_income_federal_adjusted_gross_income_limit
   kind: parameter
@@ -165,10 +169,25 @@ rules:
   versions:
   - effective_from: '2006-01-01'
     formula: '0.30'
-- name: upper_income_claimed_federal_credit_percentage
+- name: upper_middle_income_claimed_federal_credit_percentage
   kind: parameter
   dtype: Rate
-  source: La. R.S. 47:297.4(A)(3)-(4)
+  source: La. R.S. 47:297.4(A)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: ten percent of the federal credit for child care expenses claimed
+  versions:
+  - effective_from: '2006-01-01'
+    formula: '0.10'
+- name: high_income_claimed_federal_credit_percentage
+  kind: parameter
+  dtype: Rate
+  source: La. R.S. 47:297.4(A)(4)
   metadata:
     proof:
       atoms:
@@ -243,16 +262,17 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
-      - path: versions[0].formula
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
+          excerpt: If the resident individual's federal adjusted gross income is equal
+            to or less than twenty-five thousand dollars
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: Louisiana credit shall be allowed without regard to whether they
+            claimed such federal credit
   versions:
   - effective_from: '2006-01-01'
     formula: 'child_care_expense_credit_eligibility
@@ -272,12 +292,20 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: calculated based on the federal tax credit before it is reduced
+          excerpt: credit shall be calculated based on the federal tax credit before
+            it is reduced
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#low_income_unreduced_federal_credit_percentage
+          output: low_income_unreduced_federal_credit_percentage
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim
+          output: low_income_credit_allowed_without_federal_claim
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
     formula: "if low_income_credit_allowed_without_federal_claim:\n  low_income_unreduced_federal_credit_percentage\
@@ -293,20 +321,27 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than twenty-five thousand dollars and less than or equal
-            to thirty-five thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: thirty percent of the federal credit for child care expenses claimed
+          excerpt: credit shall be equal to thirty percent of the federal credit for
+            child care expenses claimed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit_eligibility
+          output: child_care_expense_credit_eligibility
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#middle_income_claimed_federal_credit_percentage
+          output: middle_income_claimed_federal_credit_percentage
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_eligibility\nand federal_adjusted_gross_income\
+      \ > middle_income_federal_adjusted_gross_income_lower_bound\nand federal_adjusted_gross_income\
       \ <= middle_income_federal_adjusted_gross_income_limit:\n  middle_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: upper_middle_income_child_care_expense_credit
@@ -320,21 +355,28 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than thirty-five thousand and less than or equal to sixty
-            thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: ten percent of the federal credit for child care expenses claimed
+          excerpt: greater than thirty-five thousand and less than or equal to sixty
+            thousand dollars, the credit shall be equal to ten percent
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit_eligibility
+          output: child_care_expense_credit_eligibility
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#upper_middle_income_claimed_federal_credit_percentage
+          output: upper_middle_income_claimed_federal_credit_percentage
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
-      \ <= upper_middle_income_federal_adjusted_gross_income_limit:\n  upper_income_claimed_federal_credit_percentage\
+    formula: "if child_care_expense_credit_eligibility\nand federal_adjusted_gross_income\
+      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\nand federal_adjusted_gross_income\
+      \ <= upper_middle_income_federal_adjusted_gross_income_limit:\n  upper_middle_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: high_income_child_care_expense_credit
   kind: derived
@@ -347,21 +389,34 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than sixty thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: lesser of twenty-five dollars or ten percent of the federal credit
-            for child care expenses claimed
+          excerpt: credit shall be equal to the lesser of twenty-five dollars or ten
+            percent of the federal credit for child care expenses claimed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit_eligibility
+          output: child_care_expense_credit_eligibility
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#high_income_credit_cap
+          output: high_income_credit_cap
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#high_income_claimed_federal_credit_percentage
+          output: high_income_claimed_federal_credit_percentage
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_eligibility\nand federal_adjusted_gross_income\
       \ > high_income_federal_adjusted_gross_income_lower_bound:\n  min(high_income_credit_cap,\
-      \ upper_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return))\n\
+      \ high_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return))\n\
       else: 0"
 - name: child_care_expense_credit
   kind: derived
@@ -369,7 +424,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: La. R.S. 47:297.4(A)(1)-(4)
+  source: La. R.S. 47:297.4(A)
   metadata:
     proof:
       atoms:
@@ -377,7 +432,32 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: The credit shall be calculated using the following percentages
+          excerpt: There shall be a credit from the tax imposed by this Part for child
+            care expenses
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#low_income_child_care_expense_credit
+          output: low_income_child_care_expense_credit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#middle_income_child_care_expense_credit
+          output: middle_income_child_care_expense_credit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit
+          output: upper_middle_income_child_care_expense_credit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#high_income_child_care_expense_credit
+          output: high_income_child_care_expense_credit
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
     formula: 'low_income_child_care_expense_credit
@@ -398,26 +478,23 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
+          excerpt: If the credit against Louisiana income tax for resident individuals
+            whose federal adjusted gross income is equal to or less than twenty-five
+            thousand dollars exceeds the amount of such individual's tax liability
       - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit shall constitute an overpayment
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit
+          output: child_care_expense_credit
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
+    formula: "if child_care_expense_credit_eligibility\nand federal_adjusted_gross_income\
+      \ <= low_income_federal_adjusted_gross_income_limit:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: child_care_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -433,9 +510,52 @@ rules:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: right to a refund of any such overpayment shall not be subject
             to the requirements of R.S. 47:1621(B)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment
+          output: child_care_expense_credit_refundable_overpayment
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
     formula: child_care_expense_credit_refundable_overpayment > 0
+- name: child_care_expense_credit_carryforward_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: excess tax credit may be carried forward as a credit against any
+            subsequent tax liability of such individual imposed by this Part for a
+            period not exceeding five years
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#excess_credit_carryforward_year_limit
+          output: excess_credit_carryforward_year_limit
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit
+          output: child_care_expense_credit
+          hash: sha256:local
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'child_care_expense_credit_eligibility
+
+      and federal_adjusted_gross_income > low_income_federal_adjusted_gross_income_limit
+
+      and child_care_expense_credit > louisiana_income_tax_liability
+
+      and carryforward_age_in_years <= excess_credit_carryforward_year_limit'
 - name: child_care_expense_credit_carryforward
   kind: derived
   entity: Person
@@ -447,46 +567,25 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is greater than twenty-five thousand
-            dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
+          excerpt: such excess tax credit may be carried forward as a credit against
+            any subsequent tax liability of such individual imposed by this Part for
+            a period not exceeding five years
       - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility
+          output: child_care_expense_credit_carryforward_eligibility
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/4#child_care_expense_credit
+          output: child_care_expense_credit
+          hash: sha256:local
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
-- name: child_care_expense_credit_carryforward_years
-  kind: derived
-  entity: Person
-  dtype: Count
-  period: Year
-  source: La. R.S. 47:297.4(B)(2)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: for a period not exceeding five years
-  versions:
-  - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_carryforward > 0:\n  excess_credit_carryforward_year_limit\n\
-      else: 0"
+    formula: "if child_care_expense_credit_carryforward_eligibility:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"

--- a/us-la/statutes/47/297/8.test.yaml
+++ b/us-la/statutes/47/297/8.test.yaml
@@ -3,48 +3,175 @@
     period_kind: tax_year
     start: '2007-01-01'
     end: '2007-12-31'
-  input: {}
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: not_holds
-- name: first_effective_year_uses_base_rate_and_refunds_excess
+- name: first_effective_year_uses_base_rate
   period:
     period_kind: tax_year
     start: '2008-01-01'
     end: '2008-12-31'
   input:
-    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: true
-    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
-  output:
-    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
-    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
-    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 15
-    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
-- name: temporary_rate_applies_but_nonresident_has_no_overpayment
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: false
-    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
-  output:
-    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
-    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
-    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
-    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: base_rate_resumes_after_temporary_period
-  period:
-    period_kind: tax_year
-    start: '2031-01-01'
-    end: '2031-12-31'
-  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
     us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
     us-la:statutes/47/297/8#input.individual_is_resident: true
     us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 40
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: base_rate_applies_through_2018
+  period:
+    period_kind: tax_year
+    start: '2018-01-01'
+    end: '2018-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 40
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: temporary_rate_starts_in_2019
+  period:
+    period_kind: tax_year
+    start: '2019-01-01'
+    end: '2019-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 50
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: temporary_rate_applies_through_2030
+  period:
+    period_kind: tax_year
+    start: '2030-01-01'
+    end: '2030-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 50
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: base_rate_resumes_in_2031
+  period:
+    period_kind: tax_year
+    start: '2031-01-01'
+    end: '2031-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 35
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: zero_federal_credit_produces_zero_louisiana_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 0
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: federally_ineligible_individual_has_no_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: false
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 0
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: not_holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: resident_positive_excess_is_refundable_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 30
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
+- name: resident_equal_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 50
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: resident_below_credit_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 60
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: nonresident_credit_does_not_create_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: false
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
     us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
     us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds

--- a/us-la/statutes/47/297/8.yaml
+++ b/us-la/statutes/47/297/8.yaml
@@ -4,13 +4,18 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:297.8
-    source_sha256: 985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb
-  summary: “there shall be a credit against the tax imposed by this Chapter for individuals”
-    equal to three and one-half percent of the federal earned income tax credit, except
-    that the rate is five percent for tax years beginning on or after January 1, 2019,
-    through December 31, 2030. For resident individuals, excess credit constitutes
-    an overpayment, and the right to its refund is not subject to R.S. 47:1621(B).
-    The enactment was effective January 1, 2008.
+    source_sha256: 8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674
+  summary: '“there shall be a credit against the tax imposed by this Chapter for individuals”
+
+    equal to three and one-half percent of the federal earned income tax credit,
+
+    except that for tax years beginning on or after January 1, 2019, through
+
+    December 31, 2030, the credit equals five percent. For resident individuals,
+
+    excess credit constitutes an overpayment and its refund is not subject to
+
+    R.S. 47:1621(B).'
 rules:
 - name: earned_income_tax_credit_enactment_indicator
   kind: parameter
@@ -34,24 +39,6 @@ rules:
     formula: '0'
   - effective_from: '2008-01-01'
     formula: '1'
-- name: earned_income_tax_credit_applies
-  kind: derived
-  entity: Person
-  dtype: Judgment
-  period: Year
-  source: Acts 2007, No. 278, §1; La. R.S. 47:297.8(A)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
-          output: earned_income_tax_credit_enactment_indicator
-          hash: sha256:local
-  versions:
-  - effective_from: '0001-01-01'
-    formula: earned_income_tax_credit_enactment_indicator == 1
 - name: earned_income_tax_credit_base_rate
   kind: parameter
   dtype: Rate
@@ -79,13 +66,19 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:297.8
           excerpt: five percent
-      - path: versions[0].formula
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: on or after January 1, 2019, through December 31, 2030
+      - path: versions[0].effective_to
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:297.8
           excerpt: on or after January 1, 2019, through December 31, 2030
   versions:
   - effective_from: '2019-01-01'
+    effective_to: '2030-12-31'
     formula: '0.05'
 - name: earned_income_tax_credit_rate
   kind: parameter
@@ -106,7 +99,12 @@ rules:
           target: us-la:statutes/47/297/8#earned_income_tax_credit_temporary_rate
           output: earned_income_tax_credit_temporary_rate
           hash: sha256:local
-      - path: versions[1].formula
+      - path: versions[1].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: on or after January 1, 2019, through December 31, 2030
+      - path: versions[1].effective_to
         kind: effective_period
         source:
           corpus_citation_path: us-la/statute/47:297.8
@@ -124,13 +122,38 @@ rules:
     formula: earned_income_tax_credit_temporary_rate
   - effective_from: '2031-01-01'
     formula: earned_income_tax_credit_base_rate
+- name: earned_income_tax_credit_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.8(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: federal earned income tax credit for which the individual is eligible
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
+          output: earned_income_tax_credit_enactment_indicator
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'earned_income_tax_credit_enactment_indicator == 1
+
+      and individual_is_eligible_for_federal_earned_income_tax_credit'
 - name: louisiana_earned_income_tax_credit
   kind: derived
   entity: Person
   dtype: Money
   period: Year
   unit: USD
-  source: La. R.S. 47:297.8(A)
+  source: La. R.S. 47:297.8(A)(1)-(2)
   metadata:
     proof:
       atoms:
@@ -138,16 +161,33 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: percent of the federal earned income tax credit
+          excerpt: amount equal to three and one-half percent of the federal earned
+            income tax credit
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: (2) For tax years beginning on or after January 1, 2019, through
+            December 31, 2030, there shall be a credit against the tax imposed by
+            this Chapter for individuals in an amount equal to five percent of the
+            federal earned income tax credit for which the individual is eligible
+            for the taxable year under Section 32 of the Internal Revenue Code.
       - path: versions[0].formula
         kind: import
         import:
           target: us-la:statutes/47/297/8#earned_income_tax_credit_rate
           output: earned_income_tax_credit_rate
           hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_applies
+          output: earned_income_tax_credit_applies
+          hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: earned_income_tax_credit_rate * max(0, federal_earned_income_tax_credit)
+    formula: "if earned_income_tax_credit_applies:\n  earned_income_tax_credit_rate\
+      \ * max(0, federal_earned_income_tax_credit)\nelse: 0"
 - name: earned_income_tax_credit_excess_overpayment
   kind: derived
   entity: Person
@@ -172,8 +212,8 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: 'if individual_is_resident: max(0, louisiana_earned_income_tax_credit
-      - louisiana_income_tax_liability) else: 0'
+    formula: "if individual_is_resident:\n  max(0, louisiana_earned_income_tax_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: earned_income_tax_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -187,7 +227,7 @@ rules:
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: right to a refund of any such overpayment shall not be subject
+          excerpt: The right to a refund of any such overpayment shall not be subject
             to the requirements of R.S. 47:1621(B)
       - path: versions[0].formula
         kind: import
@@ -197,4 +237,6 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: earned_income_tax_credit_excess_overpayment > 0
+    formula: 'individual_is_resident
+
+      and earned_income_tax_credit_excess_overpayment > 0'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:294`
Independent canonical refresh bundle: `[{"citation":"us-la/statute/47:294","review_finding":null,"rulespec_path":"us-la/statutes/47/294.yaml","rulespec_sha256":"ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97","companion_path":"us-la/statutes/47/294.test.yaml","companion_sha256":"4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/294.json","manifest_sha256":"b65610ac89991099f3cc982ab6e934476ba78ab5813bd305886068192658c291"},{"citation":"us-la/statute/47:295","review_finding":"Preserve R.S. 47:32 ownership: R.S. 47:295(A) delegates only the complete individual tax amount to R.S. 47:32, while the available 47:32 module exports only a rate and not complete tax-amount mechanics. Do not synthesize that amount in 47:295. Defer it precisely until an executable R.S. 47:32 tax-amount computation accepting the applicable Louisiana income or net-income tax base is encoded. Separately encode A's local source-stated applicability as a non-narrowed Judgment that Louisiana income tax applies to every individual, resident or nonresident; do not residency-gate it. Require both a pre-2016 witness and a current witness asserting that local applicability. Still encode every other source-stated branch locally, including Subsection C's filing and incorporation-by-reference requirement; if its executable document-processing mechanism is unavailable, defer only that exact gap rather than any source-stated rule. Review-rejected run 31222979886 incorrectly dropped A's local applicability while retaining the amount deferral. Freshly regenerate; do not adopt or repair-replay that regression. The 2016 date belongs only to B. Encode C's secretary-triggered obligation to file a complete federal return copy or a requested part separately from the rule that actually filed material becomes part of the Louisiana return. Use the repository's non-narrowing convention for C rather than inventing an effective date, and require pre-2016 witnesses. Any deferred public output fragment must be a stable legal/domain concept and must not contain implementation terms such as runtime; describe a missing runtime capability only in the deferral reason. Preserve the source-correct composed C contract from run 31222979886 without adopting its files: for the complete-copy path, require a same-period pair with identical input and output keys in which the secretary trigger remains true and only actual filing changes false to true; assert the complete-copy filing obligation remains holds while incorporation changes not_holds to holds. Require the analogous requested-part pair. Where both trigger inputs are present, keep the unselected obligation explicitly not_holds. Mechanically verify that each composed pair differs only in actual filing and asserts every reached C Judgment. Preserve B's strict $25,000 boundary and voluntary-disclosure exception witnesses. Freshly regenerate the complete four-module transaction. For subsection A and all subsection C rules, do not invent 1980-01-01, 2015-01-01, or any other substantive effective date not established by the cited source; use the repository non-narrowing convention. Tests must include a current A witness, an explicit both-residency-status-false fail-closed A witness, pre-2016 C coverage, and exact same-period complete-copy and requested-part filed-false/filed-true pairs. Each C pair must have identical full input-key and output-key sets, differ only in the corresponding actual-filing fact, keep the applicable duty holds in both cases, change only the matching incorporation Judgment from not_holds to holds, and explicitly assert every reached C Judgment. The exception proof atom for penalty_waiver_subject_to_committee_oversight must contain the complete contiguous verbatim source sentence through: under the department's voluntary disclosure program.","rulespec_path":"us-la/statutes/47/295.yaml","rulespec_sha256":"68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43","companion_path":"us-la/statutes/47/295.test.yaml","companion_sha256":"e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/295.json","manifest_sha256":"ac0483384638fe14daaa83392443bee3e5c06a2367226911fbbdaffb673d25ea"},{"citation":"us-la/statute/47:297.4","review_finding":"Freshly regenerate R.S. 47:297.4; do not adopt or repair-replay any rejected candidate, including runs 31152343675, 31218615664, and 31222979886. Encode all five source formula leaves. For a resident individual eligible under IRC Section 21, A(1)(a)(i) is 25% of the unreduced federal credit for tax year 2006 and A(1)(a)(ii) is 50% after 2006 when federal AGI is at most $25,000; include the parent A(1)(a) control and A(1)(b)'s rule that Louisiana allows this low-income credit even when no federal credit was claimed. A(2) is 30% of claimed federal credit for AGI above $25,000 through $35,000; A(3) is 10% above $35,000 through $60,000; A(4) above $60,000 is the lesser of $25 or 10% of claimed federal credit. Encode B(1)'s refundable overpayment for AGI at most $25,000 and its R.S. 47:1621(B) exemption, and B(2)'s carryforward for AGI above $25,000. Implement B(2)'s five-year limit as a local exported carryforward-eligibility Judgment that the principal carryforward amount formula actually references. The source establishes a maximum five-year eligibility window; it does not establish a derived output equal to the caller-supplied current carryforward age. Do not export child_care_expense_credit_carryforward_years or any equivalent input-echo formula, and do not assert such an output in tests. Retain only the source-backed five-year limit parameter, the eligibility Judgment that consumes the age input and limit, and the principal carryforward amount. With positive excess held constant, require a same-period pair with identical input and output key sets that varies only carryforward age from year 5 to year 6: year 5 must assert the eligibility Judgment holds and a positive principal carryforward amount, while year 6 must assert that Judgment not_holds and principal amount zero. Tests must also include exact same-period threshold pairs at $25,000/$25,001, $35,000/$35,001, and $60,000/$60,001. Every pair must have identical input-key and output-key sets, differ only in AGI, and assert the selected leaf amount, every unselected leaf as zero, the principal Louisiana credit, and every reached local derived selector. In particular, assert the resident-and-IRC-21 applicability Judgment as holds in every positive branch and boundary witness. For A(1)(a), use the $25,000/$25,001 pair with all non-AGI facts fixed and assert applicability plus every affected leaf and principal output. For B(1), hold every fact fixed except Louisiana liability between positive excess and equality, asserting refundable overpayment positive then zero and the 47:1621(B) exemption holds then not_holds. For B(2), hold every fact fixed except Louisiana liability between positive excess and equality, asserting principal carryforward positive then zero plus the referenced carryforward-eligibility Judgment and every other reached selector. Also require both 2006 and post-2006 low-income percentages; a low-income case with claimed federal credit zero but positive unreduced federal credit and positive Louisiana credit; A(4) below-cap and cap-binding cases; B(1) positive refund; and B(2) positive carryforward. A replacement is unacceptable unless the age-five/age-six pair differs only in age, the B(1) and B(2) pairs differ only in liability, both A(4) cap regimes exist, and each AGI threshold pair holds all non-AGI facts fixed. Mechanically verify identical input and output key sets for every required pair before apply. Preserve the clean formulas and symmetric witness matrix from prior review while removing the unsupported age-echo regression. Do not defer source-stated computation, leave the five-year parameter unconsumed, disconnect eligibility from the principal carryforward amount, reduce the witness matrix, or avoid valid multiline branch conditions.","rulespec_path":"us-la/statutes/47/297/4.yaml","rulespec_sha256":"2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8","companion_path":"us-la/statutes/47/297/4.test.yaml","companion_sha256":"4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/4.json","manifest_sha256":"d260c8236a18664a603a525ea0d4ad552f5f3f7f0220225a3f284dd6bcc46921"},{"citation":"us-la/statute/47:297.8","review_finding":"Preserve IRC Section 32 ownership: consume federal EITC eligibility and amount as separate upstream inputs or exact executable imports; do not recreate federal mechanics locally, and do not defer Louisiana's computation. Encode 3.5% from enactment in 2008 through tax year 2018, 5% for tax years beginning 2019 through 2030 inclusive, and 3.5% again from 2031. Any separately exported temporary 5% rate helper must have effective_to 2030-12-31 with matching effective-period proof; a principal selector that returns to 3.5% in 2031 does not cure an open-ended public helper. Review-rejected run 31222979886 regressed this helper by omitting its end date. Freshly regenerate and do not adopt or repair-replay that output; preserve the previously correct closed interval. This provision has no Louisiana dollar cap or carryforward. Subsection A applies to individuals generally; residency gates only Subsection B. For residents, a strictly positive Louisiana-credit-minus-Louisiana-liability excess is a current overpayment whose refund is exempt from R.S. 47:1621(B). Equality, below-liability, and nonresident cases produce no B overpayment or exemption, although the nonresident A credit still computes. Do not defer the express 1621(B) interaction or invent broader refund administration. Require witnesses for 2007, 2008, 2018, 2019, 2030, 2031, zero federal EITC, resident positive excess, resident equality, resident below-liability, and nonresident credit without overpayment. Add an explicit upstream federal-eligibility fact; the local applicability Judgment must require both enactment and federal eligibility, and the principal Louisiana amount must reference or otherwise be gated by that Judgment. Require a positive-federal-amount but federally ineligible case asserting applicability not_holds, principal credit zero, overpayment zero, and exemption not_holds. Keep input-key sets consistent across comparable cases. The resident positive-excess, equality, and below-liability cases must have identical input and output key sets, differ only in Louisiana liability, and all assert the unchanged principal Louisiana credit as well as overpayment and exemption so liability alone proves the B branch. Preserve every clean formula and witness from the prior review while regenerating freshly.","rulespec_path":"us-la/statutes/47/297/8.yaml","rulespec_sha256":"5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e","companion_path":"us-la/statutes/47/297/8.test.yaml","companion_sha256":"de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/8.json","manifest_sha256":"fa1ac1cf6cb785b09144ada4bcfff3bbf5735c400000b1d13816c71eaf6de593"}]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `ef9dd5f72d529ebc70f539c42144361e536d7563`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31229848070

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.