### PR TITLE
Add signed encoding manifest for us-al/statute/40-18-5

### DIFF
--- a/.axiom/encoding-manifests/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.json
+++ b/.axiom/encoding-manifests/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.json
@@ -1,69 +1,96 @@
 {
   "applied_files": [
     {
-      "path": "us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.test.yaml",
-      "sha256": "e55e3cc9e9dd1ba64e0fd6816fed2ee786c101478b9ee43c24316956f051db2b"
+      "path": "us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml",
+      "sha256": "047197d08b0bffe2ebdfd991d1c233d88773d37dfc7a1b1f525966f975b2a4c7"
     },
     {
-      "path": "us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml",
-      "sha256": "3e7fb246d7b8bd4124c8119180f4f56e56b1fbc377a4001b6ee3b3999ffef805"
+      "path": "us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.test.yaml",
+      "sha256": "e13babcb4d4a40fc431a8bb6b75d9205f2f0287fe49c0889a75d74b7748b6f6f"
     }
   ],
   "axiom_encode_git": {
-    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "commit": "3d7b494d859268f9877b8f095ac7705710ad5a7f",
     "dirty_tracked": false,
-    "root": "/Users/pavelmakarchuk/axiom-encode/.sessions/federal-qbid-integration/toolchain/axiom-encode",
-    "version": "0.2.1200",
-    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1664",
+    "version_commit": "3d7b494d859268f9877b8f095ac7705710ad5a7f"
   },
-  "axiom_encode_version": "0.2.1200",
-  "backend": "manual",
-  "citation": "us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits",
-  "context_manifest_file": null,
-  "context_manifest_sha256": null,
-  "generated_at": "2026-07-26T18:53:36.327613+00:00",
-  "generated_output_file": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpnna3adx4/sign-applied-files/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml",
-  "generated_output_root": "/var/folders/g0/_wy6p84d4811b6z4xgyy5c3w0000gn/T/tmpnna3adx4",
-  "generated_output_sha256": "3e7fb246d7b8bd4124c8119180f4f56e56b1fbc377a4001b6ee3b3999ffef805",
-  "generation_prompt_sha256": null,
-  "manual_exception": "repair",
-  "model": "",
-  "run_id": null,
-  "runner": "manual-attestation",
-  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "axiom_encode_version": "0.2.1664",
+  "backend": "openai",
+  "citation": "us-al/statute/40-18-5",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-al-statute-40-18-5/workspace/context-manifest.json",
+  "context_manifest_sha256": "1507c6e9a91aff83f9845a96f068c77e4ab383a5cd91abce491f834a44576349",
+  "generated_at": "2026-08-10T13:17:44.855741+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "047197d08b0bffe2ebdfd991d1c233d88773d37dfc7a1b1f525966f975b2a4c7",
+  "generation_prompt_sha256": "95f013c79ce50b244b27ad5060b4889f42fb19e69803fa6631216325c6b3902f",
+  "model": "gpt-5.6-sol",
+  "run_id": "2b0ce2eb",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
   "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "6039b565fb1f12b1cdb0242261fb11dd06a769b3a34c295dcdae5ff117a11a6b"
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "tferL5yeCXVp69atmQBmiqP2Hddm7hayegM5U3kFpdOUS896HXTx63/WiADe+SVjYAWEPI9mGFLeHEKHkGjRAA=="
   },
-  "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-07-26T18:53:24.951200+00:00",
-    "generation_prompt_sha256": null,
-    "manifest_sha256": "2c9919ee70572051e9cf03f2519b018b7e2c3d3ecee7d348f0a08239177b8481",
-    "prior_signature": "ee9322af6a07cdebcb639125eb609ce586b1d6eeed083b7c90a1b7aa4d821077",
-    "run_id": null,
-    "supersedes": {
-      "backend": "manual",
-      "generated_at": "2026-07-26T18:46:15.773097+00:00",
-      "generation_prompt_sha256": null,
-      "manifest_sha256": "4daec2b13f148d04fe1e1f70766d6d0eb0fb1773084529ae4dbd2aa4ddebb6f6",
-      "prior_signature": "565767a43ea579b2db7427480d33c96a67fa456f0d0fc94033bb42382e4bb35d",
-      "run_id": null,
-      "supersedes": {
-        "backend": "manual",
-        "generated_at": "2026-07-26T15:05:23.994809+00:00",
-        "generation_prompt_sha256": null,
-        "manifest_sha256": "63d3deea3ebf0f7cb3f93c9e28849b79099ac42dac8b9182e13abb0d5c4ff0ef",
-        "prior_signature": "dd2d9b85c51bf504a24f2a833cdbe1a52bb791ed7d7dcea30804c1a90d2c8e4f",
-        "run_id": null,
-        "tool": "axiom-encode sign-applied-files"
-      },
-      "tool": "axiom-encode sign-applied-files"
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-07-13",
+    "generation_input_sha256": "fc4478ba28f9fbb091887de0cb0f0050dc84ddc6d72fb0dc12fff50c11f672bf",
+    "provision_file": "data/corpus/provisions/us-al/statute/2026-07-13-recovery.jsonl",
+    "provision_file_sha256": "391ab4e42d04e0f328c9780b8577b2120d602b72b10453ea6c80522d32506f07",
+    "requested_corpus_citation_path": "us-al/statute/40-18-5",
+    "resolved_corpus_citation_path": "us-al/statute/40-18-5",
+    "resolved_text_sha256": "fc4478ba28f9fbb091887de0cb0f0050dc84ddc6d72fb0dc12fff50c11f672bf",
+    "row": {
+      "body_sha256": "fc4478ba28f9fbb091887de0cb0f0050dc84ddc6d72fb0dc12fff50c11f672bf",
+      "citation_path": "us-al/statute/40-18-5",
+      "document_class": "statute",
+      "expression_date": "2026-07-13",
+      "jurisdiction": "us-al",
+      "line_number": 3,
+      "provision_file": "data/corpus/provisions/us-al/statute/2026-07-13-recovery.jsonl",
+      "provision_file_sha256": "391ab4e42d04e0f328c9780b8577b2120d602b72b10453ea6c80522d32506f07",
+      "record_id": "a3ed5d26-1c33-5809-b05b-c005c906c99d",
+      "source_as_of": "2026-07-13",
+      "source_path": "sources/us-al/statute/2026-07-13-recovery/official-documents/us-al-code-40-18-5",
+      "version": "2026-07-13-recovery"
     },
-    "tool": "axiom-encode sign-applied-files"
+    "rulespec_root": "rulespec-us/us-al",
+    "source_as_of": "2026-07-13",
+    "source_sha256": "fc4478ba28f9fbb091887de0cb0f0050dc84ddc6d72fb0dc12fff50c11f672bf"
   },
-  "tool": "axiom-encode sign-applied-files",
-  "trace_file": null,
-  "trace_sha256": null
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-al-statute-40-18-5.json",
+  "trace_sha256": "d67fd32b6e2530eb119693cd0938368a18ba9efa9145a672987cc5bc83a98071",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "3d7b494d859268f9877b8f095ac7705710ad5a7f",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1664"
+    },
+    "axiom_rules_engine": {
+      "commit": "e5e40d40353f8459da4e46a9feae7279c2fecccc",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e632cadfd11ec976362bbb4c5047d9260bdfd40cfc34228a8a7afda29c966b15",
+      "pre_apply_file_count": 234,
+      "rulespec_root": "rulespec-us/us-al",
+      "toolchain_contract_sha256": "df0e9f33cfe7d0c4c9af08bd8e6cba89db4868a18aec122921c9bcb1b56bf4ee",
+      "validation_waiver_set_sha256": "281d08697c49dae00cd42bc44dbd690db549960cfc37398bb6fff058adf441b5"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "281d08697c49dae00cd42bc44dbd690db549960cfc37398bb6fff058adf441b5"
 }

--- a/tests/test_encoding_manifests.py
+++ b/tests/test_encoding_manifests.py
@@ -1058,7 +1058,6 @@ KNOWN_RETIRED_SCHEMA_MANIFESTS: frozenset[str] = frozenset({
     '.axiom/encoding-manifests/us-al/policies/dhr/ssp/state-supplement-payment-standard.json',
     '.axiom/encoding-manifests/us-al/policies/dhr/tanf/state-plan/2024/payment-standards.json',
     '.axiom/encoding-manifests/us-al/policies/income_tax/2026_resident_liability_source_hold.json',
-    '.axiom/encoding-manifests/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.json',
     '.axiom/encoding-manifests/us-al/policies/income_tax/pilot_liability_pipeline.json',
     '.axiom/encoding-manifests/us-al/regulations/660-4/1/01/block-1.json',
     '.axiom/encoding-manifests/us-al/regulations/660-4/1/02/block-1.json',

--- a/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.test.yaml
+++ b/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.test.yaml
@@ -1,141 +1,169 @@
-# Fixtures are independently hand-computed from Ala. Code § 40-18-5. They
-# cover zero and negative inputs, both sides of every bracket boundary,
-# fractional cents above the top boundaries, and high-income cases.
-- name: statutory rates and bracket ceilings
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input: {}
-  output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_first_rate: 0.02
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_second_rate: 0.04
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_third_rate: 0.05
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling: 500
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling: 3000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_joint_first_bracket_ceiling: 1000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_joint_second_bracket_ceiling: 6000
-- name: negative nonjoint taxable income is floored
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: negative nonjoint taxable income is clamped
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: -1000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : -1000
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: '0'
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '0'
-- name: zero joint taxable income
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 0
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: 0
+- name: nonjoint taxable income 499
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 0
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 499
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '0'
-- name: nonjoint one dollar below first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 499
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
-  output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 499
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '9.98'
-- name: nonjoint at first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: nonjoint taxable income 500
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 500
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 500
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '10'
-- name: nonjoint one dollar above first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 500
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: 10
+- name: nonjoint taxable income 501
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 501
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 501
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 501
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '10.04'
-- name: nonjoint one dollar below second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: nonjoint taxable income 2999
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 2999
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 2999
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 2999
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '109.96'
-- name: nonjoint at second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: nonjoint taxable income 3000
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 3000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 3000
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '110'
-- name: nonjoint one dollar above second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 3000
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: 110
+- name: nonjoint taxable income 3001
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 3001
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 3001
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : false
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 3001
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '110.05'
-- name: joint one dollar below first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: joint taxable income 999
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 999
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 999
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 999
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '19.98'
-- name: joint at first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: joint taxable income 1000
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 1000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 1000
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '20'
-- name: joint one dollar above first bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 1000
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: 20
+- name: joint taxable income 1001
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 1001
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 1001
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 1001
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '20.04'
-- name: joint one dollar below second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: joint taxable income 5999
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 5999
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 5999
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 5999
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '219.96'
-- name: joint at second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+- name: joint taxable income 6000
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 6000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 6000
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '220'
-- name: joint one dollar above second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 6000
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: 220
+- name: joint taxable income 6001
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
   input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 6001
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income
+    : 6001
+    ? us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies
+    : true
   output:
+    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_taxable_income_boundary: 6001
     us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '220.05'
-- name: nonjoint fractional dollar above second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 3000.01
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
-  output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '110.0005'
-- name: joint fractional dollar above second bracket ceiling
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 6000.01
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
-  output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '220.0005'
-- name: high nonjoint taxable income
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 10000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: false
-  output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '460'
-- name: high joint taxable income
-  period: {period_kind: tax_year, start: '2026-01-01', end: '2026-12-31'}
-  input:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_completed_taxable_income: 10000
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#input.al_pit_2026_section_40_18_5_married_joint_schedule_applies: true
-  output:
-    us-al:policies/income_tax/2026_section_40_18_5_schedule_before_credits#al_pit_2026_section_40_18_5_schedule_before_credits: '420'

--- a/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml
+++ b/us-al/policies/income_tax/2026_section_40_18_5_schedule_before_credits.yaml
@@ -4,233 +4,326 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us-al/statute/40-18-5
-    upstream_source_check:
-      status: official_parameter_source
-      checked_paths:
-        - us-al/statute/40-18-5
-      rationale: |-
-        Alabama Code section 40-18-5 supplies the complete ordinary
-        individual-income-tax schedule: one schedule for a single person,
-        head of family, or married persons filing separately and a wider
-        schedule for married persons filing jointly.
+    source_sha256: fc4478ba28f9fbb091887de0cb0f0050dc84ddc6d72fb0dc12fff50c11f672bf
+  summary: '“The tax levied and imposed by Section 40-18-2 shall be computed as follows”
 
-        This narrow module accepts completed Alabama taxable income and the
-        caller's completed-return classification that the married-joint
-        schedule applies. Those boundaries preserve all upstream income,
-        deduction, exemption, residency, allocation, and filing-status
-        determinations. The module computes only the section 40-18-5 schedule
-        amount before credits for tax year 2026. It makes no annual-return,
-        estimated-tax, payment, filing-obligation, credit, surtax, or final
-        liability claim.
-  summary: |-
-    Alabama tax-year-2026 individual-income-tax schedule before credits under
-    Alabama Code section 40-18-5. The caller supplies completed Alabama
-    taxable income and whether the married-joint schedule applies. Taxable
-    income is floored at zero, then the statutory 2, 4, and 5 percent brackets
-    are applied without invented rounding. Upstream taxable-income and
-    filing-status construction and all credits, surtaxes, payments, and final
-    liability are outside this narrow schedule.
-rules:
-  - name: al_pit_2026_section_40_18_5_first_rate
-    kind: parameter
-    dtype: Rate
-    period: Year
-    source: Ala. Code § 40-18-5(1)(a) and (2)(a), first marginal rate
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "Two percent of taxable income not in excess of five hundred dollars ($500)."
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '0.02'
+    using three taxable-income brackets for a single person, head of family, or
 
-  - name: al_pit_2026_section_40_18_5_second_rate
-    kind: parameter
-    dtype: Rate
-    period: Year
-    source: Ala. Code § 40-18-5(1)(b) and (2)(b), second marginal rate
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "Four percent of taxable income in excess of five hundred dollars ($500) and not in excess of three thousand dollars ($3,000)."
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '0.04'
+    married persons filing separately and three wider brackets for married
 
-  - name: al_pit_2026_section_40_18_5_third_rate
-    kind: parameter
-    dtype: Rate
-    period: Year
-    source: Ala. Code § 40-18-5(1)(c) and (2)(c), third marginal rate
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "Five percent of taxable income in excess of three thousand dollars ($3,000)."
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '0.05'
-
-  - name: al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling
-    kind: parameter
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5(1)(a), nonjoint first-bracket ceiling
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "not in excess of five hundred dollars ($500)"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '500'
-
-  - name: al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling
-    kind: parameter
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5(1)(b), nonjoint second-bracket ceiling
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "not in excess of three thousand dollars ($3,000)"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '3000'
-
-  - name: al_pit_2026_section_40_18_5_joint_first_bracket_ceiling
-    kind: parameter
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5(2)(a), married-joint first-bracket ceiling
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "not in excess of one thousand dollars ($1,000)"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '1000'
-
-  - name: al_pit_2026_section_40_18_5_joint_second_bracket_ceiling
-    kind: parameter
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5(2)(b), married-joint second-bracket ceiling
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "not in excess of six thousand dollars ($6,000)"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: '6000'
-
-  - name: al_pit_2026_section_40_18_5_taxable_income_boundary
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5, supplied completed Alabama taxable income floored at zero
-    metadata:
-      private: true
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "Two percent of taxable income not in excess of five hundred dollars ($500)."
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: max(0, al_pit_2026_section_40_18_5_completed_taxable_income)
-
-  - name: al_pit_2026_section_40_18_5_schedule_before_credits
-    kind: derived
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    source: Ala. Code § 40-18-5, graduated individual-income-tax schedule before credits
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "For a single person, head of family, or married persons filing separate returns"
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us-al/statute/40-18-5
-              excerpt: "For married persons filing a joint return"
-    versions:
-      - effective_from: '2026-01-01'
-        effective_to: '2026-12-31'
-        formula: |-
-          if al_pit_2026_section_40_18_5_married_joint_schedule_applies:
-            al_pit_2026_section_40_18_5_first_rate * min(al_pit_2026_section_40_18_5_taxable_income_boundary, al_pit_2026_section_40_18_5_joint_first_bracket_ceiling)
-            + al_pit_2026_section_40_18_5_second_rate * min(max(0, al_pit_2026_section_40_18_5_taxable_income_boundary - al_pit_2026_section_40_18_5_joint_first_bracket_ceiling), al_pit_2026_section_40_18_5_joint_second_bracket_ceiling - al_pit_2026_section_40_18_5_joint_first_bracket_ceiling)
-            + al_pit_2026_section_40_18_5_third_rate * max(0, al_pit_2026_section_40_18_5_taxable_income_boundary - al_pit_2026_section_40_18_5_joint_second_bracket_ceiling)
-          else:
-            al_pit_2026_section_40_18_5_first_rate * min(al_pit_2026_section_40_18_5_taxable_income_boundary, al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling)
-            + al_pit_2026_section_40_18_5_second_rate * min(max(0, al_pit_2026_section_40_18_5_taxable_income_boundary - al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling), al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling - al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling)
-            + al_pit_2026_section_40_18_5_third_rate * max(0, al_pit_2026_section_40_18_5_taxable_income_boundary - al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling)
-
+    persons filing a joint return.'
 inputs:
-  - name: al_pit_2026_section_40_18_5_completed_taxable_income
-    entity: TaxUnit
-    dtype: Money
-    period: Year
-    unit: USD
-    description: Completed Alabama taxable income supplied by the caller as an upstream return boundary.
-  - name: al_pit_2026_section_40_18_5_married_joint_schedule_applies
-    entity: TaxUnit
-    dtype: Judgment
-    period: Year
-    description: Caller classification that the Alabama married-joint schedule applies to the completed return.
+- name: al_pit_2026_section_40_18_5_completed_taxable_income
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+- name: al_pit_2026_section_40_18_5_married_joint_schedule_applies
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+rules:
+- name: al_pit_2026_section_40_18_5_first_rate
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Ala. Code § 40-18-5(1)(a) and (2)(a)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Two percent of taxable income
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '0.02'
+- name: al_pit_2026_section_40_18_5_second_rate
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Ala. Code § 40-18-5(1)(b) and (2)(b)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Four percent of taxable income
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '0.04'
+- name: al_pit_2026_section_40_18_5_third_rate
+  kind: parameter
+  dtype: Rate
+  period: Year
+  source: Ala. Code § 40-18-5(1)(c) and (2)(c)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Five percent of taxable income
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '0.05'
+- name: al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(1)(a)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: not in excess of five hundred dollars ($500)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '500'
+- name: al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(1)(b)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: not in excess of three thousand dollars ($3,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '3000'
+- name: al_pit_2026_section_40_18_5_joint_first_bracket_ceiling
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(2)(a)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: not in excess of one thousand dollars ($1,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '1000'
+- name: al_pit_2026_section_40_18_5_joint_second_bracket_ceiling
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(2)(b)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: not in excess of six thousand dollars ($6,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '6000'
+- name: nonjoint_second_bracket_floor
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(1)(b)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: in excess of five hundred dollars ($500)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '500'
+- name: nonjoint_third_bracket_floor
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(1)(c)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: in excess of three thousand dollars ($3,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '3000'
+- name: joint_second_bracket_floor
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(2)(b)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: in excess of one thousand dollars ($1,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '1000'
+- name: joint_third_bracket_floor
+  kind: parameter
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5(2)(c)
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: in excess of six thousand dollars ($6,000)
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: '6000'
+- name: al_pit_2026_section_40_18_5_taxable_income_boundary
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5
+  metadata:
+    private: true
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: taxable income
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: max(0, al_pit_2026_section_40_18_5_completed_taxable_income)
+- name: al_pit_2026_section_40_18_5_schedule_before_credits
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  unit: USD
+  source: Ala. Code § 40-18-5
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: 'The tax levied and imposed by Section 40-18-2 shall be computed
+            as follows:'
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: 'For a single person, head of family, or married persons filing
+            separate returns:'
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Two percent of taxable income not in excess of five hundred dollars
+            ($500).
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Four percent of taxable income in excess of five hundred dollars
+            ($500) and not in excess of three thousand dollars ($3,000).
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Five percent of taxable income in excess of three thousand dollars
+            ($3,000).
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: 'For married persons filing a joint return:'
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Two percent of taxable income not in excess of one thousand dollars
+            ($1,000).
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Four percent of taxable income in excess of one thousand dollars
+            ($1,000) and not in excess of six thousand dollars ($6,000).
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-al/statute/40-18-5
+          excerpt: Five percent of taxable income in excess of six thousand dollars
+            ($6,000).
+  versions:
+  - effective_from: '2026-01-01'
+    effective_to: '2026-12-31'
+    formula: 'if al_pit_2026_section_40_18_5_married_joint_schedule_applies: (al_pit_2026_section_40_18_5_first_rate
+      * min(al_pit_2026_section_40_18_5_taxable_income_boundary, al_pit_2026_section_40_18_5_joint_first_bracket_ceiling))
+      + (al_pit_2026_section_40_18_5_second_rate * min(max(0, al_pit_2026_section_40_18_5_taxable_income_boundary
+      - joint_second_bracket_floor), al_pit_2026_section_40_18_5_joint_second_bracket_ceiling
+      - joint_second_bracket_floor)) + (al_pit_2026_section_40_18_5_third_rate * max(0,
+      al_pit_2026_section_40_18_5_taxable_income_boundary - joint_third_bracket_floor))
+      else: (al_pit_2026_section_40_18_5_first_rate * min(al_pit_2026_section_40_18_5_taxable_income_boundary,
+      al_pit_2026_section_40_18_5_nonjoint_first_bracket_ceiling)) + (al_pit_2026_section_40_18_5_second_rate
+      * min(max(0, al_pit_2026_section_40_18_5_taxable_income_boundary - nonjoint_second_bracket_floor),
+      al_pit_2026_section_40_18_5_nonjoint_second_bracket_ceiling - nonjoint_second_bracket_floor))
+      + (al_pit_2026_section_40_18_5_third_rate * max(0, al_pit_2026_section_40_18_5_taxable_income_boundary
+      - nonjoint_third_bracket_floor))'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us-al/statute/40-18-5`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `2a503a5c9a2227c363aceaece6c547429c3c0878`
Base branch: `hard-cut/canonical-layout-us`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/31391441942

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.