### PR TITLE
Approve encoder 0.2.1683 waiver drift

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -9065,7 +9065,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-de/policies/cms/delaware-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:d707ba54aaef0866b54ac0f8407928bbfdd5ab0ae6024166bc22436d9ea84615"
+      fingerprint: "sha256:9770cff022ac4b963eba9fe3fa141a158638c468fda1241b708e6504ed629fad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -20681,7 +20681,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ri/policies/income_tax/resident_core_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:88944d21372c0b37c858371058d98fd62c6c0ceb095ae8ca1a7d302664b780b4"
+      fingerprint: "sha256:d75a9bb00e9d85c3b9a9f4fe456ecb5f0a35f7dccc2414d23c2f5a42000743ce"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
Waiver-only approval update for the two fingerprints registered by #1295. No modules, toolchain pins, workflows, or evidence artifacts change in this PR.

Changes:
- Delaware CHIP eligibility pending fingerprint
- Rhode Island resident core liability pipeline pending fingerprint

Both values exactly match protected-main .axiom/pending-validation-fingerprints.json, and both evidence module hashes match the current module bytes. Owner, issue, and expiration remain unchanged.

Checks:
- exact pending-approval/evidence/module-hash comparison
- python -m pytest -q tests/test_bulk_applied_artifacts.py (34 passed)
- git diff --check
- independent review: no actionable defects