### PR TITLE
Pin signed OBBB alien SNAP corpus release

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-axiom_corpus_release = "us-rulespec-2026-08-03-ecps-pit-tariff-union"
-axiom_corpus_release_content_sha256 = "aa034219ef1519a31c0f354149bfd4b873fb5d8f2804b5cfe78c2813ee8af4e5"
+axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
+axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
 validation_waiver_set_sha256 = "a3e25adc3b5da76e1364e1dfc071dba25553c9d3fd2b0ff05bb0e77ec496750f"


### PR DESCRIPTION
## Summary

- pin the immutable signed corpus release `us-rulespec-2026-08-08-obbb-alien-snap`
- bind exact registered content SHA `0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc`
- make the USDA/FNS OBBB alien SNAP eligibility memorandum available to the protected repair of #1248

Corpus provenance:
- selector/source merge: `e79781bddeaba4d3697c5375c7371b2a038f0f74`
- publication run: https://github.com/TheAxiomFoundation/axiom-corpus/actions/runs/31241326404
- signed release schema: `axiom-corpus/release-object/v3`
- signature: Ed25519, key id `axiom-corpus-release-v2`
- scope count: 272

## Checks

- `git diff --check`
- `uv run pytest tools/tests/test_manifest_provenance.py tests/test_repository_layout.py -q` (`21 passed`)

Independent review/fix cycle will be recorded before merge.
