### PR TITLE
Register hard-cut residual fingerprint evidence

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -32,7 +32,26 @@
       "rulespec_us_ref": "10f7a16ecbb9053f43dc198e2b8a3554e5ba9078"
     },
     "toolchain_block_note": "the top-level toolchain block is retained byte-equal to .axiom/target-validation-passes.json per the bridge's cross-evidence equality check; it describes the v5-foundation era that minted the untouched rows. The 1,021 rows refreshed for the strict-cutover approvals were minted and verified at the pins recorded here:",
-    "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in"
+    "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in",
+    "hard_cut_residual_census": {
+      "method": "authenticated isolated validation-waiver fingerprint census; module_sha256 attests protected-main bytes",
+      "rulespec_ref": "1018e3f01dc38a4246055240e6bcf2f1b55c019e",
+      "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
+      "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",
+      "axiom_corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+      "axiom_corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+      "release_provenance_commit": "e79781bddeaba4d3697c5375c7371b2a038f0f74",
+      "validation_waiver_set_sha256": "2068ef346724cc9db7e382d3dec11b284cd38305479ab7906939a606f3ee38f3",
+      "workflow_runs": [
+        "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31560518899",
+        "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31563746012",
+        "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31564521879"
+      ],
+      "requested_modules": 1453,
+      "failing_modules": 793,
+      "registered_new_or_replacement_rows": 374
+    }
   },
   "modules": {
     "us-ak/policies/cms/alaska-chip-eligibility.yaml": {
@@ -2157,7 +2176,7 @@
     },
     "us-ca/regulations/mpp/63-410/321.yaml": {
       "fingerprint": "sha256:7db8e583207465f1e54ec0bca09cc7d291a8523156dac773f0009bb8fa8ce04c",
-      "module_sha256": "sha256:d3f2a2eee1eb7851a333cbe3f2e22c8fa190092956ef910a29b62c4f7e1dab73",
+      "module_sha256": "sha256:b1d6a7415ee7b7a20102edaeee97766dcaf1e9e367030dba76b7ba5217ab7945",
       "passed": false
     },
     "us-ca/regulations/mpp/63-410/322.yaml": {
@@ -6106,23 +6125,23 @@
       "passed": false
     },
     "us-ga/statutes/48/48-7-26.yaml": {
-      "fingerprint": "sha256:a5bc8767d2c35454d17145136868798c5fae725f5e19fd71f9662388320deac3",
-      "module_sha256": "sha256:7f0830ad62d55b9f8188908a12e1870a300ea4305548b20a8f5385cbeb7f4f20",
+      "fingerprint": "sha256:900aed26ee7839c1a0f371b7f1aca6b0a73cd8f7657ee945d089e4e81a623487",
+      "module_sha256": "sha256:1a4ca8c47965b220316d028b9b07f90658e089d4e92492e945402338dad9a0f7",
       "passed": false
     },
     "us-ga/statutes/48/48-7-27.yaml": {
-      "fingerprint": "sha256:f37a6701486fa5d6f2e43a4204d192305e821c6604d2f81b67b78d51ee4fd282",
-      "module_sha256": "sha256:b44c3b89bbb15d54b39824126fc882304e4ec02bf9b1ad5f7a93f2b6b5ed8c1a",
+      "fingerprint": "sha256:16757f1b8df8d6436274f244a3dbb1c18a3fee7b001d5c5d1884408185f44b7e",
+      "module_sha256": "sha256:f9e733b5499754ed829bc6c7610eee597d0ae55ba7dbb1fbdec257859737038e",
       "passed": false
     },
     "us-ga/statutes/48/48-7-29/10.yaml": {
-      "fingerprint": "sha256:4336eb0cfb3f7742847a2e9c13726db6a97e45afca96f7a9a98a7c92861f9482",
-      "module_sha256": "sha256:20b03223506d5073e7266e04fdc7777930213c991e5aac196a462e292764f36f",
+      "fingerprint": "sha256:62568088e43b4ac250721ead6beb91a4bfe6199befc34433fa780ab9e635a9fd",
+      "module_sha256": "sha256:4ac284f36e8cc5bcd4b905b01ce889bbd93f2fa09cf21dcacbb57581d9eb2c85",
       "passed": false
     },
     "us-ga/statutes/48/48-7A-3.yaml": {
-      "fingerprint": "sha256:cf8d5ffb8037509bad65967dbbc3f991edf0a05cbef118fa4142b4fab607ec28",
-      "module_sha256": "sha256:ee857810dc2b2f5f3a9607b166d395355f6967ee0ae09f2ed653472c99946520",
+      "fingerprint": "sha256:540042a6a75a4bb806519b6047bdfdb3e7ef61a417b93892525d908d59dd4ae5",
+      "module_sha256": "sha256:be1408488645d51211fa5d43dcae6bed04b38abb8a1b9b40733f381ca4dff5b2",
       "passed": false
     },
     "us-hi/policies/cms/hawaii-chip-eligibility.yaml": {
@@ -9651,8 +9670,8 @@
       "passed": false
     },
     "us-nc/statutes/105/105-153/7.yaml": {
-      "fingerprint": "sha256:08e6179ae761930c7b42fb8daa34871b9a2ae041ee26cee9086a6bbe02a8d985",
-      "module_sha256": "sha256:594b191130912c073719a143ffca21ce1814dd1f159b68f2dcdaaa732eac8a30",
+      "fingerprint": "sha256:b3ce10ade6db4963d9cb2e2041cdb96511ec15080605a68f7935f0bbb9a4875e",
+      "module_sha256": "sha256:ea3def55651deac88f54a798ee496ca4d486f5d0d0595562fe71518411975e01",
       "passed": false
     },
     "us-nc/statutes/105/105-153/9.yaml": {
@@ -9956,8 +9975,8 @@
       "passed": false
     },
     "us-oh/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:51834b7517a7c7314c023029881a88d7d9bc12a0bc70a36c320eb853b45ec25e",
-      "module_sha256": "sha256:29e6da6ea143e00c9526b9f73bd2cda04418837def4a6b3eae66a0627e1f4997",
+      "fingerprint": "sha256:88d34d4e06d46c3b2d3489a530465e7b3596139eaf828d1cc353dab73154bb2c",
+      "module_sha256": "sha256:5707cc37b8f0fa5401ce32cde38f2fcb48cdc8af5eeef1ce22371d3a33da5a4c",
       "passed": false
     },
     "us-oh/statutes/5747/02.yaml": {
@@ -10676,8 +10695,8 @@
       "passed": false
     },
     "us-ut/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:4f7a2ac0d5f232e0148d1b42b5fcd2214bc1a323e77874568a733c9337725e47",
-      "module_sha256": "sha256:899232480598ae76d2538bf56914a6b7903a79897df9aa8f565812beb03fafcf",
+      "fingerprint": "sha256:8e1ee9b50c3199498a31393854cd55747d0a7023bcf696ccfddc9305ae9edebe",
+      "module_sha256": "sha256:0c408f0dc90d88d161ec0a08e6b129e19d377ece9a97d79db92b1f15f6477314",
       "passed": false
     },
     "us-ut/regulations/admin-rules/r986/200/204.yaml": {
@@ -10831,7 +10850,7 @@
       "passed": false
     },
     "us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml": {
-      "fingerprint": "sha256:0f7f75a8555cd01228569d79ce295510a72b6d7f9adf7872ccbb823766e645de",
+      "fingerprint": "sha256:8463a2139aad273cd60cea721e08358a7f7690e07272930d2ad73d81de5fc3b7",
       "module_sha256": "sha256:50808ccfc0d1acba5cf639fc31620169d76d8f44e82905d73644987e8c3380b9",
       "passed": false
     },
@@ -10846,12 +10865,12 @@
       "passed": false
     },
     "us/policies/irs/rev-proc-2025-32/earned-income-credit.yaml": {
-      "fingerprint": "sha256:737b7a41cc85dd1380a86d5703f0fe71a0bb561c6fbc6a1e2c2ba6e5a55e1e0b",
+      "fingerprint": "sha256:019113f18a8c213bcded99cf0801f39a3830fad0aad08207f73b9a1339bed08d",
       "module_sha256": "sha256:299a7bc8a73cfb7dfad5d49fb82fca8fa29bf1b18c09e91180ebc5b3975fad7b",
       "passed": false
     },
     "us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml": {
-      "fingerprint": "sha256:af8df97ee8f749d8617e254f0ae089cc582ad36786c240418995fb15986d8334",
+      "fingerprint": "sha256:629a0520fcfe66fe8b646c9a60951a74baf57021594da565511bfb81bc1dff44",
       "module_sha256": "sha256:71d48be45e0ef2301d016959a784d2f27cb18c8e2a1c79c941f096790199e1c2",
       "passed": false
     },
@@ -10871,7 +10890,7 @@
       "passed": false
     },
     "us/policies/ssa/poms/si-01415-058/2026/federally-administered-optional-supplement-common.yaml": {
-      "fingerprint": "sha256:38cccecc98cea21ef3f7af3722c7e2d5638d707c33f4f76a497e8d7173e80dde",
+      "fingerprint": "sha256:b6330655f81ab2b802dcc71ff2301345b9c71c9f32c41d6bec69c1ab0df81faf",
       "module_sha256": "sha256:f9d5b2c0549f5e8dadcb13c92dd159a648d94acd3afbad0b4898ac9d522209fb",
       "passed": false
     },
@@ -10891,17 +10910,17 @@
       "passed": false
     },
     "us/policies/usda/snap/fy-2024-cola/deductions.yaml": {
-      "fingerprint": "sha256:bdf497c2c23d7a8f54132a748caba6c911af0fd1e0a28f2ea205fe115c163a20",
+      "fingerprint": "sha256:06e24ad1a75afcc9386be8eb4c1814e7acbea57bf9554332a2fa25d9d1c6e89e",
       "module_sha256": "sha256:d959c81426e3dee58694262941f34b7e4ddba4dd75103820b52412f76fc6f0fd",
       "passed": false
     },
     "us/policies/usda/snap/fy-2024-cola/income-eligibility-standards.yaml": {
-      "fingerprint": "sha256:ba0271a9ce165378aacb8963fe76145da7bdfb0b6ad54f6c11d34fa8d3ec66e9",
+      "fingerprint": "sha256:c3a227846d8a3d578539a3f3d32085c3d02e49c0ddc65a67ecef46e0bf28087e",
       "module_sha256": "sha256:060f96a4c16b304dbbd38e3c7f750d67e9f17d2a6695586e9ae67ce9be0b0d48",
       "passed": false
     },
     "us/policies/usda/snap/fy-2024-cola/maximum-allotments.yaml": {
-      "fingerprint": "sha256:2ca090b5dd7bb9a8e08d6c6b447fd816c7d48ff56b6567fcac76d56887435023",
+      "fingerprint": "sha256:b97fd841f700b750c3b059452d03e4e0ebaf813cfc59d8845d2c001fcd82031d",
       "module_sha256": "sha256:623ecc0728b6a498437045e1eb8203b82e26ab23cecd62b3d8a2ca863997495a",
       "passed": false
     },
@@ -10911,7 +10930,7 @@
       "passed": false
     },
     "us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml": {
-      "fingerprint": "sha256:c7d21af674096b7f121aa24e09b491cba348778b17a6404abf8c75f7e8217e53",
+      "fingerprint": "sha256:b361767ba95f7a506cc48997a8c3e87066bfa6b764d2c388faf658a2c94b8c2c",
       "module_sha256": "sha256:94d8f5eaefa63fd65fc5f4d19ee1ff5c4dd07d26189e29007bc914218bd5c3a4",
       "passed": false
     },
@@ -11066,8 +11085,8 @@
       "passed": false
     },
     "us/regulations/42-cfr/435/552.yaml": {
-      "fingerprint": "sha256:b2eed30773675a1ca8ea17f160bf884794ed1035df34afd2937c8807d47c4969",
-      "module_sha256": "sha256:97f608de40296c4ecaa5c8c1b00f4729824cba60aca4f404c3d02cac512227de",
+      "fingerprint": "sha256:605397f7b099735e9e73c61d03b6b7d1e2f603e2f87f9b4399bad5a01b5fd5b2",
+      "module_sha256": "sha256:97d60f73fc264b92afbb20d3a9ab4da582df5885ff998c57bccf3712b5389576",
       "passed": false
     },
     "us/regulations/42-cfr/435/553.yaml": {
@@ -11081,8 +11100,8 @@
       "passed": false
     },
     "us/regulations/42-cfr/435/555.yaml": {
-      "fingerprint": "sha256:437c33ce375500099ed2ab5aa71b23a201b6ccb22bd98ed1f0241824d38b3506",
-      "module_sha256": "sha256:27afd695b50bbfe05b2a45dbc9a695e81abe7f7216eb8a45865fa56445a4e99c",
+      "fingerprint": "sha256:c78ad68a9b16c1d6a8c49d49410aa61913312c36602631a2979adfeeb1a9efd1",
+      "module_sha256": "sha256:86c12a96d468df9946f973e13dd8a828514462e7272949520ff81ae9f47e9199",
       "passed": false
     },
     "us/regulations/42-cfr/435/556.yaml": {
@@ -11096,8 +11115,8 @@
       "passed": false
     },
     "us/regulations/42-cfr/435/558.yaml": {
-      "fingerprint": "sha256:306ba700bd8cc97418ea619458733ef0c8e3333b1cd46bed19d1dc7a0ae3c11a",
-      "module_sha256": "sha256:2e845c3ff4c50f0677bd9d0123bd74ad9823682921ffa3cc6eaf03900021712c",
+      "fingerprint": "sha256:689edd33163b69cc4a5330546e77505c4e0066a2ee971d6388f3c33fdf727cec",
+      "module_sha256": "sha256:3b14f02e3a3373bea5ec6be23d718b26aa24b4295b6932d66b4b1488e9e68395",
       "passed": false
     },
     "us/regulations/42-cfr/435/559.yaml": {
@@ -11111,8 +11130,8 @@
       "passed": false
     },
     "us/regulations/42-cfr/435/561.yaml": {
-      "fingerprint": "sha256:d00804b8f948c442e55126c6773003e93c62839dd79ee50e607e3d330ec28b19",
-      "module_sha256": "sha256:942d95e242a021e2485934f1aaff7dd68c02cf56c6d0816b8b0fff39e3f94b94",
+      "fingerprint": "sha256:61b26d921389ad3be9e81e1d7d180fa9cf5eb68c8d55340532ffa82bf4b66daa",
+      "module_sha256": "sha256:b6e80128899e0c380bf2af67b22664e7c05bb7aa3ce40beadb192031c9bb3d8e",
       "passed": false
     },
     "us/regulations/42-cfr/435/562.yaml": {
@@ -11381,7 +11400,7 @@
       "passed": false
     },
     "us/statutes/26/1211.yaml": {
-      "fingerprint": "sha256:c8e81cf66e3b3cc3a4f88a21ab4e513d6d7788bb45fce5fc0db4dbbddad0ad95",
+      "fingerprint": "sha256:5e1308f4969a958e75b292b983948ae24ab985681292941dcaca446098b1eb18",
       "module_sha256": "sha256:b62892cdcd3177e8a457fa6bf76903722648ff18a1a53032ac189bdb87cea3ce",
       "passed": false
     },
@@ -13346,7 +13365,7 @@
       "passed": false
     },
     "us/statutes/42/402/w.yaml": {
-      "fingerprint": "sha256:b9092a2f4962291d97db067c947f25746ccc3e5628566d89c63ebc884968c61e",
+      "fingerprint": "sha256:c1b6095fb67c91e04bfaa2915f6fb4fe4ea0ebd7176e9d0eaae1b1da51b70264",
       "module_sha256": "sha256:44fd75d7331f338e3a8d9eb474b557780407707a8591e322efeff76aa375e62d",
       "passed": false
     },
@@ -13356,7 +13375,7 @@
       "passed": false
     },
     "us/statutes/42/416/l.yaml": {
-      "fingerprint": "sha256:7e816f6d233e067caf2c2b211c9ee1cbe04030f34a2d5e759e8d9a5a06428929",
+      "fingerprint": "sha256:c0602781af4dfc3eb6b7b5d97b4588954e2d987e6a04c20a18fac5829191298a",
       "module_sha256": "sha256:c49ec29f4805607b10cceb210c1dc444f63efd37e0f692c51ac534855f44820a",
       "passed": false
     },
@@ -13533,6 +13552,1761 @@
     "us/statutes/8/1641/b.yaml": {
       "fingerprint": "sha256:88474f12453834dd0969c56bac46508b50cb66d2cc27adcd817c566e0051c306",
       "module_sha256": "sha256:7a98dbc72ac610e0af2df7e37d61bb8b24bfc2b8da7219ac5cdfa1f3af8986bc",
+      "passed": false
+    },
+    "us-al/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:37edcc41937cd0297561e4bbcf427bbbd0a392aa622000db4167950719c6517f",
+      "module_sha256": "sha256:3667893d4da11ba1593655b00914ffd58c0c6ff476d5e22fbf845e3e9d9d970b",
+      "passed": false
+    },
+    "us-ar/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:deb3067cb5a981607d5b68d0662d13d5c77797772a29dc79f7059e09d5aac0f9",
+      "module_sha256": "sha256:98eeb4a98e7a473b82097bd5d680aa9d5cd258ce4bc21a8ec47c9edc4c0737dc",
+      "passed": false
+    },
+    "us-ar/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:e6de1361898293ef886115fa290d18f10f2219264c897d8f356460d224ffd7e1",
+      "module_sha256": "sha256:e450df6012dadcec268d7aef45679d46dddef062d811000b04783e0b74f4b210",
+      "passed": false
+    },
+    "us-az/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:33b8a33a78d62e174d0f4cd5ecfbb4728da36d259a73b4698b2b5c671444ec2a",
+      "module_sha256": "sha256:07ce2e39c5af489a60f6cdf268fc5f264f6d13aa29b54e405254e64dfdbf5f5a",
+      "passed": false
+    },
+    "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml": {
+      "fingerprint": "sha256:434dbd6078fa7de26b7b361b6d747ace34ad348b18553b6277aad21b1e198fa3",
+      "module_sha256": "sha256:a02c74c91457ac9aff7189ff069f54d9bbad0e760a59272fa82cf5d058ffc036",
+      "passed": false
+    },
+    "us-ca/policies/cdss/snap/modified-categorical-eligibility.yaml": {
+      "fingerprint": "sha256:ff2d587c4090be3096be61125239454aa060b8912ed7ee13f381f95b4f41cfb4",
+      "module_sha256": "sha256:ba01095a1d8619ece130958a128a662011c685ede2e564802f90b46e3bc628dc",
+      "passed": false
+    },
+    "us-ca/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:757ca87b91be689003412dab974347355f24dedb0d320c89f1d899a799919d31",
+      "module_sha256": "sha256:95650982722f80e40f72c112f99107eb158ebfd90d401aba2538c8ac9d38e6af",
+      "passed": false
+    },
+    "us-co/policies/income_tax/2026_full_year_resident_source_hold.yaml": {
+      "fingerprint": "sha256:7a205dfe0c2961a9a00fe5ec0ddfcf227af01b6f9e44b57af08b166237f44084",
+      "module_sha256": "sha256:6d913e1865583586284e7796f92ceefc357bd166760c096072365b6ebc9740ef",
+      "passed": false
+    },
+    "us-co/policies/income_tax/eitc_pilot_pipeline.yaml": {
+      "fingerprint": "sha256:80eafe20b0f6fd5e8497ba2e7463fe14fe2da87fca584225f7c81ae4a638d4c1",
+      "module_sha256": "sha256:6337e238dde5d23d7bbdc874f9d6ea5f77c023fd080f270d1ee8add938f53f14",
+      "passed": false
+    },
+    "us-co/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:84dfea2ccd248c3f7adf54512460757427ab137b340c59460f243af624e36db7",
+      "module_sha256": "sha256:e1006c84cb535bf92cd4ec1e8bbd0273bfecdde2de1d2d453b05da7707e3a28d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-10-101.yaml": {
+      "fingerprint": "sha256:d56e81843a5407ac801ab97ff88ada4c91b66bd1a9f16669a32a914813630aba",
+      "module_sha256": "sha256:c01598c53fef289c64cb82fd64fb0c9f857593174b49f62880b72a3df1c6edc5",
+      "passed": false
+    },
+    "us-co/statutes/39/39-10-104.5.yaml": {
+      "fingerprint": "sha256:3fe60a4ea6bbf7ccf02d8a77bfb5d9804a8935286bdc5d6dd19ce9bdb864f2f0",
+      "module_sha256": "sha256:96e7e0c505f9ad2009043bee74b0df27b83457aae624f6dd22cb4daf26501a43",
+      "passed": false
+    },
+    "us-co/statutes/39/39-10-105.yaml": {
+      "fingerprint": "sha256:b921e8a3af028d6d1df11b354fe8503db4bb1d7394ccc2545aefeebdde8bc66d",
+      "module_sha256": "sha256:4b8c30040d8ff977a10ae642bbd674654b2f2d48638a5340ceb69a4242ca3043",
+      "passed": false
+    },
+    "us-co/statutes/39/39-10-116.yaml": {
+      "fingerprint": "sha256:553542463ed04374ef99006d4c05e47a336666610cb9e7e4fdd44d7e8ee7c22e",
+      "module_sha256": "sha256:ba7c22df5e43a15dfedaa26a1d78f02803b63339d16d9ffc1c0a10176179d4e6",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-120.yaml": {
+      "fingerprint": "sha256:20bd62eafc8bf1c4b2126c3071dd59daaba83e695d26d05f506119b285ca7725",
+      "module_sha256": "sha256:241a682bee0acfd828293410933c2c77a37d20ec243518463cdb6a978f36ebd2",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-122.yaml": {
+      "fingerprint": "sha256:66bb01599c566a5bfe6fda09515d48f573ceda59f39f24a201e01daad034eecc",
+      "module_sha256": "sha256:9875dabadace0830cf23ab74b5879dba3bae6149d51abbbb8d6a542bb4d8c3a3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-128.yaml": {
+      "fingerprint": "sha256:cc30812c9319b73a3acbda0ab4905436021598195752ed7fc5ea745e1f1dffda",
+      "module_sha256": "sha256:ffc64c4f3d077e97ebfd3e68a2409c957f5f9c28639134b9978ae7590a4c3cb4",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-129.yaml": {
+      "fingerprint": "sha256:fd840b27c64c233aa80b3667a288574dc9b88fbdc791b527ba98c1c647bb0518",
+      "module_sha256": "sha256:e28854675b30e49982109a29c657df09bc5678283abdd62d88297f84412c7076",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-130.yaml": {
+      "fingerprint": "sha256:cb566963f73d3daf34f1d4a1e95ed1b4a30a23ceea249756a9aa5e3b55638239",
+      "module_sha256": "sha256:1443214af45d606ba73108b382235b3e9b113a8f72f3c822246c77a9b08c94cc",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-145.yaml": {
+      "fingerprint": "sha256:d6084d535f8089b80e12777595324f9b4235d967b53ce3ce478d5c146ad71856",
+      "module_sha256": "sha256:f8d6037f87dfec2b93ed55731ab3ea1cc58760a529e28a1dd79ac5a9aacdcc46",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-148.yaml": {
+      "fingerprint": "sha256:cff7eb4f05cf19b81968384f05a542253ec392271b44fac1a5563c3773389095",
+      "module_sha256": "sha256:d64edb691797654c141bb3cc9861f9e25a4f535b716cd0a9854276aed49c56b8",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-149.yaml": {
+      "fingerprint": "sha256:0d628d77f4ad528140cc7c5cf156ec8971ad2e0059647f79f521b5cb6613ce55",
+      "module_sha256": "sha256:ff9d22eac1c5c9c2c96d02cb5a03d1521090e3dc8d990039d0fb5ecde8994ef0",
+      "passed": false
+    },
+    "us-co/statutes/39/39-11-150.yaml": {
+      "fingerprint": "sha256:bc92093c26a3d7452d7c4b81d14da1c95482090af40b330309fe6d02b593b705",
+      "module_sha256": "sha256:fa3bb9e3d37096784cd07432a945ac84ea02773269d77aa81e231ba86a278b5d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-12-101.yaml": {
+      "fingerprint": "sha256:e330fb495ec79f71ade693b06b3fa282554178ccba854dba7800bb30644518fe",
+      "module_sha256": "sha256:2a4223b2226420137a2c92bf0e2b3fcbe6162bf35086eaea59fd68bc039d72d7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-12-103.yaml": {
+      "fingerprint": "sha256:63e3a9fe6eb6d54972016074a14db92d5554c1e1ab7cefaa4e6d03866c44c1e1",
+      "module_sha256": "sha256:3ad4fa0e2ac8c4386fac70f1a360d2434f4a23c592033ff07241e7871d383e48",
+      "passed": false
+    },
+    "us-co/statutes/39/39-12-104.yaml": {
+      "fingerprint": "sha256:d1bda0a73c4921a97882d6ba876b195869b3718d125f540552c87b8606175cb5",
+      "module_sha256": "sha256:38d91bd80727494334499801fc8d0f3e25508cb72fdbcf87e14d0917940f2c9c",
+      "passed": false
+    },
+    "us-co/statutes/39/39-13-102.yaml": {
+      "fingerprint": "sha256:1544d883d384cd36a9ca7f7fc6a66701c7affc6aa9df09bf0ea23d89eb5b0ab8",
+      "module_sha256": "sha256:b079876669a78b6ddeac0fd8c5f3e8f4a23b1df34b9c7055e28a307990d1b9a4",
+      "passed": false
+    },
+    "us-co/statutes/39/39-14-101.yaml": {
+      "fingerprint": "sha256:9b74b5d1409978fd2f89dce9d4024762272f0da6740b01a3f08588bf5cb67ca5",
+      "module_sha256": "sha256:50f9c70b04008897483720af10f59e56ae13d2b90bba34c5f0f149bd4eeef752",
+      "passed": false
+    },
+    "us-co/statutes/39/39-14-102.yaml": {
+      "fingerprint": "sha256:882959f56b746430e724ee784f3bc6f6b4a5b73aa76ad9385de9f8fb1bb0fcf6",
+      "module_sha256": "sha256:12ba36b913d62a46ee3a5f8815e2b3bfd7772b4dec9152cf28bb681a75c22d11",
+      "passed": false
+    },
+    "us-co/statutes/39/39-14-103.yaml": {
+      "fingerprint": "sha256:545d3bac01692b5279a503024ea1c588e19278d9f7e97754c651963f9425a865",
+      "module_sha256": "sha256:fe91701cb13bbeaaa3e27f67f483997d057a134618d5f0fcfb91bb20bdbea516",
+      "passed": false
+    },
+    "us-co/statutes/39/39-2-130.yaml": {
+      "fingerprint": "sha256:f3f34dfbe9e5d287ae8fda177ab9507868cd85e7d02eac7adbe06b8d6ec75490",
+      "module_sha256": "sha256:ff825cd793c1a8d50330b44325f406ff4d3e14ba83b4f8bc4b190c3657295d41",
+      "passed": false
+    },
+    "us-co/statutes/39/39-2-131.yaml": {
+      "fingerprint": "sha256:e8b2f1eec3bd96e3b20aabab62e3571f992ebd442b47defcefbc927c9352056a",
+      "module_sha256": "sha256:ae7172b11e740ac1e86518399f65ff3b8d2487d0e894eddfb6355d1dec10eda0",
+      "passed": false
+    },
+    "us-co/statutes/39/39-20-104.yaml": {
+      "fingerprint": "sha256:412fc6192d1f124d41326d99a22cec8783e2e1cf8baf9257fd14892afa6c7d0f",
+      "module_sha256": "sha256:84c3862bbb79f7d9a6c80c2ab3053b58cd4b084eaba36accc1ba48ad1ed91612",
+      "passed": false
+    },
+    "us-co/statutes/39/39-20-105.yaml": {
+      "fingerprint": "sha256:e834b409100bb7fa683731af77e539eb87d03b5f6c105b433622811076ec84c2",
+      "module_sha256": "sha256:b682932264561c264fd4c0dbf48928eae333d7892f9c6eaaa9f4a44dc708c5da",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-104.5.yaml": {
+      "fingerprint": "sha256:53f4d604023eab2000c634a4c06bc3f83c29dfdb38c87252e783e2131146d327",
+      "module_sha256": "sha256:f80bb737ee01074712a406848ed3ebedb9b43830703fbf64c57a0b110722ed4d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-105.yaml": {
+      "fingerprint": "sha256:14d5de2fefc4aaa600fcbe6bb401bb7310534231660e33eb8a18a24d799550b5",
+      "module_sha256": "sha256:052bb2697d9b19d1a39f84dc006cd6585d0f13e3cc34ce3c62a6667357e333c3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-106.yaml": {
+      "fingerprint": "sha256:daeac2dcdc5fda70a655d89f9abe2c0f0f56f6cac60d9692f3f982256115bb74",
+      "module_sha256": "sha256:f4297e687ec6e750167ebfe1d2127c199ebc7cabb620793052def4d49bb0f112",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-107.yaml": {
+      "fingerprint": "sha256:0b9ac82862b28923dade014489fdaad026fa44906980130c928cb0a1cd404352",
+      "module_sha256": "sha256:275124f4d8bd197b13074f85192bcca7936fdb6d1a0e3d4f4fbae62b43516c0f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-114.yaml": {
+      "fingerprint": "sha256:3835ca6c7d6a9f8515bcadea92a3eecf1fcd2972ac4919f5e5d876f2db9ed743",
+      "module_sha256": "sha256:d26c165129f675b64b00e019b4cb052da74ac302466e7111cc2809e39e22ccea",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-116.5.yaml": {
+      "fingerprint": "sha256:7c8dfb1ed543f857903364809c54e9a15db6af8efb63b0afbb38a0e238ba7cc8",
+      "module_sha256": "sha256:bd55427834e03ebc5e01be98e04e643372efeffffd34137eaa3c9aaf21e07ff6",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-116.yaml": {
+      "fingerprint": "sha256:e8a7f78bf827ca717729837583a7e9fbef9868cfa213ece153d434ee24e17acc",
+      "module_sha256": "sha256:2f7895c275abab7a80313eda5571d218b01a019eee2be261e1696bc994671fb7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-118.yaml": {
+      "fingerprint": "sha256:769351f724d3ea22e853a1aab7c90fb898b67945682339c1bf16c49faeff82f8",
+      "module_sha256": "sha256:b823e2fbbd4a5213aad5777c41f6faa9a22031491cd719c16bf306f7701638b0",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-119.5.yaml": {
+      "fingerprint": "sha256:ea999c24f49e44aef9be866784f9f8649bd183fdd47b0067fe4b9427a5782366",
+      "module_sha256": "sha256:ccc4e5150831fa4487167581c021a24fea5067682e653965be3c6446d9d99803",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-104.5.yaml": {
+      "fingerprint": "sha256:02001deabc755048bb594966e286a5f48638666ab77f069b301444d186e8a222",
+      "module_sha256": "sha256:a07b243f08f6093811e64da0dd784de15ddac893df1f417c13db8987a91ad11a",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-108.yaml": {
+      "fingerprint": "sha256:a5578ef315dabd5df9d9528dc9401b0bcd7d75bb7779e5929a515e90f51fb55c",
+      "module_sha256": "sha256:696f8e7a236a4a1e634869cced4050c77dedd3cd168e86d3db2fb47becc0eeec",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-109.yaml": {
+      "fingerprint": "sha256:ac4a93fa120f4a329772917c32138aab700807d91369fb00cc2dcc9034bc9202",
+      "module_sha256": "sha256:192626278bbb0a55374e9b094de9d1d1456bfac5a4b34451e11464a7974b7795",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-110.yaml": {
+      "fingerprint": "sha256:5a0c50b4f523d56a325e3303d31b0c6937a7b0e8ef6a872ac77a73218c2d6854",
+      "module_sha256": "sha256:b4cf58e6fbfcc88ed41d05ebbc8b4d686ab5f5bfd9661033f9e5c62ad44e845a",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-114.5.yaml": {
+      "fingerprint": "sha256:0ba0be3f46966f8a7106cc39f70f1aa0945f7d553c70e3cde927e7c902f7d6b1",
+      "module_sha256": "sha256:dd0174da3dcbd631d48958974170b2e7564838dc69ffbc4fd938232f8f19d686",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-116.yaml": {
+      "fingerprint": "sha256:6aee96e68684a92b507c5c068cfffd65c9b0d4873cc75b079b40265afbc027a1",
+      "module_sha256": "sha256:dd57a9881ea4a2b608be9ac9599ac5c57ba6e53113998cc20e4ace89adae4194",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-1302.yaml": {
+      "fingerprint": "sha256:f44d56dc2b16622fa7dc8cac795609ee09e089824a3125db3f71b41c3fa97d52",
+      "module_sha256": "sha256:a75b67b4f1f9e88b2b29f8a1383eb9794305d12a395df0d79892f49a9a502ee9",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-1804.yaml": {
+      "fingerprint": "sha256:d60186bc18dafc046512e3c6eebc333cdf5a9bb72643ba6d080587abff714afa",
+      "module_sha256": "sha256:aa3568236e24e06e074537c13db6e05ffd0d81f987ddc112fc23cc907068a6a3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-206.yaml": {
+      "fingerprint": "sha256:4a50b402a446b46919651de46dda19e5285ed6f66375dca331bb1d2fcdcb7b84",
+      "module_sha256": "sha256:26ec36d99b850db60c625c6d2bb63fd01a7ed0a38be08617b9dbc904e47025be",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-2101.yaml": {
+      "fingerprint": "sha256:b35476be8f4d203fe1cf9fd5f73d0d6f4d0b9eb2efb6f90d59a7e04b9f260428",
+      "module_sha256": "sha256:00e0210d0512e84ddfce86e9c17ee05e0926a0e1034ef876fe5f20bd9a19e9f3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-2102.yaml": {
+      "fingerprint": "sha256:c12c7ef43d84a64cb589e70bfa22dbfb1ae7a76878e017615ac7d2e1e70e2781",
+      "module_sha256": "sha256:e2363ae35d597a81d41c59955c8bbd05698022e535e4e3b8b5a1a3db10a68ccd",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-2103.yaml": {
+      "fingerprint": "sha256:c765d2eef3db4fc4a6d2a8f62c3b5a86c11b566ae24e4cf92c6dbc6e9a2db518",
+      "module_sha256": "sha256:97a4facfe47f14723b6818b2b547111b453e1c8881f39fe568229b648653c44b",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-2108.yaml": {
+      "fingerprint": "sha256:49e89b8dab5943e4bb427a5ed2176acb8fbcb1e8c29adccf56bc77f485a581f8",
+      "module_sha256": "sha256:50401e9c84d3b22d90232b85c39d5e908251e7d84586d965dec0860c141f9b6f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-305.yaml": {
+      "fingerprint": "sha256:a3d051081a49ed3d026621aa642e9d186535aedd21afc5db2f19623f6a584ea3",
+      "module_sha256": "sha256:f4c36e4b41bdf0a887e25d5831c8b477a301edfe06d39e5716cd0fa0dcea28ed",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-329.yaml": {
+      "fingerprint": "sha256:537565fcaeef2e5f0fd6fe9ac698268d61119a57dbbc00bfc4c6ad147856224c",
+      "module_sha256": "sha256:3d77494ce209ce37172ed92d0d5f6b088544defb5a90c9d1acc8045b1f259926",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-347.yaml": {
+      "fingerprint": "sha256:09b41d5fdf4f6dd38061a8d992c8ea659c840ecaa21fd5f8d2500fd1dc2ccbae",
+      "module_sha256": "sha256:2187df4f6216fd04ee6561b7acbadd657e8cf479dbdeae51580f69e0bd602ec3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-3603.yaml": {
+      "fingerprint": "sha256:5d8033be8e07c462bf0f662eff5e9fba2d93b0819479a3d0441b2fa3a3c9fbce",
+      "module_sha256": "sha256:585efcfb2ba4ecc92bdb0e31474a4fae338013447e67d0be6209ec17ca770af7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-4703.yaml": {
+      "fingerprint": "sha256:7c0a1bc72bb40ac315b9dea0e6db43cefe2f0a3cfc7923282791b4906c9ecbf4",
+      "module_sha256": "sha256:56c24e1fa08b582539644bfe9ea8522c0c032525641bd35ede00068715dbd30d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-4706.yaml": {
+      "fingerprint": "sha256:d31c3c47e95ebe4127a9ea981c65f6a748461197f33e8b2c70f1a93ef1d2a82b",
+      "module_sha256": "sha256:7e8eb281f8250ad7bfb509c015a4bd78d6810ddacca24dd2c4d0be20d2345413",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-504.yaml": {
+      "fingerprint": "sha256:7bf1afa79448eb9cab49f05a803d037724511fcb70b8e555ea8d6cb59738fd5a",
+      "module_sha256": "sha256:d3e253343d461761f733c7d4b1c738ccd55b024db39737997b9547688c8c1e61",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-507.5.yaml": {
+      "fingerprint": "sha256:60c95b2e8b85a96e99e49b53a5a16a9de353c1e01ff500fbd6adbaaf65b917bc",
+      "module_sha256": "sha256:674e8d4527464611ff38d96099573af4bc32a9f1e718f616f84fc1e8d48a511f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-509.yaml": {
+      "fingerprint": "sha256:ca63bd608b0766f73b8c4d823a1a45a86aa0f01b220052fe010a6778f03227b6",
+      "module_sha256": "sha256:c5b19520e60186683bc29f5a118ef61ff8cf047fb1bae680c3c62d80cf5a5faf",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-5104.yaml": {
+      "fingerprint": "sha256:9514c53927a288f5015be9fc29e52a3438d6241439bf72fe5907014ad48384a0",
+      "module_sha256": "sha256:f3035136b4e52241d11229b41009ffeabe633a44ddedcf2a964a86d3c4d4430b",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-517.yaml": {
+      "fingerprint": "sha256:a95c95089d54c0472a40efe2ea058452460fb7c15d40e22690046e24509f0a48",
+      "module_sha256": "sha256:c924e2e2f194ad120ca47131fc1011a309b4732c5c32e97ed6dca50d0b4306d5",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-531.yaml": {
+      "fingerprint": "sha256:26f95f93fe1deca9b151399d8b4670566552b48e4bc15c286045b9f8b1bb4c02",
+      "module_sha256": "sha256:d95e4e9d3d1883c254a268d6ade7dd8be570a7a4308498883f54f56c23652d64",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-535.yaml": {
+      "fingerprint": "sha256:c182afdf5b6abd879334cbb7a372a127426a6eaea3ebb1528b9e03cfbcddb5a9",
+      "module_sha256": "sha256:ad21ff64185df8f62178ed1d11b70bf0b0a47fd28f892cc23c3c6ca40e542886",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-5403.yaml": {
+      "fingerprint": "sha256:441ea40c8e1bf68d699c66c5e91d3b4afed9a9611359cfd6e477d92db3e0f5de",
+      "module_sha256": "sha256:b7d33d11807b0ced597e389aece5768391dc24632df8b4ea479b5a36cb38a8f1",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-541.yaml": {
+      "fingerprint": "sha256:7024dcd021384e4ed3829e5a01596e4a3afb23dc45a63097dc722f2407844069",
+      "module_sha256": "sha256:892f895bf460b862f2e8ea65d6a642fd2031192319cee3608ad6c63476649ebd",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-542.5.yaml": {
+      "fingerprint": "sha256:3c0859e88609c1bf099e58c691dd26f5cbc64de9e03275255c339d86bd5849ae",
+      "module_sha256": "sha256:5f71febec9eb97d0c60d1095597c02ba8a545c534db28b5a09b4ce7716308e66",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-545.yaml": {
+      "fingerprint": "sha256:60885228aacde19f9f0bb6de3e292886aeec9ea9be8888ce271a80a3a9d61177",
+      "module_sha256": "sha256:861ffe8c981fbc882eb0d7c5c9705e5513108caaf36e1d2e6e7186b1d6e8fe83",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-548.yaml": {
+      "fingerprint": "sha256:59fd6d7f64c9127e2a42d277fd9158c69667387fb56ab714893c3771ee29d064",
+      "module_sha256": "sha256:c40c3a6f959bb791a5eda239a5258690e11b65890d13e3f55b37438c334b4b79",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-549.yaml": {
+      "fingerprint": "sha256:efc03a815949d9645d7895fd17e8c16eddccddeff054b4bf5e0e683cd785ae0e",
+      "module_sha256": "sha256:6ab0fbb1e602a0553136e40a547e40febece1f86cce3f99b3fe778b83938cb27",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-550.yaml": {
+      "fingerprint": "sha256:617351776fe755b8578d8beb4af3d4351796d1bfca37336fcb799e6b2eb332ca",
+      "module_sha256": "sha256:92dd1e968abb82e2d40ce61d46b40d9bec33e46f48fc0b6b72096f0229135157",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-5503.yaml": {
+      "fingerprint": "sha256:9f0fe2ad824d36010a5336a11e5201a0f0f52a85304bfb36c032b45cf0c0e910",
+      "module_sha256": "sha256:5dbf2a46fccf16adfa346b1ca078f2c5820f45626b62fc075809ad8cc49fed0d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-5504.yaml": {
+      "fingerprint": "sha256:0cad61ad0d2a617a5b6e814921c1251535327b35aa4c61cf238bf809da4062c9",
+      "module_sha256": "sha256:99aab17eecf5511b7403db19d522fd4d94e43454a51de2b678cbd38f0e00d7d7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-552.yaml": {
+      "fingerprint": "sha256:6569a0665035a4c7568965a65efa0c4b7a655a29b14916004bf32f5e1572e17e",
+      "module_sha256": "sha256:564bdd386a1ea52acc9969cadaf256705b842c3c606dec6361ccfb4e3ee79a94",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-555.yaml": {
+      "fingerprint": "sha256:7635f20e5038cb6e5ef26b677a680928a2764731081da839e1b03c4fe75e331d",
+      "module_sha256": "sha256:c6a73da3ce363e6780aa8b6be113d601d393516a17ea8603194d81bf482054be",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-556.yaml": {
+      "fingerprint": "sha256:c2702d0e287bc5be0b82e0e0db3db8e0561aa1354f95531f9935aa0a2fe0b52f",
+      "module_sha256": "sha256:a2515650044d65e67a4b8a4393c58a358dea40ce5d9c77c36fe1faff78e4e249",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-562.yaml": {
+      "fingerprint": "sha256:250e65bd0c2b2c0e47ae5964f70a7fa57edfa26ec906b182218131d1c7f5af2b",
+      "module_sha256": "sha256:682e53e7e8d677093f3b91296297611e9fca245782b579cc35098a488b01fdc5",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-605.yaml": {
+      "fingerprint": "sha256:cfd058805c45f28cdf9eaa87c3b6dc32a792f543fade3a07f4b72db4ba11641d",
+      "module_sha256": "sha256:1a833e393907d6302052d3085c8ca366b5a06af7e1a85642430a06bebfec939b",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-606.yaml": {
+      "fingerprint": "sha256:b894f7579c33f7ebfafc644fc8706f65e8b2978509884597beeabee439eac843",
+      "module_sha256": "sha256:a99667aaafd77795eb66f395f8d6453fc1891e576d7ca7a272cf3cb2673cda19",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-608.yaml": {
+      "fingerprint": "sha256:f27fd9805c8a304aecebdd02894995adc468d297451e25f3b0a34c94011c3616",
+      "module_sha256": "sha256:cafce6dbb600dead0bd914e2f86390910b71968f5027c55f36336c40afe3703d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-621.yaml": {
+      "fingerprint": "sha256:124827c13a3357f4e02fba0fb675e0c402d25b4253f90ca1274659ff8b4683f2",
+      "module_sha256": "sha256:aa19ae79568c269d42273dc9aaaeff4015665c9415020fea02edaa29cc1308b7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-622.yaml": {
+      "fingerprint": "sha256:2c4ef10c9e8f6c88233ab38783f5821e6bb48c755bbfcaeb4e072cdf34e8cad9",
+      "module_sha256": "sha256:dfe281ae3cf49d86887097e6a36215acc679e1ec4220ea8cc4e82494c20bd5ed",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-657.yaml": {
+      "fingerprint": "sha256:2196d547b3213badc038a32bf5752504e7271287e68f13fda222c35e7a9c21a3",
+      "module_sha256": "sha256:66a996ba9e7c9b99d972d495d59d89cb258a7ea7b2e9ae043031475156b10b09",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-658.yaml": {
+      "fingerprint": "sha256:44163fbdd02ce345de6c7c222b288407999858958c32e7ac7b1f394124edba5d",
+      "module_sha256": "sha256:e90ef0933c3b3f4ef88f407bc9a244e41a9264287c8967d04d427e949f052d9f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-703.yaml": {
+      "fingerprint": "sha256:1784489a4ab5725c22cc2defa5723f1342b7b0ca1713d4f7db56d1848fcd035e",
+      "module_sha256": "sha256:074fad13277d5f7325090e75a4ce679c7a7600f631d13adb1388c065e0c14492",
+      "passed": false
+    },
+    "us-co/statutes/39/39-24-111.yaml": {
+      "fingerprint": "sha256:2349826e4262969084efea07513fa49159f4068ac6a9a9161b8b9849e18cb0bf",
+      "module_sha256": "sha256:62f8ba51fa439265e428d6a1ea8e33e85e4c4c8bd43852b81ab3dbc3cd11eaf0",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-103.3.yaml": {
+      "fingerprint": "sha256:12fa73513bd934b5f088b07ee1b2503b7588c77f1780d20abb0d89b84e6e5f05",
+      "module_sha256": "sha256:49f4cec1deeb168ec077eefec0510181202d3121c030c0f876f7050fc5492206",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-112.yaml": {
+      "fingerprint": "sha256:20c56bbd769331151273297a81ccf9ed3848e68b5f29d6ec737ab30bc7d4da80",
+      "module_sha256": "sha256:dfc5409feafba9ccb0bc327609d3bca5decbfc01858e4381aca9b3d3100accee",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-203.yaml": {
+      "fingerprint": "sha256:e5b4e6c10fa30851e97819a71be1720a25c71679756011319cc11e3faf931847",
+      "module_sha256": "sha256:7b20cbd107f98d3ff79d9def6e07f3778935644958dd9644abb3a13cb999345e",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-304.yaml": {
+      "fingerprint": "sha256:729f94cae14e8146cb4706f81106fe3722643fe7a6459ec9b943f2a1f258ac7f",
+      "module_sha256": "sha256:97d06e0bd32c1256dd2d9a36a3b3e0eda40486227277b0e7886db5a2a129adef",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-306.yaml": {
+      "fingerprint": "sha256:0988ffdac7aadf9a1e7f0c9a766fdb43efdb5e9d6062924cb2e29d9e002d1d8f",
+      "module_sha256": "sha256:dce139013dbbfabe78eaa3960896c24035c22ff198a628a8c8164171e60dcfdd",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-106.5.yaml": {
+      "fingerprint": "sha256:d72af5d6ce48c14c43546b842dc71ca56618bbdefe671b85ddee90ed0fb79f31",
+      "module_sha256": "sha256:ef84fa3725e24dfd4c5b8942860981913b7ceb9ce7ccfc4a064aeaf2190fab1e",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-106.yaml": {
+      "fingerprint": "sha256:56f0f176baafa1f63a9f19039db0877985684d96213bdb1683456eb57a12ec96",
+      "module_sha256": "sha256:c30565027fc1cbac3f4951df9c59c0c8246b75caf0dbf94249dd222567226ffe",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-108.yaml": {
+      "fingerprint": "sha256:9ca7e0f56ba70ee6459b62097e749699871fabb8c819ac13bd3ffbafc144b73f",
+      "module_sha256": "sha256:dc0ef926d6d587986f692eb1268d87f836b83cc012ba50e3beb60a1ef7a37b39",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-110.yaml": {
+      "fingerprint": "sha256:f6b0477964cf48c562436642bd9f6b6bec73d5179ae2c578706faed797f1469b",
+      "module_sha256": "sha256:2797c30cab111b3f5dcaa3a8ae7203f96761badf7ddebe2b837d254b365ae597",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-111.yaml": {
+      "fingerprint": "sha256:166b2a85bcd3452ff588fe480d1d6c74f667fbda2a2a46a5700378f313b852f5",
+      "module_sha256": "sha256:0b041ffd7f58ac47fc63b865f313d988edf53cc0dd48973d45091ba5de153f60",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-112.5.yaml": {
+      "fingerprint": "sha256:36fb362d35d845fa174fc3b844566ce82c62d1cc6c230063ca26129bc5e9426f",
+      "module_sha256": "sha256:816ba9165c5e52e5eb573ea520ff2f7a00fd552b45b9a009ebde04dbe19c58e7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-118.5.yaml": {
+      "fingerprint": "sha256:0d1eb39adb473975b6e3ea0d91993f7c5c483b74bfacaa3abcf9f717b0f5264e",
+      "module_sha256": "sha256:18f9e3e0e7da191c42406c30ef860acb889143f7c04f76d424425ac709082137",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-121.yaml": {
+      "fingerprint": "sha256:db79ae6de058b04f59f77897f57e81a2604a1be57f512812437a13e3723243fa",
+      "module_sha256": "sha256:0152d793940734dcd8b32e6cc1eef9ab99dbf2f1c746461043da011f10efb6e6",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-124.yaml": {
+      "fingerprint": "sha256:cc10827c76605b230ba955336350a66067c647a6c186ae345736f94362314344",
+      "module_sha256": "sha256:7f532020ea14aef946ba15f6269a3e37b1e58c34e4c240168eb4eaef49f7579d",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-129.yaml": {
+      "fingerprint": "sha256:8ccde8444b092aa0677911b5900d774859c4f7fe6d56e5fadc96144ec1722e6b",
+      "module_sha256": "sha256:8cb0c2aa2ae4c3445f68cb342201f4443b79fa152ffcb4780dd8e327371bc70a",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-130.yaml": {
+      "fingerprint": "sha256:7c6d9304ec1adcc1d2c28b948c48e215a6e8c8cbb843f5eaf467d2a18997abd1",
+      "module_sha256": "sha256:39465a98a01e21133678ec14d860cc24d7d667e746e474d642b8d9e9afb01921",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-131.yaml": {
+      "fingerprint": "sha256:d7a1df1ce829228e9c666b0c51b06f3c8d03e894867313f886b924f1e706b2be",
+      "module_sha256": "sha256:877ee772f8d5ac63797c22504188be54595a6b6fcdcff2036de69673d5e16c16",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-133.yaml": {
+      "fingerprint": "sha256:a23e1152ae0b2b1cb88e923dc9d9deefd5acbb6c332b319efe31563a4e19a8c3",
+      "module_sha256": "sha256:1c119ca88f13433206af43c8861783e62e286e6678cdb284df268e29de44fc40",
+      "passed": false
+    },
+    "us-co/statutes/39/39-3-138.yaml": {
+      "fingerprint": "sha256:1959b992aed66cd73cc6caa6a01b57df0b2e3675d9eb2c0b215fa8c861efe1f8",
+      "module_sha256": "sha256:dbe9eeefa2e925ad133e29a8a2bfff1ddcc78edc20e3068e46de4d9284728e8a",
+      "passed": false
+    },
+    "us-co/statutes/39/39-30-103.5.yaml": {
+      "fingerprint": "sha256:95ae62a5290b73ccee3846c23d841b4426bf0c29cb194ea7c623c0b173e8b6ef",
+      "module_sha256": "sha256:19682a878bb6bec9209a135bd5548f2f41733f18aa4748e050485211e86e800e",
+      "passed": false
+    },
+    "us-co/statutes/39/39-30-103.yaml": {
+      "fingerprint": "sha256:cb51fffc3d4c9212d288961a358a0265beffed5c8db3a44f63e41de460100786",
+      "module_sha256": "sha256:31a392cf0424010d8c147d980a58413417cb8facf5a4fccf82249c0ef0a81b2c",
+      "passed": false
+    },
+    "us-co/statutes/39/39-30-105.1.yaml": {
+      "fingerprint": "sha256:57bff20b043a0c8e2ce4124952f02fac4b12115d4b6c6cb8e314e0302dc52cd4",
+      "module_sha256": "sha256:ea64ce910786e6a58e175e3d1811523c8775bef1f9b55d166ab6ad3d7d7aadf1",
+      "passed": false
+    },
+    "us-co/statutes/39/39-30-105.5.yaml": {
+      "fingerprint": "sha256:fd8cd41be88542801fafe9c42fcaea9da3c0562f7dd7c91454d419aae86cd109",
+      "module_sha256": "sha256:f9f0b1435b2eb06bea5fac05b3e62cd184be935b6b80538115f9c19f9777636f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-30-111.yaml": {
+      "fingerprint": "sha256:e3009ad51db363fd198abf3118b2b621e9c7f96ee2aa0c7b7b476d4bcaf57dba",
+      "module_sha256": "sha256:f13c5dbb4705d8683e9a8364d16891d4bd8d4f726d0137585414fc1421372b90",
+      "passed": false
+    },
+    "us-co/statutes/39/39-36-104.yaml": {
+      "fingerprint": "sha256:52a3a7e032b88a0af87cbc17c08bcb5988a311b56498747c6655cd110441ae24",
+      "module_sha256": "sha256:c54ec43427b03135e0def8f59ced7899a38b09f3dd9fd484da15d38b482757f2",
+      "passed": false
+    },
+    "us-co/statutes/39/39-36-106.yaml": {
+      "fingerprint": "sha256:d209c50afa031c84649e1c0ba02d267ca7963d82738b512c85c032a00d32678c",
+      "module_sha256": "sha256:312140cc966e5c8c53df0e66488df90e126e434310c8dd46789e679f437840fb",
+      "passed": false
+    },
+    "us-co/statutes/39/39-37-103.yaml": {
+      "fingerprint": "sha256:2e0efd787ab828b9358236e0ef539d6ce6de0747877b3b91e9c826dab41d5204",
+      "module_sha256": "sha256:cc2e75de61bc40a4f1474a9b5fd54d6257c5f4f9d683f6fca684dead149c9bef",
+      "passed": false
+    },
+    "us-co/statutes/39/39-37-107.yaml": {
+      "fingerprint": "sha256:30300ddd6a361d6821929790596a48046a45dfd153c083228c85cee8fd54991e",
+      "module_sha256": "sha256:a4b72826c4974a43d16a49e6cda94bb6f56915a66e4b1fbffd92828b9e75049a",
+      "passed": false
+    },
+    "us-co/statutes/39/39-37-108.yaml": {
+      "fingerprint": "sha256:0910de096e89a168cf965bf96df551baaa07260dbea2a43ea07080d39d6ceabb",
+      "module_sha256": "sha256:5912abf6222f85440c15599c440a56c02c60dfd5d4f5113857ced33b5342480f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-37-109.yaml": {
+      "fingerprint": "sha256:f30be1a72d0da8a27546edc52f230612deef67a846a60ad7392f1e2601ba9da5",
+      "module_sha256": "sha256:1ad646b577c87908ee787c33b0b5bbee3f249f13177f4b608983a70a8da930d7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-37-301.yaml": {
+      "fingerprint": "sha256:900642ab0c5a564f1ca9dd4a959130697553c4704f90d88138077b0da96912c6",
+      "module_sha256": "sha256:d2633779ddd31ca061784995d260ed97aaa92790bebd51b5e3d0bb134fb3fe52",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-102.yaml": {
+      "fingerprint": "sha256:745680a6f6ef43107363d19122db35dff32975b465087950a7cc78e235837b1e",
+      "module_sha256": "sha256:068b2167cf5f87b2d960d5f0f9cc4db83ef7f2f141b18885ad3cbef659271313",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-104.7.yaml": {
+      "fingerprint": "sha256:cf6589bc8a4045cf19556464e721c0468d59b5f24f49d2f6b94417a25cefa191",
+      "module_sha256": "sha256:bdeb3b6d425d62b637c32d61d4c4df0a97ca9849473cbd49ca69dab5f21ff86b",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-105.yaml": {
+      "fingerprint": "sha256:26a61c939a66c9cffa4812f5b58676508755be9ab46b5ddd4f7d358a5cc41a47",
+      "module_sha256": "sha256:8e98a6bdeee668de053f255c0a06c6783716d27952d3c39be8af3f05528c3af6",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-113.5.yaml": {
+      "fingerprint": "sha256:84179ac9ec2aa570a4660f001a39e8fc4175f9bd3cab62c96caf067c2d0d3835",
+      "module_sha256": "sha256:ebb056127dc086f8bcd8e48327d2d653d91f190d928af10d60b5244d47df7d05",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-116.yaml": {
+      "fingerprint": "sha256:10da99b82f7ba701072f4183c6099abc3361571332f3a9e157fbb4d201a354f9",
+      "module_sha256": "sha256:ca555e1701a27e4ea53b2d556f2968af4b28f1b244fe855cb05e412a1ab65112",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-117.yaml": {
+      "fingerprint": "sha256:d033a3d2119f10f60fa2226516bc6ccc34f882977fc658aea2d92156a85a2434",
+      "module_sha256": "sha256:2cb15546780fc14b39f955e1b9146b9534249110b28d81e55d672d20ede2a663",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-119.yaml": {
+      "fingerprint": "sha256:4a170a8e109f27a495721386a9f930c8758b12d2e779db7094c94316cf4999c1",
+      "module_sha256": "sha256:6d03e7c71f7ef78133b66397ef99f26e23ff86d96871acf57ad8d5fb82a04e9f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-121.5.yaml": {
+      "fingerprint": "sha256:8aae2aeaf05fdeacfa9fd6f11af7126492d301eea4be0e7c5c4d4675417f2b67",
+      "module_sha256": "sha256:252a9804ef4cbfd6fa5912144e5d161f86be68c0f54a3728014336edf91430d1",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-128.yaml": {
+      "fingerprint": "sha256:e3e7bcd9dbc7b6f61cfd41f783b22d15eeac1621cf7b47cc1694f767959f0853",
+      "module_sha256": "sha256:53187ae55f2fbd24a2498bcc9c8f5e12f8ab2dcf6d2d2d6ad5c45a8387dd19f2",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-132.yaml": {
+      "fingerprint": "sha256:903501e3e02017350b45c169816e32a0c61a084f4a921b650a38c485f0071d0b",
+      "module_sha256": "sha256:4dff6614a1db2139ab52930f7955f90b2debce6ebe5d7fc6dd7c3570f9c1ccab",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-133.yaml": {
+      "fingerprint": "sha256:a6510b1642515c5445b69776e3ca6a7270d129b5996e2164edefe927fa270242",
+      "module_sha256": "sha256:c87f47c4027f103ba9faae298cf927107dc26bf74c69037f9b39d60f8e04b8c6",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-134.yaml": {
+      "fingerprint": "sha256:63f5c8fd1705261356ecfcef3730c1b4ca733a3bbd1b306980a42f37df6a45f5",
+      "module_sha256": "sha256:79d18470f8eb5a110085b7c1fb182c76b37412cc8b6d161db551fbf3571c48c7",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-201.yaml": {
+      "fingerprint": "sha256:eb0d3a20a5d0710c83cb4aefb9b0a790a6ba6d6fe805877860f6c409a7f6600b",
+      "module_sha256": "sha256:d9a3212561b44972d63c498f23c2df55c9f7078b4bb78619c1b745bcdc5ec4cb",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-202.yaml": {
+      "fingerprint": "sha256:4d8ebcb6e10d7a24acecdb4727e4e836d8671c64a376da0d98ad2b11241fe0fd",
+      "module_sha256": "sha256:2938aad5740d65328755617c9a372d05d3333fe074f293e69aa809a3d0bf7180",
+      "passed": false
+    },
+    "us-co/statutes/39/39-5-204.yaml": {
+      "fingerprint": "sha256:942a22e51d0068a11113883c2c66a5b2c8d77ca16f4e0d0489cb3727e33f7004",
+      "module_sha256": "sha256:25c6ea0ae2fefc31cbc074ef47c05ef554b9fc0ac36877783d0dae779c4ef10f",
+      "passed": false
+    },
+    "us-co/statutes/39/39-6-106.yaml": {
+      "fingerprint": "sha256:e6d0beaa2f798b5ec8bb9e7c8a7e9e2a119b8f58c7e619a3df7937f381cf3270",
+      "module_sha256": "sha256:52124df180889a78af7838fd51de4ed9e22a386a20b2d3fb88c32aa6c0a92ae2",
+      "passed": false
+    },
+    "us-co/statutes/39/39-7-101.yaml": {
+      "fingerprint": "sha256:abd4816fa6dc7fae64951966efb8ba288c8567b25cb60b138860f7923cca0ef1",
+      "module_sha256": "sha256:464bdf0434b2948f2220337ade3a6a9d3479fc782c7f3add949afe9a469255a3",
+      "passed": false
+    },
+    "us-co/statutes/39/39-7-109.yaml": {
+      "fingerprint": "sha256:5c5bbdbb8e7352842b48f121d5764ba87ef3ec8369891d63d69005c8f0d63d84",
+      "module_sha256": "sha256:e242353b9b9a75a22af2c4f7b13ea855fa7506b1000009e48acf1afb3482f123",
+      "passed": false
+    },
+    "us-co/statutes/39/39-8-106.yaml": {
+      "fingerprint": "sha256:62287154111cc69144c31b8a8d6bb49add079a58ff0bbd6d247528528e0e65c4",
+      "module_sha256": "sha256:47512cb625ab9f1425a65474d9e59c0dfcee588ba7cb0f906d7ccb013e86bbdc",
+      "passed": false
+    },
+    "us-co/statutes/39/39-9-102.yaml": {
+      "fingerprint": "sha256:b4d36a9e5ef8979cf3dc07a50dda9676105f7a6748ffd33ae29663ed06e5cc6b",
+      "module_sha256": "sha256:38c2e03a14b3c10edc167d6301eae98d9569fc56d32924749d9d55ba29558642",
+      "passed": false
+    },
+    "us-co/statutes/39/39-9-103.yaml": {
+      "fingerprint": "sha256:77f2094bd44c93f9c9683db0759d5cacdb9f5803abe50437aed552bfaebec801",
+      "module_sha256": "sha256:1ad58354fda561927b5ce138c529719e484bc12d373c220f70c0c2c096ba1fdb",
+      "passed": false
+    },
+    "us-ct/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:24d161d67e0ffb8a0a8f8e55b186f24dfa6269e327ca8fc98d5417bf57ac6bdb",
+      "module_sha256": "sha256:1ca9a77dd5db611cab72f71fc143029b9d3ba374b25851ccfbdb8c2c624af8ad",
+      "passed": false
+    },
+    "us-ct/policies/income_tax/2026_resident_ordinary_tax_before_personal_credit.yaml": {
+      "fingerprint": "sha256:3c982ea5729859e0e54dd09136e038a3a46a030742ba721ff20eb79a91143e63",
+      "module_sha256": "sha256:2de3cc7b1f8fc94447bac313480f235c26ca8bbed82713c37621b7756ad4cf44",
+      "passed": false
+    },
+    "us-dc/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:4c4834a45e999108cd2e75c2f1e5bd0c8ef60ab13a4bc8ebace09b20e9af644c",
+      "module_sha256": "sha256:f6b181455da7b41a73073f23124dd2dacf72998e7d97141e0ae87ce2b81853d9",
+      "passed": false
+    },
+    "us-de/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:4873b351f85001d4ca319a95f3d31c6002402b6498df6e83792d2d64f63d364b",
+      "module_sha256": "sha256:cf0d8c2ae189ae0b66c6c305003f7a58e2f27209a19ea874c9c4259605eca749",
+      "passed": false
+    },
+    "us-fl/policies/income_tax/2026_resident_zero_liability.yaml": {
+      "fingerprint": "sha256:7bf2dd5b9a560ea13990d6f849efc8fc9af92c7aaab18366db46f3b07677a5ac",
+      "module_sha256": "sha256:54ae2a8cd2b2a51a7defc560a1c765491e54f1773ad2fe558da04a13c42c3ced",
+      "passed": false
+    },
+    "us-ga/policies/income_tax/2026_annual_tax_before_nonrefundable_credits.yaml": {
+      "fingerprint": "sha256:52aaf499b4794e21633b83d19931e3ec8e79d30b348e5a98f302c08ffe0aa31f",
+      "module_sha256": "sha256:3748911b680e443b7c971f7c8468495bbf04c4123d1c47559c267cfa19654529",
+      "passed": false
+    },
+    "us-ga/statutes/48/48-7-20.yaml": {
+      "fingerprint": "sha256:9838b78a96da918f7dc5330defa007c2fa571be0752611c2f87a7e5250a89343",
+      "module_sha256": "sha256:3b14bace271098396b2e7f91054f8f5453fdd291c7ba60a776f47b1f55d5fd02",
+      "passed": false
+    },
+    "us-hi/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:e3eb4d1747019070dbe853335f73f1bb96bb6508547215263d3dc4fdde7aab43",
+      "module_sha256": "sha256:e26f8a865ba9db59540d194910acce123798e21ff32a852da6aacb2640f29081",
+      "passed": false
+    },
+    "us-hi/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:e95b8e822a5abc7c5c4919feaebd6b9d724e64a145d9caf7eb3a90799cb6b602",
+      "module_sha256": "sha256:1985629937f45947bdc5e708d7ace715949a09680d0618fc7d6f6d807c28bc5e",
+      "passed": false
+    },
+    "us-ia/policies/income_tax/2026_full_year_resident_core.yaml": {
+      "fingerprint": "sha256:84c9ec43289d6468decc606f145eef327906026bdce5fe1ace535e66f844c3d9",
+      "module_sha256": "sha256:31b2787f00144f04bf5dc6faaa49483ab159888b0a01bfa0dc161679dcdbdc0c",
+      "passed": false
+    },
+    "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml": {
+      "fingerprint": "sha256:3d2e7e912dad73fdeaf5d31f38aa8ccb47fb3a59297821fae4ef91de5c305784",
+      "module_sha256": "sha256:816ef3cbe3c96b294a8b2db425fe924060caff05375eafd1718fc637884c6655",
+      "passed": false
+    },
+    "us-il/policies/income_tax/2026_full_year_resident_core.yaml": {
+      "fingerprint": "sha256:8bec3be8176a8e20365811251eccfd13493b8c894259110498fcc0e0b9254787",
+      "module_sha256": "sha256:cf066b688bfafd4937f41395542c137e26b7996bfe5be66925155060509c20dc",
+      "passed": false
+    },
+    "us-in/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:890e2f75be97ab18c048b7aa4fb6f9323b0617df433d5c45a5f27b6961b1b362",
+      "module_sha256": "sha256:ff04236376fa9e36920e030b3c23812d852d94940ffd8c4587c64c7f23b90350",
+      "passed": false
+    },
+    "us-ks/policies/income_tax/2026_full_year_resident_core.yaml": {
+      "fingerprint": "sha256:44912a6ce4b6a2a9116e5e676416ee551da8dd707ef26abdfa6f56805689ee46",
+      "module_sha256": "sha256:4ef7e97ef6886989b66c1d4933947779c15e9d6e9ef9ea3d672789943dd954fa",
+      "passed": false
+    },
+    "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml": {
+      "fingerprint": "sha256:f2e09330010e58c532bb01d8616c3c4c44e14750955a9a5a55ea797fe8d6898a",
+      "module_sha256": "sha256:e5476d226820a4b4496660fe115e871d6a36f6e40c0ae8b65635d3c28e50a6d6",
+      "passed": false
+    },
+    "us-ks/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:eaa003d7fd0f460537864150cc21b24216af3e3356111460202f7082d648fb87",
+      "module_sha256": "sha256:81ce710ad885cd59e738c072f8e361eb0eebba6172353dd620f7e847518be926",
+      "passed": false
+    },
+    "us-ky/policies/income_tax/2026_full_year_resident_source_hold.yaml": {
+      "fingerprint": "sha256:448bb44b32bdf4c520eec1dc9c8ce8eae6407d48df83e2196ad80d15bf45b223",
+      "module_sha256": "sha256:9faf54271eca242919e8df4a85b9a763e62ed3c35fc4f0a4daa44ef1fbc6516a",
+      "passed": false
+    },
+    "us-la/policies/income_tax/2026_resident_core.yaml": {
+      "fingerprint": "sha256:4ab20071683ea1b7fbe865974b7aa96c2e6bf38e27a9513bd1c6ae1dda7803a6",
+      "module_sha256": "sha256:7c80eb245216e81a8685306218753e501dece57554fa7b6366a53f0851c6d23d",
+      "passed": false
+    },
+    "us-ma/policies/income_tax/2026_full_year_resident_source_hold.yaml": {
+      "fingerprint": "sha256:014be9ffccdc2d0a7af129814d390fae1c572b36b141f640b2e2226c66bff9ed",
+      "module_sha256": "sha256:4819f5ab42b1928772fc1d97918af64d4cda9d5acd1d7786fb210f669a80d62f",
+      "passed": false
+    },
+    "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml": {
+      "fingerprint": "sha256:c9ef70082bd875be90cfa4a1a8bf1b1b2e55339ed51ac831200c8f1421b4b8af",
+      "module_sha256": "sha256:9f6bfbf703b886720e65a6d9e30a561683ea95e4d6c55f2618519c5492dae382",
+      "passed": false
+    },
+    "us-me/policies/income_tax/2026_resident_liability_source_hold.yaml": {
+      "fingerprint": "sha256:0adfc071f99ee2a08f1cc5717c3e1b72f043eb388a1f6dfb55e91b2faa73004a",
+      "module_sha256": "sha256:8ba0b71994184d5ef4c390d260a907757580b518c5d779a9dca8e3b82a609678",
+      "passed": false
+    },
+    "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml": {
+      "fingerprint": "sha256:444afce9197e74ca12f3e49e288e5db5a75291fd0cfe6846d44f07eecf160f1f",
+      "module_sha256": "sha256:df2c03edf076630809034550628a239cf34a2dfca0db74094e65a17c2f761b15",
+      "passed": false
+    },
+    "us-mo/policies/income_tax/2026_noncombined_resident_core.yaml": {
+      "fingerprint": "sha256:c563e322936811b2a75139daa360b1e942c3f621c4bcbc7d231eabc9577fe26c",
+      "module_sha256": "sha256:1c142615d1fc36fac5ce769d4a8a137c803000e187fbef0d6cbdfe3dbe7c2cff",
+      "passed": false
+    },
+    "us-mo/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:1b5772054969e5574f07782214ca2785716cfecaa002c7c23b63ed4cb76881a5",
+      "module_sha256": "sha256:926c3bb534f25b175c5e33873dab674d01eba6709b401febad9ceeb74418694b",
+      "passed": false
+    },
+    "us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml": {
+      "fingerprint": "sha256:f3b9a0e7b84e74bc23c9af054cb16e874b37a07b89f60e09f1875dd88615fe9d",
+      "module_sha256": "sha256:cffa859e5b5531298d32f11bdecf3837bd72b796a1ec60aa394b3e67f64b53d5",
+      "passed": false
+    },
+    "us-mt/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:66b119b761968e72537eb6f9aa27319f8cce4033c699be6fc02a8e2a20e772bc",
+      "module_sha256": "sha256:77b3b276c20013b502dcc9a454556ea2e1d9a6ed397cf8b653f207fdb34fc31e",
+      "passed": false
+    },
+    "us-nd/policies/income_tax/2026_nd1es_estimated_schedule.yaml": {
+      "fingerprint": "sha256:8371d02698df2c2ccc1dbc79e45e4d7b82ea909b9c225fc4e453598dbe56d142",
+      "module_sha256": "sha256:31fc3dea8582fa5bc08d9f609197e2f69a2691a08479e934a699c6ef15de11dc",
+      "passed": false
+    },
+    "us-nd/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:a9d2a387472e813f14a5b9efc6f8e6851f279bfa8ed0e1c549815b807ffcf89c",
+      "module_sha256": "sha256:1070ee4cd88d4bca31feaed6447c4d665e86e6f1333fede05a336d62966d69bb",
+      "passed": false
+    },
+    "us-ne/policies/income_tax/2026_1040n_es_estimated_schedule.yaml": {
+      "fingerprint": "sha256:71ee8916bc7c2f10cd39286a8b66a9dbbbc07aafd74b4b4542566c5cc2632254",
+      "module_sha256": "sha256:e14d800642df7be9370e8e7d89f581c34bd3ebd846a42d016995ec02134af41d",
+      "passed": false
+    },
+    "us-nh/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:094688bf67592f716592a4886519b744f114fd7aa66b4dfda7c2862e327c4cfd",
+      "module_sha256": "sha256:52c6cb9636b49f4bd2a306113771a49f0902dbc1600ad227ab48eb1aba4f5eee",
+      "passed": false
+    },
+    "us-nj/policies/income_tax/2026_resident_ordinary_core.yaml": {
+      "fingerprint": "sha256:2cdaed6426a108001524e1c594f343b15c795397f2edc0285e5713e6f9eab2ba",
+      "module_sha256": "sha256:99ce6f41070bfd5c7f3582bb4bed1535470024852001bf1a7ca1d62cf6c01e16",
+      "passed": false
+    },
+    "us-nm/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:77d0f8860b544f7c967923b53cde4c7f09dc4b10319974d8f39fac0e40282b4e",
+      "module_sha256": "sha256:fc228d9c3a405bdd042e998ecb0ffdaf5c07d7f9759cca35adfdcca990ce0fd5",
+      "passed": false
+    },
+    "us-nv/policies/income_tax/2026_resident_zero_liability.yaml": {
+      "fingerprint": "sha256:9709089726de369b2fe9f2c87d36b37df6f24e3282e088916e5c7c9523ad83a7",
+      "module_sha256": "sha256:f49b0fbb9a2fdf0964911e8435ff024641c39abfdb97af3d332dc16c2cc1aa96",
+      "passed": false
+    },
+    "us-ok/policies/income_tax/2026_resident_ordinary_core.yaml": {
+      "fingerprint": "sha256:6eb1a8aede728d0db9aafedc5ce91cda242ce657e73e529a8a7975848f390634",
+      "module_sha256": "sha256:22e47624c19986eeba29d44edf98671db32e619e8042c5d702a9725deff889a6",
+      "passed": false
+    },
+    "us-ok/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:a962f57c5dd96703c2bc8931d960136d7420bacdce241ade054c5f55ae52fbf6",
+      "module_sha256": "sha256:0eb5ff34a3087e3bd0121ce161e5065bc8eccf75491830cc4b4e5f9ea5576cea",
+      "passed": false
+    },
+    "us-or/policies/income_tax/2026_or_estimate_schedule.yaml": {
+      "fingerprint": "sha256:d51bfad18300aae51e1a40ed7f97a2c11d85d330e48b8f4b3f477233fa4d745f",
+      "module_sha256": "sha256:a3ba974321c631b517d4d020afc15ff2e79ad015bbfee6d0e8dfb4251aa986dd",
+      "passed": false
+    },
+    "us-or/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:e28864d814eca29e5be40eb8749d9e997b2beaccfb0a71fdfa9ecc998ec1042c",
+      "module_sha256": "sha256:d5366a990437d50a0e1ddede9b7e906a59a557ead0af04c13184cc610ed19202",
+      "passed": false
+    },
+    "us-pa/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:2d1af8adb47962a855e10fcdea626b849008922619eb651e12a63066e3d39427",
+      "module_sha256": "sha256:cb154737cd58ba6384a7ab173219c3cbeaebe353aa8efc0745fc6bc7cb2a8e4e",
+      "passed": false
+    },
+    "us-ri/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:88944d21372c0b37c858371058d98fd62c6c0ceb095ae8ca1a7d302664b780b4",
+      "module_sha256": "sha256:072877539db53e7dfb787fbd38b926902fb2beeb2cd8fe371d1bcd2845bf6e8f",
+      "passed": false
+    },
+    "us-sc/policies/income_tax/2026_full_year_resident_core.yaml": {
+      "fingerprint": "sha256:9cba8f22ff1ca7610e28b74469d677125d4d0c14117fa25d17c1a8dbe54567db",
+      "module_sha256": "sha256:238eb42850716ef53f5543f792f05387344454dc98999d717991dcd1eb79ec1b",
+      "passed": false
+    },
+    "us-sd/policies/income_tax/2026_resident_zero_liability.yaml": {
+      "fingerprint": "sha256:fa7b2897498d51aa57a2233f18202c90646d1084501bc26e0f59545d724a2a58",
+      "module_sha256": "sha256:e78df148ef767efa24e4c73f305e2a55b6d82953f06c739de15846d1a2c1238b",
+      "passed": false
+    },
+    "us-tn/policies/income_tax/2026_resident_zero_liability.yaml": {
+      "fingerprint": "sha256:7c9bcc61a4d2ce2fd45065aae34ddae5abbc3d5bab6356daf4624357effff8aa",
+      "module_sha256": "sha256:9fefb8ad6499534d1ffc952473eb5bf13326db35b493b1a40adad949797cbb2a",
+      "passed": false
+    },
+    "us-vt/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:3f3076e5186d87f4caee0590b1acf71639214ac78bbce417c32d97a2b026008f",
+      "module_sha256": "sha256:9443a115dd2dc7cf9ce60681a2cc5ab86d6271affbced4a8089dac59fa92fdc2",
+      "passed": false
+    },
+    "us-wa/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:3134a9be34a28025fd534eab9447c230dcfb71fb4bae51e4e5536fa0151e0040",
+      "module_sha256": "sha256:1777a5cd91562959eebab3376117136fbe608ff4d834b0774012858fb614e6d4",
+      "passed": false
+    },
+    "us-wi/policies/income_tax/2026_form1es_estimated_schedule.yaml": {
+      "fingerprint": "sha256:cdb5b0c111bbdea57a0d704f220ce34f502f0df374052ae0e61722c88c514c41",
+      "module_sha256": "sha256:d5ba7fe5a80a24716b669eca56b6180a84cd842c259740e7b49e08ebf9284b03",
+      "passed": false
+    },
+    "us-wi/policies/income_tax/2026_full_year_resident_core.yaml": {
+      "fingerprint": "sha256:da138d85aee6702fb93ec358703f66deecc1b1ac980c2c73f319ed169bd3595a",
+      "module_sha256": "sha256:f2d1948fcfb1871d41969056e8511d7ac878ac4311a41e8f3560715f959f425a",
+      "passed": false
+    },
+    "us-wv/policies/income_tax/pilot_liability_pipeline.yaml": {
+      "fingerprint": "sha256:444ff6fcfee3aaad4cf4662b774971f6f84829f48dcecf58cf06c6dbec378080",
+      "module_sha256": "sha256:a6c7ff80df9609760dd45da5513148b1d3f03e34db3e9715a14412e9d75fa342",
+      "passed": false
+    },
+    "us-wv/policies/income_tax/resident_core_liability_pipeline.yaml": {
+      "fingerprint": "sha256:a843d9140969cc60933889aa6e780e4e3bfd29290a1710c7fc7ea909949362d2",
+      "module_sha256": "sha256:f4e63a07352fa22468db3982732386800eef84bbd711da9f19b86334cf47eabd",
+      "passed": false
+    },
+    "us/policies/aca/ptc_pipeline.yaml": {
+      "fingerprint": "sha256:c1210e32ed5bab4c0b368284c8a58b5854bd54baccb98282147e8ad03fb426f1",
+      "module_sha256": "sha256:615da98dd38f28c1ac46945f884d4aa49d27e3d49295fcbdd85e4304c40b3a46",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-duty/composition.yaml": {
+      "fingerprint": "sha256:5ae55ea895bcbe7ddcf81ca64d50685e0e2d074c48173863eba6b46e8a92a42a",
+      "module_sha256": "sha256:0745c24a9c7ca8cd54d28bf4da5ea474f479a866daf59d4890824a2f79c82c02",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-duty/de-minimis/nonpostal-suspension.yaml": {
+      "fingerprint": "sha256:cf1e42a2a216464932ccfb0d8a77a4fef52b6a35a541e21a3a9bcbc2d7406d7d",
+      "module_sha256": "sha256:6e480174354ae7a2848c1ee261d81e63df503ed80623c8bb14151a99d8acc373",
+      "passed": false
+    },
+    "us/policies/income_tax/additional_medicare_tax_pipeline.yaml": {
+      "fingerprint": "sha256:abf368341768bb90394ebc6d2b8f491dcac33ac0b83554c3894d817d565ad049",
+      "module_sha256": "sha256:3c30282d2c6c7a09e0ffb9d14d48afd68daa71ccc142beb44747d2d76ac21128",
+      "passed": false
+    },
+    "us/policies/income_tax/elderly_disabled_credit_pipeline.yaml": {
+      "fingerprint": "sha256:1c06ad89c67b75db86bc54e4d8e7dccfb83d0665643ceb3dbf3868497df43137",
+      "module_sha256": "sha256:a3f81cb607a036323110053cd40af35a13aa5905a7c4bca328473184f66e34aa",
+      "passed": false
+    },
+    "us/policies/income_tax/itemized_taxable_income_deductions_pipeline.yaml": {
+      "fingerprint": "sha256:4f63e8a60fd3a3d1804af2761bf910e147cb0ce88d50576e6a237dc2c1bb7845",
+      "module_sha256": "sha256:da533e2f7e0cfd79c11e35c502860c7c5b09b7b197ab78e6266ecbced9bde56a",
+      "passed": false
+    },
+    "us/policies/income_tax/lifetime_learning_credit_pipeline.yaml": {
+      "fingerprint": "sha256:3fc72405d75fc6a8719f6674f393d494cdfa82aa6bca83157257d0c4e12fa626",
+      "module_sha256": "sha256:d329b4bcf640a90db881d7cd6671ee2c1b8bd90b87767c4e63cc9220012b798a",
+      "passed": false
+    },
+    "us/policies/income_tax/net_investment_income_tax_pipeline.yaml": {
+      "fingerprint": "sha256:5a3ba43b88ba6d988c624095ecce987caaf9db7ea1346f3e6353709ab0b36df1",
+      "module_sha256": "sha256:12f6d3d0d9f75b8b49d1ae9944f51424bb5bef7bd2f1e832a085524d2e6c77e7",
+      "passed": false
+    },
+    "us/policies/income_tax/qualified_business_income_deduction_pipeline.yaml": {
+      "fingerprint": "sha256:cf1556415b319af39c1fff6ed46dd7cd5e6ff572b25382723ed383d12296099c",
+      "module_sha256": "sha256:0289ec52ae86438182d2ae9be281d2711c5e093c1b7cc086678f42e4c69f47c2",
+      "passed": false
+    },
+    "us/policies/income_tax/salt_deduction_pipeline.yaml": {
+      "fingerprint": "sha256:f99164488fa74da6b0c89ef63e78af01aed9f7cad17b6d27cf464651f0c2deba",
+      "module_sha256": "sha256:81d049791e96d949b63b0b7599f88b4767ab4c68d5e05389d49ead70afb063b8",
+      "passed": false
+    },
+    "us/policies/income_tax/savers_credit_pipeline.yaml": {
+      "fingerprint": "sha256:989b261c560e4b3ac53ad611933079747dd3feda50e36e84009c9474f2bee5fb",
+      "module_sha256": "sha256:87a3bf8d1d656597d3818c4cd7eb75f685ed5e7e418e58662c81d6a2f6e10372",
+      "passed": false
+    },
+    "us/policies/income_tax/self_employment_tax_pipeline.yaml": {
+      "fingerprint": "sha256:f83b1bd0dfb84f7a8452264b31b5af50707d6aad85a69a92031751434c25a40c",
+      "module_sha256": "sha256:3668c1e3e86ff0625cab484bc1a1623ac233a0c401bdef71fd2a2832a51af72b",
+      "passed": false
+    },
+    "us/policies/income_tax/taxable_income_pipeline.yaml": {
+      "fingerprint": "sha256:2d30f8e72917d87470b7a8c09d2c425137455b56468881bc8b551c9bbb4cde2f",
+      "module_sha256": "sha256:812f15410e4266a6118b9929399dbe4ae3f654eb77ad0e7bb77b15ee8c50de8f",
+      "passed": false
+    },
+    "us/policies/irs/notice-2025-67/savers-credit.yaml": {
+      "fingerprint": "sha256:980db26f953d522f5b8b20da874d64a7e8f3340fd5671f8a0ef3dd4f2af47f61",
+      "module_sha256": "sha256:40436ffee4b5f13b030a892ddcdee4873adfb0c92e990fdffa37cb981e66a366",
+      "passed": false
+    },
+    "us/policies/irs/rev-proc-2025-32/qualified-business-income.yaml": {
+      "fingerprint": "sha256:304edcfa2d3b40dd4fedc97fddcd7f6b2144b39b8855db752767f6059550e18a",
+      "module_sha256": "sha256:1220ffc5b3b22f28c7c64bdf518e2968b286d3d8d8c8a340da5ca408da9ffc32",
+      "passed": false
+    },
+    "us/policies/medicaid/magi_household_income_pipeline.yaml": {
+      "fingerprint": "sha256:d16a326c01cb2b750d427aa58afc7b7d004046c73156ddaa783145765511aaaf",
+      "module_sha256": "sha256:df6b208e1f1874924d3aca4eef0d6cd531acb4e454342fcc0e3325bb85fe824f",
+      "passed": false
+    },
+    "us/policies/usda/csfp/eligibility_pipeline.yaml": {
+      "fingerprint": "sha256:2b62ee47e52475b940adddbe3a66d6ea4a33ff3c7d7ab06b54e1a7772aa27da4",
+      "module_sha256": "sha256:9a5acd4426a2a79df2aaf68893325f6978eec6c361b19b83d257f567f5b7dc2e",
+      "passed": false
+    },
+    "us/policies/usda/wic/eligibility_pipeline.yaml": {
+      "fingerprint": "sha256:c59783f04fd493847871cf12f7628547d7d4b39a83280b15c28045df65346531",
+      "module_sha256": "sha256:c01232db85068eb796fc3310196594ef56fc53076067394d7a421708d56bce40",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/7202-11-10-00.yaml": {
+      "fingerprint": "sha256:41f0fef6c5d77b005b260eb247746d470dcb57cf7c2ac2b66da214d8ab8b87a4",
+      "module_sha256": "sha256:950a19cfde0a88ef80aa4f7d8485796d5e7fcd244095c7ea4df6e84f66ef52ca",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/7601-10-30-00.yaml": {
+      "fingerprint": "sha256:fc2b5e4a1bbc382303a72f3359c55acfa12d4808ad6291c432747f66d015d577",
+      "module_sha256": "sha256:5d62c78ab9aae17ba6a41fa2b9fd226836389b71fe46006a6ac677e713d23a26",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/9506-62-40.yaml": {
+      "fingerprint": "sha256:d3d21408ac9a086dbebf8219071276291b5bc16924dc28a45d70b981571dbaf3",
+      "module_sha256": "sha256:792dfcac50524ae5cd5e83a3a1ad0214a0028fc5a1bdf8a6248a51d8414145ac",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch01.yaml": {
+      "fingerprint": "sha256:3546c861babf4390730e801adaa378da628e02f4b7c345b812b108c8795dfb65",
+      "module_sha256": "sha256:236123027e718295dc4441b323f871d61167afe8931a3c8b3cdd0fe281663a30",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch02.yaml": {
+      "fingerprint": "sha256:5366937be89bf4909953b13d38ebe6c0a856eea9a57894a61ae5eb51d895c0c0",
+      "module_sha256": "sha256:5027637d6cf9b50d31c04dcc6e104e49d512a3b180fe13267a560b925e8b7b3e",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch03.yaml": {
+      "fingerprint": "sha256:4a602dee8ad9b9612f12ac4f1848a7ceceeb3fafac10500b836b3d04cfdf2a54",
+      "module_sha256": "sha256:5f2c2c1389b03101578663da7943ee8d9fe073d8adce6bca21e58a3e68bffcea",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch04.yaml": {
+      "fingerprint": "sha256:29bd583c37c24c983f6cb8434ff44d4dfc3ec25280ca0e3fe103670403d46644",
+      "module_sha256": "sha256:af6d37241718ca626dd706da51012593cee9454f7e058dabaae7a14a0d1aeafe",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch05.yaml": {
+      "fingerprint": "sha256:4bf4f8acdb3aa472c018ad6a0fec662e8dd7a1681f9bac33099f1e594461ee85",
+      "module_sha256": "sha256:bf45797b756f3ff1d43b809989502be2949c705d584d76bf97f4df1d199cefa3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch06.yaml": {
+      "fingerprint": "sha256:f755bfdd6a75507b3395dc979d1a2db4e0314dfa1a8a1ce9dcb5decbac123d99",
+      "module_sha256": "sha256:e6e6ffabbb46617c2c7f6af39b5c16096ef8785742f6d24ec487ee4fcf1a2030",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch07.yaml": {
+      "fingerprint": "sha256:56ea04ba2bbd4bc38da17dfb44d26f9f4d25406aed7c15cdf11082fffa907ad9",
+      "module_sha256": "sha256:074ac7acb066ec43d72ad590b2dcbfec094d88b24f29dac8190fbae31d8f737c",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch08.yaml": {
+      "fingerprint": "sha256:3955b1d1177381ca5ad08ebc0b9c8cacd84f2327e73b349052e7855dbd9b667c",
+      "module_sha256": "sha256:157cc5a6cf55af20818284f346b3d778ec7e4ba87637aac7c89adf05cb2049d0",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch09.yaml": {
+      "fingerprint": "sha256:1216385533d3db9c42bc464891fc04bb59bcf1880e0df1da4bd501820ea268a0",
+      "module_sha256": "sha256:05a53db37f7f08a5c43b6c5dd6fe6c844920442a925090e601f6d069576ea5e0",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch10.yaml": {
+      "fingerprint": "sha256:b5a5dc396d3ed0c414637b50f89b20289cbc64af35e8238eb8877ecf6460f1e2",
+      "module_sha256": "sha256:a39cd168fb6e61e8ff992b2ff1da8f8cfbe5518645d4cee9c2f5506668a31147",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch11.yaml": {
+      "fingerprint": "sha256:4848c47cc11c7cf8fe188b5c3b2ed2c92e3cb256aeb813e20437b8c1491ea616",
+      "module_sha256": "sha256:6f4f729d32fe9969b2ccc1fcab6363921120a9806b7762cf77f07408a08ea4a1",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch12.yaml": {
+      "fingerprint": "sha256:f51d4a5ad49396bcc279ce4f6a5ffe03d498f6782a461defe79715e9911542f2",
+      "module_sha256": "sha256:e8d5dfe034b52b1248a94d42fd9487a48c68ba62dfecdcf5f7e003002a214a13",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch13.yaml": {
+      "fingerprint": "sha256:9339dafefa956a745a0c0e5f36df714ccdc39b7fd946d79b5ba6ad01621a997e",
+      "module_sha256": "sha256:b43d32d6cea99bd97a2109d52c1c671ee4fa3448ae813be60def6ed343996996",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch14.yaml": {
+      "fingerprint": "sha256:afbe15aa19513654cbcb6cc30680d7c73d0c4bbafe0b64ec325674fac119e947",
+      "module_sha256": "sha256:4a276cad0571a8cd947f4a7890391daaf9312caab0f044992899ca9da10d1281",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch15.yaml": {
+      "fingerprint": "sha256:01ae58d5ae95bf8d513cb6ea1f1d8e04cf076c680ce9e795a726b53279580956",
+      "module_sha256": "sha256:0f90a5cd705c3492385169be198fd4659fc5c9f9a7d3c6b2240bf6643284640e",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch16.yaml": {
+      "fingerprint": "sha256:f32256dd4912f057d17806a46b071fac2400dc8df71ede2b53988981b6dea045",
+      "module_sha256": "sha256:9286e08e845643a5d064885b0f0ac5f1e2c8af1e12ef06255454309ebdd391f8",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch17.yaml": {
+      "fingerprint": "sha256:86bb3ad3220d7c34acd2908d88ef4c73edc4dcd5ede98b835b583651719db12d",
+      "module_sha256": "sha256:e332456dbf89a1762815551463cb160bf49ffa2922526a7a59cb653cabf4cfbb",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch18.yaml": {
+      "fingerprint": "sha256:0e525c9c171b037d27080b6d57f1663ed8301c8c142ebabedbb3761c2283eb66",
+      "module_sha256": "sha256:ca3709b4ba52f95f0b31a0957785d8ad7ad9eb618532cafa4bfa3c3d0ab3f4ea",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch19.yaml": {
+      "fingerprint": "sha256:5084e4fe9e8ed4b013d5da2ebaa12054cae4bcdcab506ff139154337e91b5e8f",
+      "module_sha256": "sha256:9db1f049ba3d55589cf30ffdd79e2aec6a0fec21149004c2d9eaec82f5a7f6e1",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch20.yaml": {
+      "fingerprint": "sha256:6bf93bb4ab7954b2fe5f494a1fe55d2b56b8cbfdd1f98a50f066621409eb9fe7",
+      "module_sha256": "sha256:6dc195ad23ee188da9ad66af37e7f3678c2464618aefee8e28e078567b71437f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch21.yaml": {
+      "fingerprint": "sha256:ade626c93f6f811701198e297376362d79176f16aeab800056253480ed7c6317",
+      "module_sha256": "sha256:b409d02b20d463c85002a4911c02cfe74867e42a762390dc5937f4b6d57796d4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch22.yaml": {
+      "fingerprint": "sha256:f977e52008392187f6a8770d8cc40f3941cb2e57233dac3b241721ea56c7d740",
+      "module_sha256": "sha256:41f2a6769e74726a649171197c5e715121856bf96d4b54c2ee1e2abec27be55b",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch23.yaml": {
+      "fingerprint": "sha256:b905129af17766cfac5d15fac4dc2df16dff4eb99d7c0fea6e1c666001673636",
+      "module_sha256": "sha256:a070bd28e7e3f862c1626d0ddbdedbe7aeb07e6ee7412745421f44f1090c7d34",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch24.yaml": {
+      "fingerprint": "sha256:8fc7589742b38c4591de2343b32295663da696f9e40e4c61913918d038269130",
+      "module_sha256": "sha256:09cd361ebc43f8d533b0464f111d0ce1ee6bf02b4ebd46c7c2f155e801eae1e7",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch25.yaml": {
+      "fingerprint": "sha256:57155c3d90f78fab29515a4fc79a1f99a09c6dfba3bab60efb005878ca73cfd0",
+      "module_sha256": "sha256:c74dff018c72715431334edf28226d28e71383bfa1101f333f83a00d3929335c",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch26.yaml": {
+      "fingerprint": "sha256:86f0f8a5d9befa34dc7f17d543fb28aebbff5c0cd88237a6b9263621f687d467",
+      "module_sha256": "sha256:c650e65fb5c5d7dde838f2c77d398487742b669a0b0782711bb2c2505650a802",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch27.yaml": {
+      "fingerprint": "sha256:1db3e5fdc481bbc91123b87fb7447193a524228b36e71bd4f8c4fe3678567537",
+      "module_sha256": "sha256:e0619432bcab715691889d81c8bb81b840711a3c8171202adca64ca6e0f46f9d",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch28.yaml": {
+      "fingerprint": "sha256:a31990bb7e6ca3aa23a5881b4812ada84c4040c19982d35eb9d7396ec03d75ce",
+      "module_sha256": "sha256:6610577c7dbeeddf1067dbc8ee73412b994c751fd124cafe770c6dc785eb2911",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch29.yaml": {
+      "fingerprint": "sha256:785803b64ae2f262dab0463630c022c9ab149d793ee00bd04cb1936c9ec662d3",
+      "module_sha256": "sha256:e10b6ab74c77709e6b0ca9274cee874e695687c27865ce638ee6d3b5aa450bcb",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch30.yaml": {
+      "fingerprint": "sha256:80dbb1f4b4f0562a8c0c7142c1bc8ca00625d59abc3dd0b32eedd7767de19507",
+      "module_sha256": "sha256:5b51aa55bcf0fee2ff4b8bb72dae511b7cffb35c7e6041c3d8718629086368af",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch31.yaml": {
+      "fingerprint": "sha256:c03afe0880d6638bec2570355eadd3fb211f9e48dfa614d767a54c0f88418ef3",
+      "module_sha256": "sha256:39fa66481f4637352012766d3bf9b195cbb659508093f1461f1b96765050518f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch32.yaml": {
+      "fingerprint": "sha256:588f2b3860d4b588b6c24a7331ac495e7eb470d28421328b745b3d60837997f8",
+      "module_sha256": "sha256:d9981f8763f2bb2a3790714d5c065e6df378553dca1546c9a53227134b819dce",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch33.yaml": {
+      "fingerprint": "sha256:14d770413bd1a74ee8ad237da0aab1deb050b40f3b630ea06df58d071bba35cc",
+      "module_sha256": "sha256:dbd6c693fe96fb47bbd589cd9ad328464eeb573f029a7a9688316047fafc33d2",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch34.yaml": {
+      "fingerprint": "sha256:24e09c7c81b785e84d2701cde6ebbb7bc064fcc0436b6f19627e9361db236dcd",
+      "module_sha256": "sha256:fc289052c374d37796ecd94ea1c9235c7aba034c20a451e3eeea6977c0126961",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch35.yaml": {
+      "fingerprint": "sha256:d00d6049b536f200132a9dc2e419970cb61081f890d9b0ca3d5a4a33dc1ed848",
+      "module_sha256": "sha256:cf399cafdc71a5d9281fe2a6a06500db43413d0a46f737b33ab7147b0edbf372",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch36.yaml": {
+      "fingerprint": "sha256:5dd04d2a07e78c5c744cdca024361b5929a8484f622b0d4eea35d3733a8fd158",
+      "module_sha256": "sha256:e5fea6f9ae394a70582a5f95113286df94be313a58ac8432eb5b4a487cd32f25",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch37.yaml": {
+      "fingerprint": "sha256:93fbb3c33e58b2fd0425a0aa046f3af1bdfdb64cebcfeb1fd1f05ddeaca633fe",
+      "module_sha256": "sha256:10320e5fcc8e60e305fcecf0ad107e1498a81e419933b782bb832180599db07d",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch38.yaml": {
+      "fingerprint": "sha256:15706a80c73cf16d8734c74a869fecab7f9cc961e8969817d602bd35900bc5d9",
+      "module_sha256": "sha256:ce0f32a0e6dc37879187c2778f34ef141526c356675f36f0159cfb08b521c955",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch39.yaml": {
+      "fingerprint": "sha256:beca7261f145856c7134e6343d73cba374584302c21924818fd7a7f569aa6b18",
+      "module_sha256": "sha256:51080e9fa397f0d2239bdef32f4b0aaa5db86fecf3dc909da481589f4f658cbc",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch40.yaml": {
+      "fingerprint": "sha256:615308a5f0e78f6f6d2b23507d97112d85461631442959e6d5c63a75b6204f91",
+      "module_sha256": "sha256:abc6df4644f9d38a35bec32c632c24cb413a918a2f3f3722d9794d36fa90d2c3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch41.yaml": {
+      "fingerprint": "sha256:d64382f4629f08a9d7f97599c4cb722d6bb8cfa8476893f73d326d76113e9b74",
+      "module_sha256": "sha256:9cfaf073a2dbf70f02bfda4ddb652ac3da62239b05f491022ad6ac22f63a8e49",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch42.yaml": {
+      "fingerprint": "sha256:6994971a1334f51c76cece8d0d920f9638e47ee1807a33d7a7f8ef42c9d230a9",
+      "module_sha256": "sha256:7cd01f51d538e68e144a89d5eab7f62a3e9a76ab2ee0e31150534e4165a79c90",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch43.yaml": {
+      "fingerprint": "sha256:e0ffcd910cc285fc83c113974f63e365be0b48e060569b14e09ec8553271df7a",
+      "module_sha256": "sha256:46fcc9168536ed5de196be347716146164d04ec333be8102fa2302cd9793aa90",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch44.yaml": {
+      "fingerprint": "sha256:ea130ad3881e5d6c33648998ea7a7de1e38b429bb0a73b0b29d3fe7c590fb488",
+      "module_sha256": "sha256:d2594304aebe759fbba6c506ac2417787263bda1b91e117aa9483f96581b2511",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch45.yaml": {
+      "fingerprint": "sha256:b4525cfc46710dc1df6c7f2988204ee7b3fc8f0d53da4c22ae1ebc40b7defe04",
+      "module_sha256": "sha256:b33099420ec44fbb45fb9303221151dd63cb8ef34a1035af965f81f6639836c0",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch46.yaml": {
+      "fingerprint": "sha256:b33039a163d760538a19cb7d142aeffb280febff8ff032e05bea538a4e41a002",
+      "module_sha256": "sha256:262673769ed3fd2c3915f75ac1fc278a26198f328cc7ab7f3248ee6c351017c3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch47.yaml": {
+      "fingerprint": "sha256:8a8411c3d961fde32e5197ff3ed1662c34aa8bba032bd1dcb67fd6f0ac814c80",
+      "module_sha256": "sha256:6aae272e99be9a4b56a6cc8a815e247473edb1c5420c06614ac5ac7fa3bdc8cf",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch48.yaml": {
+      "fingerprint": "sha256:678bdf91b65a319f39ad2c630c4d4ae6b5206b81eb573f635bbe5a6f8cd7818a",
+      "module_sha256": "sha256:783e9069bc29fdf1cc880bf24d198569b082344b04f8579c891edcc1bd3124a1",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch49.yaml": {
+      "fingerprint": "sha256:28b59bb2360423c63328bb7cb51ee719c72bfab494398d39eb5d191904018757",
+      "module_sha256": "sha256:d2903103f099452d1d0ecffb436d607fe5b38e6179284bda06a0036b21c688f8",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch50.yaml": {
+      "fingerprint": "sha256:05cfc16ed3d98ff4630a009e61f322f86b1e79cd2b229720147b3a10b23afd03",
+      "module_sha256": "sha256:e49ef95cf203ababdce459679f0add350f5b6f474da7100df19ddba662001353",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch51.yaml": {
+      "fingerprint": "sha256:f3ce53000448f5efa3e7cefa8facc6277509fec8ef961d36e3dadedd213cf6b1",
+      "module_sha256": "sha256:ad35afaa0de2c3f942b0afae8531c6177964c51fe7c9aa7af881cb3930622ed3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch52.yaml": {
+      "fingerprint": "sha256:ebb12c2fdc37e3442fd47c199b5a003ecfe28f71b62202e5b3fcd0608f6041c4",
+      "module_sha256": "sha256:1a57bb9e37539757a50d45c8870a83e1e05d130300a2adf5ac31b4f479ad2745",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch53.yaml": {
+      "fingerprint": "sha256:3c9c112663446bc1ff881ced46bfe19737ba65661a608742176f004c08a53a97",
+      "module_sha256": "sha256:2d3a9f049fcb9926e70dd546ef123a050f7b074c5e7eb9f615a5757bfebb4d4c",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch54.yaml": {
+      "fingerprint": "sha256:bd9c64ad98ccf4ea306f12390d8cf13b7ce3cb513628434b01129cfad737e644",
+      "module_sha256": "sha256:38194f3dd0977c9fd42da5f2f17daceaac1e87f53a9986c58c1fb7219447b43d",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch55.yaml": {
+      "fingerprint": "sha256:bafab518b4a85bbd4ea90abe99b6e3df3e4b9e0ed170696e1a8fa2b7581d5b1a",
+      "module_sha256": "sha256:d121dd84adce60e7345dfc86fec35ea1d9e81cb33f2dae6dd131806193533818",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch56.yaml": {
+      "fingerprint": "sha256:e948ecad620c2ef81a0e0a11f49fe86c27d90b9dc31b3bb3ccd72fd6b263b62f",
+      "module_sha256": "sha256:655e8aaf4811a278e201d2947a3556ba0d9e1924f7a13697d847a9b01ea18b8a",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch57.yaml": {
+      "fingerprint": "sha256:ce17e4d3c85b39ee2e365c4229d029793f8128542993fd55c0d12f297067b50d",
+      "module_sha256": "sha256:ce867b6d7815b4d6d74ffb84bb55a13e321b5ea7be49669b72720e617c277f4b",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch58.yaml": {
+      "fingerprint": "sha256:913e34ade14017c7f743aed26a357c884ddf99dd9e3910fb37eaf63a65536425",
+      "module_sha256": "sha256:9f47e86ed0fd46860740de43cd6455f691805898e06c13079d467ad1f19f7032",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch59.yaml": {
+      "fingerprint": "sha256:e5078e4476ab5bd61fd38cb9380fe32f39e9ea33d73540a00ba8f9d73bd19cc8",
+      "module_sha256": "sha256:01a220efaf2375282312e60ac89c5a7b7d5f3fc91fdf112851bbc332b7835a94",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch60.yaml": {
+      "fingerprint": "sha256:3de7c11486bfcf4b5d4048314a6019d90323383a26007ef3a0d6892acf8172da",
+      "module_sha256": "sha256:82380101b50dee1240bdd5a84cb0947599399ad3d09d000067aedc6fb8d5c6f4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch61.yaml": {
+      "fingerprint": "sha256:ffe9fa262cb7534d382db9c79d254b6e3266bcf16facfda0617ad09141fb750e",
+      "module_sha256": "sha256:d3d4ebba1f169b0efbd53e9813ff1f055814cc350dd674c30df06adc244efdae",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch62.yaml": {
+      "fingerprint": "sha256:76eb4a6d8755e8dde11b99a9a45c0b2843bfe0bcdec52af10cb4095a8d1c122b",
+      "module_sha256": "sha256:3c3e765c4cb0a80d14d3ee44c063d76fd74c38d35cbc208f736215aaf5f3abfa",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch63.yaml": {
+      "fingerprint": "sha256:f16c9fe1ec0c01a188a866fd82e30823f94ef59a65668c257e92d772fc2e2aa9",
+      "module_sha256": "sha256:ee7082bc094a4714ff19af58ad19a3565418ce5f93bba59e6bdb3aaa88ef865f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch64.yaml": {
+      "fingerprint": "sha256:4875e8929fdfda5215f33a47dc30e07cb1998c57296f88be4fd6cfa2a1a52c11",
+      "module_sha256": "sha256:d98be4d67a422a4274a0e49e2fcc9ab367c4b0614b2595220e81651f3d61ab28",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch65.yaml": {
+      "fingerprint": "sha256:c31e634fbdebcc9a61191c15ffa5f1ab8d54c2e9955ccde40c86e562baf95623",
+      "module_sha256": "sha256:a0e707b4c72d8752e0dce57753230a344c62bd1f06c4453d4bef78e1a3aa0ebb",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch66.yaml": {
+      "fingerprint": "sha256:ee801e96f9f17361f7709c123d7204a4e3f3e607ef3f077da4280bfa7cfa2b05",
+      "module_sha256": "sha256:2c2cb093ea5e443681e01089aa6ead476cb1e753e0d4631e67430f712e3ab27f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch67.yaml": {
+      "fingerprint": "sha256:63a5e975e754ec7fe691f6be5966382954e51ce987e5830ff9739b14530cab99",
+      "module_sha256": "sha256:61491a47952d12a136d5c6bc3688daf271c439be87900b956ee99e2c042007ab",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch68.yaml": {
+      "fingerprint": "sha256:3816ce76a5acc0c5d399356aebdf6e7f2cdf45555a2b1d9e0bacc2e8a8181b12",
+      "module_sha256": "sha256:1889d792267f0cf13536d611780e1dc1783326f368fdb5367c473e59ff99fe23",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch69.yaml": {
+      "fingerprint": "sha256:688a0842bf11f3d64e8346c8a4157278167645464b100fc549c1d01decb7e4fd",
+      "module_sha256": "sha256:b6d26fa119c4c4fc08ab166ba9d1d514cbc74288239f657fda85ac3012136843",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch70.yaml": {
+      "fingerprint": "sha256:76810c9e9d166b053d6192601d257664d1ac5c0bb0bd5c9d4a37fb991b1b384d",
+      "module_sha256": "sha256:a07bfe2d8c7cfd2dffb93e08a82215c9a5bbfd403775e4fb84a3b6fbc2a4f28c",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch71.yaml": {
+      "fingerprint": "sha256:480908e683d42206985f3576742af4229fb03815412c87fcc9804ddcf87f21cf",
+      "module_sha256": "sha256:54632e334e399ace4d96219d00fe84ecc85403216829a85c3c3252af583dba84",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch72.yaml": {
+      "fingerprint": "sha256:c59cd057ea1643711c3aa17f40644fa0bb4858087de7853fb47de8fe89ead543",
+      "module_sha256": "sha256:64f5c778e364e633da4660acdb9f579e679418cbff476c48cbc47d40273261d6",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch73.yaml": {
+      "fingerprint": "sha256:2cd6125bee07f91e0d8050af2a604ab8747374ca5c6f99066c89f248a6ae9742",
+      "module_sha256": "sha256:b5f75f1d6075294a3664421ad97998683df575f726fadb747bcb5640d3e6eaef",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch74.yaml": {
+      "fingerprint": "sha256:2ad6519e71329ad05091183054bdca839a90bb63ff95709ed741fc4139e62c19",
+      "module_sha256": "sha256:48e858641e8fdc77d59f128213279cc099638d3f263989c9741e3ae61feeabe4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch75.yaml": {
+      "fingerprint": "sha256:fcc9ec53b6e267d311f6cc8599a3195025004513ce92aea32c6012d3f2f1283d",
+      "module_sha256": "sha256:28f2f4252b9eb79d1982712fe14e4b7b8f92a1f2cd3ec0ebc1bd64db4fd3a1b4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/fentanyl-energy-9903-01-13.yaml": {
+      "fingerprint": "sha256:314ff5a81531ba79ddc0c01621332d6ba8ca671c414a80f2e8ebf0dfa40c0be3",
+      "module_sha256": "sha256:6061eee3994dd483776a8413e90289072a883b89098b5d5b98feedf8588766c9",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-annex-exclusion-9903-01-32.yaml": {
+      "fingerprint": "sha256:7cfda459a8194c36d2d396e92757225a0ed0aed8cfa2c1e30fda4bcdb253125d",
+      "module_sha256": "sha256:bba87ac41936db0898ffb2c5e1683c13ea37007b08b96fec4a087f61fde8cd85",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-36.yaml": {
+      "fingerprint": "sha256:c0776c04bd0af6329257132c0e817d322b2f4b69aeb7565d1f17449cd07df5a7",
+      "module_sha256": "sha256:01696568b0a8099295ad656cc7cd94082b277477b7f0359aab8afacb739e7a86",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-87.yaml": {
+      "fingerprint": "sha256:698387c8ec7415a365d5df35780eec9e8fe690f55f1b0c6d625f25c3694e30cc",
+      "module_sha256": "sha256:aa0406d3f687f7c31e0fd9bcf72d26084df2de7dcbcd0d85248ab53bbac1d121",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-88.yaml": {
+      "fingerprint": "sha256:a0bea94bc6427bfed677b1f7c15066a42f69158276d33c7d339b70ea3a6aed5b",
+      "module_sha256": "sha256:78ab11e458fc2f7c8ee074dccf1ded4a4d4329fa74d0a045c6f2cc9b71a1d5f2",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-metals-exclusion-9903-01-33.yaml": {
+      "fingerprint": "sha256:8a5a17e0a11db7d4a6c3daa6972a95204233f728848d866071c3827587ddd5fa",
+      "module_sha256": "sha256:c0ab0a6e46c9981dc64843f957f2d91745319cc6fa1b31c342096f08f17cba07",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-79.yaml": {
+      "fingerprint": "sha256:15d26c0a176041f129f5a34fc541500f2ccd0553fbf551978f9a4999b2eb9d60",
+      "module_sha256": "sha256:dc09df293bffb71ea133b2aedd597f7a98e5302704873c05bc6fa770a92679aa",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-80.yaml": {
+      "fingerprint": "sha256:e000ba2a87bd3cdee5141ecd10463ba9395aa861b393eeb140f68682015cb0cc",
+      "module_sha256": "sha256:063e2322ecb04743e4c0da9d4d883aa7e88a12dcbedc6bd8d4a81536caebc1da",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-58.yaml": {
+      "fingerprint": "sha256:d0ee792ce3d9d14b957326dd20f9fa64fabef083a335960e27d4968b751113e5",
+      "module_sha256": "sha256:1d398646459246d7e3bb20657cb43fea150d45cf96953e4059133edc6933dfbd",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-82.yaml": {
+      "fingerprint": "sha256:72c2709a6e2f8d00e28ead1501e1175ca4860d6ef8ffbd2631d3f829f1486314",
+      "module_sha256": "sha256:53604cba5c40eee4708a748cd5102d2869c3bd273c08df5cf1698b7c68ebd735",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-83.yaml": {
+      "fingerprint": "sha256:4485d121b855785dbeaf769fc087a44d6720f82533a5bb47279f791a664d88d6",
+      "module_sha256": "sha256:06181de02c109532734f852695642a73225204abb7c3e743fb716974fe12f0fe",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-122/proclamation.yaml": {
+      "fingerprint": "sha256:6b88562c033a6078e48696e2c31c48ce776c69e9d1a3594006f4a256acee6fbc",
+      "module_sha256": "sha256:1e367fde4bf26e7192b555bad41bcfe2b5b9637340b7926c0670abccc0274dc6",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-122/section-232-exclusion-9903-03-06.yaml": {
+      "fingerprint": "sha256:b145a422f635fda2b3a14fefe614d0aa209be60370b05527a5e6c4284f199aa1",
+      "module_sha256": "sha256:1ca0c02069a7564ce74d7f7053dfd3d024022f3de97d351e33eccd5334f7bfc4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-eu-9903-05-39.yaml": {
+      "fingerprint": "sha256:1730e0116bdf859aabc538afddf1aae80ae0019a964e20b2e6fee88e69bd0ab2",
+      "module_sha256": "sha256:c32d43192ef5c6d5fd2deada4fecc156d34ada1ecc842284291a578a8e54f00b",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-japan-9903-05-49.yaml": {
+      "fingerprint": "sha256:0e2613a0f84d9851fdcd9f4a10f86457cd5ce4842a3f5526bedd2a7c586b6197",
+      "module_sha256": "sha256:0dd895c3a850780a9563c59b07c77b08d5d58493e7d89e6b4f8f33a9e59674d1",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-south-korea-9903-05-71.yaml": {
+      "fingerprint": "sha256:9e0ebc3bfe170d856ef7d99e0f835e22425145745d8fa691a09b4e58062d8d17",
+      "module_sha256": "sha256:a166e97815ab187d43044818a618e53eaf1b71e8ce03bae4e08bfd39a386e342",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-switzerland-9903-05-74.yaml": {
+      "fingerprint": "sha256:f619ccd4e6dcbe84deb75acb3764948bb2ffd6f3f1ed82411d66e61fc7234146",
+      "module_sha256": "sha256:4b94e7cef04e84d5892d82962dbf9196ba6cfcb4bb889a983a657329d6de5a38",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-taiwan-9903-05-76.yaml": {
+      "fingerprint": "sha256:64e7a74c211b7d2e4a4fcddd7192188ba9ea7644fbb218bfdbe439498f356ccb",
+      "module_sha256": "sha256:d8787098e520dc19dbb9354122db913a3a8139a49b7cf8743d33bee4e9b02b80",
+      "passed": false
+    },
+    "us/regulations/7-cfr/273/24.yaml": {
+      "fingerprint": "sha256:19f07f96f1250a2c18ef8c2d1d7e6fb7d1efb5e303591bcdc72c981eca0360be",
+      "module_sha256": "sha256:089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec",
+      "passed": false
+    },
+    "us/regulations/7-cfr/273/7.yaml": {
+      "fingerprint": "sha256:221ff92fc5f81543ca2f614d2bbe59667afd49e878fdd990378f3ab953a0c442",
+      "module_sha256": "sha256:39dc6d050ebcc8db6eb7b8c4711a082a3707e0761258e159eb516d090e72bf87",
+      "passed": false
+    },
+    "us/statutes/12/1441a.yaml": {
+      "fingerprint": "sha256:a844b2292d635c376de9882526a4737251b625c858028f4d5be27f47564104bd",
+      "module_sha256": "sha256:9af5dc47eca36265f95bf1e1a71bec9c03378b8666aa8de9f2566017777d7ff1",
+      "passed": false
+    },
+    "us/statutes/12/1467a.yaml": {
+      "fingerprint": "sha256:a4c359fbc0b3322fd6f0f402102553715b4791700a8548e820b62db36623831c",
+      "module_sha256": "sha256:073ef80d8d3ce12cd63acbc284fdd3b478cfdaa556e3e34c14032ce0337c9437",
+      "passed": false
+    },
+    "us/statutes/12/1701s.yaml": {
+      "fingerprint": "sha256:20c2d67f6932a8b3940a2363edbef46af04d8579c3033db2bd5ac46cf572e52c",
+      "module_sha256": "sha256:b4cd4eaa5960b0fa2c9fcbcf70042527a87402a66c046c3fd74d804f77411342",
+      "passed": false
+    },
+    "us/statutes/12/1703.yaml": {
+      "fingerprint": "sha256:f61e636e3bb169a3ea7155b9d25357daa2b889187deae8feea97304db924dc06",
+      "module_sha256": "sha256:337d0329225149e0651b0eb5f7f4a467255985b9d74916eaff779f33d7f0e9e0",
+      "passed": false
+    },
+    "us/statutes/12/1712a.yaml": {
+      "fingerprint": "sha256:615c8491907b964700eebcfee0739d8c5d6e3ef19b77dbca6a0c4d9022b81ac5",
+      "module_sha256": "sha256:f383b188f251b4cd28cda2ff582b9e8584fc9b75a5b8f223c3122614d66e43b6",
+      "passed": false
+    },
+    "us/statutes/12/1713.yaml": {
+      "fingerprint": "sha256:d403970aaa9dc6bb3c5d6dcd9543b00c1d94b49ad630780fd3f0a2eaac446f21",
+      "module_sha256": "sha256:224e7b471783f2f4d24d9505569b90bc6ef88168c1b58102d73c876d827bef8e",
+      "passed": false
+    },
+    "us/statutes/12/1715l.yaml": {
+      "fingerprint": "sha256:12035fd8523afe8dc936cf2c6ab16dbc107d5e31e31714026c953ddf7eb82e90",
+      "module_sha256": "sha256:15e21394d88d651e564aee7f093d329e6ecd79b019fcb4441fdeda979997e611",
+      "passed": false
+    },
+    "us/statutes/12/1715r.yaml": {
+      "fingerprint": "sha256:9324c90aa752af66a664392ae422ae3bc21aaa932506cf1537664f023c60c1de",
+      "module_sha256": "sha256:5a4fa02f8931c09df894666664e2224161b26cc13bdcbcd20a5e936cf875910a",
+      "passed": false
+    },
+    "us/statutes/12/1720.yaml": {
+      "fingerprint": "sha256:76e7281997d6ee756fb330d6d9105579e25264b6b4ef3df611b0c7e4ea000d80",
+      "module_sha256": "sha256:790edc260be38ded9489b38cb8e0bf3d0fea5324489659768193d77ef4bbea64",
+      "passed": false
+    },
+    "us/statutes/12/1842.yaml": {
+      "fingerprint": "sha256:f5ecb24aaff14199dda85673a8440ce872051a2bed039a1e34f9f73969a7563f",
+      "module_sha256": "sha256:90a197e6ec8f3978c124bcfbed0c56af9c3f6f836bc193130037a6ededcf7804",
+      "passed": false
+    },
+    "us/statutes/12/375b.yaml": {
+      "fingerprint": "sha256:734652352a3c65bbc5ea2016e8b2d5c8acbfc6fa32eb3cfaa2a664858505e96e",
+      "module_sha256": "sha256:b00f751a251e08fb3a5a7dbe5cb82593f927ba0f0f40f89bff22656b05725820",
+      "passed": false
+    },
+    "us/statutes/19/1321.yaml": {
+      "fingerprint": "sha256:7b1b25435527c56504f330a98bcdff2d4e1ed71e096f604a1460ce3706442c0a",
+      "module_sha256": "sha256:1166ac925b8f8c3ee5e988147f6f45180decc5a4fd8beb996f8f20d545f0d353",
+      "passed": false
+    },
+    "us/statutes/26/32.yaml": {
+      "fingerprint": "sha256:d92dec59e652a0a291e74a4eea582730ca7e3d5dc8e9f6863b776085603128f2",
+      "module_sha256": "sha256:979e101eb20ac9f43fd37884e7241f3afc1abb7f3eea5abc93cc1b67067d8179",
+      "passed": false
+    },
+    "us/statutes/26/42.yaml": {
+      "fingerprint": "sha256:320a2bd6e6e88cbc02c418ed381e91d5f0892e535b7489ff4be31956c99d1b0f",
+      "module_sha256": "sha256:c7ba5a2e6af5193337c1997bc276d2b93a9091ec1c108bade33a48d393073845",
+      "passed": false
+    },
+    "us/statutes/26/55.yaml": {
+      "fingerprint": "sha256:f48d8225cc3a0cee58179d0c8fc50dda60e03460d77fd81243396ae06a3b4adf",
+      "module_sha256": "sha256:3b7a78143c80aac06860b129fc859a200e339fa49d185ce1c0f76e126a5be4aa",
+      "passed": false
+    },
+    "us/statutes/26/57.yaml": {
+      "fingerprint": "sha256:c89bcce4f05afc48d828bcaf41bcdeedb8a7824bb41b3ff02f93a3a684a18abf",
+      "module_sha256": "sha256:61497fe678e465dc6f52b8a2e8b97c905932d85d0d989aa2bb836eeeee5e8dfa",
+      "passed": false
+    },
+    "us/statutes/26/58.yaml": {
+      "fingerprint": "sha256:ca2bb21115a72463bc1bf5dc2a6cdab6a76b5d09a4717813f48496c6e41013f8",
+      "module_sha256": "sha256:b93ffa4fce240ee5d8511502d07e8cee8fc14cd5764683efc820e9e42157ea8e",
+      "passed": false
+    },
+    "us/statutes/26/59.yaml": {
+      "fingerprint": "sha256:6ef556d6a917adb1a039e96e0a6facd7d2e38da44427c7a3115df4cc26550be5",
+      "module_sha256": "sha256:d1e8f213150c74ed437fb6786aff5465f65a65efc1b021137a5a1ea8102012d1",
+      "passed": false
+    },
+    "us/statutes/26/63/c/6.yaml": {
+      "fingerprint": "sha256:babdf988f3f47f7715f41152c0caae57f5ec32c78190b3f6a275014867fda774",
+      "module_sha256": "sha256:ee32cfd0ed49ed31983fd36e7a8fd74b3c0a2f7adc4ce6151d95c0956de8d2b3",
+      "passed": false
+    },
+    "us/statutes/26/7701.yaml": {
+      "fingerprint": "sha256:8b23a10a85836142761939df5625051b376e67a076944cbbdeb655b519c6c64f",
+      "module_sha256": "sha256:7124da89e5edfc3e8af35aa19c9c72e18918fb94b42eb753a966469b12aa0c2e",
+      "passed": false
+    },
+    "us/statutes/38/1521.yaml": {
+      "fingerprint": "sha256:b1eebf5f43344a667be429b0662ce86b3bd7afd2a32ddaa445879e2a3bfa3fec",
+      "module_sha256": "sha256:5376f13c9d41c1abf2906c0bf61b38c579647fe51b2fc238ca8b79d162923a2d",
+      "passed": false
+    },
+    "us/statutes/42/12705.yaml": {
+      "fingerprint": "sha256:76871d4e71b83e820a4c47ae8d9b6ff4dc263436a1ec244bcce1c54485304efd",
+      "module_sha256": "sha256:e76c27144023e0bd454253aa5cd4b6c3e39979f2f675ba0588c672ea26dff04b",
+      "passed": false
+    },
+    "us/statutes/42/12709.yaml": {
+      "fingerprint": "sha256:4edf83b21ff9955e07720d439a1dd59796e97f5f37b2f03309a7a0729c7a1f2e",
+      "module_sha256": "sha256:6a57c234f3515a19c2932aa4d0eb87384328452f9b93b97c11b98cb6269d2a3a",
+      "passed": false
+    },
+    "us/statutes/42/12742.yaml": {
+      "fingerprint": "sha256:b70e65e9f8c91b58cb47937571109c06d25a8a566b7240ce377e997e4b28d5c3",
+      "module_sha256": "sha256:6cabf5f63be282b79498d9d3859ca7cc92042e79ea2b611feeef1aa08be2da7e",
+      "passed": false
+    },
+    "us/statutes/42/12746.yaml": {
+      "fingerprint": "sha256:b5bc410825e919f83d2f8046f5a510f8ddca794f2728aa3fc40f5014b12f8190",
+      "module_sha256": "sha256:40f1316899ae739f7cb089309c5f834e3971a9f9a26102e3b20d92131a779d26",
+      "passed": false
+    },
+    "us/statutes/42/12747.yaml": {
+      "fingerprint": "sha256:f5ee3849cba344d94e35a5be73359d2823846d53a4ef428732fdc27d8d5dc6f0",
+      "module_sha256": "sha256:03b7ae4b307f5198a57b87c42dc4c34015081a3e97492e873266008696c78ee2",
+      "passed": false
+    },
+    "us/statutes/42/12748.yaml": {
+      "fingerprint": "sha256:e4c508820b508bc93cbefa8e4ab991881a45d6d489f477983588993454a8a31c",
+      "module_sha256": "sha256:029adc9a07799c045be1e5507e899ca628696cd02d8bdddc20f0cd14077c0bdf",
+      "passed": false
+    },
+    "us/statutes/42/12753.yaml": {
+      "fingerprint": "sha256:464cc6afc844bbcece98f3c5a008ac9fb1d1f6a527695788a794814826fc499a",
+      "module_sha256": "sha256:72760bd49833e583222ab2f5225e925a7a5158a3bc099849a2159dbbd3ce2585",
+      "passed": false
+    },
+    "us/statutes/42/12755.yaml": {
+      "fingerprint": "sha256:201f73ef6d10ddec759d82ff2097ee8abfdc06f95b5b7793230d1370f1a52636",
+      "module_sha256": "sha256:cab7981097d93c1f209fa03c605db41293e9423f42bd56805a3a0700b14a691e",
+      "passed": false
+    },
+    "us/statutes/42/1437f/d.yaml": {
+      "fingerprint": "sha256:654cd3ff64d1d48ba2608fb481777912af33ba8358fa7f769809767680242e80",
+      "module_sha256": "sha256:6b4fcf3eca0e705a3c38348fe896c922d97f52e64497735af48af7a03816db45",
+      "passed": false
+    },
+    "us/statutes/42/1437f/o.yaml": {
+      "fingerprint": "sha256:8a65091c46abcdb9e2ed001ef5527410e0a2c7646af0254b12c4b9beafdc0e74",
+      "module_sha256": "sha256:315406f52835e72933d32a32c54f2966e4097660e4c69175e29e76e4300e164f",
+      "passed": false
+    },
+    "us/statutes/42/1437g.yaml": {
+      "fingerprint": "sha256:5895d2a391e935871f3fda8572041ae06ebc19d81fd0f3a385210b1610775403",
+      "module_sha256": "sha256:cd9888e2ada45db266386b662e1614202a1f0ba410014db57b0f25a04c4abcdb",
+      "passed": false
+    },
+    "us/statutes/42/1437n.yaml": {
+      "fingerprint": "sha256:bd3a99d874e27a209b7d53f9e71e38521fc89d2acb2a687b2fc52718fc5cb8fe",
+      "module_sha256": "sha256:d17266ec3d8042f209c8f0bcadd4b8a674117af3e0348ec83f10b1f5211465d9",
+      "passed": false
+    },
+    "us/statutes/42/1472.yaml": {
+      "fingerprint": "sha256:d98d7759a3adfd79b9745aa9e9c4342d0655cd7cd285914a68343108bf5622bc",
+      "module_sha256": "sha256:aa28a38bccbeb31ed9a376584a3018f2af27538adb861507d44f5216a6a194ad",
+      "passed": false
+    },
+    "us/statutes/42/1484.yaml": {
+      "fingerprint": "sha256:52556cb3f24fb17da239186935650658c261bbfcda006ea998e9eca1fc3ba36f",
+      "module_sha256": "sha256:bf026f56beb6754017ff013bc1d32cb18e92d119d3a84986137767c880cb0ff8",
+      "passed": false
+    },
+    "us/statutes/42/1485.yaml": {
+      "fingerprint": "sha256:79dce93ff693c6d7a71e9d0b9a1bc444450a1a7e8607ab918fa49a11bf07f6b0",
+      "module_sha256": "sha256:e8c676f3ce9e9595fbc2cf7ff9f26ec8248b5c291b13e9fb2395a384f2cb7514",
+      "passed": false
+    },
+    "us/statutes/42/1486.yaml": {
+      "fingerprint": "sha256:14dbcd6dfd7e2d3a351a56de97570ed8d6559a2e25fcbfaf426ae0ad15eae40d",
+      "module_sha256": "sha256:0e8dc8d3b9182003a40f9844f4bd12673df172ab23fe29cde35faaba96407f40",
+      "passed": false
+    },
+    "us/statutes/42/1487.yaml": {
+      "fingerprint": "sha256:bb113dca4a3f10df15412345ba39e073bfe124736d8317dc8ceddce99426df13",
+      "module_sha256": "sha256:d458b1b1c2a0f360db0447a3c031027a545a6ebaec4b8564821033303404052a",
+      "passed": false
+    },
+    "us/statutes/42/1490m.yaml": {
+      "fingerprint": "sha256:cb28fd6656c413171f71b4c4dca3ac4df7fd363042372b467b41756d989dc55a",
+      "module_sha256": "sha256:28e56064d897796ba5bc585a034681429280b556e4e96672b20e3371ed2b7ef4",
+      "passed": false
+    },
+    "us/statutes/42/1490r.yaml": {
+      "fingerprint": "sha256:5c92e80da9debdd9d9860d54cf6e62da2d1beb28d94252cf333579a2a92514ef",
+      "module_sha256": "sha256:c41da58aa16f2f64889a9668d448b0e227cc10518b8c7c0a8722a05cf5fcbe7b",
+      "passed": false
+    },
+    "us/statutes/42/5301.yaml": {
+      "fingerprint": "sha256:bc98c7a286092e53ada8c86ab2d97115c0dd56afe6aa9cca8fc06a437a16fdfc",
+      "module_sha256": "sha256:2fad60a2c0227ae75cfdf20ce7f9bdc3b944cce913b6e0896c68793d9c08d40d",
+      "passed": false
+    },
+    "us/statutes/42/5305.yaml": {
+      "fingerprint": "sha256:036482a137615440b02086a0fa4a4a17ab8422dfbc96fec1d15259747e78ab78",
+      "module_sha256": "sha256:5c6890c43cf4ec3e85a53de1be590dc4a5aaec998b2ccd512663a7510e96d71c",
+      "passed": false
+    },
+    "us/statutes/42/5306.yaml": {
+      "fingerprint": "sha256:96bd506bda3bf9cf99246f71dce53b89cb3c84ed80fccdcd5b2d654a3d6e4f13",
+      "module_sha256": "sha256:d1a96ff3f3a1c4e563d46189c5757cba85144ba00da19135638793c1f5075a11",
+      "passed": false
+    },
+    "us/statutes/42/8011.yaml": {
+      "fingerprint": "sha256:6b2c65b7fc460f90a8e90ec1167999ab9aef33ff45c9cd10b7ab41792c3abd6b",
+      "module_sha256": "sha256:af583d53925c94a4e1140537193fc4451c2607cada2fcd8eed2004e563e716a0",
       "passed": false
     }
   },

--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -35,7 +35,7 @@
     "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in",
     "hard_cut_residual_census": {
       "method": "authenticated isolated validation-waiver fingerprint census; module_sha256 attests protected-main bytes",
-      "rulespec_ref": "1018e3f01dc38a4246055240e6bcf2f1b55c019e",
+      "rulespec_ref": "436fad35d2724375ba2831082a2ef00bf166f781",
       "axiom_encode_ref": "caebbda1a190181ef8184ed7aaffedb3789202a3",
       "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
       "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",


### PR DESCRIPTION
## Summary

- register authenticated fingerprint evidence for the 638 new and 11 replacement residual hard-cut failures
- attest each changed row to the current protected-main module bytes
- record exact signed-release/toolchain provenance and the three census workflow runs
- do not change the waiver ledger or activate/approve any waiver

## Evidence

The isolated authenticated census covered 1,453 modules exactly once: 793 failed and 660 passed. This PR changes 649 evidence rows: 638 additions and 11 replacements; the other 144 failing rows already matched protected evidence.

Pins and runs are recorded in `generated_from.hard_cut_residual_census`. The signed release is `us-rulespec-2026-08-08-obbb-alien-snap` at content SHA-256 `0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc`, with provenance commit `e79781bddeaba4d3697c5375c7371b2a038f0f74`.

## Checks

- JSON parse passes
- exact evidence reconciliation passes for all 793 failing census rows
- every new/replacement `module_sha256` equals the protected-main file bytes
- diff scope: `.axiom/pending-validation-fingerprints.json` only

Prerequisite to pending-only approval PR #1282; part of #1248 and #1279.
