### PR TITLE
Add signed encoding manifest for us-la/statute/47:294

### DIFF
--- a/.axiom/encoding-manifests/us-la/statutes/47/294.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/294.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/294.yaml",
-      "sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97"
+      "sha256": "d76af1ffc7fb75f10daf906f103f287058a6a8335e0c0b297381048a35ebd3b0"
     },
     {
       "path": "us-la/statutes/47/294.test.yaml",
-      "sha256": "4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c"
+      "sha256": "4ec34bade409203a47583da9e7dca5eaae1e64891503048808d6856e09b3e21f"
     }
   ],
   "axiom_encode_git": {
-    "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+    "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1565",
-    "version_commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a"
+    "version": "0.2.1634",
+    "version_commit": "6997cb35c4681adc21afcf3e460b62bfd3834810"
   },
-  "axiom_encode_version": "0.2.1565",
+  "axiom_encode_version": "0.2.1634",
   "backend": "openai",
   "citation": "us-la/statute/47:294",
   "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-294/workspace/context-manifest.json",
-  "context_manifest_sha256": "c58145b6cbe3e010cf28da0359b6f05b3807ab27dc5e78120b5e1ded7d77c21d",
-  "generated_at": "2026-08-05T21:19:16.008462+00:00",
+  "context_manifest_sha256": "cb3ce7844416d3e210217595bc76b68fe5569aa500fee3f7a526c463aa2380cf",
+  "generated_at": "2026-08-08T02:14:03.213682+00:00",
   "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/statutes/47/294.yaml",
   "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97",
-  "generation_prompt_sha256": "a91cdd30ebe54b35d2f6fa78aa00553521c376604a3d2dd0601ff2acb1e992f1",
+  "generated_output_sha256": "d76af1ffc7fb75f10daf906f103f287058a6a8335e0c0b297381048a35ebd3b0",
+  "generation_prompt_sha256": "bcede0084f36a5ec909d481e61f67330ba7fc47148f9f5a1a1479c4539102e05",
   "model": "gpt-5.6-terra",
-  "run_id": "5126c68d",
+  "run_id": "bef796a6",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "g81jJ6957cxgruXAxFtLdprIKSu4RioFrWnF7LSztmbse01U0XS4VlfMIurZIcVJZhUZT2NBNbCKhZ/Q7nTBAA=="
+    "value": "vjCrCIol8MD3BsQRfcJ+/XP0nMxVLsoxcTJXcF2e4eZ7awfNWKYGukZE2r9D75qHnmCo2RiOy8aAQH4W0NoKBw=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -69,20 +69,20 @@
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-la-statute-47-294.json",
-  "trace_sha256": "171231e115570152432c61fcc3d57124fcc4d17d81d0be916eb6a6b63d843438",
+  "trace_sha256": "3793a696b401a63731a03b336f6a34b1596829f403f0da55e2d9c47d867baf0c",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "0e73e533b03d88688863cd2cdfb0fd42b293884a",
+      "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1565"
+      "version": "0.2.1634"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "6e88ec73d78075712862bfe7cb959262ef88c9989d86c10c1f25941378f7c73c",
+      "pre_apply_content_sha256": "b79478a25f93aa622ad742dbc28d5130c99d453f47eb025953ae2645159f75e2",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/295.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/295.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/295.yaml",
-      "sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43"
+      "sha256": "b0bbc573565688bfea46bc3445bb5dd00ade37eccd6f949c8636fcfb1ff328c4"
     },
     {
       "path": "us-la/statutes/47/295.test.yaml",
-      "sha256": "e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3"
+      "sha256": "52c72abe171cbaa47ca250ed6466d8b4fd274c07da017b97a838ff7593654514"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1634",
+    "version_commit": "6997cb35c4681adc21afcf3e460b62bfd3834810"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1634",
   "backend": "openai",
   "citation": "us-la/statute/47:295",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
-  "context_manifest_sha256": "a46538f2df21ad37301111b54a0c3f87465beeeaf69fe728628b1d27b2c1e891",
-  "generated_at": "2026-07-19T01:15:42.847716+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-terra/statutes/47/295.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43",
-  "generation_prompt_sha256": "517ba3adc79ac2e317a6706e0d3902b6f6a37acdcd8cd939bc2e0cda568b877d",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-01/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-295/workspace/context-manifest.json",
+  "context_manifest_sha256": "d8738c65229e6851943c126e4d3a55fd53f45043e05a910c2549a548fb95db1c",
+  "generated_at": "2026-08-08T02:16:51.182220+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-01/openai-gpt-5.6-terra/statutes/47/295.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-01",
+  "generated_output_sha256": "b0bbc573565688bfea46bc3445bb5dd00ade37eccd6f949c8636fcfb1ff328c4",
+  "generation_prompt_sha256": "59f41f9332a6e61f9050f17d804c407644e8c5a5f2bb6b10b7b56b5177a18a98",
   "model": "gpt-5.6-terra",
-  "run_id": "ee4501d0",
+  "run_id": "e7c98be2",
   "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "jPgfkJVUkRtpmv3/Cck7a+eE6Kyj3T48LEmFi3puX2dCA1ufJMV3M8rlkVV4cKosXolGHxo17MpK+sBzc+ppDg=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "VWLhKVZYFiGE61b7o0rKHhO6dJNcYbrAA3bgZ5aQtbClgPn0j+ZUBx7mWRfBwm1DC1rueKIU61RrzCaQmwnVDQ=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:295",
     "resolved_corpus_citation_path": "us-la/statute/47:295",
-    "resolved_text_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+    "resolved_text_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
     "row": {
-      "body_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06",
+      "body_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959",
       "citation_path": "us-la/statute/47:295",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 2,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 367,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "bf28763e-16ac-5832-9fd4-133ce0ec0099",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-295",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/101762.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
-  "trace_sha256": "21744ad6c860a433dfb8ab2fd794b7d129c5da23066f262741188cd30c7169e3",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-01/traces/openai-gpt-5.6-terra/us-la-statute-47-295.json",
+  "trace_sha256": "5a7f63c64a07586719b0926d9d8dae749df480a8f7f30cb71442397b56674406",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1634"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "5af1d5c04b8754c1d1c3383068de3c7d1f3a18e07ce8b224b66b7a1792a2c422",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "76093f1c7d52bd71e50ee787a9646efe94120339e0c7d4f0c2b88ef6c20adf92",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/4.json
@@ -2,39 +2,39 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/4.yaml",
-      "sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8"
+      "sha256": "59c3956a480c3a7737e3c2dd6cfee24d921c0cbc2b7fc831def76808b304cdef"
     },
     {
       "path": "us-la/statutes/47/297/4.test.yaml",
-      "sha256": "4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07"
+      "sha256": "31f9a75dc49b3890ac958e4b09fa41b44652794a3561455b0fc757a8f28e1995"
     }
   ],
   "axiom_encode_git": {
-    "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+    "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1628",
-    "version_commit": "1c032e53f8af8b22298d7395f9547b38df3bf151"
+    "version": "0.2.1634",
+    "version_commit": "6997cb35c4681adc21afcf3e460b62bfd3834810"
   },
-  "axiom_encode_version": "0.2.1628",
+  "axiom_encode_version": "0.2.1634",
   "backend": "openai",
   "citation": "us-la/statute/47:297.4",
-  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.4/workspace/context-manifest.json",
-  "context_manifest_sha256": "9f067f29062029dd07ef9821a67fc057f5d575c46751559e5a9fcc99b289390f",
-  "generated_at": "2026-08-07T19:54:30.344798+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/47/297/4.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated/target",
-  "generated_output_sha256": "2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8",
-  "generation_prompt_sha256": "2aa63a053c6c7491958ede6b5863ac4bf312ca87348be64226d88a5c8d5093e2",
-  "model": "gpt-5.6-sol",
-  "run_id": "5aa3d35a",
-  "runner": "openai-gpt-5.6-sol",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-02/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.4/workspace/context-manifest.json",
+  "context_manifest_sha256": "f2936aba6ec938332f6877ca499a3a82e1c238de637fda422f53373a3e2cd837",
+  "generated_at": "2026-08-08T02:20:23.224662+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-02/openai-gpt-5.6-terra/statutes/47/297/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-02",
+  "generated_output_sha256": "59c3956a480c3a7737e3c2dd6cfee24d921c0cbc2b7fc831def76808b304cdef",
+  "generation_prompt_sha256": "0ad64d1ca2c071c0db47eb66a6623f8210dbd14cfdaaa3dee88348a213f5fcd4",
+  "model": "gpt-5.6-terra",
+  "run_id": "ba987a84",
+  "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
     "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
-    "value": "1Sj7eNLEuzWudh4wIdj0bX9uEtzMJ67RSGj5msnbad2hT6pZA4iB6mH/2UUSAf0ZqOapVg9S0OEQDW2Amf3yCQ=="
+    "value": "AP1Hrn7XOr9VV5Q2HFSV7A1FHAO+dNaqQHyQXnuvl00dX2K6wTLT+fSlH5p71Amq12sSurcPM+F4Z67K+tGGAw=="
   },
   "source_attestation": {
     "component_rows": [],
@@ -68,21 +68,21 @@
     "source_sha256": "34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-la-statute-47-297.4.json",
-  "trace_sha256": "f0743a7721cc3f9a7ffb847554cb47f44bd2e59678730af59be9993b74067d78",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-02/traces/openai-gpt-5.6-terra/us-la-statute-47-297.4.json",
+  "trace_sha256": "77b2690a8fc2904769939690b09bdbcd9b467cd19e27d6606c281c7b203b57aa",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "1c032e53f8af8b22298d7395f9547b38df3bf151",
+      "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1628"
+      "version": "0.2.1634"
     },
     "axiom_rules_engine": {
-      "commit": "4658144031f8ef1b39a971eb7002997fa0880b5a",
+      "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "8e5fbf3dbcdfa99086654e757b0b05556df6cf4ef69194b38fd310d3ea458cd2",
+      "pre_apply_content_sha256": "c423f8b0270970abb6f0581f3c6eebc1f87330656164937bdf03f5a2a1e1980d",
       "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
       "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",

--- a/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
+++ b/.axiom/encoding-manifests/us-la/statutes/47/297/8.json
@@ -2,94 +2,95 @@
   "applied_files": [
     {
       "path": "us-la/statutes/47/297/8.yaml",
-      "sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e"
+      "sha256": "42a1245bef3faa99fdbda9b35e8f89542ab2974e01185e3098871ffbd7063f40"
     },
     {
       "path": "us-la/statutes/47/297/8.test.yaml",
-      "sha256": "de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578"
+      "sha256": "8091e8ad1b7e10593310bec162855a3304d7ead65ccdcd7f1ec04f48555aa37c"
     }
   ],
   "axiom_encode_git": {
-    "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+    "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
     "dirty_tracked": false,
     "identity_source": "trusted-runtime-attestation",
     "root": "/opt/axiom-verification/python/runtime-attestation.json",
-    "version": "0.2.1293",
-    "version_commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214"
+    "version": "0.2.1634",
+    "version_commit": "6997cb35c4681adc21afcf3e460b62bfd3834810"
   },
-  "axiom_encode_version": "0.2.1293",
+  "axiom_encode_version": "0.2.1634",
   "backend": "openai",
   "citation": "us-la/statute/47:297.8",
-  "context_manifest_file": "/home/runner/work/_temp/generated/_eval_workspaces/openai-gpt-5.6-sol/us-la-statute-47-297.8/workspace/context-manifest.json",
-  "context_manifest_sha256": "a0a1dd5de900c45973482295e4d175b147bc4fb6114eab6158f7738347eee26f",
-  "generated_at": "2026-07-19T02:06:54.880854+00:00",
-  "generated_output_file": "/home/runner/work/_temp/generated/openai-gpt-5.6-sol/statutes/47/297/8.yaml",
-  "generated_output_root": "/home/runner/work/_temp/generated",
-  "generated_output_sha256": "5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e",
-  "generation_prompt_sha256": "7a3002768df2698b0cc315a2a76856c72f048e940ae3215794199723273eca24",
-  "model": "gpt-5.6-sol",
-  "run_id": "e614c338",
-  "runner": "openai-gpt-5.6-sol",
+  "context_manifest_file": "/home/runner/work/_temp/generated/canonical-refresh-03/_eval_workspaces/openai-gpt-5.6-terra/us-la-statute-47-297.8/workspace/context-manifest.json",
+  "context_manifest_sha256": "ac19c7bca901576b74e81cc9fa87e2a34f7d0bfa90602431a68a4ce43d596f94",
+  "generated_at": "2026-08-08T02:22:54.213606+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/canonical-refresh-03/openai-gpt-5.6-terra/statutes/47/297/8.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/canonical-refresh-03",
+  "generated_output_sha256": "42a1245bef3faa99fdbda9b35e8f89542ab2974e01185e3098871ffbd7063f40",
+  "generation_prompt_sha256": "9bc15cd1eb9ed33d4dda736e145b6d2821f9560b56ac356b6539531a5745c3ac",
+  "model": "gpt-5.6-terra",
+  "run_id": "05f2ff2b",
+  "runner": "openai-gpt-5.6-terra",
   "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
     "algorithm": "ed25519-domain-v1",
-    "key_id": "sha256:ba63baeacae566f384a97430e10d2d323b71528678262d1240769facd798e497",
-    "value": "q0n9MgDvv1NG2xvFjJAgw07e5p1mP9rHgXLFvYioKTfFsY9cfu5p8I9u08VfIMztj7082cTZSl/d1jkQ79qdAw=="
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "zOdKrhCV89AX/TCSrEIKnEBgEnxHv99FfBipzW1iKIf+gbEiEKLwKTuF4MqF73RUZ8nY+ieyPs0ulU+ZyixkDA=="
   },
   "source_attestation": {
     "component_rows": [],
-    "corpus_release": "us-rulespec-2026-07-18",
-    "corpus_release_content_sha256": "853fe774d13f27b92480c62d990a88b00122c8887d09dd5dc2d7b09fee4d0648",
-    "corpus_release_selector_sha256": "8e3919eacc86fe4c092f6a1a5d1c5d35cacd3bac461337590a63372c2e789311",
+    "corpus_release": "us-rulespec-2026-08-03-ecps-pit-tariff-union",
+    "corpus_release_content_sha256": "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5",
+    "corpus_release_selector_sha256": "700f831ff225df410c389e2edb075ff911c7711feccf0410ec32d3bfef45e238",
     "corpus_source": "local",
-    "expression_date": "2026-07-13",
-    "generation_input_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
-    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-    "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+    "expression_date": "2026-07-22",
+    "generation_input_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
+    "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+    "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
     "requested_corpus_citation_path": "us-la/statute/47:297.8",
     "resolved_corpus_citation_path": "us-la/statute/47:297.8",
-    "resolved_text_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+    "resolved_text_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
     "row": {
-      "body_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb",
+      "body_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674",
       "citation_path": "us-la/statute/47:297.8",
       "document_class": "statute",
-      "expression_date": "2026-07-13",
+      "expression_date": "2026-07-22",
       "jurisdiction": "us-la",
-      "line_number": 4,
-      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-13-recovery.jsonl",
-      "provision_file_sha256": "639cc93586c98bad917f7ab871eb9fe2bab548e0d2ee037caf5e3785a42da465",
+      "line_number": 380,
+      "provision_file": "data/corpus/provisions/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47.jsonl",
+      "provision_file_sha256": "5718e5920daf430b4529b156bbf88d6a00d00d1df510a91ea1654812989c1f15",
       "record_id": "4dd82690-cd40-5a42-b7bd-b1c8bd7a740c",
-      "source_as_of": "2026-07-13",
-      "source_path": "sources/us-la/statute/2026-07-13-recovery/official-documents/us-la-code-47-297.8",
-      "version": "2026-07-13-recovery"
+      "source_as_of": "2026-07-22",
+      "source_path": "sources/us-la/statute/2026-07-22-la-title-47-official-current-us-la-title-47/louisiana-rs-lawprint-html/title-47/453085.html",
+      "version": "2026-07-22-la-title-47-official-current-us-la-title-47"
     },
     "rulespec_root": "rulespec-us/us-la",
-    "source_as_of": "2026-07-13",
-    "source_sha256": "985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb"
+    "source_as_of": "2026-07-22",
+    "source_sha256": "8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674"
   },
   "tool": "axiom-encode encode --apply",
-  "trace_file": "/home/runner/work/_temp/generated/traces/openai-gpt-5.6-sol/us-la-statute-47-297.8.json",
-  "trace_sha256": "64fa9b53984cfe738148bccee3bc9504df20aad56f79a4e81000b3096259def6",
+  "trace_file": "/home/runner/work/_temp/generated/canonical-refresh-03/traces/openai-gpt-5.6-terra/us-la-statute-47-297.8.json",
+  "trace_sha256": "e96727dc0c4689dd8a8803b0d651b695421c8ad1cff76c9278621d6797a612cb",
   "validation_execution": {
     "axiom_encode": {
-      "commit": "aea54ba8ffaf1c36c5505c485de9a80fde277214",
+      "commit": "6997cb35c4681adc21afcf3e460b62bfd3834810",
       "identity_source": "trusted-runtime-attestation",
       "repository": "github.com/TheAxiomFoundation/axiom-encode",
-      "version": "0.2.1293"
+      "version": "0.2.1634"
     },
     "axiom_rules_engine": {
       "commit": "05eac9d2f89dabe5c6673176260762cef3a58f47",
       "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
     },
     "policy_pre_apply": {
-      "pre_apply_content_sha256": "c1842d557337d06a3bdbb4f1417acc0cdaffdc79bacaf63ef7f67d44721c8eb8",
-      "pre_apply_file_count": 14,
+      "pre_apply_content_sha256": "b8f83ed6fa7facb9f241d5526a186fa2a5eb37729cefc3ea9747a0ac82c56c65",
+      "pre_apply_file_count": 30,
       "rulespec_root": "rulespec-us/us-la",
-      "toolchain_contract_sha256": "d6bc9300e3cfb748fd6b1f4b3075fc06cd25c84a6c64c3f3108161c2522049fd",
-      "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+      "toolchain_contract_sha256": "5411d5439785d8b5bb1643af11d68566e6935505c02fa45e0c31774bef87d952",
+      "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
     },
     "rulespec_dependencies": [],
-    "schema": "axiom-encode/apply-validation-execution/v1"
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
   },
-  "validation_waiver_set_sha256": "b90d949810f67a5ebdfde9794812425138a6ed82a4a39ca92e3eca583b0ce99a"
+  "validation_waiver_set_sha256": "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"
 }

--- a/us-la/statutes/47/294.test.yaml
+++ b/us-la/statutes/47/294.test.yaml
@@ -1,20 +1,134 @@
-- name: joint surviving spouse and head of household standard deduction for tax year
-    2025
+- name: 2025 single or married-separate standard deduction
   period:
     period_kind: tax_year
     start: '2025-01-01'
     end: '2025-12-31'
-  input: {}
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 12500
+- name: 2025 joint surviving spouse or head of household standard deduction
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: true
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
   output:
     us-la:statutes/47/294#standard_deduction_joint_surviving_spouse_head_of_household: 25000
-- name: annual standard deduction adjustment beginning in 2026
+    us-la:statutes/47/294#standard_deduction: 25000
+- name: 2025 unrecognized filing-status group fails closed
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#standard_deduction: 0
+- name: 2026 single or married-separate deduction adjusted by four percent
   period:
     period_kind: tax_year
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us-la:statutes/47/294#input.prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
     us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
   output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 12500
     us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 500
     us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000
+    us-la:statutes/47/294#standard_deduction: 13000
+- name: 2026 joint surviving spouse or head of household deduction adjusted by four
+    percent
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: true
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 25000
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 1000
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 26000
+    us-la:statutes/47/294#standard_deduction: 26000
+- name: later single or married-separate recurrence uses adjusted prior-year deduction
+  period:
+    period_kind: tax_year
+    start: '2027-01-01'
+    end: '2027-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 13000
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 26000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.03
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 13000
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 390
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13390
+    us-la:statutes/47/294#standard_deduction: 13390
+- name: positive CPI adjustment for single or married-separate group
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0.04
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 500
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 13000
+    us-la:statutes/47/294#standard_deduction: 13000
+- name: zero CPI adjustment preserves single or married-separate prior-year deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: true
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 12500
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 25000
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 12500
+    us-la:statutes/47/294#standard_deduction_annual_adjustment_amount: 0
+    us-la:statutes/47/294#standard_deduction_after_annual_adjustment: 12500
+    us-la:statutes/47/294#standard_deduction: 12500
+- name: auto_zero_applicable_prior_year_standard_deduction
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-la:statutes/47/294#input.federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household: false
+    us-la:statutes/47/294#input.federal_return_filing_status_is_single_or_married_separate: false
+    us-la:statutes/47/294#input.previous_calendar_year_cpi_u_percentage_increase: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_joint_surviving_spouse_head_of_household: 0
+    us-la:statutes/47/294#input.prior_year_standard_deduction_single_individual_married_separate: 0
+  output:
+    us-la:statutes/47/294#applicable_prior_year_standard_deduction: 0

--- a/us-la/statutes/47/294.yaml
+++ b/us-la/statutes/47/294.yaml
@@ -5,20 +5,17 @@ module:
   source_verification:
     corpus_citation_path: us-la/statute/47:294
     source_sha256: 2d7ceb0e2e4f07667becfe83ee45f652b1b793d3b72fb0f47c56a184dc28f17b
-  summary: '"For tax year 2025" the standard deduction for "Single Individual and
+  summary: '"For tax year 2025" the standard deduction is "$12,500.00" for
 
-    Married-Separate" is "$12,500.00"; specified joint-return statuses receive
+    "Single Individual and Married-Separate" and "200% of the dollar amount"
 
-    "200% of the dollar amount." "Beginning January 1, 2026" the deduction is
+    for a Married-Joint Return, Qualified Surviving Spouse, and Head of
 
-    adjusted annually using the CPI-U percentage increase for the previous
+    Household. Beginning January 1, 2026, it is adjusted annually by the
 
-    calendar year.'
-  deferred_outputs:
-  - output: us-la:statutes/47/294#standard_deduction
-    reason: Determining the taxpayer-specific standard deduction requires the federally
-      derived filing status used on the federal income tax return, and no executable
-      upstream filing-status RuleSpec export is supplied.
+    prior year''s deduction multiplied by the prior calendar year''s CPI-U
+
+    percentage increase.'
 rules:
 - name: standard_deduction_single_individual_married_separate
   kind: parameter
@@ -111,6 +108,37 @@ rules:
   - effective_from: '2025-01-01'
     effective_to: '2025-12-31'
     formula: standard_deduction_single_individual_married_separate * standard_deduction_joint_surviving_spouse_head_of_household_multiplier
+- name: applicable_prior_year_standard_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Taxpayers are required to use the same filing status on their return
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: the amount of the prior year's standard deduction
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026
+  versions:
+  - effective_from: '2026-01-01'
+    formula: "if federal_return_filing_status_is_single_or_married_separate:\n  prior_year_standard_deduction_single_individual_married_separate\n\
+      else:\n  if federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household:\n\
+      \    prior_year_standard_deduction_joint_surviving_spouse_head_of_household\n\
+      \  else:\n    0"
 - name: standard_deduction_annual_adjustment_amount
   kind: derived
   entity: TaxUnit
@@ -127,6 +155,12 @@ rules:
           corpus_citation_path: us-la/statute/47:294
           excerpt: multiplying the amount of the prior year's standard deduction by
             the percentage increase
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#applicable_prior_year_standard_deduction
+          output: applicable_prior_year_standard_deduction
+          hash: sha256:local
       - path: versions[0].effective_from
         kind: effective_period
         source:
@@ -134,7 +168,7 @@ rules:
           excerpt: Beginning January 1, 2026
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
+    formula: applicable_prior_year_standard_deduction * previous_calendar_year_cpi_u_percentage_increase
 - name: standard_deduction_after_annual_adjustment
   kind: derived
   entity: TaxUnit
@@ -153,6 +187,12 @@ rules:
       - path: versions[0].formula
         kind: import
         import:
+          target: us-la:statutes/47/294#applicable_prior_year_standard_deduction
+          output: applicable_prior_year_standard_deduction
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
           target: us-la:statutes/47/294#standard_deduction_annual_adjustment_amount
           output: standard_deduction_annual_adjustment_amount
           hash: sha256:local
@@ -163,4 +203,51 @@ rules:
           excerpt: Beginning January 1, 2026
   versions:
   - effective_from: '2026-01-01'
-    formula: prior_year_standard_deduction + standard_deduction_annual_adjustment_amount
+    formula: applicable_prior_year_standard_deduction + standard_deduction_annual_adjustment_amount
+- name: standard_deduction
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  unit: USD
+  period: Year
+  source: La. R.S. 47:294(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Taxpayers are required to use the same filing status on their return
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Single Individual and Married-Separate $12,500.00
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: (2) Married-Joint Return, a Qualified Surviving 200% of the dollar
+            amount
+      - path: versions[1].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:294
+          excerpt: Beginning January 1, 2026, and thereafter
+      - path: versions[1].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/294#standard_deduction_after_annual_adjustment
+          output: standard_deduction_after_annual_adjustment
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-01-01'
+    effective_to: '2025-12-31'
+    formula: "if federal_return_filing_status_is_single_or_married_separate:\n  standard_deduction_single_individual_married_separate\n\
+      else:\n  if federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household:\n\
+      \    standard_deduction_joint_surviving_spouse_head_of_household\n  else:\n\
+      \    0"
+  - effective_from: '2026-01-01'
+    formula: 'if federal_return_filing_status_is_single_or_married_separate or federal_return_filing_status_is_joint_surviving_spouse_or_head_of_household:
+      standard_deduction_after_annual_adjustment else: 0'

--- a/us-la/statutes/47/295.test.yaml
+++ b/us-la/statutes/47/295.test.yaml
@@ -1,3 +1,73 @@
+- name: pre-2016 resident individual is subject to Louisiana income tax
+  period:
+    period_kind: tax_year
+    start: '2015-01-01'
+    end: '2015-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: true
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#louisiana_income_tax_applies_to_individual: holds
+- name: pre-2016 nonresident individual is subject to Louisiana income tax
+  period:
+    period_kind: tax_year
+    start: '2015-01-01'
+    end: '2015-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: false
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: true
+  output:
+    us-la:statutes/47/295#louisiana_income_tax_applies_to_individual: holds
+- name: individual outside stated resident and nonresident statuses fails closed
+  period:
+    period_kind: tax_year
+    start: '2015-01-01'
+    end: '2015-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: false
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#louisiana_income_tax_applies_to_individual: not_holds
+- name: current resident individual is subject to Louisiana income tax
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/295#input.individual_is_louisiana_resident: true
+    us-la:statutes/47/295#input.individual_is_louisiana_nonresident: false
+  output:
+    us-la:statutes/47/295#louisiana_income_tax_applies_to_individual: holds
+- name: secretary administers and may implement the Part
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input: {}
+  output:
+    us-la:statutes/47/295#secretary_administers_and_enforces_part: holds
+    us-la:statutes/47/295#secretary_may_implement_part_with_reasonable_rules_orders_and_regulations: holds
+- name: recorded reasons permit compromise of Part amounts
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_made_record_of_reasons: true
+  output:
+    us-la:statutes/47/295#secretary_may_compromise_part_amounts: holds
+- name: absent recorded reasons block compromise discretion
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_made_record_of_reasons: false
+  output:
+    us-la:statutes/47/295#secretary_may_compromise_part_amounts: not_holds
 - name: penalty waiver above threshold requires oversight
   period:
     period_kind: custom
@@ -9,7 +79,7 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: holds
-- name: voluntary disclosure waiver exception blocks oversight
+- name: voluntary disclosure penalty waiver does not require oversight
   period:
     period_kind: custom
     name: day
@@ -20,7 +90,7 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: true
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
-- name: penalty at threshold does not require oversight
+- name: penalty waiver at threshold does not require oversight
   period:
     period_kind: custom
     name: day
@@ -31,3 +101,84 @@
     us-la:statutes/47/295#input.penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations: false
   output:
     us-la:statutes/47/295#penalty_waiver_subject_to_committee_oversight: not_holds
+- name: complete copy required but not filed before 2016
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: false
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: not_holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: complete copy required and filed becomes part of Louisiana return before 2016
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: false
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: true
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: not_holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#filed_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: requested part required but not filed before 2016
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: false
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: true
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: false
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: not_holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_federal_return_part_becomes_part_of_louisiana_return: not_holds
+- name: requested part required and filed becomes part of Louisiana return before
+    2016
+  period:
+    period_kind: custom
+    name: day
+    start: '2015-01-15'
+    end: '2015-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: false
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: true
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: false
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: not_holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: not_holds
+    us-la:statutes/47/295#filed_federal_return_part_becomes_part_of_louisiana_return: holds
+- name: both federal return requirements and filings are independently incorporated
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-01-15'
+    end: '2024-01-15'
+  input:
+    us-la:statutes/47/295#input.secretary_requires_complete_federal_return_copy: true
+    us-la:statutes/47/295#input.secretary_requires_federal_return_part: true
+    us-la:statutes/47/295#input.complete_federal_return_copy_is_filed: true
+    us-la:statutes/47/295#input.requested_federal_return_part_is_filed: true
+  output:
+    us-la:statutes/47/295#complete_federal_return_copy_filing_required: holds
+    us-la:statutes/47/295#requested_federal_return_part_filing_required: holds
+    us-la:statutes/47/295#filed_complete_federal_return_copy_becomes_part_of_louisiana_return: holds
+    us-la:statutes/47/295#filed_federal_return_part_becomes_part_of_louisiana_return: holds

--- a/us-la/statutes/47/295.yaml
+++ b/us-la/statutes/47/295.yaml
@@ -4,16 +4,106 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:295
-    source_sha256: eb53217f2da796ec6740de0f4be8b74e29f72cf343423d1cfd76f55708ed5d06
-  summary: '"Beginning January 1, 2016, waivers of all penalties exceeding twenty-five
-    thousand dollars shall be subject to oversight by the House Committee on Ways
-    and Means and the Senate Committee on Revenue and Fiscal Affairs."'
+    source_sha256: 4ed6c1f6ba4d139958048efe17bd95386bb5158911671ea9b02cc3f9254ab959
+  summary: '“There is imposed an income tax for each taxable year upon the Louisiana
+    income
+
+    of every individual, whether resident or nonresident.” The secretary shall
+
+    administer and enforce this Part, may implement it through reasonable rules,
+
+    orders, and regulations, and may compromise amounts upon making a record of
+
+    reasons. Beginning January 1, 2016, qualifying penalty waivers exceeding
+
+    twenty-five thousand dollars are subject to committee oversight. A required
+
+    federal return copy or part, when filed, becomes part of the Louisiana return.'
   deferred_outputs:
-  - output: us-la:statutes/47/295#individual_louisiana_income_tax_amount
-    reason: The source imposes the tax but provides that its amount is determined
-      in accordance with R.S. 47:32, whose executable computation is not supplied
-      in this prompt.
+  - output: us-la:statutes/47/295/a#individual_louisiana_income_tax_amount
+    reason: us-la/statute/47:295(a) requires the individual Louisiana income tax amount
+      to be determined in accordance with R.S. 47:32, but the available R.S. 47:32
+      RuleSpec exports only the individual income tax rate and lacks an executable
+      tax-amount computation accepting the applicable Louisiana income or net-income
+      tax base.
 rules:
+- name: louisiana_income_tax_applies_to_individual
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: R.S. 47:295(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: every individual, whether resident or nonresident
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'individual_is_louisiana_resident
+
+      or individual_is_louisiana_nonresident'
+- name: secretary_administers_and_enforces_part
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: shall administer and enforce this Part
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'true'
+- name: secretary_may_implement_part_with_reasonable_rules_orders_and_regulations
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: may adopt, prescribe, and from time to time alter and enforce reasonable
+            rules, orders, and regulations
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'true'
+- name: secretary_may_compromise_part_amounts
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: upon making a record of his reasons therefor
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: waive, reduce, or compromise any of the taxes, penalties, or interest
+            or other amounts
+  versions:
+  - effective_from: '0001-01-01'
+    formula: secretary_made_record_of_reasons
 - name: penalty_waiver_oversight_threshold
   kind: parameter
   dtype: Money
@@ -28,6 +118,11 @@ rules:
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: penalties exceeding twenty-five thousand dollars
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: beginning January 1, 2016
   versions:
   - effective_from: '2016-01-01'
     formula: '25000'
@@ -41,19 +136,19 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:295
-          excerpt: shall not apply to any penalty the secretary remits or waives in
-            accordance with rules and regulations promulgated pursuant to the Administrative
-            Procedure Act regarding the remittance or waiver of penalties under the
-            department's voluntary disclosure program.
-      - path: versions[0].formula
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:295
           excerpt: waivers of all penalties exceeding twenty-five thousand dollars
             shall be subject to oversight
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: This provision shall not apply to any penalty the secretary remits
+            or waives in accordance with rules and regulations promulgated pursuant
+            to the Administrative Procedure Act regarding the remittance or waiver
+            of penalties under the department's voluntary disclosure program.
       - path: versions[0].formula
         kind: import
         import:
@@ -65,3 +160,92 @@ rules:
     formula: 'penalty_amount > penalty_waiver_oversight_threshold
 
       and not penalty_remitted_or_waived_under_voluntary_disclosure_program_regulations'
+- name: complete_federal_return_copy_filing_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: 'C. The secretary may require that a complete copy of the taxpayer''s
+            federal income
+
+            tax return, or any part thereof, be filed. When the return is filed, the
+            federal income tax
+
+            return, or part thereof, shall constitute and become part of the return
+            required to be filed
+
+            under this Part.'
+  versions:
+  - effective_from: '0001-01-01'
+    formula: secretary_requires_complete_federal_return_copy
+- name: requested_federal_return_part_filing_required
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: or any part thereof, be filed
+  versions:
+  - effective_from: '0001-01-01'
+    formula: secretary_requires_federal_return_part
+- name: filed_complete_federal_return_copy_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: the federal income tax return, or part thereof, shall constitute
+            and become part of the return required to be filed under this Part
+  versions:
+  - effective_from: '0001-01-01'
+    formula: complete_federal_return_copy_is_filed
+- name: filed_federal_return_part_becomes_part_of_louisiana_return
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Day
+  source: R.S. 47:295(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: When the return is filed
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:295
+          excerpt: the federal income tax return, or part thereof, shall constitute
+            and become part of the return required to be filed under this Part
+  versions:
+  - effective_from: '0001-01-01'
+    formula: requested_federal_return_part_is_filed

--- a/us-la/statutes/47/297/4.test.yaml
+++ b/us-la/statutes/47/297/4.test.yaml
@@ -1,4 +1,4 @@
-- name: low_income_zero_claimed_credit_uses_initial_rate
+- name: low_income_2006_unreduced_credit
   period:
     period_kind: tax_year
     start: '2006-01-01'
@@ -10,6 +10,7 @@
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 0
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
@@ -20,247 +21,34 @@
     us-la:statutes/47/297/4#child_care_expense_credit: 250
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 150
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_zero_claimed_credit_uses_later_rate
+- name: low_income_post_2006_no_federal_claim
   period:
     period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
+    start: '2024-01-01'
+    end: '2024-12-31'
   input:
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 0
   output:
     us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
     us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
     us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_nonzero_claimed_credit_same_unreduced_result
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 400
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
-- name: low_income_credit_blocked_when_not_federally_eligible
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: false
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: low_income_credit_blocked_for_nonresident
-  period:
-    period_kind: tax_year
-    start: '2007-01-01'
-    end: '2007-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: false
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 100
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: not_holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: clause_2_lower_boundary_25000
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_above_lower_boundary_25001
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 360
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
-    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_2_upper_boundary_35000
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
     us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_3_above_35000_boundary
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 0
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 0
-- name: clause_2_at_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 180
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
-- name: clause_3_above_35000_claimed_credit
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 1000
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
-- name: upper_middle_income_boundary_60000
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 60
     us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#child_care_expense_credit: 60
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 50
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: high_income_boundary_60001
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
-  output:
-    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
-    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
-    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
-    us-la:statutes/47/297/4#child_care_expense_credit: 25
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 15
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: low_income_credit_exceeds_liability
-  period:
-    period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
-  input:
-    us-la:statutes/47/297/4#input.individual_is_resident: true
-    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
-    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 499
-  output:
     us-la:statutes/47/297/4#child_care_expense_credit: 500
-    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 1
-    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: low_income_credit_does_not_exceed_liability
+- name: low_income_post_2006_positive_federal_claim
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -272,13 +60,45 @@
     us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
     us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
     us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 500
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 0
   output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 500
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
     us-la:statutes/47/297/4#child_care_expense_credit: 500
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0
-- name: above_low_income_credit_exceeds_liability
+- name: threshold_25000_low_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 50
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 50
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 50
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: threshold_25001_middle_income
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -287,16 +107,148 @@
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 179
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 0
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 30
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 30
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 1
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 5
-- name: above_low_income_credit_does_not_exceed_liability
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 30
+- name: threshold_35000_middle_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 30
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 30
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 30
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: threshold_35001_upper_middle_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 35001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: threshold_60000_upper_middle_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60000
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: threshold_60001_high_income_below_cap
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit: 10
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: high_income_cap_binding
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 60001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 1000
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 25
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 25
+    us-la:statutes/47/297/4#child_care_expense_credit: 25
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
+- name: carryforward_age_five
   period:
     period_kind: tax_year
     start: '2024-01-01'
@@ -305,12 +257,44 @@
     us-la:statutes/47/297/4#input.individual_is_resident: true
     us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
     us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
-    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 1000
-    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 600
-    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 180
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 5
   output:
-    us-la:statutes/47/297/4#child_care_expense_credit: 180
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 30
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 30
     us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
     us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 20
+- name: carryforward_age_six
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/4#input.individual_is_resident: true
+    us-la:statutes/47/297/4#input.eligible_for_federal_child_care_credit_under_section_21: true
+    us-la:statutes/47/297/4#input.federal_adjusted_gross_income: 25001
+    us-la:statutes/47/297/4#input.unreduced_federal_child_care_credit: 100
+    us-la:statutes/47/297/4#input.federal_child_care_credit_claimed_on_federal_return: 100
+    us-la:statutes/47/297/4#input.louisiana_income_tax_liability: 10
+    us-la:statutes/47/297/4#input.carryforward_age_in_years: 6
+  output:
+    us-la:statutes/47/297/4#child_care_expense_credit_eligibility: holds
+    us-la:statutes/47/297/4#low_income_credit_allowed_without_federal_claim: not_holds
+    us-la:statutes/47/297/4#low_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#middle_income_child_care_expense_credit: 30
+    us-la:statutes/47/297/4#upper_middle_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#high_income_child_care_expense_credit: 0
+    us-la:statutes/47/297/4#child_care_expense_credit: 30
+    us-la:statutes/47/297/4#child_care_expense_credit_refundable_overpayment: 0
+    us-la:statutes/47/297/4#child_care_credit_refund_exempt_from_overpayment_requirements: not_holds
+    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_eligibility: not_holds
     us-la:statutes/47/297/4#child_care_expense_credit_carryforward: 0
-    us-la:statutes/47/297/4#child_care_expense_credit_carryforward_years: 0

--- a/us-la/statutes/47/297/4.yaml
+++ b/us-la/statutes/47/297/4.yaml
@@ -5,15 +5,11 @@ module:
   source_verification:
     corpus_citation_path: us-la/statute/47:297.4
     source_sha256: 34c473b9741200f16db2e0eb9e2a15faf38e9e7f111416619273a07a0e6e7528
-  summary: '“There shall be a credit from the tax imposed by this Part for child care
-
-    expenses for which a resident individual is eligible pursuant to the federal
-
-    income tax credit provided by Internal Revenue Code Section 21 for the same
-
-    taxable year.” Low-income excess credit constitutes an overpayment; excess
-
-    credit above the low-income threshold may be carried forward for up to five years.'
+  summary: “There shall be a credit from the tax imposed by this Part for child care
+    expenses for which a resident individual is eligible pursuant to the federal income
+    tax credit provided by Internal Revenue Code Section 21 for the same taxable year.”
+    Low-income excess credit constitutes an overpayment; excess credit above the low-income
+    threshold may be carried forward for a period not exceeding five years.
 rules:
 - name: low_income_federal_adjusted_gross_income_limit
   kind: parameter
@@ -124,24 +120,13 @@ rules:
   metadata:
     proof:
       atoms:
-      - path: versions[0].effective_from
-        kind: effective_period
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: beginning after December 31, 2005 and ending before January 1,
-            2007
       - path: versions[0].formula
-        kind: parameter
+        kind: amount
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: twenty-five percent of the unreduced federal credit
-      - path: versions[1].effective_from
-        kind: effective_period
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: beginning after December 31, 2006
       - path: versions[1].formula
-        kind: parameter
+        kind: amount
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: fifty percent of the unreduced federal credit
@@ -158,7 +143,7 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: parameter
+        kind: amount
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: thirty percent of the federal credit for child care expenses claimed
@@ -173,7 +158,7 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: parameter
+        kind: amount
         source:
           corpus_citation_path: us-la/statute/47:297.4
           excerpt: ten percent of the federal credit for child care expenses claimed
@@ -246,13 +231,8 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
+          excerpt: the Louisiana credit shall be allowed without regard to whether
+            they claimed such federal credit
   versions:
   - effective_from: '2006-01-01'
     formula: 'child_care_expense_credit_eligibility
@@ -272,12 +252,9 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: calculated based on the federal tax credit before it is reduced
-      - path: versions[0].formula
-        kind: exception
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: allowed without regard to whether they claimed such federal credit
+          excerpt: the credit shall be calculated based on the federal tax credit
+            before it is reduced by the amount of the individual's federal income
+            tax
   versions:
   - effective_from: '2006-01-01'
     formula: "if low_income_credit_allowed_without_federal_claim:\n  low_income_unreduced_federal_credit_percentage\
@@ -293,20 +270,16 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than twenty-five thousand dollars and less than or equal
-            to thirty-five thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: thirty percent of the federal credit for child care expenses claimed
+          excerpt: the credit shall be equal to thirty percent of the federal credit
+            for child care expenses claimed on the resident individual's federal tax
+            return
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_eligibility\n  and federal_adjusted_gross_income\
+      \ > middle_income_federal_adjusted_gross_income_lower_bound\n  and federal_adjusted_gross_income\
       \ <= middle_income_federal_adjusted_gross_income_limit:\n  middle_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: upper_middle_income_child_care_expense_credit
@@ -320,20 +293,18 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than thirty-five thousand and less than or equal to sixty
-            thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: ten percent of the federal credit for child care expenses claimed
+          excerpt: (3) If the resident individual's federal adjusted gross income
+            is greater than thirty-five thousand and less than or equal to sixty thousand
+            dollars, the credit shall be equal to ten percent of the federal credit
+            for child care expenses claimed on the resident individual's federal tax
+            return.
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
-      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_eligibility\n  and federal_adjusted_gross_income\
+      \ > upper_middle_income_federal_adjusted_gross_income_lower_bound\n  and federal_adjusted_gross_income\
       \ <= upper_middle_income_federal_adjusted_gross_income_limit:\n  upper_income_claimed_federal_credit_percentage\
       \ * max(0, federal_child_care_credit_claimed_on_federal_return)\nelse: 0"
 - name: high_income_child_care_expense_credit
@@ -347,19 +318,15 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: greater than sixty thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: lesser of twenty-five dollars or ten percent of the federal credit
-            for child care expenses claimed
+          excerpt: the credit shall be equal to the lesser of twenty-five dollars
+            or ten percent of the federal credit for child care expenses claimed on
+            the resident individual's federal tax return
   versions:
   - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_eligibility\n   and federal_adjusted_gross_income\
+    formula: "if child_care_expense_credit_eligibility\n  and federal_adjusted_gross_income\
       \ > high_income_federal_adjusted_gross_income_lower_bound:\n  min(high_income_credit_cap,\
       \ upper_income_claimed_federal_credit_percentage * max(0, federal_child_care_credit_claimed_on_federal_return))\n\
       else: 0"
@@ -369,7 +336,7 @@ rules:
   dtype: Money
   unit: USD
   period: Year
-  source: La. R.S. 47:297.4(A)(1)-(4)
+  source: La. R.S. 47:297.4(A)
   metadata:
     proof:
       atoms:
@@ -377,7 +344,8 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: The credit shall be calculated using the following percentages
+          excerpt: There shall be a credit from the tax imposed by this Part for child
+            care expenses
   versions:
   - effective_from: '2006-01-01'
     formula: 'low_income_child_care_expense_credit
@@ -398,26 +366,19 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is equal to or less than twenty-five
-            thousand dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit shall constitute an overpayment
+          excerpt: If the credit against Louisiana income tax for resident individuals
+            whose federal adjusted gross income is equal to or less than twenty-five
+            thousand dollars exceeds the amount of such individual's tax liability
+            for the taxable year, then such excess tax credit shall constitute an
+            overpayment
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income <= low_income_federal_adjusted_gross_income_limit:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
+    formula: "if child_care_expense_credit_eligibility\n  and federal_adjusted_gross_income\
+      \ <= low_income_federal_adjusted_gross_income_limit:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: child_care_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -431,11 +392,43 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: right to a refund of any such overpayment shall not be subject
-            to the requirements of R.S. 47:1621(B)
+          excerpt: The right to a refund of any such overpayment shall not be subject
+            to the requirements of R.S. 47:1621(B).
   versions:
   - effective_from: '2006-01-01'
     formula: child_care_expense_credit_refundable_overpayment > 0
+- name: child_care_expense_credit_carryforward_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.4(B)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: If the credit against Louisiana income tax for resident individuals
+            whose federal adjusted gross income is greater than twenty-five thousand
+            dollars exceeds the amount of such individual's tax liability for the
+            taxable period, then such excess tax credit may be carried forward as
+            a credit against any subsequent tax liability
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-la/statute/47:297.4
+          excerpt: for a period not exceeding five years
+  versions:
+  - effective_from: '2006-01-01'
+    formula: 'child_care_expense_credit_eligibility
+
+      and federal_adjusted_gross_income > low_income_federal_adjusted_gross_income_limit
+
+      and child_care_expense_credit > louisiana_income_tax_liability
+
+      and carryforward_age_in_years <= excess_credit_carryforward_year_limit'
 - name: child_care_expense_credit_carryforward
   kind: derived
   entity: Person
@@ -447,46 +440,13 @@ rules:
     proof:
       atoms:
       - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: federal adjusted gross income is greater than twenty-five thousand
-            dollars
-      - path: versions[0].formula
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.4
-          excerpt: exceeds the amount of such individual's tax liability
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
+          excerpt: such excess tax credit may be carried forward as a credit against
+            any subsequent tax liability of such individual imposed by this Part for
+            a period not exceeding five years
   versions:
   - effective_from: '2006-01-01'
-    formula: "if individual_is_resident\n   and federal_adjusted_gross_income > middle_income_federal_adjusted_gross_income_lower_bound:\n\
-      \  max(0, child_care_expense_credit - louisiana_income_tax_liability)\nelse:\
-      \ 0"
-- name: child_care_expense_credit_carryforward_years
-  kind: derived
-  entity: Person
-  dtype: Count
-  period: Year
-  source: La. R.S. 47:297.4(B)(2)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: condition
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: such excess tax credit may be carried forward
-      - path: versions[0].formula
-        kind: formula
-        source:
-          corpus_citation_path: us-la/statute/47:297.4
-          excerpt: for a period not exceeding five years
-  versions:
-  - effective_from: '2006-01-01'
-    formula: "if child_care_expense_credit_carryforward > 0:\n  excess_credit_carryforward_year_limit\n\
-      else: 0"
+    formula: "if child_care_expense_credit_carryforward_eligibility:\n  max(0, child_care_expense_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"

--- a/us-la/statutes/47/297/8.test.yaml
+++ b/us-la/statutes/47/297/8.test.yaml
@@ -3,29 +3,47 @@
     period_kind: tax_year
     start: '2007-01-01'
     end: '2007-12-31'
-  input: {}
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: not_holds
-- name: first_effective_year_uses_base_rate_and_refunds_excess
+- name: first_effective_year_uses_base_rate
   period:
     period_kind: tax_year
     start: '2008-01-01'
     end: '2008-12-31'
   input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
     us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.individual_is_resident: false
     us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
-    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 15
-    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
-- name: temporary_rate_applies_but_nonresident_has_no_overpayment
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: final_base_rate_year_uses_three_and_one_half_percent
   period:
     period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
+    start: '2018-01-01'
+    end: '2018-12-31'
   input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: false
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: temporary_rate_starts_in_2019
+  period:
+    period_kind: tax_year
+    start: '2019-01-01'
+    end: '2019-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
     us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
     us-la:statutes/47/297/8#input.individual_is_resident: false
     us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
@@ -34,17 +52,123 @@
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
     us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
     us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
-- name: base_rate_resumes_after_temporary_period
+- name: temporary_rate_includes_2030
+  period:
+    period_kind: tax_year
+    start: '2030-01-01'
+    end: '2030-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: false
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: base_rate_resumes_in_2031
   period:
     period_kind: tax_year
     start: '2031-01-01'
     end: '2031-12-31'
   input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
     us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
-    us-la:statutes/47/297/8#input.individual_is_resident: true
-    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 40
+    us-la:statutes/47/297/8#input.individual_is_resident: false
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
   output:
     us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
     us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 35
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: zero_federal_credit_produces_zero_louisiana_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 0
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: federally_ineligible_individual_has_no_louisiana_credit
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: false
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 0
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: not_holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: resident_positive_excess_is_refundable_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 30
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: holds
+- name: resident_equal_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 50
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: resident_below_liability_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: true
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 60
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
+    us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
+    us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds
+- name: nonresident_credit_has_no_overpayment
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-la:statutes/47/297/8#input.individual_is_eligible_for_federal_earned_income_tax_credit: true
+    us-la:statutes/47/297/8#input.federal_earned_income_tax_credit: 1000
+    us-la:statutes/47/297/8#input.individual_is_resident: false
+    us-la:statutes/47/297/8#input.louisiana_income_tax_liability: 20
+  output:
+    us-la:statutes/47/297/8#earned_income_tax_credit_applies: holds
+    us-la:statutes/47/297/8#louisiana_earned_income_tax_credit: 50
     us-la:statutes/47/297/8#earned_income_tax_credit_excess_overpayment: 0
     us-la:statutes/47/297/8#earned_income_tax_credit_refund_exempt_from_overpayment_requirements: not_holds

--- a/us-la/statutes/47/297/8.yaml
+++ b/us-la/statutes/47/297/8.yaml
@@ -4,13 +4,16 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-la/statute/47:297.8
-    source_sha256: 985cbec0bc2a0ce34cbe744b20251c2049f85727f88d71621e1c2db902ec3beb
-  summary: “there shall be a credit against the tax imposed by this Chapter for individuals”
-    equal to three and one-half percent of the federal earned income tax credit, except
-    that the rate is five percent for tax years beginning on or after January 1, 2019,
-    through December 31, 2030. For resident individuals, excess credit constitutes
-    an overpayment, and the right to its refund is not subject to R.S. 47:1621(B).
-    The enactment was effective January 1, 2008.
+    source_sha256: 8f1bf58221983b011e20236decc2ade27781ca073be5881d1046fa8e61259674
+  summary: '“there shall be a credit against the tax imposed by this Chapter for individuals”
+
+    equal to three and one-half percent of the federal earned income tax credit,
+
+    except that it is five percent for tax years beginning on or after January 1,
+
+    2019, through December 31, 2030. Excess resident credit constitutes an
+
+    overpayment whose refund is not subject to R.S. 47:1621(B).'
 rules:
 - name: earned_income_tax_credit_enactment_indicator
   kind: parameter
@@ -34,24 +37,6 @@ rules:
     formula: '0'
   - effective_from: '2008-01-01'
     formula: '1'
-- name: earned_income_tax_credit_applies
-  kind: derived
-  entity: Person
-  dtype: Judgment
-  period: Year
-  source: Acts 2007, No. 278, §1; La. R.S. 47:297.8(A)
-  metadata:
-    proof:
-      atoms:
-      - path: versions[0].formula
-        kind: import
-        import:
-          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
-          output: earned_income_tax_credit_enactment_indicator
-          hash: sha256:local
-  versions:
-  - effective_from: '0001-01-01'
-    formula: earned_income_tax_credit_enactment_indicator == 1
 - name: earned_income_tax_credit_base_rate
   kind: parameter
   dtype: Rate
@@ -86,6 +71,7 @@ rules:
           excerpt: on or after January 1, 2019, through December 31, 2030
   versions:
   - effective_from: '2019-01-01'
+    effective_to: '2030-12-31'
     formula: '0.05'
 - name: earned_income_tax_credit_rate
   kind: parameter
@@ -124,13 +110,39 @@ rules:
     formula: earned_income_tax_credit_temporary_rate
   - effective_from: '2031-01-01'
     formula: earned_income_tax_credit_base_rate
+- name: earned_income_tax_credit_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: La. R.S. 47:297.8(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: individual is eligible for the taxable year pursuant to Section
+            32
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_enactment_indicator
+          output: earned_income_tax_credit_enactment_indicator
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'earned_income_tax_credit_enactment_indicator == 1
+
+      and individual_is_eligible_for_federal_earned_income_tax_credit'
 - name: louisiana_earned_income_tax_credit
   kind: derived
   entity: Person
   dtype: Money
   period: Year
   unit: USD
-  source: La. R.S. 47:297.8(A)
+  source: La. R.S. 47:297.8(A)(1)-(2)
   metadata:
     proof:
       atoms:
@@ -138,16 +150,36 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: percent of the federal earned income tax credit
+          excerpt: Except as provided in Paragraph (2) of this Subsection, there shall
+            be a credit against the tax imposed by this Chapter for individuals in
+            an amount equal to three and one-half percent of the federal earned income
+            tax credit for which the individual is eligible for the taxable year pursuant
+            to Section 32 of the Internal Revenue Code.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: (2) For tax years beginning on or after January 1, 2019, through
+            December 31, 2030, there shall be a credit against the tax imposed by
+            this Chapter for individuals in an amount equal to five percent of the
+            federal earned income tax credit for which the individual is eligible
+            for the taxable year under Section 32 of the Internal Revenue Code.
       - path: versions[0].formula
         kind: import
         import:
           target: us-la:statutes/47/297/8#earned_income_tax_credit_rate
           output: earned_income_tax_credit_rate
           hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-la:statutes/47/297/8#earned_income_tax_credit_applies
+          output: earned_income_tax_credit_applies
+          hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: earned_income_tax_credit_rate * max(0, federal_earned_income_tax_credit)
+    formula: "if earned_income_tax_credit_applies:\n  earned_income_tax_credit_rate\
+      \ * max(0, federal_earned_income_tax_credit)\nelse: 0"
 - name: earned_income_tax_credit_excess_overpayment
   kind: derived
   entity: Person
@@ -158,6 +190,11 @@ rules:
   metadata:
     proof:
       atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-la/statute/47:297.8
+          excerpt: such excess tax credit shall constitute an overpayment
       - path: versions[0].formula
         kind: condition
         source:
@@ -172,8 +209,8 @@ rules:
           hash: sha256:local
   versions:
   - effective_from: '2008-01-01'
-    formula: 'if individual_is_resident: max(0, louisiana_earned_income_tax_credit
-      - louisiana_income_tax_liability) else: 0'
+    formula: "if individual_is_resident:\n  max(0, louisiana_earned_income_tax_credit\
+      \ - louisiana_income_tax_liability)\nelse: 0"
 - name: earned_income_tax_credit_refund_exempt_from_overpayment_requirements
   kind: derived
   entity: Person
@@ -187,8 +224,8 @@ rules:
         kind: condition
         source:
           corpus_citation_path: us-la/statute/47:297.8
-          excerpt: right to a refund of any such overpayment shall not be subject
-            to the requirements of R.S. 47:1621(B)
+          excerpt: The right to a refund of any such overpayment shall not be subject
+            to the requirements of R.S. 47:1621(B).
       - path: versions[0].formula
         kind: import
         import:


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-la/statute/47:294`
Independent canonical refresh bundle: `[{"citation":"us-la/statute/47:294","review_finding":null,"deferred_output_contracts":[],"rulespec_path":"us-la/statutes/47/294.yaml","rulespec_sha256":"ca671876a0749156cdb9d9eb679162b19732d5554920bb36c86cbc3e9b70cf97","companion_path":"us-la/statutes/47/294.test.yaml","companion_sha256":"4afff0b6d7b8eb0200b008fda31773ce08ca430c4a77fe7c750abc79715a4d1c","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/294.json","manifest_sha256":"b65610ac89991099f3cc982ab6e934476ba78ab5813bd305886068192658c291"},{"citation":"us-la/statute/47:295","review_finding":"Preserve R.S. 47:32 ownership: R.S. 47:295(A) delegates only the complete individual tax amount to R.S. 47:32, while the available 47:32 module exports only a rate and not complete tax-amount mechanics. Do not synthesize that amount in 47:295. Defer it precisely until an executable R.S. 47:32 tax-amount computation accepting the applicable Louisiana income or net-income tax base is encoded. The only permitted deferral shape for this exact A amount gap is the subsection-scoped output us-la:statutes/47/295/a#individual_louisiana_income_tax_amount. Its reason must name the canonical source branch us-la/statute/47:295(a) verbatim and then name the concrete missing executable dependency: the complete R.S. 47:32 tax-amount output accepting the applicable Louisiana income or net-income tax base. Do not use the parent module path us-la:statutes/47/295#individual_louisiana_income_tax_amount, a <source-unit> placeholder, a generic unavailable-in-this-prompt reason, or any other whole-source-unit deferral. Failed runs 31226171324, 31226769501, and standalone 31227274908 all used that parent path and exhausted validation with complete-source-unit:deferral; freshly regenerate and do not rerun, repair-replay, or adopt any partial file from those runs. Repair-replay run 31227711461 then reused forbidden run 31227274908 and emitted the subsection-scoped output but still failed complete-source-unit:deferral because its reason omitted the literal canonical branch us-la/statute/47:295(a); do not rerun, repair-replay, or adopt any file from either run. Second repair-replay run 31228073710 reused forbidden run 31227711461 and named the canonical branch plus the existing R.S. 47:32 rate export, but still failed complete-source-unit:deferral because naming the existing rate is not naming the exact missing executable dependency; the reason must identify the missing complete R.S. 47:32 tax-amount output itself, accepting the applicable Louisiana income or net-income tax base. Do not rerun, repair-replay, or adopt any file from run 31228073710. Successful repair-replay run 31228557280 then reused forbidden run 31228073710 and opened review-rejected PR 1245; do not adopt its signed files. That candidate invented effective_from 2015-01-01 for undated A and C, lacked a current A witness and both-status-false witness, lacked pre-2016 C coverage, and lacked both required composed C filed-false/filed-true pairs. Fresh standalone run 31229148263 and review-rejected PR 1246 repeated those semantic gaps with invented effective_from 1980-01-01 dates for A and C; it also used the wrong standalone scope and rules-engine pin. Do not adopt its signed files. Freshly regenerate all behavior rather than repairing either candidate. The subsection-scoped output and exact dependency reason are a pre-apply hard gate. Set module.deferred_outputs[0].output to exactly us-la:statutes/47/295/a#individual_louisiana_income_tax_amount and set module.deferred_outputs[0].reason to exactly the following YAML-decoded string, byte-for-byte: `us-la/statute/47:295(a) requires the individual Louisiana income tax amount to be determined in accordance with R.S. 47:32, but the available R.S. 47:32 RuleSpec exports only the individual income tax rate and lacks an executable tax-amount computation accepting the applicable Louisiana income or net-income tax base.` Do not paraphrase, shorten, reorder, or substitute synonyms in that reason. Before apply, deterministically parse the candidate YAML and reject it unless both the output and reason are exactly equal to those required strings. Separately encode A's local source-stated applicability as a non-narrowed Judgment that Louisiana income tax applies to every individual, resident or nonresident; do not gate it to residents. Represent the source's exhaustive status coverage with separate local factual inputs for Louisiana resident and Louisiana nonresident and make the applicability formula their disjunction, never either status alone. Require separate pre-2016 resident and pre-2016 nonresident witnesses: each must supply both status facts, set exactly one true, use identical input and output key sets, and assert the same A applicability Judgment holds. Also require a current resident or nonresident witness asserting that applicability. If both status facts are false, fail closed rather than invent a third classification; require an explicit same-period witness supplying the same two status input keys as the positive status witnesses, setting both false, and asserting the applicability Judgment not_holds. Still encode every other source-stated branch locally, including Subsection C's filing and incorporation-by-reference requirement; if its executable document-processing mechanism is unavailable, defer only that exact gap rather than any source-stated rule. Review-rejected run 31222979886 incorrectly dropped A's local applicability while retaining the amount deferral. Freshly regenerate; do not adopt or repair-replay that regression. The January 1, 2016 date applies only to B's penalty-oversight threshold and its voluntary-disclosure exception. B's administration-and-enforcement, rule/order/regulation, and recorded-reason discretion branches are undated; use the repository's non-narrowing convention for those branches and invent no effective date. Encode C's secretary-triggered obligation to file a complete federal return copy or a requested part separately from the rule that actually filed material becomes part of the Louisiana return. Use the repository's non-narrowing convention for C rather than inventing an effective date, and require pre-2016 witnesses. Any deferred public output fragment must be a stable legal/domain concept and must not contain implementation terms such as runtime; describe a missing runtime capability only in the deferral reason. Preserve the source-correct composed C contract from run 31222979886 without adopting its files: for the complete-copy path, require a same-period pair with identical input and output keys in which the secretary trigger remains true and only actual filing changes false to true; assert the complete-copy filing obligation remains holds while incorporation changes not_holds to holds. Require the analogous requested-part pair. In each single-path composed pair, include both trigger input keys, hold the selected trigger true, and hold the other trigger false; only in that false-trigger situation is the unselected obligation not_holds. The two triggers are independent and must never negate each other. If both secretary triggers are true, both filing obligations must hold; each incorporation Judgment must then follow only its corresponding actual-filing fact. Add a simultaneous-trigger witness asserting both obligations holds and, with both documents actually filed, both incorporation Judgments holds. Review-rejected run 31224636831 added unsupported cross-negations and a both-triggers-true fail-closed test; freshly regenerate and do not adopt or repair-replay that graph. Mechanically verify that each composed pair differs only in actual filing and asserts every reached C Judgment. Encode all of B's source-stated branches rather than reducing B to the penalty threshold and voluntary-disclosure exception: encode the secretary's duty to administer and enforce this Part; the authority to adopt, prescribe, alter, and enforce reasonable rules, orders, and regulations for implementing this Part; and, upon making a record of the reasons, the discretion to waive, reduce, or compromise any taxes, penalties, interest, or other amounts provided by this Part. Use stable legal concepts and source-backed conditions or, only where a concrete executable mechanism is genuinely unavailable, an exact branch-scoped deferral that satisfies the same validator contract. Require focused witness assertions for every restored executable B output. If recorded-reason discretion is executable, require a same-period pair with identical input and output key sets that differs only in whether the secretary made the required record of reasons, asserting the discretion Judgment holds when the record exists and not_holds when it does not. If any restored branch is genuinely deferred, its output and reason must identify that exact branch and missing capability; no source-unit-wide or other B-branch deferral is permitted. Preserve B's strict $25,000 boundary and voluntary-disclosure exception witnesses. For B's voluntary-disclosure exception proof atom, include the complete source evidence from 'This provision shall not apply' through the department's 'voluntary disclosure program'; a truncated excerpt that omits the qualifying program language is invalid.","deferred_output_contracts":[{"output":"us-la:statutes/47/295/a#individual_louisiana_income_tax_amount","reason":"us-la/statute/47:295(a) requires the individual Louisiana income tax amount to be determined in accordance with R.S. 47:32, but the available R.S. 47:32 RuleSpec exports only the individual income tax rate and lacks an executable tax-amount computation accepting the applicable Louisiana income or net-income tax base."}],"rulespec_path":"us-la/statutes/47/295.yaml","rulespec_sha256":"68a2fa8caa56f72e6ce6779c6dcd61257cb4039029942cada2952b4853a1ef43","companion_path":"us-la/statutes/47/295.test.yaml","companion_sha256":"e7dc040f485b2af5d89c8fe587dde0259d19ab6925f647f00892a95079a931f3","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/295.json","manifest_sha256":"ac0483384638fe14daaa83392443bee3e5c06a2367226911fbbdaffb673d25ea"},{"citation":"us-la/statute/47:297.4","review_finding":"Freshly regenerate R.S. 47:297.4; do not adopt or repair-replay any rejected candidate, including runs 31152343675, 31218615664, 31222979886, and 31224636831. Encode all five source formula leaves. For a resident individual eligible under IRC Section 21, A(1)(a)(i) is 25% of the unreduced federal credit for tax year 2006 and A(1)(a)(ii) is 50% after 2006 when federal AGI is at most $25,000; include the parent A(1)(a) control and A(1)(b)'s rule that Louisiana allows this low-income credit even when no federal credit was claimed. A(2) is 30% of claimed federal credit for AGI above $25,000 through $35,000; A(3) is 10% above $35,000 through $60,000; A(4) above $60,000 is the lesser of $25 or 10% of claimed federal credit. Encode B(1)'s refundable overpayment for AGI at most $25,000 and its R.S. 47:1621(B) exemption, and B(2)'s carryforward for AGI above $25,000. Implement B(2)'s five-year limit as a local exported carryforward-eligibility Judgment that the principal carryforward amount formula actually references. Name it child_care_expense_credit_carryforward_eligibility or an equally stable nonnumeric legal concept; do not embed five or any parameter value in a durable public concept name. Its formula must conjoin the parent resident-and-IRC-21 applicability, federal AGI above $25,000, Louisiana credit strictly greater than Louisiana liability, and carryforward age at or below the parameterized limit. The principal carryforward must consume that complete Judgment and return the positive excess only when it holds. Review-rejected run 31224636831 exported only an age-window predicate named carryforward_within_five_year_window, left it holds at liability equality, and placed the other conditions directly in the principal; freshly regenerate and do not preserve that incomplete graph or numeric public name. The source establishes a maximum five-year eligibility window; it does not establish a derived output equal to the caller-supplied current carryforward age. Do not export child_care_expense_credit_carryforward_years or any equivalent input-echo formula, and do not assert such an output in tests. Retain only the source-backed five-year limit parameter, the eligibility Judgment that consumes the age input and limit, and the principal carryforward amount. With positive excess held constant, require a same-period pair with identical input and output key sets that varies only carryforward age from year 5 to year 6: year 5 must assert the eligibility Judgment holds and a positive principal carryforward amount, while year 6 must assert that Judgment not_holds and principal amount zero. Tests must also include exact same-period threshold pairs at $25,000/$25,001, $35,000/$35,001, and $60,000/$60,001. Every pair must have identical input-key and output-key sets, differ only in AGI, and assert the selected leaf amount, every unselected leaf as zero, the principal Louisiana credit, and every reached local derived selector. In particular, assert the resident-and-IRC-21 applicability Judgment as holds in every positive branch and boundary witness. For A(1)(a), use the $25,000/$25,001 pair with all non-AGI facts fixed and assert applicability plus every affected leaf and principal output. For B(1), hold every fact fixed except Louisiana liability between positive excess and equality, asserting refundable overpayment positive then zero and the 47:1621(B) exemption holds then not_holds. For B(2), hold every fact fixed except Louisiana liability between positive excess and equality, asserting the complete carryforward-eligibility Judgment holds then not_holds, principal carryforward positive then zero, and every other reached selector. Also require both 2006 and post-2006 low-income percentages; a low-income case with claimed federal credit zero but positive unreduced federal credit and positive Louisiana credit; A(4) below-cap and cap-binding cases; B(1) positive refund; and B(2) positive carryforward. Add an exact same-period low-income federal-claim pair with identical input and output key sets that holds residency, IRC Section 21 eligibility, AGI, unreduced federal credit, liability, and every other fact fixed and differs only in federal_child_care_credit_claimed_on_federal_return between zero and a positive amount. Both cases must assert applicability holds, low-income-credit-without-federal-claim holds, every component credit, the same positive principal Louisiana credit, and every reached downstream output unchanged; this proves A(1)(b) rather than relying on cases from different years. Also add two exact applicability-blocker pairs from one otherwise positive above-$25,000 carryforward witness with age inside the limit and credit above liability. One pair must vary only individual residency from resident to nonresident; the other must vary only IRC Section 21 eligibility from eligible to ineligible. Each pair must have identical input and output key sets. Each blocked case must assert the applicability Judgment and complete carryforward-eligibility Judgment not_holds; every low-, middle-, upper-middle-, and high-income component credit zero; principal Louisiana credit zero; refundable overpayment zero; the R.S. 47:1621(B) exemption not_holds; and principal carryforward amount zero. A replacement is unacceptable unless the age-five/age-six pair differs only in age, the B(1) and B(2) pairs differ only in liability, both A(4) cap regimes exist, and each AGI threshold pair holds all non-AGI facts fixed. Mechanically verify identical input and output key sets for every required pair before apply. Preserve the clean formulas and symmetric witness matrix from prior review while removing the unsupported age-echo regression. Do not defer source-stated computation, leave the five-year parameter unconsumed, disconnect eligibility from the principal carryforward amount, reduce the witness matrix, or avoid valid multiline branch conditions.","deferred_output_contracts":[],"rulespec_path":"us-la/statutes/47/297/4.yaml","rulespec_sha256":"2747930f6d0a4d1ed1c72e53e85953dc63879d0b072610941640225a2467d9e8","companion_path":"us-la/statutes/47/297/4.test.yaml","companion_sha256":"4c33f9932b9a4acf6fd31e741722c0eeeae6ef2d3af22ae8cb6975744d9d1a07","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/4.json","manifest_sha256":"d260c8236a18664a603a525ea0d4ad552f5f3f7f0220225a3f284dd6bcc46921"},{"citation":"us-la/statute/47:297.8","review_finding":"Preserve IRC Section 32 ownership: consume federal EITC eligibility and amount as separate upstream inputs or exact executable imports; do not recreate federal mechanics locally, and do not defer Louisiana's computation. Encode 3.5% from enactment in 2008 through tax year 2018, 5% for tax years beginning 2019 through 2030 inclusive, and 3.5% again from 2031. Any separately exported temporary 5% rate helper must have effective_to 2030-12-31 with matching effective-period proof; a principal selector that returns to 3.5% in 2031 does not cure an open-ended public helper. Review-rejected run 31222979886 regressed this helper by omitting its end date. Freshly regenerate and do not adopt or repair-replay that output; preserve the previously correct closed interval. This provision has no Louisiana dollar cap or carryforward. Subsection A applies to individuals generally; residency gates only Subsection B. For residents, a strictly positive Louisiana-credit-minus-Louisiana-liability excess is a current overpayment whose refund is exempt from R.S. 47:1621(B). Equality, below-liability, and nonresident cases produce no B overpayment or exemption, although the nonresident A credit still computes. Do not defer the express 1621(B) interaction or invent broader refund administration. Require witnesses for 2007, 2008, 2018, 2019, 2030, 2031, zero federal EITC, resident positive excess, resident equality, resident below-liability, and nonresident credit without overpayment. Add an explicit upstream federal-eligibility fact; the local applicability Judgment must require both enactment and federal eligibility, and the principal Louisiana amount must reference or otherwise be gated by that Judgment. Require a positive-federal-amount but federally ineligible case asserting applicability not_holds, principal credit zero, overpayment zero, and exemption not_holds. Keep input-key sets consistent across comparable cases. The resident positive-excess, equality, and below-liability cases must have identical input and output key sets, differ only in Louisiana liability, and all assert the unchanged principal Louisiana credit as well as overpayment and exemption so liability alone proves the B branch. Preserve every clean formula and witness from the prior review while regenerating freshly. The 47:297.8 portion of review-rejected run 31224636831 was independently clean, but the atomic transaction was rejected; do not adopt or repair-replay its files.","deferred_output_contracts":[],"rulespec_path":"us-la/statutes/47/297/8.yaml","rulespec_sha256":"5e2af233eeef40ffa38572f111d231fed4b9f857b702278d1fb12b3dd8d7628e","companion_path":"us-la/statutes/47/297/8.test.yaml","companion_sha256":"de39355acea4f97fb32354c54bd46c0fd103992e364fcece9286626c23404578","manifest_path":".axiom/encoding-manifests/us-la/statutes/47/297/8.json","manifest_sha256":"fa1ac1cf6cb785b09144ada4bcfff3bbf5735c400000b1d13816c71eaf6de593"}]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `ef9dd5f72d529ebc70f539c42144361e536d7563`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31234285886

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.