### PR TITLE
Register encoder 0.2.1683 waiver drift evidence

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -32,7 +32,19 @@
       "rulespec_us_ref": "10f7a16ecbb9053f43dc198e2b8a3554e5ba9078"
     },
     "toolchain_block_note": "the top-level toolchain block is retained byte-equal to .axiom/target-validation-passes.json per the bridge's cross-evidence equality check; it describes the v5-foundation era that minted the untouched rows. The 1,021 rows refreshed for the strict-cutover approvals were minted and verified at the pins recorded here:",
-    "workflow_runs_note": "emptied: the historical runs minted rows this refresh does not touch (their provenance remains in git history); no GitHub workflow produced the refreshed rows \u2014 the local census receipts and Sol gates 8/8b/9/10 stand in",
+    "workflow_runs_note": "historical runs for the 1,021-row local census remain in git history; workflow_runs lists only authenticated workflow-backed refreshes added afterward",
+    "encoder_1683_partition_audit": {
+      "method": "authenticated isolated validation-waiver audit; only the two independently confirmed drift rows are refreshed",
+      "workflow_run": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31643900892",
+      "workflow_head_ref": "fd98e8b5fda081f84d879da18464fbbf5e0d1537",
+      "validated_rules_repository_ref": "72232e72e06f2353a02633a38bb8e679b1de7a34",
+      "canonical_targets_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",
+      "axiom_encode_ref": "40009d295e74784f45bb98e3d3f0f20b73df7561",
+      "axiom_encode_version": "0.2.1683",
+      "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",
+      "refreshed_rows": 2
+    },
     "hard_cut_residual_census": {
       "method": "authenticated isolated validation-waiver fingerprint census; module_sha256 attests protected-main bytes",
       "rulespec_ref": "436fad35d2724375ba2831082a2ef00bf166f781",
@@ -5610,7 +5622,7 @@
       "passed": false
     },
     "us-de/policies/cms/delaware-chip-eligibility.yaml": {
-      "fingerprint": "sha256:d707ba54aaef0866b54ac0f8407928bbfdd5ab0ae6024166bc22436d9ea84615",
+      "fingerprint": "sha256:9770cff022ac4b963eba9fe3fa141a158638c468fda1241b708e6504ed629fad",
       "module_sha256": "sha256:3305328822090bd838f834649a82846ba2d61080fd162b45e85811784403830a",
       "passed": false
     },
@@ -14460,7 +14472,7 @@
       "passed": false
     },
     "us-ri/policies/income_tax/resident_core_liability_pipeline.yaml": {
-      "fingerprint": "sha256:88944d21372c0b37c858371058d98fd62c6c0ceb095ae8ca1a7d302664b780b4",
+      "fingerprint": "sha256:d75a9bb00e9d85c3b9a9f4fe456ecb5f0a35f7dccc2414d23c2f5a42000743ce",
       "module_sha256": "sha256:072877539db53e7dfb787fbd38b926902fb2beeb2cd8fe371d1bcd2845bf6e8f",
       "passed": false
     },
@@ -15319,5 +15331,12 @@
     "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
     "rulespec_us_ref": "265da6828fd6b040bac71bbd02f462c1bfddcef1"
   },
-  "workflow_runs": []
+  "workflow_runs": [
+    {
+      "run_id": 31643900892,
+      "head_sha": "fd98e8b5fda081f84d879da18464fbbf5e0d1537",
+      "conclusion": "failure",
+      "url": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31643900892"
+    }
+  ]
 }


### PR DESCRIPTION
Records authenticated evidence for the two validation-waiver fingerprints that changed under the partition-isolated encoder audit. This is evidence-only; it does not approve or activate either waiver.

Evidence:
- workflow run: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31643900892
- workflow head: fd98e8b5fda081f84d879da18464fbbf5e0d1537
- validated merge checkout: 72232e72e06f2353a02633a38bb8e679b1de7a34
- canonical target checkout: 6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5
- axiom-encode: 40009d295e74784f45bb98e3d3f0f20b73df7561 (0.2.1683)
- exact current module SHA-256 values verified for both rows

Checks:
- python -m json.tool .axiom/pending-validation-fingerprints.json
- python -m pytest -q tests/test_bulk_applied_artifacts.py (34 passed)
- git diff --check

Review-fix cycle:
- Round 1: corrected ambiguous RuleSpec provenance
- Round 2: reconciled the canonical workflow-run record and stale provenance note
- Round 3: independent review found no actionable defects