### PR TITLE
Compose Georgia SNAP utility allowance into shelter costs

### DIFF
--- a/tests/test_program_specs.py
+++ b/tests/test_program_specs.py
@@ -104,3 +104,21 @@ def test_scope_entries_resolve_or_are_allowlisted() -> None:
         for stale in sorted(allowlist - seen)
     )
     assert problems == []
+
+
+def test_georgia_snap_shelter_composes_the_utility_allowance() -> None:
+    spec = yaml.safe_load((ROOT / "us-ga/programs/snap/fy-2026.yaml").read_text())
+    shelter = next(
+        transformation
+        for transformation in spec["transformations"]
+        if transformation.get("name") == "snap_total_allowable_shelter_expenses"
+    )
+
+    assert shelter["pattern"] == "derived_formula"
+    assert shelter["formula"] == (
+        "monthly_allowable_shelter_costs\n"
+        "+ max(\n"
+        "    max(snap_standard_utility_allowance, snap_limited_utility_allowance),\n"
+        "    max(snap_one_utility_allowance, snap_individual_utility_allowance)\n"
+        "  )"
+    )

--- a/us-ga/programs/snap/fy-2026.yaml
+++ b/us-ga/programs/snap/fy-2026.yaml
@@ -140,7 +140,7 @@ transformations:
       - snap_countable_earned_income
       - snap_countable_unearned_income
 
-  - pattern: sum_terms
+  - pattern: derived_formula
     name: snap_total_allowable_shelter_expenses
     effective_from: '2026-01-01'
     entity: Household
@@ -148,8 +148,12 @@ transformations:
     period: Month
     unit: USD
     source: axiom-programs/us-ga/snap/fy-2026 shelter-cost composition
-    terms:
-      - monthly_allowable_shelter_costs
+    formula: |-
+      monthly_allowable_shelter_costs
+      + max(
+          max(snap_standard_utility_allowance, snap_limited_utility_allowance),
+          max(snap_one_utility_allowance, snap_individual_utility_allowance)
+        )
 
   - pattern: sum_terms
     name: snap_excess_shelter_deduction


### PR DESCRIPTION
## Summary
- add Georgia's computed utility allowance to `snap_total_allowable_shelter_expenses`
- pin the exact two-term ProgramSpec composition in a regression test
- leave signed atomic RuleSpec modules unchanged; this is declarative composition wiring

Closes #1249.

## Reproduction
Against `program-artifacts-09d8d50a9add`, the heating/cooling SUA evaluates to $405 but the published composition leaves total allowable shelter at $1,300 and excess shelter cost at $573.

Composing this ProgramSpec with axiom-compose `fabe0b3b3fd6e90d3e8f075516f9b668f524f711`, then compiling and running the same household, produces:

```
snap_standard_utility_allowance_eligible: holds
snap_standard_utility_allowance: 405
snap_utility_allowance_for_shelter_costs: 405
snap_total_allowable_shelter_expenses: 1705
snap_excess_shelter_cost: 978
```

The exact +$405 propagation closes the dropped-term defect.

## Checks
- `pytest -q tests/test_program_specs.py tests/test_bulk_applied_artifacts.py`: 38 passed
- deterministic composition generated successfully
- composed RuleSpec compiled successfully: 189 derived outputs
- focused engine replay produced the values above
- `git diff --check`: passed
