### PR TITLE
Bump axiom_corpus_ref for the full-schedule HTS provisions version

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -14,7 +14,13 @@ axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
 # wave-6 UK council CTR ingest and uk-rulespec-2026-08-04 cut that
 # landed on corpus main in between (UK-scoped, no us/* provision
 # changes).
-axiom_corpus_ref = "1e8bfc0a52d2d5fa38ce7cf4ab2577b0536d971e"
+# Full-schedule USITC HTS Rev 15 provisions (axiom-corpus PR #595, merge
+# 60de5efa): version 2026-08-09-usitc-hts-2026-rev15-full-schedule - all
+# 29,845 HTS-numbered rows as per-line provisions, additive-only, bodies
+# byte-identical to the witness-chapter version for every overlapping
+# citation path. Grounds the generated full-schedule us-tariff-duty rate
+# tables (rulespec-us#1190 B1). Successor of 1e8bfc0a.
+axiom_corpus_ref = "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a"
 # Canonical-targets checkout for cross-repo validation. This remains on
 # the pre-HR6644 target until the newer encoder/toolchain schema migration.
 rulespec_us_ref = "0dac590f4e40a98f887d080d6e22a124136f1a17"


### PR DESCRIPTION
Dedicated corpus-only toolchain bump (toolchain moves only via dedicated PRs per the canonical-provenance regime).

- `axiom_corpus_ref`: `1e8bfc0a` → `60de5efa` — [axiom-corpus#595](https://github.com/TheAxiomFoundation/axiom-corpus/pull/595) (merged, sol-reviewed to APPROVE over 3 rounds): version `2026-08-09-usitc-hts-2026-rev15-full-schedule`, all 29,845 HTS-numbered rows of the pinned Rev 15 snapshot as per-line provisions. Additive only; overlapping provision bodies byte-identical to the witness-chapter version.
- Purpose: proof-atom grounding for the generated full-schedule us-tariff-duty rate tables (B1 lane, rulespec-us#1190 — next PR).
- Safety: the only selected-body changes under local-corpus resolution are three allowlisted Rev4→Rev15 footnote drops (2203.00.00, 8541.42.00, 8541.43.00), pinned by body sha in the corpus reproducer's own gate; existing tariff modules (witness lines, composition, IEEPA + section-301 overlays, de-minimis) proof-validate green against the new corpus state under the pinned encode toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)