### PR TITLE
Approve residual hard-cut validation waivers

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -14777,7 +14777,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml":
     pending:
-      fingerprint: "sha256:0f7f75a8555cd01228569d79ce295510a72b6d7f9adf7872ccbb823766e645de"
+      fingerprint: "sha256:8463a2139aad273cd60cea721e08358a7f7690e07272930d2ad73d81de5fc3b7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14795,13 +14795,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml":
     pending:
-      fingerprint: "sha256:737b7a41cc85dd1380a86d5703f0fe71a0bb561c6fbc6a1e2c2ba6e5a55e1e0b"
+      fingerprint: "sha256:019113f18a8c213bcded99cf0801f39a3830fad0aad08207f73b9a1339bed08d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml":
     pending:
-      fingerprint: "sha256:af8df97ee8f749d8617e254f0ae089cc582ad36786c240418995fb15986d8334"
+      fingerprint: "sha256:629a0520fcfe66fe8b646c9a60951a74baf57021594da565511bfb81bc1dff44"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14813,25 +14813,25 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml":
     pending:
-      fingerprint: "sha256:38cccecc98cea21ef3f7af3722c7e2d5638d707c33f4f76a497e8d7173e80dde"
+      fingerprint: "sha256:b6330655f81ab2b802dcc71ff2301345b9c71c9f32c41d6bec69c1ab0df81faf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/deductions.yaml":
     pending:
-      fingerprint: "sha256:bdf497c2c23d7a8f54132a748caba6c911af0fd1e0a28f2ea205fe115c163a20"
+      fingerprint: "sha256:06e24ad1a75afcc9386be8eb4c1814e7acbea57bf9554332a2fa25d9d1c6e89e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/income-eligibility-standards.yaml":
     pending:
-      fingerprint: "sha256:ba0271a9ce165378aacb8963fe76145da7bdfb0b6ad54f6c11d34fa8d3ec66e9"
+      fingerprint: "sha256:c3a227846d8a3d578539a3f3d32085c3d02e49c0ddc65a67ecef46e0bf28087e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/maximum-allotments.yaml":
     pending:
-      fingerprint: "sha256:2ca090b5dd7bb9a8e08d6c6b447fd816c7d48ff56b6567fcac76d56887435023"
+      fingerprint: "sha256:b97fd841f700b750c3b059452d03e4e0ebaf813cfc59d8845d2c001fcd82031d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14843,7 +14843,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml":
     pending:
-      fingerprint: "sha256:c7d21af674096b7f121aa24e09b491cba348778b17a6404abf8c75f7e8217e53"
+      fingerprint: "sha256:b361767ba95f7a506cc48997a8c3e87066bfa6b764d2c388faf658a2c94b8c2c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15359,7 +15359,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/1211.yaml":
     pending:
-      fingerprint: "sha256:c8e81cf66e3b3cc3a4f88a21ab4e513d6d7788bb45fce5fc0db4dbbddad0ad95"
+      fingerprint: "sha256:5e1308f4969a958e75b292b983948ae24ab985681292941dcaca446098b1eb18"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17681,13 +17681,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/402/w.yaml":
     pending:
-      fingerprint: "sha256:b9092a2f4962291d97db067c947f25746ccc3e5628566d89c63ebc884968c61e"
+      fingerprint: "sha256:c1b6095fb67c91e04bfaa2915f6fb4fe4ea0ebd7176e9d0eaae1b1da51b70264"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/416/l.yaml":
     pending:
-      fingerprint: "sha256:7e816f6d233e067caf2c2b211c9ee1cbe04030f34a2d5e759e8d9a5a06428929"
+      fingerprint: "sha256:c0602781af4dfc3eb6b7b5d97b4588954e2d987e6a04c20a18fac5829191298a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17898,6 +17898,3834 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/8/1641/b.yaml":
     pending:
       fingerprint: "sha256:88474f12453834dd0969c56bac46508b50cb66d2cc27adcd817c566e0051c306"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-al/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:37edcc41937cd0297561e4bbcf427bbbd0a392aa622000db4167950719c6517f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ar/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:deb3067cb5a981607d5b68d0662d13d5c77797772a29dc79f7059e09d5aac0f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ar/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:e6de1361898293ef886115fa290d18f10f2219264c897d8f356460d224ffd7e1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-az/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:33b8a33a78d62e174d0f4cd5ecfbb4728da36d259a73b4698b2b5c671444ec2a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:434dbd6078fa7de26b7b361b6d747ace34ad348b18553b6277aad21b1e198fa3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/cdss/snap/modified-categorical-eligibility.yaml":
+    pending:
+      fingerprint: "sha256:ff2d587c4090be3096be61125239454aa060b8912ed7ee13f381f95b4f41cfb4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:757ca87b91be689003412dab974347355f24dedb0d320c89f1d899a799919d31"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/21.yaml":
+    pending:
+      fingerprint: "sha256:5f6274daf7efc2bbf939a4cc151b0d24fbb2e144df9927b1643789afc372bef0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/23.yaml":
+    pending:
+      fingerprint: "sha256:7508426f95658aba1746002744f41ba3981fca6a62b67901def63c6e0cd7b9bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/232.yaml":
+    pending:
+      fingerprint: "sha256:e5f2bb743159fd7609a95778a5d8370eab45b083ceeb80e1a8330071f6f1c7b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/233.yaml":
+    pending:
+      fingerprint: "sha256:1aac4f6b1f104f4f9dca9e530ef9f22d2508789a015cfae31f038e43fa672683"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/234.yaml":
+    pending:
+      fingerprint: "sha256:40656e84528f312d8a27f668ddaf9e641f7f726bf2f68c94e821564a03decd5a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/3.yaml":
+    pending:
+      fingerprint: "sha256:24f1409b29a50818ad9e28e2167e50c3c2511dd4c2e9bab2fe8163b531d574ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/31.yaml":
+    pending:
+      fingerprint: "sha256:2b824e7be5dd6a9cf37d3b9731802a06201649fdab2d2acd3e48188945d1f565"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/32.yaml":
+    pending:
+      fingerprint: "sha256:e8abeadacdc1296dac0708d104a77e977f3f057c32c06fd105acff4fd24c4f38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/34.yaml":
+    pending:
+      fingerprint: "sha256:7c24b73d4f9b4bc6be945096695353daa7a7eaf67ae2b443476f27c71ee56927"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/36.yaml":
+    pending:
+      fingerprint: "sha256:8773d2895029bba35d75a05c0a1414f6dfddb4558266d0ac77bab06144bb4447"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/37.yaml":
+    pending:
+      fingerprint: "sha256:7c6e0656ca867c78903997b0e2c55bd36311dc352394805abff772ac6f9ca78a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/381.yaml":
+    pending:
+      fingerprint: "sha256:74efea23d293804a6799b2045a199b7983a14f8131b44a5213ad4cdfdb55d96a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/42.yaml":
+    pending:
+      fingerprint: "sha256:cfb11317040a78c430d3b29fc622410f87f76fc629c53beea10c89b45ba5d434"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/43.yaml":
+    pending:
+      fingerprint: "sha256:c91a9dd84c0a6e5a105b455abb44f00cd88c28be3ff7502f6882549f8b358b1a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/44.yaml":
+    pending:
+      fingerprint: "sha256:d8928d8b56dc413f14be8a34d78c344de9e2f9d72c91399598bf8dbf99a072a4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/45.yaml":
+    pending:
+      fingerprint: "sha256:af9bdf80dad3236084a30a18e6675870577e39db444242d9d352b5c9cea10d42"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/46.yaml":
+    pending:
+      fingerprint: "sha256:c8d17c89a40513a1bdaa2133723bd501b585efb57ea6f8350be659dc43da0fc1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/461.yaml":
+    pending:
+      fingerprint: "sha256:de6686a17e6484a02235546589d2be05492cab77213589178f7d9ebd7c5ba264"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/462.yaml":
+    pending:
+      fingerprint: "sha256:47a4cdb2f327d977bbcc3a72034d158c6075282b66b68a372b46ae196be5cfd5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/463.yaml":
+    pending:
+      fingerprint: "sha256:21d0466104fe9a59850d2c509730cd5fa2531a87b2411dce063dca4022bfba89"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/464.yaml":
+    pending:
+      fingerprint: "sha256:e85c890fcc68f54251b321afda33e27c450ef6dfd6ef4f69c9ae1e635294e9bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/465.yaml":
+    pending:
+      fingerprint: "sha256:be4302c39c5cd91eecebf53b4169ccf00df44f01144747a42ef392a2812c0a0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/6.yaml":
+    pending:
+      fingerprint: "sha256:6074a06c7bdb2459170b4b1681023db96db57616e58b88a6562186cefa81e18f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/622.yaml":
+    pending:
+      fingerprint: "sha256:132f105212455d9293babdb32111cb2c7f04b12f512328f4ea5d82edd5456937"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-300/623.yaml":
+    pending:
+      fingerprint: "sha256:ec0c508bb23df41abde9d6525952be602a28d6e16094ccf02c47c805d7030582"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/1.yaml":
+    pending:
+      fingerprint: "sha256:70a794d89c4463480adab29b39a2084cb5a4ebf15acc6a23e4f4ccd62c051331"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/2.yaml":
+    pending:
+      fingerprint: "sha256:c0d597f9b152aae0e1cb8b09dbc775f3726b2bacb559a678350f6f56e588962c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/3.yaml":
+    pending:
+      fingerprint: "sha256:2e18c268d2eb2e663aa0992ef9049f5a61bbf1ce659dba875b4ebb04dde3c546"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/31.yaml":
+    pending:
+      fingerprint: "sha256:1566ca24ba229297f6586b640fd79aeeaf0b177223d0ec8ade5bff8959fec900"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/311.yaml":
+    pending:
+      fingerprint: "sha256:323efb1e83c7c3c43c90ea767b57f374531ec773cac6f0db9fcdf8787106152a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/33.yaml":
+    pending:
+      fingerprint: "sha256:3e44036f594677f99b762a4f6c0f523ea9f2dec8ab5a536c01e353fa584cfdce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/4.yaml":
+    pending:
+      fingerprint: "sha256:e063133ea50cec86dba8b29f0c9ff4318e6811b45fefb0f74a03667cd220ec86"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/411.yaml":
+    pending:
+      fingerprint: "sha256:839a2385161723dc202463ce72fda193dbf0b63df602e0dacab7ceb0327982c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/412.yaml":
+    pending:
+      fingerprint: "sha256:5cfe77a4dc26e0746f268ebc4a5fde17ee637522595e258b5ef9ef7f97872090"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/42.yaml":
+    pending:
+      fingerprint: "sha256:c0edfc5b177b4a7cd989d3fd1f0db18a2c8ccc0381d9043b5f44691071d20ff3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/421.yaml":
+    pending:
+      fingerprint: "sha256:c116ea55b6e1cf0ba4070c3d9c90e9b434c928c6c5dfaabfe899fbf5c66f7bee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/422.yaml":
+    pending:
+      fingerprint: "sha256:9dfecde40b52e751f654060da44cece409273b0b88904cb989e37ee0b2581442"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/423.yaml":
+    pending:
+      fingerprint: "sha256:7569bc3a207040291538defba17afcbfdf6d01a7f9e0fde3865d49c1b4a081d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/424.yaml":
+    pending:
+      fingerprint: "sha256:5aa3f9a533b3059b82ec7dd6f0f252dffc8887e590f9b1c66742e0df8b25c9d8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/431.yaml":
+    pending:
+      fingerprint: "sha256:91ca72fef8652aac8c449c3892e56719f88226b2d78124647835b358242c9adb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/432.yaml":
+    pending:
+      fingerprint: "sha256:99cd4882edba2ccb2aff3c89c0f9a70edadce5c3160103ab7e0ad7078b56564c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/442.yaml":
+    pending:
+      fingerprint: "sha256:471836ac2b9427a6f19bf3a89c92e4ba399fdea521a8bf323a4968ef9c523b6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/511.yaml":
+    pending:
+      fingerprint: "sha256:5ebc82e0694c82d0a57dfe309f80c187e42825716247041b0cd7c763942e0f12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/512.yaml":
+    pending:
+      fingerprint: "sha256:e8247b185ab78f7367b8770700b662d8441a9b64ebeb132479c009e288297df6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/513.yaml":
+    pending:
+      fingerprint: "sha256:6f2ca40d88245fffab107656970cc9f04993b56e25887c998d0860596d538e65"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/523.yaml":
+    pending:
+      fingerprint: "sha256:a8202521fa3a4afb89ea83b9a4a2e8c5acaf12aa484d6ab9edd44fb9c07a86e4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/532.yaml":
+    pending:
+      fingerprint: "sha256:9235f801df7a328ee8ec1e9f1020e46049c96f36cf5e5ed27c575536a45ccf07"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/533.yaml":
+    pending:
+      fingerprint: "sha256:3b24a7e5addb94867bfd12c1227aea50735298312d976a6df9161721da7bef92"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/542.yaml":
+    pending:
+      fingerprint: "sha256:f034b5a9d7514549b1d7ecdc432cd1e30bb2bfaeb3daeabd424645de5665fb81"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/546.yaml":
+    pending:
+      fingerprint: "sha256:ffea4fe4fa6f1afc73c8d241a0a29947cb60616ad5f9055cc48d77addb223a5a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/548.yaml":
+    pending:
+      fingerprint: "sha256:0f87d45f322769610642713d9d9caf5af6f99fa5d147723040e67ee2253becd2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/61.yaml":
+    pending:
+      fingerprint: "sha256:5ca84e4c0ad3f94b8873b5e70adc17371a16c84ace001c56710d4538b480da1b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/611.yaml":
+    pending:
+      fingerprint: "sha256:6fad97cb5b53ab4c1736d11c22ef8b283a6d0824ba2d9076208013d77ec5fdef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/62.yaml":
+    pending:
+      fingerprint: "sha256:dc2a1efb25f04eb3cc88e0a545e9d65281cf871800b88ca355e275655413884a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/63.yaml":
+    pending:
+      fingerprint: "sha256:81f7a5004a7f741d004275b9ff71d9ae7b9dd571438163ffab88d3be5b71b8d8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/71.yaml":
+    pending:
+      fingerprint: "sha256:bb5010ced6ecbdd5b82625cca8ec85b6f8398458bf829f3cf7f8759a5d0adad7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/72.yaml":
+    pending:
+      fingerprint: "sha256:855232e5018b7c9d5ff20826f0260c948f06dc2c3959bdb05c34c15eeef73d53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/73.yaml":
+    pending:
+      fingerprint: "sha256:9a64f56c3469523cd90419c26f202a345b314f461aaf73333feb67713ff00635"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/733.yaml":
+    pending:
+      fingerprint: "sha256:041d069c8250105f9eeed920f3c7bbcceee206b39225133fb813f76fac091017"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/734.yaml":
+    pending:
+      fingerprint: "sha256:58ba1b46acc553da5fdf62628ea27529e48b39e3e3b9aad56140bd57303df95d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/741.yaml":
+    pending:
+      fingerprint: "sha256:7085d07198ff97f746fa0c1ff4a283e8ef6fc41345ebaac3c871c14902100f21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/751.yaml":
+    pending:
+      fingerprint: "sha256:91749afa8d2b9e65ba8ba91bb866f2657c156c42db73c2ab870ad68c8406a23e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/752.yaml":
+    pending:
+      fingerprint: "sha256:46969ae15c8b42e30e6e09d9df8e5ceba56b7a41466f49349a83c607832b3810"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/753.yaml":
+    pending:
+      fingerprint: "sha256:0378f8542580a7188924359c1842d48594b7a49c15fd71caa042e3b5f663382d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/755.yaml":
+    pending:
+      fingerprint: "sha256:0486787d0f9cd886b0f8d8ebb3257ba3c635cd1515f9f8418e27c5f5423f0bcf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/756.yaml":
+    pending:
+      fingerprint: "sha256:9603174116b2f68015a2d84dc2acd0bb6996b955c6b1f4ffb6260ee1d2116380"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/76.yaml":
+    pending:
+      fingerprint: "sha256:5fa2ae1c982213f2eb2a9ed06cbb8eb4758c365f0df5b47c3a7ec9373c1e6ef0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/81.yaml":
+    pending:
+      fingerprint: "sha256:86909b281c6542b9d9eef72f62a7443ecf1f74e277e00b4b01125f0aec887abb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/812.yaml":
+    pending:
+      fingerprint: "sha256:57499d80ef845e93b3b0d46d31ac945d64cc2d3c27c4cd7971b5f7a96e5192be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/823.yaml":
+    pending:
+      fingerprint: "sha256:cb871f863922c47282cb618170bae558aa2cc004e91550c24e5d67c763184bc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/9.yaml":
+    pending:
+      fingerprint: "sha256:2ad8d959f462b304b3860d33337806ed288aa690f807cee280c5d25bd97d2f54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-301/91.yaml":
+    pending:
+      fingerprint: "sha256:f3aec372cf77fd976e7d84b6678a24adfc093d3ea9cd794cbba8a926567f1c4c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/1.yaml":
+    pending:
+      fingerprint: "sha256:6e6944889af668630bcc3a841cf2838efeae754ffb9b6af1198e3fe35c01d5ba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/2.yaml":
+    pending:
+      fingerprint: "sha256:9cc8e85791381dac9442aa986f13b2bbb7f4ba588715d1d66ab7920c5d63a99a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-401/5.yaml":
+    pending:
+      fingerprint: "sha256:8592c3878547a63b3760cac887e5dce7e97dd6074efb9e0fd3ab1ca07903dba7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/1.yaml":
+    pending:
+      fingerprint: "sha256:338c33bbebb237e27ce62cf7e672cd9f650769544543e61f2c4830fac607d409"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/141.yaml":
+    pending:
+      fingerprint: "sha256:c75ed777a7f21ec99f57a2d94661be11d49e6391d07b0f4246c6e68eddaea62a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/142.yaml":
+    pending:
+      fingerprint: "sha256:ff86a1e1c6558e89051b72cd83f097cc70493b5f58ce36d59ab5dd06fc75cbdf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/143.yaml":
+    pending:
+      fingerprint: "sha256:e4f7f36495356a55a9ff3f3782e969d7171aebd36b09603b73893d6f4583fc0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/144.yaml":
+    pending:
+      fingerprint: "sha256:2f4756911a1c35948e71ea484ff32be47fdcddc92542d6e501896396e5e08e0e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/146.yaml":
+    pending:
+      fingerprint: "sha256:b51cb25d6493709dd702f54a8bdbec9203a0d7dd67cab0c6822750ea3eb99e1a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/151.yaml":
+    pending:
+      fingerprint: "sha256:99568ec63896c6dc3ca7e1890f4c028afee417058b0f2a8fd9c787eea438bf22"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-402/211.yaml":
+    pending:
+      fingerprint: "sha256:a27fe173c240b3c5395b08d168d297f228a4e5b34cfdd7c060043beef2e52b5c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/1.yaml":
+    pending:
+      fingerprint: "sha256:aa0b386553c883092b69c60ed035a9c216dc139b596c876ad6b280a950287ad4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/2.yaml":
+    pending:
+      fingerprint: "sha256:958dc02b1fad6589760b5a3a9dccb595d53aafc26fe49f21f49e514bad8460b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/21.yaml":
+    pending:
+      fingerprint: "sha256:55282f391db753079047c39f82ffcc09010e906d0ba565aafbc344cdc5883095"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-403/31.yaml":
+    pending:
+      fingerprint: "sha256:e1310032da3c440ddb4a210b042d7a0ba08ee3fac677c3e83d3604c6c16492f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/11.yaml":
+    pending:
+      fingerprint: "sha256:ad7f53ded612ef8fff07212e4c05cb7dd79d53d75604dba112b90d54d9f4ac75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/13.yaml":
+    pending:
+      fingerprint: "sha256:069f59dcbe2e7bd9dec6ef11aec71789adc35005ab39bf71a75e61292795fb09"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/31.yaml":
+    pending:
+      fingerprint: "sha256:20501bc6c27a597ee29a757121c667cda6a90312650661615ceedb2d9a1194c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/33.yaml":
+    pending:
+      fingerprint: "sha256:689d793617473d589ff24c1c1638568b6fbfaf59da93d85a511cc39fa47341eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/34.yaml":
+    pending:
+      fingerprint: "sha256:3b52718399b6813a7a0626010ef3455c3514978d6083b9ba9f07205abb56033a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/41.yaml":
+    pending:
+      fingerprint: "sha256:cac5ee0fb222e4f5aff4e82d1c10e32af8bd956a494e08c43f328d9b4b1eb888"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/52.yaml":
+    pending:
+      fingerprint: "sha256:fe003c1e57daf6aee9a7f5c0721060651af4755f745450e13ba995db95e9d4a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/53.yaml":
+    pending:
+      fingerprint: "sha256:ecfa47fef1674f3bcb1b7ef016ff5cb4dae4451981ced5174763bb356c900660"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/62.yaml":
+    pending:
+      fingerprint: "sha256:922e7cb19e713b1549d8a83756ca8dfb32e259e6fdfaeffed2fd72fe232cf8ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/64.yaml":
+    pending:
+      fingerprint: "sha256:74949650257296b5f65d71708f24bfbf1a8f6b550665339161c852a474dfb668"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-404/7.yaml":
+    pending:
+      fingerprint: "sha256:b188d181da163c2576dbad886f0fb35fac75b522ad7d13611abe72f88f0df319"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/1.yaml":
+    pending:
+      fingerprint: "sha256:20ecd14df56c857c318929f3dacbf112d1999edf124472cc83daf9d00854ca5e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/111.yaml":
+    pending:
+      fingerprint: "sha256:dc10d7772fdc8a04988c53cea304c61374c1e29c595ed89d5034fddcf8aafecc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/112.yaml":
+    pending:
+      fingerprint: "sha256:1f0ec9e4fa1de60144cb5b70cad1870db4fceb46842a2864babe0457d42a562b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/113.yaml":
+    pending:
+      fingerprint: "sha256:d70054cba5b8cdc768d0561010112092e304b0fc5c6e116a0fa098abbe30c649"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/114.yaml":
+    pending:
+      fingerprint: "sha256:9bd6b3a31056e727737c7ad431f99aad066a6f9a57675a97dfdfe616e3ea6c6c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/115.yaml":
+    pending:
+      fingerprint: "sha256:78baf493125bab6bc83534592773f0bce12763019b050cadf80ece50ea53a024"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/116.yaml":
+    pending:
+      fingerprint: "sha256:59df76f8355b70d9e1bc48969ce3553b2fd6291f94efd06c321ff002c7a4226d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/117.yaml":
+    pending:
+      fingerprint: "sha256:74cc5707e53f4ae335d23f2cba464d949ce30f8cedeef4b15504fd8de267ec05"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/121.yaml":
+    pending:
+      fingerprint: "sha256:b33a2cbcceab6c6fb72a4ae4504b18f8501249aff7c7bdb6882edb0dc7dc23be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/122.yaml":
+    pending:
+      fingerprint: "sha256:1f4028ce527134822b19d58b11e09529a70abe7d03ecb622b7001cce00680410"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/123.yaml":
+    pending:
+      fingerprint: "sha256:6fbba4d5b8e99cebeb8dd9ba216ad7601a3c265ed2b136f121a963d5ecaaae9a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/124.yaml":
+    pending:
+      fingerprint: "sha256:9ea33455cdfb4cfd59a052738f76175b1dbfc101b8486a87bb16057bc3a88ccc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/125.yaml":
+    pending:
+      fingerprint: "sha256:53783a58c015a639fc165337372e919988070e3f7ee1715d2d44d688595b66b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/126.yaml":
+    pending:
+      fingerprint: "sha256:3df7e461ff370edbc19575bacb9053c33769a7d2006f106c4c8f5474c48a27f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/211.yaml":
+    pending:
+      fingerprint: "sha256:fdd0242a40651fec4ee0b60345b49e98e56176db6808c0c8ffb8fecb0fd551df"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/212.yaml":
+    pending:
+      fingerprint: "sha256:91a57618bba7689430bc7a72616dce2495b1411bd97f235d1be9fa514c9a84b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/221.yaml":
+    pending:
+      fingerprint: "sha256:e10dc67ce51a15a32e98c7249994b1c0f4e80201fe837a2421f5de4725dd0067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/222.yaml":
+    pending:
+      fingerprint: "sha256:c4c5f2eb2589b7b21de650fde20ba59cc0be6e7a2e5c14f758b63cb3236b2305"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/3.yaml":
+    pending:
+      fingerprint: "sha256:54d01c2943f7c13ec04d1977c7305dcf8b16e930e23a55e9db135f152e6bf039"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/311.yaml":
+    pending:
+      fingerprint: "sha256:2517f10dc79c8092acde57bec0c2bbc2b9b8642106b615de32709f75b1db9239"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/312.yaml":
+    pending:
+      fingerprint: "sha256:588d870c0c5ee10d19506e57ba716bbb8da4bf7f4b4e69c268bf7854339d2444"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/331.yaml":
+    pending:
+      fingerprint: "sha256:45cfc0157b14351588c4ade984ebf444704a56eb6d616e2659c20337bdda6334"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/332.yaml":
+    pending:
+      fingerprint: "sha256:0755472526f6a9c5af8bbb2858ac79440a22709321c7a54d2ff43aa1e8618d6a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/333.yaml":
+    pending:
+      fingerprint: "sha256:23e6eaf06687868cbdc1a5ac87263e1cd9c0043f0cb695a97ef80e84974480ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/4.yaml":
+    pending:
+      fingerprint: "sha256:f368acddb5368ef5f79307c1a72a55b5c8df812cb273ebb70fd6b878949c42a4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/411.yaml":
+    pending:
+      fingerprint: "sha256:b18ff85ce29c6de76da80d82cd673255bd423edbb9865be97dcac1b586936ec0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/412.yaml":
+    pending:
+      fingerprint: "sha256:47f18e7b4b01e2501aee78d11b67afb91ce6b72d0ef203ea6faa71b71df8d77a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/42.yaml":
+    pending:
+      fingerprint: "sha256:af58decd3edaf96ba2865e45fbe1f11f7589bce189dccb7f80dac1b8639164cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/51.yaml":
+    pending:
+      fingerprint: "sha256:819c5b6926ba31817e28f78b4359064725418173b868b4326cf9aa936f491f2a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/511.yaml":
+    pending:
+      fingerprint: "sha256:20c02eeb64ffe4304b69e89c8fbf7d7f55739397071adfa82cb2df5e9fb34969"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/512.yaml":
+    pending:
+      fingerprint: "sha256:8a62a830ccfa62cb9bc1249d0aeddea8cb4a4897a6a5e75c4a71ab40865bfde8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/52.yaml":
+    pending:
+      fingerprint: "sha256:b2b5ee416ab1a0a394d413a39b55f814e80a0dc4cc18c0a7c8a3680d321ce655"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/522.yaml":
+    pending:
+      fingerprint: "sha256:b5963ae386f071f86101348cfad79d3e679128216daf97f93894eef80c458b52"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/53.yaml":
+    pending:
+      fingerprint: "sha256:9b724515981650861472b82685623c89797cf6a8a8c27987950aae0f57168a63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/531.yaml":
+    pending:
+      fingerprint: "sha256:b64688365b255662ad3cacbc19553ee7c4f3e6a1559d877acbaeafcf9acb6d47"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/532.yaml":
+    pending:
+      fingerprint: "sha256:aad5b62324d8b09a81abfe46db998c2d0a4a8e706a52c607503308e34cd1870f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/551.yaml":
+    pending:
+      fingerprint: "sha256:b176e20819f75f35eb9f129f8d9908e2948a7dd76268bfe6c2f9fa7c680039b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/552.yaml":
+    pending:
+      fingerprint: "sha256:15ba55ad5442ca4ccab19ac3ac588b1c2cf6932b897728c6213d11c65d3d36df"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/555.yaml":
+    pending:
+      fingerprint: "sha256:56cf27594f4a91688e8467a1e438f4fc23754674b8d43d375c5177eb0c09698b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/556.yaml":
+    pending:
+      fingerprint: "sha256:e94347be06169c72aa2175a73ff20c80a1cf272d9fc4ea62a1f337ebfcc017d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/558.yaml":
+    pending:
+      fingerprint: "sha256:a44de3572442db52af039f6d62ccd91b2d3a3542b6ca4dba5c80c241b57ecd2a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/71.yaml":
+    pending:
+      fingerprint: "sha256:0529c871cfeeb9e7afb68895179f62340f64081bde601810f05dc6ba63c21630"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-405/72.yaml":
+    pending:
+      fingerprint: "sha256:0ec542eff0e9b99806371b0027f5cd1fc20e8e3c981a9d75245e9222c07412e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/11.yaml":
+    pending:
+      fingerprint: "sha256:e79dff7c3bc5bde098e363061b15c6df0ad71e92251f0b1682959e53e56b6e63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/111.yaml":
+    pending:
+      fingerprint: "sha256:32982940a2d7fef7ba4389a123801ecee8a9ab7b8c61cf6a3cd8851ee1a0ed3b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/121.yaml":
+    pending:
+      fingerprint: "sha256:1291cfda6e385716da7e1921d8533994f8fa42f8ea7b6a6010368b24b3388503"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/122.yaml":
+    pending:
+      fingerprint: "sha256:675ba25a1d377231abcc80145c997d74039aa02b1c8229aa26b87f088a1d49d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/21.yaml":
+    pending:
+      fingerprint: "sha256:7acf8bec0dbe0f93b1b13101eb84d979515645bcf817be701a61d0a55805c104"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/212.yaml":
+    pending:
+      fingerprint: "sha256:a8ebd3dd81f221604790a202d33bdd83cff410d34747c7c2b08248bdbf55fba6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/213.yaml":
+    pending:
+      fingerprint: "sha256:229c319ed8f9022f2c2beabb3b83a363f6e020c52fb60dbd42b3b382c3af3554"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/214.yaml":
+    pending:
+      fingerprint: "sha256:b1c0cec6e607c0fc754e57619605f8e3d4bdfb9a26d7b8526e80e4838fc513eb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/215.yaml":
+    pending:
+      fingerprint: "sha256:12b5dc5404c02c8a20cdc4e199cf844bc05ad4579dff5afe4b89f3c41ab95129"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/216.yaml":
+    pending:
+      fingerprint: "sha256:354985815e47840986acaea44c7372bb7f573ab59a366d440e56829058a51e46"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/217.yaml":
+    pending:
+      fingerprint: "sha256:b0d3387ba1621414201ba4a1754ab3be0972aa81981d356d26a72dda966218ec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/22.yaml":
+    pending:
+      fingerprint: "sha256:48c4f8371f266cb3317e98d35ab74157a3f17005d92b904599b906b8d531381f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/231.yaml":
+    pending:
+      fingerprint: "sha256:b48fbdea26a94182857fea1890f1494df60e016f11d74bc63281369625d17ee8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/232.yaml":
+    pending:
+      fingerprint: "sha256:ef7737da23d63735260d151b8e970aee9c36e37a126442a01365d7e3cdae9997"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/233.yaml":
+    pending:
+      fingerprint: "sha256:c4c7622be404dce80e84ff26f17f4be54df17121480a74573923fc5795ca36d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-406/3.yaml":
+    pending:
+      fingerprint: "sha256:704621a52a262c5a359aff110e8a5f352568e771a716d543a3eea4b6f6f6b20b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/1.yaml":
+    pending:
+      fingerprint: "sha256:973ba204cb5e29bbf739455fb8a705cc780a7c4dac5f35bbe8adb6050fd20d37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/21.yaml":
+    pending:
+      fingerprint: "sha256:adee266324be9516e9754fd66c9729e2720d6a2078a002dcf18bd1b7ac5d023e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/211.yaml":
+    pending:
+      fingerprint: "sha256:584ef3e51d36a97b88797068e1dca161ffbcd143c5a4336e3e2a9f9a6ddc185e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/221.yaml":
+    pending:
+      fingerprint: "sha256:4986e513326809afdcf036d948560dba4520d0f82bd75d467730038772067dec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/222.yaml":
+    pending:
+      fingerprint: "sha256:eb626e2ab2dacb48e9ca869091212b33e30e5bf568e0048a960dafcd63d7032d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/23.yaml":
+    pending:
+      fingerprint: "sha256:0bd0b03e738e5343573125576984c154b9bcaf638268d8884f3409ecb340e248"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/231.yaml":
+    pending:
+      fingerprint: "sha256:a7b48bf06fcc0e18bcd55fd9b20c1eb331c1c3e40941be8c385622307aa0441a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/24.yaml":
+    pending:
+      fingerprint: "sha256:5006dd15234aff6a10d6c9076b155fec073ae321bed46e946f0b2205b9e33d8a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/242.yaml":
+    pending:
+      fingerprint: "sha256:961914d251158a0d4b1edb2ea3dbfc4bc7ef7bddbe7445a0d72af499096e0da1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/311.yaml":
+    pending:
+      fingerprint: "sha256:4948f7f0b5207ed9402accc2cf6496d9fd11bd338bad005bb474be6b5d65f95a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/313.yaml":
+    pending:
+      fingerprint: "sha256:da66577e70488ab0a45a70b5e497ed3500e18cdc222b2c0ff0dea14bdd5ab63b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/41.yaml":
+    pending:
+      fingerprint: "sha256:697fed335863bbff539af7689852ee3f5a28d9391a3fa0ccfc518bd61e1cd02c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/42.yaml":
+    pending:
+      fingerprint: "sha256:d1fc3e32d9ac10a64462d4fb5cc6f11cd5b649ab6f2eb743f8cf05a84a544ae8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/43.yaml":
+    pending:
+      fingerprint: "sha256:f5bb595fd562e952458e975ab00cba5c16e57e0c4d433ce82eb8d3cb970e702b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/44.yaml":
+    pending:
+      fingerprint: "sha256:1ccbba2a23c9cddbe3b8cc9fe193b47e24adc6a5656d4cc0c93ed3d346a94db6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/51.yaml":
+    pending:
+      fingerprint: "sha256:a0a32b50bd002027ad6c57ba95e1df0bd634331481a0fe467e0216cf1fd20d93"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/53.yaml":
+    pending:
+      fingerprint: "sha256:c53ae2cf90a20f847e0747071ce89ad785f85f81ba707f0a6461e3850b0e3c25"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/531.yaml":
+    pending:
+      fingerprint: "sha256:0a46ecb4742c7960a543e9fd0c7badae4187e317d3451a608e8614e096790b4d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/532.yaml":
+    pending:
+      fingerprint: "sha256:c66ddb92ace402050b69abec19b35b1aef560097732b2f9e282f52d98ddf73f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/533.yaml":
+    pending:
+      fingerprint: "sha256:79e39d65aacc4dee26cd78c1f0ab2ef2361a07b126537142ea334a8c30ee1191"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/54.yaml":
+    pending:
+      fingerprint: "sha256:1ac368497f26b06f3686feeeb9c749e49723d4016814ed6edef0119a8931fff8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/543.yaml":
+    pending:
+      fingerprint: "sha256:3e171db2cf6a69cc933563c6228a4015c6004b000ff018a74357aa8bc8bde06f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/61.yaml":
+    pending:
+      fingerprint: "sha256:84274ca22a1f6af12485d583eead25de8810f229ca1e16ecb6a2dafb3ec447b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/62.yaml":
+    pending:
+      fingerprint: "sha256:d9292fca45d53f11901b1d6d1bc7a717f85b07e590cf497a8f753edfe9df1801"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/711.yaml":
+    pending:
+      fingerprint: "sha256:64a29900d65c20ca6fc24ef9d623cabbab254337641019d2fe10cedef0a5f1c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/713.yaml":
+    pending:
+      fingerprint: "sha256:8328073d59c6f4b3f6800b89a68335f36a50f79859afa0366300639f242ba4bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/714.yaml":
+    pending:
+      fingerprint: "sha256:c47619a2650b2995511e8a3ca64f1211e6e5a936c6f0556f2ca7a69391257070"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/721.yaml":
+    pending:
+      fingerprint: "sha256:898369cf95213b5395e140dcead6346a34880be9d507284a9fcf7f714f6c2d24"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/722.yaml":
+    pending:
+      fingerprint: "sha256:97605d9b1ba57e6c1cddc8421d69b66a8808d9484822c8c3784a52adac0feff5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/723.yaml":
+    pending:
+      fingerprint: "sha256:0920f4ec16db6d4d4a7c640feaa45b18c2baab892ded5d964233f4d1f102d319"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/724.yaml":
+    pending:
+      fingerprint: "sha256:10e3d9af9925819bb94f54b16fbd84b1386a828cf10f666a7ce71938d7247205"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/725.yaml":
+    pending:
+      fingerprint: "sha256:9c588ba22fde29797c7aa331d9c2991627a0fd3b9b914339563b041c5b0baeaf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/81.yaml":
+    pending:
+      fingerprint: "sha256:f83d3f0ebe10d8e655dca5dfae2766d18b7b0ca95dda1d2f0e80155681eb33b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/813.yaml":
+    pending:
+      fingerprint: "sha256:771311ee1bc8c3bf4ccb481682a86b98b0140a9460378804442e80cdf03fd067"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/814.yaml":
+    pending:
+      fingerprint: "sha256:e68f8258e7c3b4e2d20533856d31bf3c9c871b30ed1056c1d389e73dc50c160c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/815.yaml":
+    pending:
+      fingerprint: "sha256:8ca676a644caf471e6055ef2402ca6f9d48ad259e547ea7c4591aae2192c8147"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/82.yaml":
+    pending:
+      fingerprint: "sha256:6f2d7f55a231a8ce099738935a2756c48fc3882cdef19c261cb66e8c851420cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/821.yaml":
+    pending:
+      fingerprint: "sha256:9044a53159af7cd93b41eb85513b1e8631eb040177c24b0bbddc770fc35a4459"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/83.yaml":
+    pending:
+      fingerprint: "sha256:dc462da8b15476f340160bca4174e26a2cb1934e87a6873524be4dc61b8831b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/841.yaml":
+    pending:
+      fingerprint: "sha256:53409d424492ce6328c3b9683ea903ecd70d736a5f51ffad8841ecb0b9da79dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/842.yaml":
+    pending:
+      fingerprint: "sha256:57521468d4d3ae42279c32f28259de70fa907ae1553c14ed303220c0d443dd78"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/851.yaml":
+    pending:
+      fingerprint: "sha256:de0f64aecd6610e587c07738f5e6540366fe05c8dd90facf95e479690dd3f169"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/854.yaml":
+    pending:
+      fingerprint: "sha256:fc00fd4ec20719c36717faadd4c46f44f6a2ae53f0c5a4ce9bbb38b7e014cb54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/856.yaml":
+    pending:
+      fingerprint: "sha256:2e49f87a2fd95c15fa4eec7f53d7b1a8fb110f0de8dc7cf639c97b13afc9ea40"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/857.yaml":
+    pending:
+      fingerprint: "sha256:fb15288b6856a6eb943979802bb35b36f695c55fab27d72462881132487d8f76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/861.yaml":
+    pending:
+      fingerprint: "sha256:e53fc3990d9d2f7d4506a5bca636dcc9afa04a9431a77f6fe5dfbe0095ee79d5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/862.yaml":
+    pending:
+      fingerprint: "sha256:d92d7dec415e13a451b95b606cd48ef935471bbdefed55216fffea2ada0ac010"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/863.yaml":
+    pending:
+      fingerprint: "sha256:8c5ac09000f18468d5bb236846632adf75a3e4fa6f350eb1a05546d777de98b3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/87.yaml":
+    pending:
+      fingerprint: "sha256:1d3fdd3ab1afd3dd6399d3ecd693c98307175619ab160862dc53cd4691ebe86f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-407/89.yaml":
+    pending:
+      fingerprint: "sha256:2a7bc449c0fcb3c228cc7aac7b9a3db6a9d4a05bc1001cdcbfd11a680f5c30f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/1.yaml":
+    pending:
+      fingerprint: "sha256:a853a0427e07e62e7318d43d41f87877d4c41177e2a8799077360cd8d9d3edaf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/111.yaml":
+    pending:
+      fingerprint: "sha256:1cf97ae111a26616e5c9548c99ebb8874b49c1f350c75ca877f0860f70f08bf0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/12.yaml":
+    pending:
+      fingerprint: "sha256:260b307f459c5f1dfb10c9142504d0fa65e16c70c5f63ac5c24a8afe7f2668f4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/121.yaml":
+    pending:
+      fingerprint: "sha256:ef38e1429288d6b1a2088d0c8fdbcf0ca3670d89a1ece52993e62ed204e2f423"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/211.yaml":
+    pending:
+      fingerprint: "sha256:19d7645314395769752c209a5807fa886732637220c0edd3e9e36bbe6cf3e024"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/212.yaml":
+    pending:
+      fingerprint: "sha256:dffa7f64f83fea493e2e40f415d37fd9b14c726f8ca1c5a63676333e810e8157"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/221.yaml":
+    pending:
+      fingerprint: "sha256:161c6afd581fcdb49a8558fd53f97bc6428acef81de7ad7c668c833d8e7d6006"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/222.yaml":
+    pending:
+      fingerprint: "sha256:162a1198d99087666288717df136737f1d3e2f8b5fcf60be946d4cd709dcf107"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/223.yaml":
+    pending:
+      fingerprint: "sha256:681af401c2d983be07fde672b76efa185febf50f605bc513a53b0a1c1b751f50"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/225.yaml":
+    pending:
+      fingerprint: "sha256:c8055698c3ddc4102de08ecea90db5e5a27868359e8a48af9a35659033c2abd8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/31.yaml":
+    pending:
+      fingerprint: "sha256:86dd51a75e314e939456f76040fb9337841cbc00e6215fa9ee96c2b6b1d6bccc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/4.yaml":
+    pending:
+      fingerprint: "sha256:6f25b3d4d8354eeac2bf2e2ab8d0b1caa28892b352c0f9cf272a48f782f6f90d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/42.yaml":
+    pending:
+      fingerprint: "sha256:795cdba2394bac5f56aa0120f8800315d1587dd450e14cbbbdd4b5b55137517c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/5.yaml":
+    pending:
+      fingerprint: "sha256:aadb95a8994e10aa7c9d47a3eefbe84088e3b7e3ef0a558bb6c8f0d8076f3443"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/61.yaml":
+    pending:
+      fingerprint: "sha256:c930d67c60ac08200fbb0921e9125cf2af26514e99001424e30ac2d3771c4933"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/62.yaml":
+    pending:
+      fingerprint: "sha256:5ab04c52b6ddb23bd4a43e43c108192c7327ff2462af90dda49642fe0c76c2b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-408/63.yaml":
+    pending:
+      fingerprint: "sha256:820ae705ce7c4e93a2c106d20813458bc8717869363e77272651a3f26ff29449"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/1.yaml":
+    pending:
+      fingerprint: "sha256:143935a8e4c289edc74dab7fe752cc6ed3f161faaac98036f9c4ec362616d5c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/12.yaml":
+    pending:
+      fingerprint: "sha256:c1c2e89085dd6efff09a11c7421645d7879a48555ead7341bf78049a01f29e2e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/13.yaml":
+    pending:
+      fingerprint: "sha256:f8cf0d33f2335bf8e8f1faca1a5f7293b594ab69cf92941f3cdb06e6841b4f53"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/14.yaml":
+    pending:
+      fingerprint: "sha256:0be5fcc6b06d46aff8c2611bc62c2bec400f4cf21740ef58d2b7c1ad1617b1db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/211.yaml":
+    pending:
+      fingerprint: "sha256:8fdd5bfb9230c55d1032d7d0b72b8a00d90e26f29798a0a08a1991878e80ec02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/212.yaml":
+    pending:
+      fingerprint: "sha256:75c63f71becd0416ddf345ab86bb803627f2d493489e9d5f54113bff61060852"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/213.yaml":
+    pending:
+      fingerprint: "sha256:99d704f9fb14688b85d4fd706edf5570abb4c0c1876d5bde7d5e24bbd45393fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/221.yaml":
+    pending:
+      fingerprint: "sha256:d352aa6a51cbb61fdc3768ecb864dc8776b62b092522f97ec6ea64f21601f9b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/222.yaml":
+    pending:
+      fingerprint: "sha256:a214d007aafe9ce5a69ea727ccf77c613082da81c932daf8259421b4d31f2362"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/321.yaml":
+    pending:
+      fingerprint: "sha256:7db8e583207465f1e54ec0bca09cc7d291a8523156dac773f0009bb8fa8ce04c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/322.yaml":
+    pending:
+      fingerprint: "sha256:f4fd3bd77272afc532e593e7f2f9b5c8c23ccddc49d970667e56fcc1592c08ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/323.yaml":
+    pending:
+      fingerprint: "sha256:af17133055b9130b999abb30c060dec16b9150674df98a1e37f76c7d2d1ddb02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/33.yaml":
+    pending:
+      fingerprint: "sha256:b9e520d77ef78832869fcd7ba3c3f2af91156bd6121178cf1eb8a8a3de07c762"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/34.yaml":
+    pending:
+      fingerprint: "sha256:c46df1e149584b6942c252dbeb747f8ae77a8482c1832b6cb0ac253d4ff8ead8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/35.yaml":
+    pending:
+      fingerprint: "sha256:a56bcc4ddb4b9be7d8d69aaa8fb81fb3a6f442bcd2fb3fd5b3030c5b86790b64"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/41.yaml":
+    pending:
+      fingerprint: "sha256:04e2ce4d34e1d6d59e4b91456f91afa52cbb435125306950c026a3f4058b79ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/411.yaml":
+    pending:
+      fingerprint: "sha256:bdfcb5e994ce394994dbbcee86375af0be3c501968b08e1142c65b87938b3862"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/412.yaml":
+    pending:
+      fingerprint: "sha256:530457cf12d466ca1b7686a3792b08d7a6d224eab2e3e5a30a7b63c472a8dcf2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/413.yaml":
+    pending:
+      fingerprint: "sha256:becbb8d8a3b781fdc3b968d7cc1e023db151151802427460bb87d0aa373b79bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/42.yaml":
+    pending:
+      fingerprint: "sha256:f33d9039feb95eae2c52bee603e2d6f33698170b45cc3d2d84402b717ce4bbe7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/431.yaml":
+    pending:
+      fingerprint: "sha256:b2250bbaa5f5fde310e25916e7df358d3da9188e4daef5b9c24d0abe24b12493"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/44.yaml":
+    pending:
+      fingerprint: "sha256:21e526d1e97a2e864b8e2d62a44f1e36b7089165c68448e99c814b0c0f195969"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/51.yaml":
+    pending:
+      fingerprint: "sha256:e513c857c420e2f471ed9355af4170b290c391bbd879019abf8a28601c0036bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/511.yaml":
+    pending:
+      fingerprint: "sha256:6e098d00b9292c8a3a4e05ec883e79ff39802e6714763cf3816a21f035e194e4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/513.yaml":
+    pending:
+      fingerprint: "sha256:0b383f785282591adb8730cb7401f41dcc620b156ce1ce6ea0b003983fdf3dc6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/52.yaml":
+    pending:
+      fingerprint: "sha256:9ceac3dabf5f87103cc06d1cd762c5715aedf44925c54f416ff73605fc612ea4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/521.yaml":
+    pending:
+      fingerprint: "sha256:e64f3558a03a63a01dbdf8cc39f9cbb2e977d07c2b4aa2ffac07abf479ec874b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-410/53.yaml":
+    pending:
+      fingerprint: "sha256:f48e66fe1fb30d0509d674ecec4637a49be097281717650bf761de97c7d6d6b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/1.yaml":
+    pending:
+      fingerprint: "sha256:2eaeea8f9a0663afb4d219f4986dafc4391fd1bc1cfa7553b76edc545482f348"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/11.yaml":
+    pending:
+      fingerprint: "sha256:5537d8e530627086a6de4f2c6d0eb2bd7e4500a176d9268e4a9ea11c38cff3be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/2.yaml":
+    pending:
+      fingerprint: "sha256:cf0a77b487df07dbb77bf2820d860472dda39eb9ccb0a7bd0ecccfe7d73dd410"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/21.yaml":
+    pending:
+      fingerprint: "sha256:73473f469c7ef2e7f31752bb631b56ca2553a579ae4497f22514c3fdc5a59e1d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/22.yaml":
+    pending:
+      fingerprint: "sha256:32468ca2329a9759d544ee1155cf69c25cfebc6c4773088d33ea5b1d340d825e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-411/3.yaml":
+    pending:
+      fingerprint: "sha256:cbfe7abef01407ac9a231f62e14ed75e42ffef2a7de06e51289e220940a9d7fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-501/11.yaml":
+    pending:
+      fingerprint: "sha256:6b2dece0d47a4e95003674d5f4484bd0cf26528d87f5882f07299f3cae816580"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-501/112.yaml":
+    pending:
+      fingerprint: "sha256:60c096d9e191be170bb99c5ad9396c93826a53cd7f0426c74332c08f4eb3ee3c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/1.yaml":
+    pending:
+      fingerprint: "sha256:d942d941dfeb462b42488e3746d9573db5bb9abd0bb64e709f7202aa17ed6fb1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/11.yaml":
+    pending:
+      fingerprint: "sha256:1fafef708484293044c11dc4827e10f633e067c1a3abb1700a74dcaa8f15395b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/111.yaml":
+    pending:
+      fingerprint: "sha256:ef22054e5fad831c3d329359decb444f18dc6d390567b8ea81416d2729939e51"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-502/121.yaml":
+    pending:
+      fingerprint: "sha256:f46652f9d3d92eb1d703a58572e7b20969bba9f40c6c5fcabd457206f49e0340"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/12.yaml":
+    pending:
+      fingerprint: "sha256:46c007c5272be69d2b05d77be19e6ab41542c03f66f9c9d9f1dca5eb7193b2cd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/16.yaml":
+    pending:
+      fingerprint: "sha256:c00e4e5a0981078cd7491062be3fe7ce3051eb41698f824fb59546818e0291f6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/241.yaml":
+    pending:
+      fingerprint: "sha256:4e137a75f0532affdfca0b393e0d278a850661778cce1a8141f07b3695f7ad45"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/25.yaml":
+    pending:
+      fingerprint: "sha256:b786478674d0ba29f59391a5abc9e7ae984f5d6b66d952336a0bee5a8e97809d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/254.yaml":
+    pending:
+      fingerprint: "sha256:7602553a3b25671073102ed9aebc5a693b0a70fa6f4b9b0d9da652821fc9468f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/255.yaml":
+    pending:
+      fingerprint: "sha256:04d20cd9125690e82739a1880eca17abdad694d68c2f8abad380e72ac63390c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/312.yaml":
+    pending:
+      fingerprint: "sha256:08b3042ceb366532ba1166a368b5727e7a55846694d660684ad071ecaebc5002"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/328.yaml":
+    pending:
+      fingerprint: "sha256:41688574a4d29f28baf53f5895011e39ab30f7248e200d78a26cda9092642b46"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/41.yaml":
+    pending:
+      fingerprint: "sha256:14b7715e1898c59ad134205f269e63c9ba30627a00882ea2d844335214154fbf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/413.yaml":
+    pending:
+      fingerprint: "sha256:d9fc242d5b095e26c20b1887a50ee0cf391e1c19880ab14fb954b38fb0b2119f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/433.yaml":
+    pending:
+      fingerprint: "sha256:96a3811c16c1ac15b08297773cafdc7c59e67f0a5adf25bd75689646aff25b71"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ca/regulations/mpp/63-503/434.yaml":
+    pending:
+      fingerprint: "sha256:65f37ffc1a020ba7c38ca4d6981c0060d77199be3910fe051cf9883220050390"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:7a205dfe0c2961a9a00fe5ec0ddfcf227af01b6f9e44b57af08b166237f44084"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/policies/income_tax/eitc_pilot_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:80eafe20b0f6fd5e8497ba2e7463fe14fe2da87fca584225f7c81ae4a638d4c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:84dfea2ccd248c3f7adf54512460757427ab137b340c59460f243af624e36db7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-10-101.yaml":
+    pending:
+      fingerprint: "sha256:d56e81843a5407ac801ab97ff88ada4c91b66bd1a9f16669a32a914813630aba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-10-104.5.yaml":
+    pending:
+      fingerprint: "sha256:3fe60a4ea6bbf7ccf02d8a77bfb5d9804a8935286bdc5d6dd19ce9bdb864f2f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-10-105.yaml":
+    pending:
+      fingerprint: "sha256:b921e8a3af028d6d1df11b354fe8503db4bb1d7394ccc2545aefeebdde8bc66d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-10-116.yaml":
+    pending:
+      fingerprint: "sha256:553542463ed04374ef99006d4c05e47a336666610cb9e7e4fdd44d7e8ee7c22e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-120.yaml":
+    pending:
+      fingerprint: "sha256:20bd62eafc8bf1c4b2126c3071dd59daaba83e695d26d05f506119b285ca7725"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-122.yaml":
+    pending:
+      fingerprint: "sha256:66bb01599c566a5bfe6fda09515d48f573ceda59f39f24a201e01daad034eecc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-128.yaml":
+    pending:
+      fingerprint: "sha256:cc30812c9319b73a3acbda0ab4905436021598195752ed7fc5ea745e1f1dffda"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-129.yaml":
+    pending:
+      fingerprint: "sha256:fd840b27c64c233aa80b3667a288574dc9b88fbdc791b527ba98c1c647bb0518"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-130.yaml":
+    pending:
+      fingerprint: "sha256:cb566963f73d3daf34f1d4a1e95ed1b4a30a23ceea249756a9aa5e3b55638239"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-145.yaml":
+    pending:
+      fingerprint: "sha256:d6084d535f8089b80e12777595324f9b4235d967b53ce3ce478d5c146ad71856"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-148.yaml":
+    pending:
+      fingerprint: "sha256:cff7eb4f05cf19b81968384f05a542253ec392271b44fac1a5563c3773389095"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-149.yaml":
+    pending:
+      fingerprint: "sha256:0d628d77f4ad528140cc7c5cf156ec8971ad2e0059647f79f521b5cb6613ce55"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-11-150.yaml":
+    pending:
+      fingerprint: "sha256:bc92093c26a3d7452d7c4b81d14da1c95482090af40b330309fe6d02b593b705"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-12-101.yaml":
+    pending:
+      fingerprint: "sha256:e330fb495ec79f71ade693b06b3fa282554178ccba854dba7800bb30644518fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-12-103.yaml":
+    pending:
+      fingerprint: "sha256:63e3a9fe6eb6d54972016074a14db92d5554c1e1ab7cefaa4e6d03866c44c1e1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-12-104.yaml":
+    pending:
+      fingerprint: "sha256:d1bda0a73c4921a97882d6ba876b195869b3718d125f540552c87b8606175cb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-13-102.yaml":
+    pending:
+      fingerprint: "sha256:1544d883d384cd36a9ca7f7fc6a66701c7affc6aa9df09bf0ea23d89eb5b0ab8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-14-101.yaml":
+    pending:
+      fingerprint: "sha256:9b74b5d1409978fd2f89dce9d4024762272f0da6740b01a3f08588bf5cb67ca5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-14-102.yaml":
+    pending:
+      fingerprint: "sha256:882959f56b746430e724ee784f3bc6f6b4a5b73aa76ad9385de9f8fb1bb0fcf6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-14-103.yaml":
+    pending:
+      fingerprint: "sha256:545d3bac01692b5279a503024ea1c588e19278d9f7e97754c651963f9425a865"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-2-130.yaml":
+    pending:
+      fingerprint: "sha256:f3f34dfbe9e5d287ae8fda177ab9507868cd85e7d02eac7adbe06b8d6ec75490"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-2-131.yaml":
+    pending:
+      fingerprint: "sha256:e8b2f1eec3bd96e3b20aabab62e3571f992ebd442b47defcefbc927c9352056a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-20-104.yaml":
+    pending:
+      fingerprint: "sha256:412fc6192d1f124d41326d99a22cec8783e2e1cf8baf9257fd14892afa6c7d0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-20-105.yaml":
+    pending:
+      fingerprint: "sha256:e834b409100bb7fa683731af77e539eb87d03b5f6c105b433622811076ec84c2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-104.5.yaml":
+    pending:
+      fingerprint: "sha256:53f4d604023eab2000c634a4c06bc3f83c29dfdb38c87252e783e2131146d327"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-105.yaml":
+    pending:
+      fingerprint: "sha256:14d5de2fefc4aaa600fcbe6bb401bb7310534231660e33eb8a18a24d799550b5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-106.yaml":
+    pending:
+      fingerprint: "sha256:daeac2dcdc5fda70a655d89f9abe2c0f0f56f6cac60d9692f3f982256115bb74"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-107.yaml":
+    pending:
+      fingerprint: "sha256:0b9ac82862b28923dade014489fdaad026fa44906980130c928cb0a1cd404352"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-114.yaml":
+    pending:
+      fingerprint: "sha256:3835ca6c7d6a9f8515bcadea92a3eecf1fcd2972ac4919f5e5d876f2db9ed743"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-116.5.yaml":
+    pending:
+      fingerprint: "sha256:7c8dfb1ed543f857903364809c54e9a15db6af8efb63b0afbb38a0e238ba7cc8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-116.yaml":
+    pending:
+      fingerprint: "sha256:e8a7f78bf827ca717729837583a7e9fbef9868cfa213ece153d434ee24e17acc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-118.yaml":
+    pending:
+      fingerprint: "sha256:769351f724d3ea22e853a1aab7c90fb898b67945682339c1bf16c49faeff82f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-21-119.5.yaml":
+    pending:
+      fingerprint: "sha256:ea999c24f49e44aef9be866784f9f8649bd183fdd47b0067fe4b9427a5782366"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-104.5.yaml":
+    pending:
+      fingerprint: "sha256:02001deabc755048bb594966e286a5f48638666ab77f069b301444d186e8a222"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-108.yaml":
+    pending:
+      fingerprint: "sha256:a5578ef315dabd5df9d9528dc9401b0bcd7d75bb7779e5929a515e90f51fb55c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-109.yaml":
+    pending:
+      fingerprint: "sha256:ac4a93fa120f4a329772917c32138aab700807d91369fb00cc2dcc9034bc9202"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-110.yaml":
+    pending:
+      fingerprint: "sha256:5a0c50b4f523d56a325e3303d31b0c6937a7b0e8ef6a872ac77a73218c2d6854"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-114.5.yaml":
+    pending:
+      fingerprint: "sha256:0ba0be3f46966f8a7106cc39f70f1aa0945f7d553c70e3cde927e7c902f7d6b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-116.yaml":
+    pending:
+      fingerprint: "sha256:6aee96e68684a92b507c5c068cfffd65c9b0d4873cc75b079b40265afbc027a1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-1302.yaml":
+    pending:
+      fingerprint: "sha256:f44d56dc2b16622fa7dc8cac795609ee09e089824a3125db3f71b41c3fa97d52"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-1804.yaml":
+    pending:
+      fingerprint: "sha256:d60186bc18dafc046512e3c6eebc333cdf5a9bb72643ba6d080587abff714afa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-206.yaml":
+    pending:
+      fingerprint: "sha256:4a50b402a446b46919651de46dda19e5285ed6f66375dca331bb1d2fcdcb7b84"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-2101.yaml":
+    pending:
+      fingerprint: "sha256:b35476be8f4d203fe1cf9fd5f73d0d6f4d0b9eb2efb6f90d59a7e04b9f260428"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-2102.yaml":
+    pending:
+      fingerprint: "sha256:c12c7ef43d84a64cb589e70bfa22dbfb1ae7a76878e017615ac7d2e1e70e2781"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-2103.yaml":
+    pending:
+      fingerprint: "sha256:c765d2eef3db4fc4a6d2a8f62c3b5a86c11b566ae24e4cf92c6dbc6e9a2db518"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-2108.yaml":
+    pending:
+      fingerprint: "sha256:49e89b8dab5943e4bb427a5ed2176acb8fbcb1e8c29adccf56bc77f485a581f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-305.yaml":
+    pending:
+      fingerprint: "sha256:a3d051081a49ed3d026621aa642e9d186535aedd21afc5db2f19623f6a584ea3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-329.yaml":
+    pending:
+      fingerprint: "sha256:537565fcaeef2e5f0fd6fe9ac698268d61119a57dbbc00bfc4c6ad147856224c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-347.yaml":
+    pending:
+      fingerprint: "sha256:09b41d5fdf4f6dd38061a8d992c8ea659c840ecaa21fd5f8d2500fd1dc2ccbae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-3603.yaml":
+    pending:
+      fingerprint: "sha256:5d8033be8e07c462bf0f662eff5e9fba2d93b0819479a3d0441b2fa3a3c9fbce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-4703.yaml":
+    pending:
+      fingerprint: "sha256:7c0a1bc72bb40ac315b9dea0e6db43cefe2f0a3cfc7923282791b4906c9ecbf4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-4706.yaml":
+    pending:
+      fingerprint: "sha256:d31c3c47e95ebe4127a9ea981c65f6a748461197f33e8b2c70f1a93ef1d2a82b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-504.yaml":
+    pending:
+      fingerprint: "sha256:7bf1afa79448eb9cab49f05a803d037724511fcb70b8e555ea8d6cb59738fd5a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-507.5.yaml":
+    pending:
+      fingerprint: "sha256:60c95b2e8b85a96e99e49b53a5a16a9de353c1e01ff500fbd6adbaaf65b917bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-509.yaml":
+    pending:
+      fingerprint: "sha256:ca63bd608b0766f73b8c4d823a1a45a86aa0f01b220052fe010a6778f03227b6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-5104.yaml":
+    pending:
+      fingerprint: "sha256:9514c53927a288f5015be9fc29e52a3438d6241439bf72fe5907014ad48384a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-517.yaml":
+    pending:
+      fingerprint: "sha256:a95c95089d54c0472a40efe2ea058452460fb7c15d40e22690046e24509f0a48"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-531.yaml":
+    pending:
+      fingerprint: "sha256:26f95f93fe1deca9b151399d8b4670566552b48e4bc15c286045b9f8b1bb4c02"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-535.yaml":
+    pending:
+      fingerprint: "sha256:c182afdf5b6abd879334cbb7a372a127426a6eaea3ebb1528b9e03cfbcddb5a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-5403.yaml":
+    pending:
+      fingerprint: "sha256:441ea40c8e1bf68d699c66c5e91d3b4afed9a9611359cfd6e477d92db3e0f5de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-541.yaml":
+    pending:
+      fingerprint: "sha256:7024dcd021384e4ed3829e5a01596e4a3afb23dc45a63097dc722f2407844069"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-542.5.yaml":
+    pending:
+      fingerprint: "sha256:3c0859e88609c1bf099e58c691dd26f5cbc64de9e03275255c339d86bd5849ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-545.yaml":
+    pending:
+      fingerprint: "sha256:60885228aacde19f9f0bb6de3e292886aeec9ea9be8888ce271a80a3a9d61177"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-548.yaml":
+    pending:
+      fingerprint: "sha256:59fd6d7f64c9127e2a42d277fd9158c69667387fb56ab714893c3771ee29d064"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-549.yaml":
+    pending:
+      fingerprint: "sha256:efc03a815949d9645d7895fd17e8c16eddccddeff054b4bf5e0e683cd785ae0e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-550.yaml":
+    pending:
+      fingerprint: "sha256:617351776fe755b8578d8beb4af3d4351796d1bfca37336fcb799e6b2eb332ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-5503.yaml":
+    pending:
+      fingerprint: "sha256:9f0fe2ad824d36010a5336a11e5201a0f0f52a85304bfb36c032b45cf0c0e910"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-5504.yaml":
+    pending:
+      fingerprint: "sha256:0cad61ad0d2a617a5b6e814921c1251535327b35aa4c61cf238bf809da4062c9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-552.yaml":
+    pending:
+      fingerprint: "sha256:6569a0665035a4c7568965a65efa0c4b7a655a29b14916004bf32f5e1572e17e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-555.yaml":
+    pending:
+      fingerprint: "sha256:7635f20e5038cb6e5ef26b677a680928a2764731081da839e1b03c4fe75e331d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-556.yaml":
+    pending:
+      fingerprint: "sha256:c2702d0e287bc5be0b82e0e0db3db8e0561aa1354f95531f9935aa0a2fe0b52f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-562.yaml":
+    pending:
+      fingerprint: "sha256:250e65bd0c2b2c0e47ae5964f70a7fa57edfa26ec906b182218131d1c7f5af2b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-605.yaml":
+    pending:
+      fingerprint: "sha256:cfd058805c45f28cdf9eaa87c3b6dc32a792f543fade3a07f4b72db4ba11641d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-606.yaml":
+    pending:
+      fingerprint: "sha256:b894f7579c33f7ebfafc644fc8706f65e8b2978509884597beeabee439eac843"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-608.yaml":
+    pending:
+      fingerprint: "sha256:f27fd9805c8a304aecebdd02894995adc468d297451e25f3b0a34c94011c3616"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-621.yaml":
+    pending:
+      fingerprint: "sha256:124827c13a3357f4e02fba0fb675e0c402d25b4253f90ca1274659ff8b4683f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-622.yaml":
+    pending:
+      fingerprint: "sha256:2c4ef10c9e8f6c88233ab38783f5821e6bb48c755bbfcaeb4e072cdf34e8cad9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-657.yaml":
+    pending:
+      fingerprint: "sha256:2196d547b3213badc038a32bf5752504e7271287e68f13fda222c35e7a9c21a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-658.yaml":
+    pending:
+      fingerprint: "sha256:44163fbdd02ce345de6c7c222b288407999858958c32e7ac7b1f394124edba5d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-22-703.yaml":
+    pending:
+      fingerprint: "sha256:1784489a4ab5725c22cc2defa5723f1342b7b0ca1713d4f7db56d1848fcd035e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-24-111.yaml":
+    pending:
+      fingerprint: "sha256:2349826e4262969084efea07513fa49159f4068ac6a9a9161b8b9849e18cb0bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-28-103.3.yaml":
+    pending:
+      fingerprint: "sha256:12fa73513bd934b5f088b07ee1b2503b7588c77f1780d20abb0d89b84e6e5f05"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-28-112.yaml":
+    pending:
+      fingerprint: "sha256:20c56bbd769331151273297a81ccf9ed3848e68b5f29d6ec737ab30bc7d4da80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-28-203.yaml":
+    pending:
+      fingerprint: "sha256:e5b4e6c10fa30851e97819a71be1720a25c71679756011319cc11e3faf931847"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-28-304.yaml":
+    pending:
+      fingerprint: "sha256:729f94cae14e8146cb4706f81106fe3722643fe7a6459ec9b943f2a1f258ac7f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-28-306.yaml":
+    pending:
+      fingerprint: "sha256:0988ffdac7aadf9a1e7f0c9a766fdb43efdb5e9d6062924cb2e29d9e002d1d8f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-106.5.yaml":
+    pending:
+      fingerprint: "sha256:d72af5d6ce48c14c43546b842dc71ca56618bbdefe671b85ddee90ed0fb79f31"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-106.yaml":
+    pending:
+      fingerprint: "sha256:56f0f176baafa1f63a9f19039db0877985684d96213bdb1683456eb57a12ec96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-108.yaml":
+    pending:
+      fingerprint: "sha256:9ca7e0f56ba70ee6459b62097e749699871fabb8c819ac13bd3ffbafc144b73f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-110.yaml":
+    pending:
+      fingerprint: "sha256:f6b0477964cf48c562436642bd9f6b6bec73d5179ae2c578706faed797f1469b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-111.yaml":
+    pending:
+      fingerprint: "sha256:166b2a85bcd3452ff588fe480d1d6c74f667fbda2a2a46a5700378f313b852f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-112.5.yaml":
+    pending:
+      fingerprint: "sha256:36fb362d35d845fa174fc3b844566ce82c62d1cc6c230063ca26129bc5e9426f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-118.5.yaml":
+    pending:
+      fingerprint: "sha256:0d1eb39adb473975b6e3ea0d91993f7c5c483b74bfacaa3abcf9f717b0f5264e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-121.yaml":
+    pending:
+      fingerprint: "sha256:db79ae6de058b04f59f77897f57e81a2604a1be57f512812437a13e3723243fa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-124.yaml":
+    pending:
+      fingerprint: "sha256:cc10827c76605b230ba955336350a66067c647a6c186ae345736f94362314344"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-129.yaml":
+    pending:
+      fingerprint: "sha256:8ccde8444b092aa0677911b5900d774859c4f7fe6d56e5fadc96144ec1722e6b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-130.yaml":
+    pending:
+      fingerprint: "sha256:7c6d9304ec1adcc1d2c28b948c48e215a6e8c8cbb843f5eaf467d2a18997abd1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-131.yaml":
+    pending:
+      fingerprint: "sha256:d7a1df1ce829228e9c666b0c51b06f3c8d03e894867313f886b924f1e706b2be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-133.yaml":
+    pending:
+      fingerprint: "sha256:a23e1152ae0b2b1cb88e923dc9d9deefd5acbb6c332b319efe31563a4e19a8c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-3-138.yaml":
+    pending:
+      fingerprint: "sha256:1959b992aed66cd73cc6caa6a01b57df0b2e3675d9eb2c0b215fa8c861efe1f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-30-103.5.yaml":
+    pending:
+      fingerprint: "sha256:95ae62a5290b73ccee3846c23d841b4426bf0c29cb194ea7c623c0b173e8b6ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-30-103.yaml":
+    pending:
+      fingerprint: "sha256:cb51fffc3d4c9212d288961a358a0265beffed5c8db3a44f63e41de460100786"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-30-105.1.yaml":
+    pending:
+      fingerprint: "sha256:57bff20b043a0c8e2ce4124952f02fac4b12115d4b6c6cb8e314e0302dc52cd4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-30-105.5.yaml":
+    pending:
+      fingerprint: "sha256:fd8cd41be88542801fafe9c42fcaea9da3c0562f7dd7c91454d419aae86cd109"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-30-111.yaml":
+    pending:
+      fingerprint: "sha256:e3009ad51db363fd198abf3118b2b621e9c7f96ee2aa0c7b7b476d4bcaf57dba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-36-104.yaml":
+    pending:
+      fingerprint: "sha256:52a3a7e032b88a0af87cbc17c08bcb5988a311b56498747c6655cd110441ae24"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-36-106.yaml":
+    pending:
+      fingerprint: "sha256:d209c50afa031c84649e1c0ba02d267ca7963d82738b512c85c032a00d32678c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-37-103.yaml":
+    pending:
+      fingerprint: "sha256:2e0efd787ab828b9358236e0ef539d6ce6de0747877b3b91e9c826dab41d5204"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-37-107.yaml":
+    pending:
+      fingerprint: "sha256:30300ddd6a361d6821929790596a48046a45dfd153c083228c85cee8fd54991e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-37-108.yaml":
+    pending:
+      fingerprint: "sha256:0910de096e89a168cf965bf96df551baaa07260dbea2a43ea07080d39d6ceabb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-37-109.yaml":
+    pending:
+      fingerprint: "sha256:f30be1a72d0da8a27546edc52f230612deef67a846a60ad7392f1e2601ba9da5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-37-301.yaml":
+    pending:
+      fingerprint: "sha256:900642ab0c5a564f1ca9dd4a959130697553c4704f90d88138077b0da96912c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-102.yaml":
+    pending:
+      fingerprint: "sha256:745680a6f6ef43107363d19122db35dff32975b465087950a7cc78e235837b1e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-104.7.yaml":
+    pending:
+      fingerprint: "sha256:cf6589bc8a4045cf19556464e721c0468d59b5f24f49d2f6b94417a25cefa191"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-105.yaml":
+    pending:
+      fingerprint: "sha256:26a61c939a66c9cffa4812f5b58676508755be9ab46b5ddd4f7d358a5cc41a47"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-113.5.yaml":
+    pending:
+      fingerprint: "sha256:84179ac9ec2aa570a4660f001a39e8fc4175f9bd3cab62c96caf067c2d0d3835"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-116.yaml":
+    pending:
+      fingerprint: "sha256:10da99b82f7ba701072f4183c6099abc3361571332f3a9e157fbb4d201a354f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-117.yaml":
+    pending:
+      fingerprint: "sha256:d033a3d2119f10f60fa2226516bc6ccc34f882977fc658aea2d92156a85a2434"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-119.yaml":
+    pending:
+      fingerprint: "sha256:4a170a8e109f27a495721386a9f930c8758b12d2e779db7094c94316cf4999c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-121.5.yaml":
+    pending:
+      fingerprint: "sha256:8aae2aeaf05fdeacfa9fd6f11af7126492d301eea4be0e7c5c4d4675417f2b67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-128.yaml":
+    pending:
+      fingerprint: "sha256:e3e7bcd9dbc7b6f61cfd41f783b22d15eeac1621cf7b47cc1694f767959f0853"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-132.yaml":
+    pending:
+      fingerprint: "sha256:903501e3e02017350b45c169816e32a0c61a084f4a921b650a38c485f0071d0b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-133.yaml":
+    pending:
+      fingerprint: "sha256:a6510b1642515c5445b69776e3ca6a7270d129b5996e2164edefe927fa270242"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-134.yaml":
+    pending:
+      fingerprint: "sha256:63f5c8fd1705261356ecfcef3730c1b4ca733a3bbd1b306980a42f37df6a45f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-201.yaml":
+    pending:
+      fingerprint: "sha256:eb0d3a20a5d0710c83cb4aefb9b0a790a6ba6d6fe805877860f6c409a7f6600b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-202.yaml":
+    pending:
+      fingerprint: "sha256:4d8ebcb6e10d7a24acecdb4727e4e836d8671c64a376da0d98ad2b11241fe0fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-5-204.yaml":
+    pending:
+      fingerprint: "sha256:942a22e51d0068a11113883c2c66a5b2c8d77ca16f4e0d0489cb3727e33f7004"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-6-106.yaml":
+    pending:
+      fingerprint: "sha256:e6d0beaa2f798b5ec8bb9e7c8a7e9e2a119b8f58c7e619a3df7937f381cf3270"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-7-101.yaml":
+    pending:
+      fingerprint: "sha256:abd4816fa6dc7fae64951966efb8ba288c8567b25cb60b138860f7923cca0ef1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-7-109.yaml":
+    pending:
+      fingerprint: "sha256:5c5bbdbb8e7352842b48f121d5764ba87ef3ec8369891d63d69005c8f0d63d84"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-8-106.yaml":
+    pending:
+      fingerprint: "sha256:62287154111cc69144c31b8a8d6bb49add079a58ff0bbd6d247528528e0e65c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-9-102.yaml":
+    pending:
+      fingerprint: "sha256:b4d36a9e5ef8979cf3dc07a50dda9676105f7a6748ffd33ae29663ed06e5cc6b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-co/statutes/39/39-9-103.yaml":
+    pending:
+      fingerprint: "sha256:77f2094bd44c93f9c9683db0759d5cacdb9f5803abe50437aed552bfaebec801"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ct/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:24d161d67e0ffb8a0a8f8e55b186f24dfa6269e327ca8fc98d5417bf57ac6bdb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ct/policies/income_tax/2026_resident_ordinary_tax_before_personal_credit.yaml":
+    pending:
+      fingerprint: "sha256:3c982ea5729859e0e54dd09136e038a3a46a030742ba721ff20eb79a91143e63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-dc/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:4c4834a45e999108cd2e75c2f1e5bd0c8ef60ab13a4bc8ebace09b20e9af644c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-de/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:4873b351f85001d4ca319a95f3d31c6002402b6498df6e83792d2d64f63d364b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-fl/policies/income_tax/2026_resident_zero_liability.yaml":
+    pending:
+      fingerprint: "sha256:7bf2dd5b9a560ea13990d6f849efc8fc9af92c7aaab18366db46f3b07677a5ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/policies/income_tax/2026_annual_tax_before_nonrefundable_credits.yaml":
+    pending:
+      fingerprint: "sha256:52aaf499b4794e21633b83d19931e3ec8e79d30b348e5a98f302c08ffe0aa31f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/statutes/48/48-7-20.yaml":
+    pending:
+      fingerprint: "sha256:9838b78a96da918f7dc5330defa007c2fa571be0752611c2f87a7e5250a89343"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/statutes/48/48-7-26.yaml":
+    pending:
+      fingerprint: "sha256:900aed26ee7839c1a0f371b7f1aca6b0a73cd8f7657ee945d089e4e81a623487"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/statutes/48/48-7-27.yaml":
+    pending:
+      fingerprint: "sha256:16757f1b8df8d6436274f244a3dbb1c18a3fee7b001d5c5d1884408185f44b7e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/statutes/48/48-7-29/10.yaml":
+    pending:
+      fingerprint: "sha256:62568088e43b4ac250721ead6beb91a4bfe6199befc34433fa780ab9e635a9fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ga/statutes/48/48-7A-3.yaml":
+    pending:
+      fingerprint: "sha256:540042a6a75a4bb806519b6047bdfdb3e7ef61a417b93892525d908d59dd4ae5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-hi/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:e3eb4d1747019070dbe853335f73f1bb96bb6508547215263d3dc4fdde7aab43"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-hi/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:e95b8e822a5abc7c5c4919feaebd6b9d724e64a145d9caf7eb3a90799cb6b602"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ia/policies/income_tax/2026_full_year_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:84c9ec43289d6468decc606f145eef327906026bdce5fe1ace535e66f844c3d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:3d2e7e912dad73fdeaf5d31f38aa8ccb47fb3a59297821fae4ef91de5c305784"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-il/policies/income_tax/2026_full_year_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:8bec3be8176a8e20365811251eccfd13493b8c894259110498fcc0e0b9254787"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-in/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:890e2f75be97ab18c048b7aa4fb6f9323b0617df433d5c45a5f27b6961b1b362"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ks/policies/income_tax/2026_full_year_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:44912a6ce4b6a2a9116e5e676416ee551da8dd707ef26abdfa6f56805689ee46"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml":
+    pending:
+      fingerprint: "sha256:f2e09330010e58c532bb01d8616c3c4c44e14750955a9a5a55ea797fe8d6898a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ks/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:eaa003d7fd0f460537864150cc21b24216af3e3356111460202f7082d648fb87"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:448bb44b32bdf4c520eec1dc9c8ce8eae6407d48df83e2196ad80d15bf45b223"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-la/policies/income_tax/2026_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:4ab20071683ea1b7fbe865974b7aa96c2e6bf38e27a9513bd1c6ae1dda7803a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:014be9ffccdc2d0a7af129814d390fae1c572b36b141f640b2e2226c66bff9ed"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:c9ef70082bd875be90cfa4a1a8bf1b1b2e55339ed51ac831200c8f1421b4b8af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-me/policies/income_tax/2026_resident_liability_source_hold.yaml":
+    pending:
+      fingerprint: "sha256:0adfc071f99ee2a08f1cc5717c3e1b72f043eb388a1f6dfb55e91b2faa73004a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:444afce9197e74ca12f3e49e288e5db5a75291fd0cfe6846d44f07eecf160f1f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mo/policies/income_tax/2026_noncombined_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:c563e322936811b2a75139daa360b1e942c3f621c4bcbc7d231eabc9577fe26c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mo/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:1b5772054969e5574f07782214ca2785716cfecaa002c7c23b63ed4cb76881a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml":
+    pending:
+      fingerprint: "sha256:f3b9a0e7b84e74bc23c9af054cb16e874b37a07b89f60e09f1875dd88615fe9d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-mt/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:66b119b761968e72537eb6f9aa27319f8cce4033c699be6fc02a8e2a20e772bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/statutes/105/105-153/7.yaml":
+    pending:
+      fingerprint: "sha256:b3ce10ade6db4963d9cb2e2041cdb96511ec15080605a68f7935f0bbb9a4875e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nd/policies/income_tax/2026_nd1es_estimated_schedule.yaml":
+    pending:
+      fingerprint: "sha256:8371d02698df2c2ccc1dbc79e45e4d7b82ea909b9c225fc4e453598dbe56d142"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nd/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:a9d2a387472e813f14a5b9efc6f8e6851f279bfa8ed0e1c549815b807ffcf89c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ne/policies/income_tax/2026_1040n_es_estimated_schedule.yaml":
+    pending:
+      fingerprint: "sha256:71ee8916bc7c2f10cd39286a8b66a9dbbbc07aafd74b4b4542566c5cc2632254"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nh/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:094688bf67592f716592a4886519b744f114fd7aa66b4dfda7c2862e327c4cfd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nj/policies/income_tax/2026_resident_ordinary_core.yaml":
+    pending:
+      fingerprint: "sha256:2cdaed6426a108001524e1c594f343b15c795397f2edc0285e5713e6f9eab2ba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nm/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:77d0f8860b544f7c967923b53cde4c7f09dc4b10319974d8f39fac0e40282b4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nv/policies/income_tax/2026_resident_zero_liability.yaml":
+    pending:
+      fingerprint: "sha256:9709089726de369b2fe9f2c87d36b37df6f24e3282e088916e5c7c9523ad83a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-oh/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:88d34d4e06d46c3b2d3489a530465e7b3596139eaf828d1cc353dab73154bb2c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ok/policies/income_tax/2026_resident_ordinary_core.yaml":
+    pending:
+      fingerprint: "sha256:6eb1a8aede728d0db9aafedc5ce91cda242ce657e73e529a8a7975848f390634"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ok/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:a962f57c5dd96703c2bc8931d960136d7420bacdce241ade054c5f55ae52fbf6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-or/policies/income_tax/2026_or_estimate_schedule.yaml":
+    pending:
+      fingerprint: "sha256:d51bfad18300aae51e1a40ed7f97a2c11d85d330e48b8f4b3f477233fa4d745f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-or/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:e28864d814eca29e5be40eb8749d9e997b2beaccfb0a71fdfa9ecc998ec1042c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:2d1af8adb47962a855e10fcdea626b849008922619eb651e12a63066e3d39427"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ri/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:88944d21372c0b37c858371058d98fd62c6c0ceb095ae8ca1a7d302664b780b4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sc/policies/income_tax/2026_full_year_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:9cba8f22ff1ca7610e28b74469d677125d4d0c14117fa25d17c1a8dbe54567db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-sd/policies/income_tax/2026_resident_zero_liability.yaml":
+    pending:
+      fingerprint: "sha256:fa7b2897498d51aa57a2233f18202c90646d1084501bc26e0f59545d724a2a58"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tn/policies/income_tax/2026_resident_zero_liability.yaml":
+    pending:
+      fingerprint: "sha256:7c9bcc61a4d2ce2fd45065aae34ddae5abbc3d5bab6356daf4624357effff8aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-ut/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:8e1ee9b50c3199498a31393854cd55747d0a7023bcf696ccfddc9305ae9edebe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-vt/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:3f3076e5186d87f4caee0590b1acf71639214ac78bbce417c32d97a2b026008f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wa/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:3134a9be34a28025fd534eab9447c230dcfb71fb4bae51e4e5536fa0151e0040"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wi/policies/income_tax/2026_form1es_estimated_schedule.yaml":
+    pending:
+      fingerprint: "sha256:cdb5b0c111bbdea57a0d704f220ce34f502f0df374052ae0e61722c88c514c41"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wi/policies/income_tax/2026_full_year_resident_core.yaml":
+    pending:
+      fingerprint: "sha256:da138d85aee6702fb93ec358703f66deecc1b1ac980c2c73f319ed169bd3595a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wv/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:444ff6fcfee3aaad4cf4662b774971f6f84829f48dcecf58cf06c6dbec378080"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:a843d9140969cc60933889aa6e780e4e3bfd29290a1710c7fc7ea909949362d2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/aca/ptc_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:c1210e32ed5bab4c0b368284c8a58b5854bd54baccb98282147e8ad03fb426f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/cbp/us-tariff-duty/composition.yaml":
+    pending:
+      fingerprint: "sha256:5ae55ea895bcbe7ddcf81ca64d50685e0e2d074c48173863eba6b46e8a92a42a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/cbp/us-tariff-duty/de-minimis/nonpostal-suspension.yaml":
+    pending:
+      fingerprint: "sha256:cf1e42a2a216464932ccfb0d8a77a4fef52b6a35a541e21a3a9bcbc2d7406d7d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/additional_medicare_tax_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:abf368341768bb90394ebc6d2b8f491dcac33ac0b83554c3894d817d565ad049"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/elderly_disabled_credit_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:1c06ad89c67b75db86bc54e4d8e7dccfb83d0665643ceb3dbf3868497df43137"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/itemized_taxable_income_deductions_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:4f63e8a60fd3a3d1804af2761bf910e147cb0ce88d50576e6a237dc2c1bb7845"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/lifetime_learning_credit_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:3fc72405d75fc6a8719f6674f393d494cdfa82aa6bca83157257d0c4e12fa626"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/net_investment_income_tax_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:5a3ba43b88ba6d988c624095ecce987caaf9db7ea1346f3e6353709ab0b36df1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/qualified_business_income_deduction_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:cf1556415b319af39c1fff6ed46dd7cd5e6ff572b25382723ed383d12296099c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/salt_deduction_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:f99164488fa74da6b0c89ef63e78af01aed9f7cad17b6d27cf464651f0c2deba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/savers_credit_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:989b261c560e4b3ac53ad611933079747dd3feda50e36e84009c9474f2bee5fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/self_employment_tax_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:f83b1bd0dfb84f7a8452264b31b5af50707d6aad85a69a92031751434c25a40c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/income_tax/taxable_income_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:2d30f8e72917d87470b7a8c09d2c425137455b56468881bc8b551c9bbb4cde2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/irs/notice-2025-67/savers-credit.yaml":
+    pending:
+      fingerprint: "sha256:980db26f953d522f5b8b20da874d64a7e8f3340fd5671f8a0ef3dd4f2af47f61"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/irs/rev-proc-2025-32/qualified-business-income.yaml":
+    pending:
+      fingerprint: "sha256:304edcfa2d3b40dd4fedc97fddcd7f6b2144b39b8855db752767f6059550e18a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/medicaid/magi_household_income_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:d16a326c01cb2b750d427aa58afc7b7d004046c73156ddaa783145765511aaaf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usda/csfp/eligibility_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:2b62ee47e52475b940adddbe3a66d6ea4a33ff3c7d7ab06b54e1a7772aa27da4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usda/wic/eligibility_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:c59783f04fd493847871cf12f7628547d7d4b39a83280b15c28045df65346531"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/7202-11-10-00.yaml":
+    pending:
+      fingerprint: "sha256:41f0fef6c5d77b005b260eb247746d470dcb57cf7c2ac2b66da214d8ab8b87a4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/7601-10-30-00.yaml":
+    pending:
+      fingerprint: "sha256:fc2b5e4a1bbc382303a72f3359c55acfa12d4808ad6291c432747f66d015d577"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/9506-62-40.yaml":
+    pending:
+      fingerprint: "sha256:d3d21408ac9a086dbebf8219071276291b5bc16924dc28a45d70b981571dbaf3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch01.yaml":
+    pending:
+      fingerprint: "sha256:3546c861babf4390730e801adaa378da628e02f4b7c345b812b108c8795dfb65"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch02.yaml":
+    pending:
+      fingerprint: "sha256:5366937be89bf4909953b13d38ebe6c0a856eea9a57894a61ae5eb51d895c0c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch03.yaml":
+    pending:
+      fingerprint: "sha256:4a602dee8ad9b9612f12ac4f1848a7ceceeb3fafac10500b836b3d04cfdf2a54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch04.yaml":
+    pending:
+      fingerprint: "sha256:29bd583c37c24c983f6cb8434ff44d4dfc3ec25280ca0e3fe103670403d46644"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch05.yaml":
+    pending:
+      fingerprint: "sha256:4bf4f8acdb3aa472c018ad6a0fec662e8dd7a1681f9bac33099f1e594461ee85"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch06.yaml":
+    pending:
+      fingerprint: "sha256:f755bfdd6a75507b3395dc979d1a2db4e0314dfa1a8a1ce9dcb5decbac123d99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch07.yaml":
+    pending:
+      fingerprint: "sha256:56ea04ba2bbd4bc38da17dfb44d26f9f4d25406aed7c15cdf11082fffa907ad9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch08.yaml":
+    pending:
+      fingerprint: "sha256:3955b1d1177381ca5ad08ebc0b9c8cacd84f2327e73b349052e7855dbd9b667c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch09.yaml":
+    pending:
+      fingerprint: "sha256:1216385533d3db9c42bc464891fc04bb59bcf1880e0df1da4bd501820ea268a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch10.yaml":
+    pending:
+      fingerprint: "sha256:b5a5dc396d3ed0c414637b50f89b20289cbc64af35e8238eb8877ecf6460f1e2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch11.yaml":
+    pending:
+      fingerprint: "sha256:4848c47cc11c7cf8fe188b5c3b2ed2c92e3cb256aeb813e20437b8c1491ea616"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch12.yaml":
+    pending:
+      fingerprint: "sha256:f51d4a5ad49396bcc279ce4f6a5ffe03d498f6782a461defe79715e9911542f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch13.yaml":
+    pending:
+      fingerprint: "sha256:9339dafefa956a745a0c0e5f36df714ccdc39b7fd946d79b5ba6ad01621a997e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch14.yaml":
+    pending:
+      fingerprint: "sha256:afbe15aa19513654cbcb6cc30680d7c73d0c4bbafe0b64ec325674fac119e947"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch15.yaml":
+    pending:
+      fingerprint: "sha256:01ae58d5ae95bf8d513cb6ea1f1d8e04cf076c680ce9e795a726b53279580956"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch16.yaml":
+    pending:
+      fingerprint: "sha256:f32256dd4912f057d17806a46b071fac2400dc8df71ede2b53988981b6dea045"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch17.yaml":
+    pending:
+      fingerprint: "sha256:86bb3ad3220d7c34acd2908d88ef4c73edc4dcd5ede98b835b583651719db12d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch18.yaml":
+    pending:
+      fingerprint: "sha256:0e525c9c171b037d27080b6d57f1663ed8301c8c142ebabedbb3761c2283eb66"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch19.yaml":
+    pending:
+      fingerprint: "sha256:5084e4fe9e8ed4b013d5da2ebaa12054cae4bcdcab506ff139154337e91b5e8f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch20.yaml":
+    pending:
+      fingerprint: "sha256:6bf93bb4ab7954b2fe5f494a1fe55d2b56b8cbfdd1f98a50f066621409eb9fe7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch21.yaml":
+    pending:
+      fingerprint: "sha256:ade626c93f6f811701198e297376362d79176f16aeab800056253480ed7c6317"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch22.yaml":
+    pending:
+      fingerprint: "sha256:f977e52008392187f6a8770d8cc40f3941cb2e57233dac3b241721ea56c7d740"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch23.yaml":
+    pending:
+      fingerprint: "sha256:b905129af17766cfac5d15fac4dc2df16dff4eb99d7c0fea6e1c666001673636"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch24.yaml":
+    pending:
+      fingerprint: "sha256:8fc7589742b38c4591de2343b32295663da696f9e40e4c61913918d038269130"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch25.yaml":
+    pending:
+      fingerprint: "sha256:57155c3d90f78fab29515a4fc79a1f99a09c6dfba3bab60efb005878ca73cfd0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch26.yaml":
+    pending:
+      fingerprint: "sha256:86f0f8a5d9befa34dc7f17d543fb28aebbff5c0cd88237a6b9263621f687d467"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch27.yaml":
+    pending:
+      fingerprint: "sha256:1db3e5fdc481bbc91123b87fb7447193a524228b36e71bd4f8c4fe3678567537"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch28.yaml":
+    pending:
+      fingerprint: "sha256:a31990bb7e6ca3aa23a5881b4812ada84c4040c19982d35eb9d7396ec03d75ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch29.yaml":
+    pending:
+      fingerprint: "sha256:785803b64ae2f262dab0463630c022c9ab149d793ee00bd04cb1936c9ec662d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch30.yaml":
+    pending:
+      fingerprint: "sha256:80dbb1f4b4f0562a8c0c7142c1bc8ca00625d59abc3dd0b32eedd7767de19507"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch31.yaml":
+    pending:
+      fingerprint: "sha256:c03afe0880d6638bec2570355eadd3fb211f9e48dfa614d767a54c0f88418ef3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch32.yaml":
+    pending:
+      fingerprint: "sha256:588f2b3860d4b588b6c24a7331ac495e7eb470d28421328b745b3d60837997f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch33.yaml":
+    pending:
+      fingerprint: "sha256:14d770413bd1a74ee8ad237da0aab1deb050b40f3b630ea06df58d071bba35cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch34.yaml":
+    pending:
+      fingerprint: "sha256:24e09c7c81b785e84d2701cde6ebbb7bc064fcc0436b6f19627e9361db236dcd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch35.yaml":
+    pending:
+      fingerprint: "sha256:d00d6049b536f200132a9dc2e419970cb61081f890d9b0ca3d5a4a33dc1ed848"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch36.yaml":
+    pending:
+      fingerprint: "sha256:5dd04d2a07e78c5c744cdca024361b5929a8484f622b0d4eea35d3733a8fd158"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch37.yaml":
+    pending:
+      fingerprint: "sha256:93fbb3c33e58b2fd0425a0aa046f3af1bdfdb64cebcfeb1fd1f05ddeaca633fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch38.yaml":
+    pending:
+      fingerprint: "sha256:15706a80c73cf16d8734c74a869fecab7f9cc961e8969817d602bd35900bc5d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch39.yaml":
+    pending:
+      fingerprint: "sha256:beca7261f145856c7134e6343d73cba374584302c21924818fd7a7f569aa6b18"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch40.yaml":
+    pending:
+      fingerprint: "sha256:615308a5f0e78f6f6d2b23507d97112d85461631442959e6d5c63a75b6204f91"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch41.yaml":
+    pending:
+      fingerprint: "sha256:d64382f4629f08a9d7f97599c4cb722d6bb8cfa8476893f73d326d76113e9b74"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch42.yaml":
+    pending:
+      fingerprint: "sha256:6994971a1334f51c76cece8d0d920f9638e47ee1807a33d7a7f8ef42c9d230a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch43.yaml":
+    pending:
+      fingerprint: "sha256:e0ffcd910cc285fc83c113974f63e365be0b48e060569b14e09ec8553271df7a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch44.yaml":
+    pending:
+      fingerprint: "sha256:ea130ad3881e5d6c33648998ea7a7de1e38b429bb0a73b0b29d3fe7c590fb488"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch45.yaml":
+    pending:
+      fingerprint: "sha256:b4525cfc46710dc1df6c7f2988204ee7b3fc8f0d53da4c22ae1ebc40b7defe04"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch46.yaml":
+    pending:
+      fingerprint: "sha256:b33039a163d760538a19cb7d142aeffb280febff8ff032e05bea538a4e41a002"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch47.yaml":
+    pending:
+      fingerprint: "sha256:8a8411c3d961fde32e5197ff3ed1662c34aa8bba032bd1dcb67fd6f0ac814c80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch48.yaml":
+    pending:
+      fingerprint: "sha256:678bdf91b65a319f39ad2c630c4d4ae6b5206b81eb573f635bbe5a6f8cd7818a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch49.yaml":
+    pending:
+      fingerprint: "sha256:28b59bb2360423c63328bb7cb51ee719c72bfab494398d39eb5d191904018757"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch50.yaml":
+    pending:
+      fingerprint: "sha256:05cfc16ed3d98ff4630a009e61f322f86b1e79cd2b229720147b3a10b23afd03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch51.yaml":
+    pending:
+      fingerprint: "sha256:f3ce53000448f5efa3e7cefa8facc6277509fec8ef961d36e3dadedd213cf6b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch52.yaml":
+    pending:
+      fingerprint: "sha256:ebb12c2fdc37e3442fd47c199b5a003ecfe28f71b62202e5b3fcd0608f6041c4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch53.yaml":
+    pending:
+      fingerprint: "sha256:3c9c112663446bc1ff881ced46bfe19737ba65661a608742176f004c08a53a97"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch54.yaml":
+    pending:
+      fingerprint: "sha256:bd9c64ad98ccf4ea306f12390d8cf13b7ce3cb513628434b01129cfad737e644"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch55.yaml":
+    pending:
+      fingerprint: "sha256:bafab518b4a85bbd4ea90abe99b6e3df3e4b9e0ed170696e1a8fa2b7581d5b1a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch56.yaml":
+    pending:
+      fingerprint: "sha256:e948ecad620c2ef81a0e0a11f49fe86c27d90b9dc31b3bb3ccd72fd6b263b62f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch57.yaml":
+    pending:
+      fingerprint: "sha256:ce17e4d3c85b39ee2e365c4229d029793f8128542993fd55c0d12f297067b50d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch58.yaml":
+    pending:
+      fingerprint: "sha256:913e34ade14017c7f743aed26a357c884ddf99dd9e3910fb37eaf63a65536425"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch59.yaml":
+    pending:
+      fingerprint: "sha256:e5078e4476ab5bd61fd38cb9380fe32f39e9ea33d73540a00ba8f9d73bd19cc8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch60.yaml":
+    pending:
+      fingerprint: "sha256:3de7c11486bfcf4b5d4048314a6019d90323383a26007ef3a0d6892acf8172da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch61.yaml":
+    pending:
+      fingerprint: "sha256:ffe9fa262cb7534d382db9c79d254b6e3266bcf16facfda0617ad09141fb750e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch62.yaml":
+    pending:
+      fingerprint: "sha256:76eb4a6d8755e8dde11b99a9a45c0b2843bfe0bcdec52af10cb4095a8d1c122b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch63.yaml":
+    pending:
+      fingerprint: "sha256:f16c9fe1ec0c01a188a866fd82e30823f94ef59a65668c257e92d772fc2e2aa9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch64.yaml":
+    pending:
+      fingerprint: "sha256:4875e8929fdfda5215f33a47dc30e07cb1998c57296f88be4fd6cfa2a1a52c11"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch65.yaml":
+    pending:
+      fingerprint: "sha256:c31e634fbdebcc9a61191c15ffa5f1ab8d54c2e9955ccde40c86e562baf95623"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch66.yaml":
+    pending:
+      fingerprint: "sha256:ee801e96f9f17361f7709c123d7204a4e3f3e607ef3f077da4280bfa7cfa2b05"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch67.yaml":
+    pending:
+      fingerprint: "sha256:63a5e975e754ec7fe691f6be5966382954e51ce987e5830ff9739b14530cab99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch68.yaml":
+    pending:
+      fingerprint: "sha256:3816ce76a5acc0c5d399356aebdf6e7f2cdf45555a2b1d9e0bacc2e8a8181b12"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch69.yaml":
+    pending:
+      fingerprint: "sha256:688a0842bf11f3d64e8346c8a4157278167645464b100fc549c1d01decb7e4fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch70.yaml":
+    pending:
+      fingerprint: "sha256:76810c9e9d166b053d6192601d257664d1ac5c0bb0bd5c9d4a37fb991b1b384d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch71.yaml":
+    pending:
+      fingerprint: "sha256:480908e683d42206985f3576742af4229fb03815412c87fcc9804ddcf87f21cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch72.yaml":
+    pending:
+      fingerprint: "sha256:c59cd057ea1643711c3aa17f40644fa0bb4858087de7853fb47de8fe89ead543"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch73.yaml":
+    pending:
+      fingerprint: "sha256:2cd6125bee07f91e0d8050af2a604ab8747374ca5c6f99066c89f248a6ae9742"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch74.yaml":
+    pending:
+      fingerprint: "sha256:2ad6519e71329ad05091183054bdca839a90bb63ff95709ed741fc4139e62c19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch75.yaml":
+    pending:
+      fingerprint: "sha256:fcc9ec53b6e267d311f6cc8599a3195025004513ce92aea32c6012d3f2f1283d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/fentanyl-energy-9903-01-13.yaml":
+    pending:
+      fingerprint: "sha256:314ff5a81531ba79ddc0c01621332d6ba8ca671c414a80f2e8ebf0dfa40c0be3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-annex-exclusion-9903-01-32.yaml":
+    pending:
+      fingerprint: "sha256:7cfda459a8194c36d2d396e92757225a0ed0aed8cfa2c1e30fda4bcdb253125d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-36.yaml":
+    pending:
+      fingerprint: "sha256:c0776c04bd0af6329257132c0e817d322b2f4b69aeb7565d1f17449cd07df5a7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-87.yaml":
+    pending:
+      fingerprint: "sha256:698387c8ec7415a365d5df35780eec9e8fe690f55f1b0c6d625f25c3694e30cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-88.yaml":
+    pending:
+      fingerprint: "sha256:a0bea94bc6427bfed677b1f7c15066a42f69158276d33c7d339b70ea3a6aed5b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-metals-exclusion-9903-01-33.yaml":
+    pending:
+      fingerprint: "sha256:8a5a17e0a11db7d4a6c3daa6972a95204233f728848d866071c3827587ddd5fa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-79.yaml":
+    pending:
+      fingerprint: "sha256:15d26c0a176041f129f5a34fc541500f2ccd0553fbf551978f9a4999b2eb9d60"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-80.yaml":
+    pending:
+      fingerprint: "sha256:e000ba2a87bd3cdee5141ecd10463ba9395aa861b393eeb140f68682015cb0cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-58.yaml":
+    pending:
+      fingerprint: "sha256:d0ee792ce3d9d14b957326dd20f9fa64fabef083a335960e27d4968b751113e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-82.yaml":
+    pending:
+      fingerprint: "sha256:72c2709a6e2f8d00e28ead1501e1175ca4860d6ef8ffbd2631d3f829f1486314"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-83.yaml":
+    pending:
+      fingerprint: "sha256:4485d121b855785dbeaf769fc087a44d6720f82533a5bb47279f791a664d88d6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-122/proclamation.yaml":
+    pending:
+      fingerprint: "sha256:6b88562c033a6078e48696e2c31c48ce776c69e9d1a3594006f4a256acee6fbc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-122/section-232-exclusion-9903-03-06.yaml":
+    pending:
+      fingerprint: "sha256:b145a422f635fda2b3a14fefe614d0aa209be60370b05527a5e6c4284f199aa1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-eu-9903-05-39.yaml":
+    pending:
+      fingerprint: "sha256:1730e0116bdf859aabc538afddf1aae80ae0019a964e20b2e6fee88e69bd0ab2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-japan-9903-05-49.yaml":
+    pending:
+      fingerprint: "sha256:0e2613a0f84d9851fdcd9f4a10f86457cd5ce4842a3f5526bedd2a7c586b6197"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-south-korea-9903-05-71.yaml":
+    pending:
+      fingerprint: "sha256:9e0ebc3bfe170d856ef7d99e0f835e22425145745d8fa691a09b4e58062d8d17"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-switzerland-9903-05-74.yaml":
+    pending:
+      fingerprint: "sha256:f619ccd4e6dcbe84deb75acb3764948bb2ffd6f3f1ed82411d66e61fc7234146"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-taiwan-9903-05-76.yaml":
+    pending:
+      fingerprint: "sha256:64e7a74c211b7d2e4a4fcddd7192188ba9ea7644fbb218bfdbe439498f356ccb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/552.yaml":
+    pending:
+      fingerprint: "sha256:605397f7b099735e9e73c61d03b6b7d1e2f603e2f87f9b4399bad5a01b5fd5b2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/555.yaml":
+    pending:
+      fingerprint: "sha256:c78ad68a9b16c1d6a8c49d49410aa61913312c36602631a2979adfeeb1a9efd1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/558.yaml":
+    pending:
+      fingerprint: "sha256:689edd33163b69cc4a5330546e77505c4e0066a2ee971d6388f3c33fdf727cec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/561.yaml":
+    pending:
+      fingerprint: "sha256:61b26d921389ad3be9e81e1d7d180fa9cf5eb68c8d55340532ffa82bf4b66daa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/7-cfr/273/24.yaml":
+    pending:
+      fingerprint: "sha256:19f07f96f1250a2c18ef8c2d1d7e6fb7d1efb5e303591bcdc72c981eca0360be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/7-cfr/273/7.yaml":
+    pending:
+      fingerprint: "sha256:221ff92fc5f81543ca2f614d2bbe59667afd49e878fdd990378f3ab953a0c442"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1441a.yaml":
+    pending:
+      fingerprint: "sha256:a844b2292d635c376de9882526a4737251b625c858028f4d5be27f47564104bd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1467a.yaml":
+    pending:
+      fingerprint: "sha256:a4c359fbc0b3322fd6f0f402102553715b4791700a8548e820b62db36623831c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1701s.yaml":
+    pending:
+      fingerprint: "sha256:20c2d67f6932a8b3940a2363edbef46af04d8579c3033db2bd5ac46cf572e52c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1703.yaml":
+    pending:
+      fingerprint: "sha256:f61e636e3bb169a3ea7155b9d25357daa2b889187deae8feea97304db924dc06"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1712a.yaml":
+    pending:
+      fingerprint: "sha256:615c8491907b964700eebcfee0739d8c5d6e3ef19b77dbca6a0c4d9022b81ac5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1713.yaml":
+    pending:
+      fingerprint: "sha256:d403970aaa9dc6bb3c5d6dcd9543b00c1d94b49ad630780fd3f0a2eaac446f21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1715l.yaml":
+    pending:
+      fingerprint: "sha256:12035fd8523afe8dc936cf2c6ab16dbc107d5e31e31714026c953ddf7eb82e90"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1715r.yaml":
+    pending:
+      fingerprint: "sha256:9324c90aa752af66a664392ae422ae3bc21aaa932506cf1537664f023c60c1de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1720.yaml":
+    pending:
+      fingerprint: "sha256:76e7281997d6ee756fb330d6d9105579e25264b6b4ef3df611b0c7e4ea000d80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/1842.yaml":
+    pending:
+      fingerprint: "sha256:f5ecb24aaff14199dda85673a8440ce872051a2bed039a1e34f9f73969a7563f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/12/375b.yaml":
+    pending:
+      fingerprint: "sha256:734652352a3c65bbc5ea2016e8b2d5c8acbfc6fa32eb3cfaa2a664858505e96e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/19/1321.yaml":
+    pending:
+      fingerprint: "sha256:7b1b25435527c56504f330a98bcdff2d4e1ed71e096f604a1460ce3706442c0a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/32.yaml":
+    pending:
+      fingerprint: "sha256:d92dec59e652a0a291e74a4eea582730ca7e3d5dc8e9f6863b776085603128f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/42.yaml":
+    pending:
+      fingerprint: "sha256:320a2bd6e6e88cbc02c418ed381e91d5f0892e535b7489ff4be31956c99d1b0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/55.yaml":
+    pending:
+      fingerprint: "sha256:f48d8225cc3a0cee58179d0c8fc50dda60e03460d77fd81243396ae06a3b4adf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/57.yaml":
+    pending:
+      fingerprint: "sha256:c89bcce4f05afc48d828bcaf41bcdeedb8a7824bb41b3ff02f93a3a684a18abf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/58.yaml":
+    pending:
+      fingerprint: "sha256:ca2bb21115a72463bc1bf5dc2a6cdab6a76b5d09a4717813f48496c6e41013f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/59.yaml":
+    pending:
+      fingerprint: "sha256:6ef556d6a917adb1a039e96e0a6facd7d2e38da44427c7a3115df4cc26550be5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/63/c/6.yaml":
+    pending:
+      fingerprint: "sha256:babdf988f3f47f7715f41152c0caae57f5ec32c78190b3f6a275014867fda774"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/7701.yaml":
+    pending:
+      fingerprint: "sha256:8b23a10a85836142761939df5625051b376e67a076944cbbdeb655b519c6c64f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/38/1521.yaml":
+    pending:
+      fingerprint: "sha256:b1eebf5f43344a667be429b0662ce86b3bd7afd2a32ddaa445879e2a3bfa3fec"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12705.yaml":
+    pending:
+      fingerprint: "sha256:76871d4e71b83e820a4c47ae8d9b6ff4dc263436a1ec244bcce1c54485304efd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12709.yaml":
+    pending:
+      fingerprint: "sha256:4edf83b21ff9955e07720d439a1dd59796e97f5f37b2f03309a7a0729c7a1f2e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12742.yaml":
+    pending:
+      fingerprint: "sha256:b70e65e9f8c91b58cb47937571109c06d25a8a566b7240ce377e997e4b28d5c3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12746.yaml":
+    pending:
+      fingerprint: "sha256:b5bc410825e919f83d2f8046f5a510f8ddca794f2728aa3fc40f5014b12f8190"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12747.yaml":
+    pending:
+      fingerprint: "sha256:f5ee3849cba344d94e35a5be73359d2823846d53a4ef428732fdc27d8d5dc6f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12748.yaml":
+    pending:
+      fingerprint: "sha256:e4c508820b508bc93cbefa8e4ab991881a45d6d489f477983588993454a8a31c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12753.yaml":
+    pending:
+      fingerprint: "sha256:464cc6afc844bbcece98f3c5a008ac9fb1d1f6a527695788a794814826fc499a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/12755.yaml":
+    pending:
+      fingerprint: "sha256:201f73ef6d10ddec759d82ff2097ee8abfdc06f95b5b7793230d1370f1a52636"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1437f/d.yaml":
+    pending:
+      fingerprint: "sha256:654cd3ff64d1d48ba2608fb481777912af33ba8358fa7f769809767680242e80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1437f/o.yaml":
+    pending:
+      fingerprint: "sha256:8a65091c46abcdb9e2ed001ef5527410e0a2c7646af0254b12c4b9beafdc0e74"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1437g.yaml":
+    pending:
+      fingerprint: "sha256:5895d2a391e935871f3fda8572041ae06ebc19d81fd0f3a385210b1610775403"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1437n.yaml":
+    pending:
+      fingerprint: "sha256:bd3a99d874e27a209b7d53f9e71e38521fc89d2acb2a687b2fc52718fc5cb8fe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1472.yaml":
+    pending:
+      fingerprint: "sha256:d98d7759a3adfd79b9745aa9e9c4342d0655cd7cd285914a68343108bf5622bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1484.yaml":
+    pending:
+      fingerprint: "sha256:52556cb3f24fb17da239186935650658c261bbfcda006ea998e9eca1fc3ba36f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1485.yaml":
+    pending:
+      fingerprint: "sha256:79dce93ff693c6d7a71e9d0b9a1bc444450a1a7e8607ab918fa49a11bf07f6b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1486.yaml":
+    pending:
+      fingerprint: "sha256:14dbcd6dfd7e2d3a351a56de97570ed8d6559a2e25fcbfaf426ae0ad15eae40d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1487.yaml":
+    pending:
+      fingerprint: "sha256:bb113dca4a3f10df15412345ba39e073bfe124736d8317dc8ceddce99426df13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1490m.yaml":
+    pending:
+      fingerprint: "sha256:cb28fd6656c413171f71b4c4dca3ac4df7fd363042372b467b41756d989dc55a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/1490r.yaml":
+    pending:
+      fingerprint: "sha256:5c92e80da9debdd9d9860d54cf6e62da2d1beb28d94252cf333579a2a92514ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/5301.yaml":
+    pending:
+      fingerprint: "sha256:bc98c7a286092e53ada8c86ab2d97115c0dd56afe6aa9cca8fc06a437a16fdfc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/5305.yaml":
+    pending:
+      fingerprint: "sha256:036482a137615440b02086a0fa4a4a17ab8422dfbc96fec1d15259747e78ab78"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/5306.yaml":
+    pending:
+      fingerprint: "sha256:96bd506bda3bf9cf99246f71dce53b89cb3c84ed80fccdcd5b2d654a3d6e4f13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/42/8011.yaml":
+    pending:
+      fingerprint: "sha256:6b2c65b7fc460f90a8e90ec1167999ab9aef33ff45c9cd10b7ab41792c3abd6b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Summary

- add pending-only validation-waiver approvals for 638 modules newly exposed by the authenticated modern validator
- refresh 11 superseded pending fingerprints using the same authenticated census
- leave all approvals pending; this PR does not activate or consume any waiver

## Evidence

Authenticated fingerprint census used:
- signed corpus release `us-rulespec-2026-08-08-obbb-alien-snap`
- content SHA-256 `0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc`
- release provenance commit `e79781bddeaba4d3697c5375c7371b2a038f0f74`
- encoder `caebbda1a190181ef8184ed7aaffedb3789202a3`
- rules engine `48797e101c093bb388be718c6f5d8fc9d9f94a7d`
- corpus checkout `60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a`
- protected waiver-set SHA-256 `2068ef346724cc9db7e382d3dec11b284cd38305479ab7906939a606f3ee38f3`
- runs: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31560518899 and https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31563746012 and https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31564521879

The aggregated evidence covers all 1,453 requested modules exactly once: 793 fail and have exact pending fingerprints here; 660 pass. Of the 793 failures, 144 pending fingerprints were already exact on protected main, 11 are refreshed here, and 638 are new pending approvals.

## Checks

- `pytest -q tests/test_repository_layout.py` (4 passed)
- YAML parse and exact fingerprint reconciliation: all 793 failing evidence rows match a pending ledger record
- diff scope: `known-validation-gaps.yaml` only

Part of #1248 and infrastructure follow-up to #1279.
