### PR TITLE
Bump axiom_encode_ref for indexed local-corpus source resolution

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -2,9 +2,16 @@
 # validate-rulespec workflow). Bump deliberately — PRs that change this
 # file trigger full-repository revalidation.
 [toolchain]
-axiom_encode_version = "0.2.1200"
+axiom_encode_version = "0.2.10000"
 axiom_rules_engine_ref = "ffd8213271947b0189a9dd61a055c1e0e78908a0"
-axiom_encode_ref = "3869d66d009f52258be35901edbef370e65a399c"
+# Local-corpus source resolution index (branch perf/local-corpus-source-index,
+# cut from this pin's prior ref 3869d66d + memoization and its review fixes): provisions
+# files are parsed once per content identity instead of once per citation
+# path. Required for the generated full-schedule HTS rate tables
+# (rulespec-us#1267), whose ~12k cited provisions made the us-shard validate
+# leg exceed the CI hour under the unindexed resolver. Zero behavior change;
+# measured chapter-72 full validate 60+min -> 27.5s.
+axiom_encode_ref = "de8be96ce7263a211cbdcc830ab4ea0ac23be769"
 # US tariff parity feedstock (axiom-corpus PRs #560-#569, #572) plus
 # the FNS OBBBA ABAWD exceptions implementation memorandum (2025-10-03,
 # us/guidance scope 2026-08-03-snap-obbb-abawd-exceptions-implementation-memo;


### PR DESCRIPTION
Dedicated corpus-toolchain bump (toolchain moves only via dedicated PRs).

- `axiom_encode_ref`: `3869d66d` → `de8be96c` ([branch `perf/local-corpus-source-index`](https://github.com/TheAxiomFoundation/axiom-encode/compare/3869d66d...de8be96c) — the prior pin + a provisions-index memoization, its review fixes, and version bump). `axiom_encode_version`: `0.2.1200` → `0.2.10000` (three-part numeric required by this workflow's toolchain validator — the first attempt `0.2.1200.1` failed the bridge's semver check across every shard; `0.2.10000` is bridge-valid, orders above the pin in the encoder's numeric comparator, and sits far outside mainline's 0.2.12xx–13xx range so it cannot collide).
- **Why**: local corpus source resolution re-parsed every provisions JSONL once per citation path — O(paths × corpus bytes). The generated full-schedule HTS rate tables (#1267) cite one provision per rated line, which made the us-shard validate leg exceed the CI hour. With the index: chapter-72 full validate 60+ min → ~28 s; the 98-module battery passes 98/98 locally under this exact ref.
- **Scope**: pure memoization + regression tests + version bump; the branch deliberately does NOT track encode main (main's resolver now requires a bound release, which is the us strict-cutover work, not this repo's current bridge).
- **Review**: sol adversarial convergence to APPROVE over three rounds (r1: caught a collaterally deleted Supabase `lru_cache` decorator; r2: missing encoder version bump; r3: no findings, mutation-bite verified). The final head re-numbers the version to satisfy the bridge validator; content otherwise identical to the approved head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)