### PR TITLE
Acknowledge unwired SNAP member-eligibility gates in ca/ga program specs

### DIFF
--- a/programs/us-ca/snap/fy-2026.yaml
+++ b/programs/us-ca/snap/fy-2026.yaml
@@ -28,6 +28,14 @@ outputs:
 auto_gate_outputs:
   - snap_eligible
 
+# The 2026-08 axiom-compose completeness audit flags eligibility-shaped
+# rules in scope that no output wires (SSN, student, work-requirement,
+# veteran gates). The composed program has never enforced them (verified
+# against the 2026-07-30 composition); acknowledged here to keep the
+# comparison semantics unchanged until they are wired deliberately.
+acknowledged_incomplete:
+  - snap_eligible
+
 scope:
   federal:
     - policies/usda/snap/state-plan-composition

--- a/programs/us-ga/snap/fy-2026.yaml
+++ b/programs/us-ga/snap/fy-2026.yaml
@@ -15,6 +15,14 @@ outputs:
 auto_gate_outputs:
   - snap_eligible
 
+# The 2026-08 axiom-compose completeness audit flags eligibility-shaped
+# rules in scope that no output wires (SSN, student, work-requirement,
+# veteran gates). The composed program has never enforced them (verified
+# against the 2026-07-30 composition); acknowledged here to keep the
+# comparison semantics unchanged until they are wired deliberately.
+acknowledged_incomplete:
+  - snap_eligible
+
 scope:
   federal:
     - regulations/7-cfr/273/2/j


### PR DESCRIPTION
The updated axiom-compose completeness audit refuses to compose the us-ca and us-ga SNAP programs because four eligibility-shaped rules in scope (SSN, student, work-requirement, veteran gates) are not wired into `snap_eligible`. Verified against the 2026-07-30 composed outputs: **they were never wired** — the audit exposes a pre-existing modeling gap rather than introducing one.

This PR takes the minimal honest step: `acknowledged_incomplete: snap_eligible` with an in-file comment, so the oracle comparison lanes can regenerate with semantics identical to the published reports. Wiring the gates properly (the FL-spec pattern) is left as a deliberate follow-up because it changes comparison behavior and deserves its own review.

Part of the axiom-oracles#455 flip-back; found while re-testing the manual lane after axiom-compose went public and #29's fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)