### PR TITLE
Register complete encoder 0.2.1683 waiver audit

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -34,7 +34,7 @@
     "toolchain_block_note": "the top-level toolchain block is retained byte-equal to .axiom/target-validation-passes.json per the bridge's cross-evidence equality check; it describes the v5-foundation era that minted the untouched rows. The 1,021 rows refreshed for the strict-cutover approvals were minted and verified at the pins recorded here:",
     "workflow_runs_note": "historical runs for the 1,021-row local census remain in git history; workflow_runs lists only authenticated workflow-backed refreshes added afterward",
     "encoder_1683_partition_audit": {
-      "method": "authenticated isolated validation-waiver audit; only the two independently confirmed drift rows are refreshed",
+      "method": "authenticated isolated validation-waiver audit; all 130 independently confirmed drift rows are refreshed",
       "workflow_run": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31643900892",
       "workflow_head_ref": "fd98e8b5fda081f84d879da18464fbbf5e0d1537",
       "validated_rules_repository_ref": "72232e72e06f2353a02633a38bb8e679b1de7a34",
@@ -43,7 +43,7 @@
       "axiom_encode_version": "0.2.1683",
       "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
       "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",
-      "refreshed_rows": 2
+      "refreshed_rows": 130
     },
     "hard_cut_residual_census": {
       "method": "authenticated isolated validation-waiver fingerprint census; module_sha256 attests protected-main bytes",
@@ -107,7 +107,7 @@
       "passed": false
     },
     "us-al/policies/cms/alabama-chip-eligibility.yaml": {
-      "fingerprint": "sha256:d52a750541f767040650e6346868b6963d6a600a9c126ef843273872c1cff40d",
+      "fingerprint": "sha256:fb7faaebb01c9bb45d844175c426670f79f142b85582f035893d6b0998be5ac5",
       "module_sha256": "sha256:9e4c00e601fa616f58054b3ba88e8f0e76451294099483b24efd80e3219f02c9",
       "passed": false
     },
@@ -397,7 +397,7 @@
       "passed": false
     },
     "us-al/policies/dhr/public-assistance-payment-manual/appendix-n/section-2/payment-computation.yaml": {
-      "fingerprint": "sha256:bfd76eb9b27478619131f2eef6b0f37a085886b1578ac25ee4e62030fa423a82",
+      "fingerprint": "sha256:8e016476c4173f5168145a12d81f02fcc03bb3ce21823fa822c076ea62d7ab01",
       "module_sha256": "sha256:65203d8990f3b537f66f4b1fe90c12bd6ffa78e83385ed0bd5ecd9340a1bf7ea",
       "passed": false
     },
@@ -527,7 +527,7 @@
       "passed": false
     },
     "us-ar/policies/cms/arkansas-chip-eligibility.yaml": {
-      "fingerprint": "sha256:6c9894f3c587f3580fbcd238464445854950b827eb2b164090207d9c5934c6a4",
+      "fingerprint": "sha256:b3429291c9bea3cb0ee084cd4f602c45792138b4156658f0bec5ffb8fa071b6b",
       "module_sha256": "sha256:207020c2f5ac4fe6f207334d7240b258329f6827354244c259e4eece26dce19c",
       "passed": false
     },
@@ -537,8 +537,13 @@
       "passed": false
     },
     "us-az/policies/cms/arizona-chip-eligibility.yaml": {
-      "fingerprint": "sha256:0b40725f2ab06768efd34a40fbba62d467872dd82706b73f577ce8633b99f0d5",
+      "fingerprint": "sha256:47e3aac62f4ce656aa54f6d31002a7fda0dde8f6b2f71e384dff48cf8f9a369a",
       "module_sha256": "sha256:b029819d9c766c9b3bcd1401bdda96b3facd9a1713cae7543f19c198f9ea55cd",
+      "passed": false
+    },
+    "us-az/policies/des/ccap/reimbursement-rates.yaml": {
+      "fingerprint": "sha256:bf6baec0883005cdc6afca8eca029efd0edeaedb9cf22a0bcf34a3d154ba3d76",
+      "module_sha256": "sha256:0d5458ea9c9478b3bcf186e2ddef3b2f551863562f3e1afa67287a7dc319d40b",
       "passed": false
     },
     "us-az/policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction.yaml": {
@@ -547,7 +552,7 @@
       "passed": false
     },
     "us-az/policies/des/faa5/ca-benefit-determination/payment-standard-test.yaml": {
-      "fingerprint": "sha256:d99acf79580ebdcd41bae15fd6f88bfa0f98fcf449e1026db3e0ee75abfbb82d",
+      "fingerprint": "sha256:32d8387abf9b96f21e4b26a5ba427ae2e749d4b533f11b0319268d2b64fb93da",
       "module_sha256": "sha256:df9424da3a11fec4139558ba112f41110295e6d68482ba17a94616d8e32d43fe",
       "passed": false
     },
@@ -682,7 +687,7 @@
       "passed": false
     },
     "us-az/statutes/43-1041.yaml": {
-      "fingerprint": "sha256:f88233370d200d58ec6df00c1a79644b661cf7a2c04e942826e8f4ff20725120",
+      "fingerprint": "sha256:a8672397310e350a5005786df193c1ab113004ce3f2321697feb5a6fbb8c1cd0",
       "module_sha256": "sha256:565ae621b55f617f4f1ee856911058f5e04481572778b08c702dd489b0de1ffb",
       "passed": false
     },
@@ -737,12 +742,12 @@
       "passed": false
     },
     "us-ca/policies/cms/california-chip-eligibility.yaml": {
-      "fingerprint": "sha256:8444cdddaa2c5f7cda562d8bdd0b06aa4c32fef233fa65e6045a6dfd26126365",
+      "fingerprint": "sha256:47b7407bbd50109d3cfb1621d32070bd89d87bd10067f2e7f642fb362f67c3e4",
       "module_sha256": "sha256:071b6dd12446abde36770c8c93dc5384cf81dff222d3547e0b243f6dc8407470",
       "passed": false
     },
     "us-ca/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:b156021da63599575025a5a768fb7d484ba833b5f8808703914de84a7903a476",
+      "fingerprint": "sha256:3d6e0d52cbfadeb61efe39411cacd24c9206c59eef6f2d3a70c5bfc4c3b982f9",
       "module_sha256": "sha256:0ae43c1f1879e7c1c124dac07c6a301e62c510c05606f67a7f301f39729d451b",
       "passed": false
     },
@@ -2632,7 +2637,7 @@
       "passed": false
     },
     "us-co/policies/cms/colorado-chip-eligibility.yaml": {
-      "fingerprint": "sha256:23944cb9c34904e01113f246b5f58cea3b42df20421464fcaa2a993674c243e1",
+      "fingerprint": "sha256:abd7df7554d0ed54e21282b91af5fd786abde45240312df444eb596e6b32db6c",
       "module_sha256": "sha256:64bfbd2f3878bd5c6dfca39aa86ee18787e55f0a96b2b355a7a86b0cabb2243d",
       "passed": false
     },
@@ -4807,7 +4812,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-104/4/y.yaml": {
-      "fingerprint": "sha256:7afa9bd42436a651ce0bfab0b8409e3ddb67163c8a9148438d59e8e7a9efa970",
+      "fingerprint": "sha256:6400b43993f2676cf65fc41b10019367b1f4fe5218b297505d74fe697b1142fa",
       "module_sha256": "sha256:5e6bffafbc8bfbb4e9e197c4abe64f2ca91049fe89a0ad6eaf7d8b9bb03b4277",
       "passed": false
     },
@@ -4827,12 +4832,12 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-119.yaml": {
-      "fingerprint": "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356",
+      "fingerprint": "sha256:02cbb30ee17236234b834f5e5b1715d6e6d7f050203e8190bbb862e0fddc7d78",
       "module_sha256": "sha256:471d5b98a2bdae21448adba9585631328cb9dcdcab6672d4ed1e49c8a06c535c",
       "passed": false
     },
     "us-co/statutes/39/39-22-123.5.yaml": {
-      "fingerprint": "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232",
+      "fingerprint": "sha256:cba44b1395f9f30a97ce413a4deeda672cc06cdffd7c7ae3c6f021fb65a01b7a",
       "module_sha256": "sha256:4b063b891583e67973bf071c32c20e86448500ebe4c876e221db19b17c372633",
       "passed": false
     },
@@ -5397,7 +5402,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-104.yaml": {
-      "fingerprint": "sha256:074b7b631e8a1d6abf9c636ee05a80486b8aa8f2c744b024f941a2788b51330d",
+      "fingerprint": "sha256:ab63248987f8ebc5894bb09643b2b6f6d08a85badc0cd12b4af371190841b536",
       "module_sha256": "sha256:a68c1ea685288864a4352a6c2a31ad788b61098fb79a917ef27baf19d50ac112",
       "passed": false
     },
@@ -5407,7 +5412,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-106.yaml": {
-      "fingerprint": "sha256:e9b9c2dd130e47faf074c888a0e5284184ac9bb0a4adb4afdd8fa8ccd47dd8c8",
+      "fingerprint": "sha256:152705fce15ee61c86aa83c17ccde6282ce2e95ca6039f8f4f2f8034d7e00974",
       "module_sha256": "sha256:36ab247833ed74fbaafaa9e76922540e1f35c9fc533900c50f77cfea035327ea",
       "passed": false
     },
@@ -5462,7 +5467,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-29-115.yaml": {
-      "fingerprint": "sha256:6cdacc5669b27163917c8618f28403e34d69ead6f65d18276cc8ec85e9b62ff6",
+      "fingerprint": "sha256:e443dfda26fef125f9a1046f48dfeae53f8d8abac388bf9fcdb95d1a648bce4e",
       "module_sha256": "sha256:20529b6df104ba8b51befef4812340b4c9aec660d1f8da760e7eb2e36abfdc55",
       "passed": false
     },
@@ -5537,7 +5542,7 @@
       "passed": false
     },
     "us-ct/policies/cms/connecticut-chip-eligibility.yaml": {
-      "fingerprint": "sha256:983bfdd236e763735a6670e3a1ca9f5993038f2a4afc6b6a7fe4d47bf3b16823",
+      "fingerprint": "sha256:4e3b8d335a71bcd27d7c2cfdb83bb330d2a0eab9287cd4460835d005af5d4ad5",
       "module_sha256": "sha256:7885d562896e7e177f9bdd5b793b70e15632851ee09f7d0788d9c581bf3c7b58",
       "passed": false
     },
@@ -5587,12 +5592,12 @@
       "passed": false
     },
     "us-ct/statutes/17b-104.yaml": {
-      "fingerprint": "sha256:49f4ea201b3867c2b2d24551d69c3ebdaed2d02bc0378442982904e08a46e8c5",
+      "fingerprint": "sha256:5b958b4ec199bc18b2b25f290eef98e037feb1e2bab5851ba5a424459381b8d3",
       "module_sha256": "sha256:d50a4704d355edd0ccffac4303d07679b6f556f14fda3bedbf1307d6550dff17",
       "passed": false
     },
     "us-ct/statutes/17b-112.yaml": {
-      "fingerprint": "sha256:2ddd17796f0d1532cbabbdcb8377dd513699ae2bb28ad5396d1cf92b0563934b",
+      "fingerprint": "sha256:3ec2db61a00ad8e47a52dc402c7ad2dbce60c44537fc173aeeb2ff7f3480bb6f",
       "module_sha256": "sha256:539de97f827b9c8ca637ba93a677c217db359231cbdbdb6105072b60d409017e",
       "passed": false
     },
@@ -5667,12 +5672,12 @@
       "passed": false
     },
     "us-de/statutes/30/1117.yaml": {
-      "fingerprint": "sha256:6d427e9ecded2dc602254fee8afc05745e5b9459fa3237ce3e4da0881e4f3af2",
+      "fingerprint": "sha256:b861d72db13edb55e8b899e579e9dc417c2cfc8a19816fc892176683faf82199",
       "module_sha256": "sha256:8cc23821498347b466183abcd5493e85e87735094958a397fce3ca48c77d8de1",
       "passed": false
     },
     "us-fl/policies/cms/florida-chip-eligibility.yaml": {
-      "fingerprint": "sha256:77d7e41c59ffc066c0087e31c32905aae0f9975326d96a84414453e6d4694c6b",
+      "fingerprint": "sha256:6a329e1327d4172b9735b2404f3b9840cdbb1467b088490b33c1f08be312c065",
       "module_sha256": "sha256:30f94d9c56d8d202264af2a2378abf2e8edab67e3a90442d5c5723054fac0fb9",
       "passed": false
     },
@@ -6087,7 +6092,7 @@
       "passed": false
     },
     "us-ga/policies/cms/georgia-chip-eligibility.yaml": {
-      "fingerprint": "sha256:202dab1602b63d439bb069bcbe8c9ba050bfbf43cd738e447e0c0f8ec1896074",
+      "fingerprint": "sha256:d011dc8dabdf1efaeaca67e18f12f68c776be12671f0edc7afc97cfc0660df13",
       "module_sha256": "sha256:1207f85bbc9c3d38b078bf447add98bd36bc779a417b3afabbcbdecd9ccc5454",
       "passed": false
     },
@@ -6127,7 +6132,7 @@
       "passed": false
     },
     "us-ga/policies/dfcs/snap/standard-utility-allowances.yaml": {
-      "fingerprint": "sha256:e516ba057f68e2410e58fd4e2468204f206edbeaf460504cfc459cd4345cde14",
+      "fingerprint": "sha256:11f089a25d3663dc4d06a30d64e507f2926b199ab1074408236bbdb5af2de3f0",
       "module_sha256": "sha256:9a61a2fca229bd71e4640b5e34373a41c45d5540f04d2cc0a8d94af85d4be559",
       "passed": false
     },
@@ -6142,7 +6147,7 @@
       "passed": false
     },
     "us-ga/statutes/48/48-7-27.yaml": {
-      "fingerprint": "sha256:16757f1b8df8d6436274f244a3dbb1c18a3fee7b001d5c5d1884408185f44b7e",
+      "fingerprint": "sha256:cb68de4b514bf9531bfa7bce50e1bb818846b576994e16f60f6a033c5f9c6737",
       "module_sha256": "sha256:f9e733b5499754ed829bc6c7610eee597d0ae55ba7dbb1fbdec257859737038e",
       "passed": false
     },
@@ -6162,7 +6167,7 @@
       "passed": false
     },
     "us-hi/regulations/har/17/680/17-680-12.yaml": {
-      "fingerprint": "sha256:30df6025e52afff121ee0701db1d665c879e99705cf230fbaacc0ac4fc2d234c",
+      "fingerprint": "sha256:5dc6574917304d05933c304f4e0b4b3991e2ac781459c595c465c97a11760572",
       "module_sha256": "sha256:c263ccb2f500244a844d0934f80693b62d49a201c38deb003b85f759b69c9f5e",
       "passed": false
     },
@@ -6187,12 +6192,12 @@
       "passed": false
     },
     "us-ia/policies/cms/iowa-chip-eligibility.yaml": {
-      "fingerprint": "sha256:29c75315d77a6f04fc0da21e97fa398aff39a8b6b2116b2ecaf2fdbc88e62e62",
+      "fingerprint": "sha256:19d31a903a27d959d18766bdfb2d9ec4b91020b8cec99b7efb5416192f5086f4",
       "module_sha256": "sha256:4a5db5e1f8597a33a256ba11371a016f7821f7ae66bedd5219f1080a96ffc75a",
       "passed": false
     },
     "us-ia/regulations/iac/441/41/41/28.yaml": {
-      "fingerprint": "sha256:297f4e353ebff26ecc0c6e7fa3955c31e43e21bc3d1d55b43b0e08c5ad3da32b",
+      "fingerprint": "sha256:397a47d3c45078ce09ff8777d82d4d2c4324888859b641c05ad7de3abb06ab27",
       "module_sha256": "sha256:dca67e69b4d240a5da5491e931ba5b83b89c2b5090de3e3b22c782b073be27c2",
       "passed": false
     },
@@ -6212,7 +6217,7 @@
       "passed": false
     },
     "us-id/policies/cms/idaho-chip-eligibility.yaml": {
-      "fingerprint": "sha256:0f5bbcc56b42a0c5e41f209306e0eaaada8d69af8686a4d4e5c4de8d88283132",
+      "fingerprint": "sha256:88105b96ece2d70053e5da23461075ede5ffc81cc6afec3ead6353bda585e30e",
       "module_sha256": "sha256:6c1a0eac72c9bf3098fdc709ef2e8cd4398090a2b1583973a7944ef07a40b0f7",
       "passed": false
     },
@@ -6222,7 +6227,7 @@
       "passed": false
     },
     "us-id/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:6ca089b2f0ced2adb339b6684dc655e50d478bd82d52c84e07339b4972cde5fc",
+      "fingerprint": "sha256:047107a3d04219fd1eda20c84dd391ad48d8929c377c4e2d94b5a0ff431bf13c",
       "module_sha256": "sha256:884daa010cfc3020d2040677f160e547a07323f4efcbd114b00de5204bc62b48",
       "passed": false
     },
@@ -6322,12 +6327,12 @@
       "passed": false
     },
     "us-id/statutes/63-3024.yaml": {
-      "fingerprint": "sha256:ca9683f4cdd253b1aff76f70c85c35b34425ce2710e3ec8ed43b1cfe5d932822",
+      "fingerprint": "sha256:6c6a967648656991da1196cb04f6d0d052991d9da53525ed5ed300c2f9f0bbef",
       "module_sha256": "sha256:943464ff714e3a06a965da01844522582ff119b1a6211b6d70be877680f1d0d6",
       "passed": false
     },
     "us-id/statutes/63-3024A.yaml": {
-      "fingerprint": "sha256:353f17baab59363920c29851390ec45e95653cdb5cad64bc8d802fecdb2bc2ce",
+      "fingerprint": "sha256:73e01766b0c4d6ccd55278570d0c68d082f67eb11fc4a3725cbc3f9a78a7f658",
       "module_sha256": "sha256:ceb2204c1c528ab8777ece0e4b58758ad26211e746803b7cb4eba89e829ee992",
       "passed": false
     },
@@ -6337,7 +6342,7 @@
       "passed": false
     },
     "us-il/policies/cms/illinois-chip-eligibility.yaml": {
-      "fingerprint": "sha256:28aeacc70e26818c36c65851581da5ea17cfbe18414c18bc989d1d6957a6793b",
+      "fingerprint": "sha256:208243bce9a4dd564301ddc0c6bb94184f67efa95aedd80dd8ff7b25c2f3d831",
       "module_sha256": "sha256:a405c8828882ecc0b8f0df8cd902719c12d0f597812daaae7f58d40911bd9515",
       "passed": false
     },
@@ -6467,8 +6472,13 @@
       "passed": false
     },
     "us-in/policies/cms/indiana-chip-eligibility.yaml": {
-      "fingerprint": "sha256:19cc449233bec72f5034d7e8faadb2f12fc374642ba1c830bc60370b51ce6b99",
+      "fingerprint": "sha256:bb4a2b4f81d3b956f1e271e035b1b57aeb4c31eeb7bbff6da04b031d1a729970",
       "module_sha256": "sha256:03f130eec5c03e53301b2bf38b6c75526ed3b27fb98ab04827c9346ed39ce2ca",
+      "passed": false
+    },
+    "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml": {
+      "fingerprint": "sha256:36058ec19f9c1017dc5858a79bfd25715f239ff544c780d96e3ff573fc7aebd7",
+      "module_sha256": "sha256:b3cf35192043c90868ef8ed28681246e999fad5c57806c1e0a6c7c29dc984a69",
       "passed": false
     },
     "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml": {
@@ -6542,7 +6552,7 @@
       "passed": false
     },
     "us-ks/policies/cms/kansas-chip-eligibility.yaml": {
-      "fingerprint": "sha256:06d48e81dd5a712b8af45ff2d9316b3da5c6b814d80b63b5d0bb51eb4228f2ea",
+      "fingerprint": "sha256:27ff5fb08a396a0cb009c451efbfacb035ba818137299f0fe2d456dc15232cf1",
       "module_sha256": "sha256:4ed338258c701014a42dd77430b45a0370e64304f52715e94658f0f2077053c8",
       "passed": false
     },
@@ -6572,7 +6582,7 @@
       "passed": false
     },
     "us-la/policies/cms/louisiana-chip-eligibility.yaml": {
-      "fingerprint": "sha256:aa25a8f48d4bf46e067dcf3cbef4cb9f8495eaf17e5e315d846584aaf63a98c1",
+      "fingerprint": "sha256:749f09a92602ab4c11e90836900f2b4cfc0067796692b69b22310ba24f3bb064",
       "module_sha256": "sha256:88bd443317eb985b3acbaa8a7c134a3e61dded603552cf8be1cac17a8260682d",
       "passed": false
     },
@@ -6582,27 +6592,27 @@
       "passed": false
     },
     "us-la/statutes/47:294.yaml": {
-      "fingerprint": "sha256:95f9824e34d0164cc571a8f15aa9f4a8664e4b4450cf87f0de9391b72037d907",
+      "fingerprint": "sha256:acf7b3c922e39cb7d9f9900c78d23c7bc0ef1c5549f73261b53b72029fa1a3be",
       "module_sha256": "sha256:e15f2047bcf10c773cdc2d430501019ccb3cb96a238fe5eaed3ae9f2eadfc34e",
       "passed": false
     },
     "us-la/statutes/47:295.yaml": {
-      "fingerprint": "sha256:cd34a64600107eede6f8d9ffe58ddb886627bdac1fda0667a34e79a0e4ff292d",
+      "fingerprint": "sha256:a1054bbed22003e7272993c691aeb04250122c093e3adcfd63e5564f9d882b79",
       "module_sha256": "sha256:9430e4dc37fc74334d04665cd534f044cc5e5fe5c3cbbfbc25f68e3e4b24a712",
       "passed": false
     },
     "us-la/statutes/47:297/4.yaml": {
-      "fingerprint": "sha256:bf597a272c1736ae2564a841c4b6ef6cd92142e59ebe8e218efa6b7ceb8c8c7e",
+      "fingerprint": "sha256:e30f8976d8d763993252f35708b73276796d417309beadcdf135bb6b7bb9d7f3",
       "module_sha256": "sha256:fbb722050bd38639b942bfdf8a3cf5823b0128e64561a93aeb5e261b82cbb88a",
       "passed": false
     },
     "us-la/statutes/47:297/8.yaml": {
-      "fingerprint": "sha256:c445ef7df5f66ffcde86a567872a60de534b0f2b3c4b31656f19424f66a71db7",
+      "fingerprint": "sha256:6a7c9fa90c562839ab9f8f6e7131b3a015cd4a0fc5804e1a35cbde9846d50db2",
       "module_sha256": "sha256:f0ff5ef671c53292923302a93ac91784a86783c2f6e5f2c6f5bb166305997812",
       "passed": false
     },
     "us-ma/policies/cms/massachusetts-chip-eligibility.yaml": {
-      "fingerprint": "sha256:107cc1a620ad112089f2e93b84e6ec431f10c7d3110f2bca63470fa60fb94d4c",
+      "fingerprint": "sha256:ce9ef693d3c3a7c3be04ff91cdd13df9ea05e1cc3b5cba1d84fd8fb079bd6106",
       "module_sha256": "sha256:b374acc9420dde32989099203a67fe193fcaa3ffac52fc01479a49017c26d51a",
       "passed": false
     },
@@ -6617,12 +6627,12 @@
       "passed": false
     },
     "us-ma/policies/dta/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling.yaml": {
-      "fingerprint": "sha256:63988ec7c07a416301f46aaf3fef7f7d9a7a9a8268108b9b3ad4750c6d9aa832",
+      "fingerprint": "sha256:0e41165edf5c09fba976ce61cf508f4cbf55d78ea29e39d0642abb2424495259",
       "module_sha256": "sha256:bd8c4f1358b13c553845d1dac21452742ebb46517683c8b32daa0494d55130c8",
       "passed": false
     },
     "us-ma/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:caa362d34ec667700697f2d495b3ffcb0b9a193cf2d1fd0cfe65ca523efb508a",
+      "fingerprint": "sha256:0a9bc84b5af07aa08f76694137f106b4b7b3f83e3adeca3f04dc0477646a4631",
       "module_sha256": "sha256:1c96452744b23e0bde1b40baf4b611b2c869f5cf422337d85467be2cdf46392c",
       "passed": false
     },
@@ -7317,7 +7327,7 @@
       "passed": false
     },
     "us-ma/statutes/62/4.yaml": {
-      "fingerprint": "sha256:24c26da31b62a11345f31fe7ec030e1bec611d3e13026b3292232701cedbeed7",
+      "fingerprint": "sha256:c5822b9ce764e9787a7993fef14f6146fed0900ec78506e8e2f7ffb2e31ec570",
       "module_sha256": "sha256:dd298cd73ec52aad6e4bec6fae7bca294b944f20091ab2773c8442bff9c0b714",
       "passed": false
     },
@@ -7352,7 +7362,7 @@
       "passed": false
     },
     "us-md/policies/cms/maryland-chip-eligibility.yaml": {
-      "fingerprint": "sha256:5143b2945206f1bbfb5095a4929f26562f753ab61bb430ecd6876f79b214403b",
+      "fingerprint": "sha256:82eab885665e1cb9689abb3f5ad0822cbcd0f3c738233cdeb493a3b6eea990fb",
       "module_sha256": "sha256:58afc97dd3e244fb34b2d3056b2a2e9d137eb22e9ce832dd287f472a31907300",
       "passed": false
     },
@@ -7367,7 +7377,7 @@
       "passed": false
     },
     "us-md/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:1b4d7acca34a3c9d03c1b8b2deac31011054bea42b7e3a36ec423926ecc3d314",
+      "fingerprint": "sha256:108c236be3aef44c4dcca1beacf28450d8c403247460af8b3d23695fa17f6635",
       "module_sha256": "sha256:22515bfc361b9abb013e4f53fb5d3a63d53a272abcd0e0df0f5a38a7acdc389e",
       "passed": false
     },
@@ -7382,12 +7392,12 @@
       "passed": false
     },
     "us-me/policies/cms/maine-chip-eligibility.yaml": {
-      "fingerprint": "sha256:f810361994fb23061931a82b0c6509e1c48a0b189d5ef1db4e0cc33f28c0d597",
+      "fingerprint": "sha256:e0d21464d1b7807f91adb749a9b34bcb1020e495958b59f715b09e4cc74179f2",
       "module_sha256": "sha256:2388009be55b5973e0cd3b120f0dadd30732f8a9b09fecbd1b6e726bf625a6e6",
       "passed": false
     },
     "us-me/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:fd34302a6cf7596cba8149ef9c8dff4983049781dfc933bb89f56c60a55c1192",
+      "fingerprint": "sha256:34dcdb0a007e6c3b0c2fe52039931a2f3aafd8720f4293e64226da26dcb21cd0",
       "module_sha256": "sha256:f9b6dc2499f7ce2630bb5142f37f74a536d330b7a680760dd3ac70de40b3caf3",
       "passed": false
     },
@@ -7487,12 +7497,12 @@
       "passed": false
     },
     "us-mi/statutes/206/272.yaml": {
-      "fingerprint": "sha256:b7224cb5fcf34cf248d985f30a3117acecfeac3b21572a892c713929272ab282",
+      "fingerprint": "sha256:ffeb887443d379ea47a750f7bd82e292bd22723d4de29634976be1303e9eceec",
       "module_sha256": "sha256:5b2256baba0f0a5fe762a4c101f6ac4d5c26dca4943956edfb7124581abd96dd",
       "passed": false
     },
     "us-mn/policies/cms/minnesota-chip-eligibility.yaml": {
-      "fingerprint": "sha256:24290720b90dfa81612c9a34869d1b248dde2e499593dd62086439de771143ae",
+      "fingerprint": "sha256:f1e758f263fe144795b1d310179a5ce989b4959a2596864b20f5b69abb2edc3b",
       "module_sha256": "sha256:cd1c4d71e1155929704526aa37a2c78ea3c7f721217f8416c0a37a952e188d73",
       "passed": false
     },
@@ -7507,12 +7517,12 @@
       "passed": false
     },
     "us-mn/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:e71b0de04947fdc750303f74101ce7cd0585cabae6c5f407b55bfda3ae58dd35",
+      "fingerprint": "sha256:4be73e357a287db74d10d83d7de3b2d7affc4ffa80419621be592aa59eab8ca3",
       "module_sha256": "sha256:897851e2f8fc945272e1e8b4bc40dbb2e72a88a756ebd22005c8c9f40ff10f4c",
       "passed": false
     },
     "us-mn/statutes/290/0121.yaml": {
-      "fingerprint": "sha256:757312db07924c40384f1c506855c059c0680a4ff89c92a9f3280943bbd97e6b",
+      "fingerprint": "sha256:a04c6b54b22d1d09ac72e210c7a0f748340c633b67f7c709acd75997e4b07917",
       "module_sha256": "sha256:79cc0793f21a73ca8711790ccd38090e0d495cd5b46f4193194f001ec3cab625",
       "passed": false
     },
@@ -7537,17 +7547,17 @@
       "passed": false
     },
     "us-mo/policies/cms/missouri-chip-eligibility.yaml": {
-      "fingerprint": "sha256:68623d8668b95af9939a49199baf31fbc65878ca9814d28797247def6b9c0a0f",
+      "fingerprint": "sha256:293786957f2b481b9da64fe0194b4bee307657766e971b06541d40615012a249",
       "module_sha256": "sha256:4a211888b30ace6ddd74ef87829d4c2c8f759c2f18982f4caa320a3ce5000393",
       "passed": false
     },
     "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml": {
-      "fingerprint": "sha256:5db3072a51b7b98e70de62aa9faa599e954fa1fb081a3c910c814b3278e6578b",
+      "fingerprint": "sha256:f45be004d7e73ebf37f1e5c3e9f07acf8f082e2086ab80377c9c52e123e381b1",
       "module_sha256": "sha256:3944c23f44e0f376288d5bbc678ace3eeec1e23cb55327315b7e7d84698f80be",
       "passed": false
     },
     "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1.yaml": {
-      "fingerprint": "sha256:096dbcaaa6416de45c236f2bc99479ab914fc52e7eef9038c3c86c3d0740c555",
+      "fingerprint": "sha256:d0ab845ddd6d2af1e6c5d336ecee39be37eaad0b47fb48e35065e90e934a5855",
       "module_sha256": "sha256:53645d729a71c69537c0c41f3700a0c92f1fc01569932ca9a566933879f54000",
       "passed": false
     },
@@ -7557,17 +7567,17 @@
       "passed": false
     },
     "us-mo/policies/dss/snap/1105-000-00/1105-015-00/block-1.yaml": {
-      "fingerprint": "sha256:ab1a6ee4a2010bc2c7a2fc7ae55355f064d2a7e6a6b4a22e0ea27d20f9f95653",
+      "fingerprint": "sha256:de3104f5e1bbb2ac19b5565c0bdd1ddfe2afed8ef3e3609677e2426d568aad0c",
       "module_sha256": "sha256:d08543c511ddcc649c7dec2512bb8c2fe4eaf722729020d9431ca5f55083d412",
       "passed": false
     },
     "us-ms/policies/cms/mississippi-chip-eligibility.yaml": {
-      "fingerprint": "sha256:ee0eb1420e1b3391b8a46eae209d9c0fb978abc2a264055e8d69a5dacc59e91a",
+      "fingerprint": "sha256:9dbd0a814489767ca654c3a4a66c65bab7768d6028a17c045ce7ec5986805e5e",
       "module_sha256": "sha256:cb2b16c5d107472e7776d66809b77e65542471163fb8783385fb1a6893741901",
       "passed": false
     },
     "us-mt/policies/cms/montana-chip-eligibility.yaml": {
-      "fingerprint": "sha256:fe6ca2ea7b257f33a846c9c4a376b55a121f6e9ab4e5d0aaf621bf5ef8218727",
+      "fingerprint": "sha256:4a0d66ec09150fcdf28cb9e7c16f5a4547cd62857fd79badf0cc4459cc8954b7",
       "module_sha256": "sha256:3ea1d7382dcfba76435e5449cb0157508dd8714f3b910d1fd109622fd57a5a2a",
       "passed": false
     },
@@ -7607,12 +7617,12 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/appendix-3300-glossary/page-12.yaml": {
-      "fingerprint": "sha256:19671fc8d874ae6816e3b73b8e887769be21771ee0cf06c4d934f1bd24df6f56",
+      "fingerprint": "sha256:37be4acbbb659e18b9ad06b5b35d41dc9681b83cfea8ae57c4e2b403b04bb2db",
       "module_sha256": "sha256:3f2518e327401f3588fe46dfaa2cc7d8d53d0c40df0254ef2ec3789da80ec6a3",
       "passed": false
     },
     "us-nc/policies/dhhs/fns/appendix-3300-glossary/page-13.yaml": {
-      "fingerprint": "sha256:3432bf868a7491f15d7c6a9f56c0e140da55f4a924e36a4228c8454190c78439",
+      "fingerprint": "sha256:37affe026c13fa8fe73d21ea80ea65f04ad69db16908fbe79b29bc3d3e984244",
       "module_sha256": "sha256:6a9d3b4127520000222085f5de7aa2c9f7e14581baa2dd0d5a4316e20840523d",
       "passed": false
     },
@@ -7862,7 +7872,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-170-notices/page-7.yaml": {
-      "fingerprint": "sha256:b8afdc6e92ed2a43e8a84c938eca2bd597de1065decc15c25f652e15c7413807",
+      "fingerprint": "sha256:b86c3bf811624edd623be0d2095b321e282012a4d96e9a8e2b2f1c7d5c803be9",
       "module_sha256": "sha256:4e4bfe7c4440f43ffc1fc4f76b734604c1103a95e7a8dcc6a65bb0bc6d53a09c",
       "passed": false
     },
@@ -8162,7 +8172,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-5.yaml": {
-      "fingerprint": "sha256:d17014f6c7f9753a116fb0cc11c377e5732662a20c8dbfe4b8cb85cafbcea887",
+      "fingerprint": "sha256:8fdbe65abd980cf936cf3196c26430ff63edba5a83f320a6b1a5aa5018875820",
       "module_sha256": "sha256:a013d825beafad054293161a5a5826e37a07abc292de6eb174c4e971c59d92fe",
       "passed": false
     },
@@ -8252,7 +8262,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-250-workfare/page-7.yaml": {
-      "fingerprint": "sha256:3f105c8605c5f6e06c167d6f7e279144ee0d54560a9039e310fca4da394cecc9",
+      "fingerprint": "sha256:f506a5fd01cdc3b8c072fb5960cd00b19a9810979925623e4eb01e13af9e8b75",
       "module_sha256": "sha256:c9ebfa9173a2601237cf5783c5fb5f29103abbc01ce649b5528ee80368129051",
       "passed": false
     },
@@ -8272,7 +8282,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-4.yaml": {
-      "fingerprint": "sha256:5719bcbdfde82dfe4f761716e476c42ba0acc70eceedb28370e200deb9c893a4",
+      "fingerprint": "sha256:0b4590f6cfb71403e0f2eeb75b345383d98417220a4cd924e5fa28e1faff536c",
       "module_sha256": "sha256:9ad4e205147d4a97ff8f3586f7d3f81e122b16937943bebf825736d2efc7060f",
       "passed": false
     },
@@ -8322,7 +8332,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-21.yaml": {
-      "fingerprint": "sha256:ca3c6962381e3f49a3f36e45207c5d41c2f31912aa9174bcc5c2dc6afe998f02",
+      "fingerprint": "sha256:0634fa65d1a6fa4703cb1edde56b78bb8ef42ad20a5a0bca41a2cdee68dd65f2",
       "module_sha256": "sha256:8442b6e61e039ce7dc5fb82adaef4af1913ceeada3f1374e94fddd8fa44f5931",
       "passed": false
     },
@@ -8547,7 +8557,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-10.yaml": {
-      "fingerprint": "sha256:1a438f6ca8c400016390ecbf5cf93fd25b879edd35f42452fb4ba2725e740acc",
+      "fingerprint": "sha256:bde7759ce30de0dc4c238cb4d3ead6fe407f1b09a691d1502a1e3a41db2e013d",
       "module_sha256": "sha256:a441be39c41607dead69fc082c246534bb435ebb94bcc72e037c51161b0e0d9f",
       "passed": false
     },
@@ -8597,7 +8607,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-27.yaml": {
-      "fingerprint": "sha256:d1de098c930689878e4db29b625f8547f1f4a870687b5ba2ee3109dbec0690f3",
+      "fingerprint": "sha256:f1e6064d75adc8d1f1debb9f07bdc654b82a66d4be75ed288ba7738415129c82",
       "module_sha256": "sha256:17f3b110ec7bb740b75bc79127c60a04e4d34af78b641d3a52ab56786b6bde1d",
       "passed": false
     },
@@ -8617,7 +8627,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-8.yaml": {
-      "fingerprint": "sha256:62899d5485fe503aeb9e38399597f7d351af3d63f7397ee4464e6d82d5f670b7",
+      "fingerprint": "sha256:5a2ea12484e0d7db71da0e76963d1e49de659c954a043244cbae307f56f47097",
       "module_sha256": "sha256:aeae50ef216167b2843d3b12e1dbb1017a95c8d8b76bf39f0d05402774b0b0a0",
       "passed": false
     },
@@ -9472,7 +9482,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-4.yaml": {
-      "fingerprint": "sha256:a8b28d567f0f4adb347f696d4c5e3ad30d3c005bdc67e7b53bf8e8827b6d5741",
+      "fingerprint": "sha256:c7d92b8f63c60423a690e0f5e7610e63b806b468757ee956394c1ddca7f6c008",
       "module_sha256": "sha256:9c61327302afcf88ebed9e4fe6fc15c8cd5ac27568028bc6d8dc0ca766d3b8e7",
       "passed": false
     },
@@ -9537,7 +9547,7 @@
       "passed": false
     },
     "us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-1.yaml": {
-      "fingerprint": "sha256:dd1f1768393fdd0288277f0e0558bb1162e5e966df16ca1c27981df6d0d9e56a",
+      "fingerprint": "sha256:7f6da63c39b7096b59a43fa9dffbeb3ff3b3dea47f90971ef2e37b6b79e8c73f",
       "module_sha256": "sha256:d4f74e48cd649e5633e739d128270f4e8dd8657e66fdc6f0b6ff71595d47ec96",
       "passed": false
     },
@@ -9702,7 +9712,7 @@
       "passed": false
     },
     "us-ne/policies/cms/nebraska-chip-eligibility.yaml": {
-      "fingerprint": "sha256:e0529fad790b3b3f4dcf6af6b98f891464782e9ed9fdfbcc274e56d303d008b4",
+      "fingerprint": "sha256:2c9170a512429e892e51fac3b28ac1cab00be152641febf020ff5457ae84c36c",
       "module_sha256": "sha256:30643a0f952d24a7a0b7340aadae4ca6ebb51c30ed4fc3d49cdc0d0f15d3b8db",
       "passed": false
     },
@@ -9727,7 +9737,7 @@
       "passed": false
     },
     "us-nh/regulations/he-w-700/742/02/standard-utility-allowances.yaml": {
-      "fingerprint": "sha256:538f9056b0714e200f3abf010827e198a9fb824a53f58355554b15836e2bdb12",
+      "fingerprint": "sha256:506d2bafcb3ef975f3165f66c04cfcceb45d342572b5b91c5b79af063a31e16f",
       "module_sha256": "sha256:415eb7630f52964188ee7a0dc5af87fa2c65cc57afd91a367a2a8cf981f42def",
       "passed": false
     },
@@ -9752,7 +9762,7 @@
       "passed": false
     },
     "us-nj/policies/cms/new-jersey-chip-eligibility.yaml": {
-      "fingerprint": "sha256:cf65846332e30ea8d40a3a92651cfbe5fb0ea9cf797f4ecfaa7eddc4d8c19d28",
+      "fingerprint": "sha256:e1c4adfc35cd700e0cdc9393e4a7dbdb3a1db06f2cd0edc4814e9112c4f1b005",
       "module_sha256": "sha256:e10daba1d49f233e8968357a50b91c7d58987439038ba90445e1689ae8d4556b",
       "passed": false
     },
@@ -9787,7 +9797,7 @@
       "passed": false
     },
     "us-nj/statutes/54a:4-7.yaml": {
-      "fingerprint": "sha256:871759062002193ec88a1deca9a5fdad34677db67382c2a0f882f8b9d96de20e",
+      "fingerprint": "sha256:23224c7ea1b2c1cc2a2d7f9d883eae66e99121713b6be6d1a7b1144c90e480a1",
       "module_sha256": "sha256:bf317f9438648582ecc75380c2def4963055c31d68469d25cdab9e13f6e9a684",
       "passed": false
     },
@@ -9807,22 +9817,22 @@
       "passed": false
     },
     "us-nv/policies/cms/nevada-chip-eligibility.yaml": {
-      "fingerprint": "sha256:98a57a01dd8d840d9cd02b7fddbbc5a917dff52145d0d902eb8da291d1d56f02",
+      "fingerprint": "sha256:1a71f714a9a24e8d4bc533dfb0585f705ed2ec4a76564e2c210c51d4dc828063",
       "module_sha256": "sha256:5d673872a710aec05c5632e65068f1f388048dee7e5ff8f1e9371f98987e6a1e",
       "passed": false
     },
     "us-ny/policies/cms/new-york-chip-eligibility.yaml": {
-      "fingerprint": "sha256:dffc89bf089e62eee8997a902ac57ef68e3ffc2d6973993579123a8d018068d6",
+      "fingerprint": "sha256:2078477b9e0007b479b0d88337d5457c37948e29ef1a430d658f4678f2a73588",
       "module_sha256": "sha256:6eaed6e4e08231b309b8a926ad281082952aafadccc5b7b927804cb5770d4e32",
       "passed": false
     },
     "us-ny/policies/income_tax/nyc_composed_liability_pipeline.yaml": {
-      "fingerprint": "sha256:107c6999f7522eab5912336130cb99e2e1740a40200765c5e0a5058ed16f46dc",
+      "fingerprint": "sha256:6775fd7bf90cb7103b5fe4792a408a039c73742dd647f9ed1c2b2d1c8cd70b38",
       "module_sha256": "sha256:65989d40579576e19b0fe70652d87f56ab5325a43bfd158cf5dacb021d423ec3",
       "passed": false
     },
     "us-ny/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:3d812a02cedc20a5fee110a59660c251a77cdee3692e1bae2d1bf77b6435121c",
+      "fingerprint": "sha256:5b54a5ccd5fe81b016a66fc11fa7cfb5d176f67e6ab59806f65b399c825cec3d",
       "module_sha256": "sha256:e3805559bffd7ccecc7fa153fea5bc9a71e7b163d7fdb79018054907db4c5b2c",
       "passed": false
     },
@@ -9842,12 +9852,12 @@
       "passed": false
     },
     "us-ny/policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant.yaml": {
-      "fingerprint": "sha256:cea24e9a1a7645daf26ceb37e1036a85eceebf811e7a0d309d00255d3cf9a1ce",
+      "fingerprint": "sha256:3b9e9acaa5ee9f987ba0e533a54f0c5a7ee532d356bf7b9584c7d0d4d0206a9f",
       "module_sha256": "sha256:41d403d4629ab8160bba4f359abdd6a8a7ad01ad8373443f413c0ad1642361f2",
       "passed": false
     },
     "us-ny/policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction.yaml": {
-      "fingerprint": "sha256:b7a69436fc2161c2947b3aebe804992c4ce7e463a6c17fd2b2d0f8f86fdd7b76",
+      "fingerprint": "sha256:aeae923fed952d4562e322f4abc7610a34392c300021d02b7cca667c1efda049",
       "module_sha256": "sha256:b4ce08c868f15a04e3fedde5985a336383438c013f67837aabd97ee876a6dbbb",
       "passed": false
     },
@@ -9857,12 +9867,12 @@
       "passed": false
     },
     "us-ny/regulations/18-nycrr/385/3.yaml": {
-      "fingerprint": "sha256:2dab9532f756c49907cf74ad4ffafc7bfedc146b28858b03455d06361b80552a",
+      "fingerprint": "sha256:5cc864823c87aab941ee172905669d9c0c95e1692181e4ac00f689d760304921",
       "module_sha256": "sha256:9d0d8d63eef9d6c6d1033cd77ba6e64080988948a18ad839e39261ad4f8c24be",
       "passed": false
     },
     "us-ny/regulations/18-nycrr/387/10.yaml": {
-      "fingerprint": "sha256:9a63a2bebd4eae18977fed1bb899c2512997362969ec5c0c8c9d878d58b038be",
+      "fingerprint": "sha256:63ee6ac9d2c04ecb2c145d94b9f08ff4a310a0d1d836bd02acf98cd47ce1f90b",
       "module_sha256": "sha256:efc966e447d94398837146a9c669f1a8e0f41849df79b79447d696e2cd399435",
       "passed": false
     },
@@ -9887,17 +9897,17 @@
       "passed": false
     },
     "us-ny/regulations/18-nycrr/387/14/a/5.yaml": {
-      "fingerprint": "sha256:40297939f335ef39f3cdb97741361f50d6eebb25961094589f35451226841bf2",
+      "fingerprint": "sha256:ec8b4135ee9a318410f56efa803ff56feda02c382c65103fd2a50baef4bb0eda",
       "module_sha256": "sha256:a65a90278be408d64c0495c706ad01bad2d65671857406426d90c9833dc9eded",
       "passed": false
     },
     "us-ny/regulations/18-nycrr/387/9/a/2.yaml": {
-      "fingerprint": "sha256:b76db6e9b1e4a2b4a4739f156f05d6ee586319cf529eb72401779cd66585cad5",
+      "fingerprint": "sha256:f9fa246a24b950c1a52c4ef8964cba557acc96e001b2164ca911cca7ce1965a3",
       "module_sha256": "sha256:61767c5fec7b8a1640a9a88fb1c9807eb239ba3828e5ccb0dee6524dd4511991",
       "passed": false
     },
     "us-ny/statutes/NYC/11-1701.yaml": {
-      "fingerprint": "sha256:988847e32cca202fa902b17c81ac23591b53be14664b2b5f670dc065f23ea070",
+      "fingerprint": "sha256:c44346ff79acce3723c819ae88dd1f020d9e43d1eb13968bf72f92d0c8fdc1c2",
       "module_sha256": "sha256:7bbba6387ec0ff1a813fdf9abc738f1f3c0588bea7ebdc16202520cbcbec50a7",
       "passed": false
     },
@@ -9907,12 +9917,12 @@
       "passed": false
     },
     "us-ny/statutes/NYC/11-1706.yaml": {
-      "fingerprint": "sha256:bc8de961b79da8d6351c11eb04f490531a4aab51144de4299263afc835a4d157",
+      "fingerprint": "sha256:194b38dbe26ffe48a8b30ab2c630effd4199c03cd44f09eaf801c8f40b3e4fde",
       "module_sha256": "sha256:acaa1fff8d38aa143b037aa802e27f21dc75163da09dd8c13803d04b44ec85a1",
       "passed": false
     },
     "us-ny/statutes/TAX/601-A.yaml": {
-      "fingerprint": "sha256:81209afbe41752ca14110f9057ebc2f13e451ce1cea6c8c05a3576927878eae8",
+      "fingerprint": "sha256:93ed4a1dbaeb3f01153a6cfba097eeb4d74fbd46770f3629f467a319c02350f1",
       "module_sha256": "sha256:0afde12da54d63434cc5c699f506162d66cbd739b0e52acefc0da0401f49fecd",
       "passed": false
     },
@@ -9932,12 +9942,12 @@
       "passed": false
     },
     "us-ny/statutes/TAX/614.yaml": {
-      "fingerprint": "sha256:bddf348d7f1e2c82ae251386cd57842f4a3402d6a2b6bd612545814854c786f3",
+      "fingerprint": "sha256:809a4695d9f55933b3b7c6d7ef00b5024f8877f8b22e5b9be5d312d7b1a8c648",
       "module_sha256": "sha256:3ba36cbd15ec565af1315e28b6dd27d773337155fea554d81db0c42db7c50a65",
       "passed": false
     },
     "us-ny/statutes/TAX/616.yaml": {
-      "fingerprint": "sha256:7f870613e4322bffa42d37651fe168376fb1647d17f159202d3d8f8529cc98e6",
+      "fingerprint": "sha256:c066d57865ec6764a3cad7750896e1041613b1f19a7f44ad7eef6d48c8d5bf8c",
       "module_sha256": "sha256:66d17d37659e2d14cae3360777c87de7f84a3cae051f557ff3a749c228378cd1",
       "passed": false
     },
@@ -9947,12 +9957,12 @@
       "passed": false
     },
     "us-ny/statutes/TAX/618.yaml": {
-      "fingerprint": "sha256:b538691cc3d7c5940af879aaa3392d5302413b348e6e236fe4567b4a9dc306e7",
+      "fingerprint": "sha256:2840df3601ec834ee48be20848c8d4628411f3a9b092d4e21be48289867591a0",
       "module_sha256": "sha256:be0e26df82caca4940379aa9b2bf897baaea78e28551654f890f6810729e351d",
       "passed": false
     },
     "us-ny/statutes/TAX/620-A.yaml": {
-      "fingerprint": "sha256:2df0768eaee157c1606909c5af6b87b871a58aba049e501e26a33703fd548ca1",
+      "fingerprint": "sha256:d07271d0dbfdeada85bfcb8316469fd726c5182747e633237a16254e1f59c660",
       "module_sha256": "sha256:15b7ce64f2fbc7e130c7fb72cdafac5be50dd98753e51f3b8e8fa316ec74d1f7",
       "passed": false
     },
@@ -9962,17 +9972,17 @@
       "passed": false
     },
     "us-ny/statutes/TAX/672.yaml": {
-      "fingerprint": "sha256:cf1af855b5bf94c12a8498583fbc867f6992a19b2750b7ab5dc70b1a3b7a6434",
+      "fingerprint": "sha256:e2acb8fa3961050429c8a6a672872761acafb530e9cfe618e29016f20a387c91",
       "module_sha256": "sha256:2125b6742cf831ff3c1a025a09ac4ef88c988611245ea9399f4ad112278a31c9",
       "passed": false
     },
     "us-ny/statutes/TAX/673.yaml": {
-      "fingerprint": "sha256:29df80d86a9ff2b5de548d7a382d01210dcf9df0c5a9e18775b84393c37b319f",
+      "fingerprint": "sha256:d9650a532b73db83c5cffbd97833cc2d7d8a3e318de7e287f0690224812023c2",
       "module_sha256": "sha256:b61ebae09ae689afee5f2e8e125b745380fd9ab1e6167fce912b5b8f6a91dc75",
       "passed": false
     },
     "us-ny/statutes/TAX/674.yaml": {
-      "fingerprint": "sha256:41e053ef0f870f37301b0bd9146abd739a192df2347fbe6bed0abb5651d76587",
+      "fingerprint": "sha256:f7459a12cfcbe37f8f60666dc85894d4b26ecc136995a0af5e18a11c199fecfe",
       "module_sha256": "sha256:45ab4d6ccfd5e91aabf0c3890031d189ad8e0d58390bc1e70dceb92ec17a9d7d",
       "passed": false
     },
@@ -9997,7 +10007,7 @@
       "passed": false
     },
     "us-oh/statutes/5747/025.yaml": {
-      "fingerprint": "sha256:64acfe3ab816885471f3f71434bc394755feb365aa5157064890e99bd2692f74",
+      "fingerprint": "sha256:04e93c5b129018dfd40faae09b61ee260f4f8d1bf250039cf9f5f2d72643a696",
       "module_sha256": "sha256:9ee0edb818e09639697487892b9c34a95e0ebfc11d7904a0a66eb68cd7d86f14",
       "passed": false
     },
@@ -10007,12 +10017,12 @@
       "passed": false
     },
     "us-ok/policies/cms/oklahoma-chip-eligibility.yaml": {
-      "fingerprint": "sha256:c41c81f3bd0ea88c6f4b46bbd7045fbfaa6d37e0aa9f54f6cc7271bc9e6bd407",
+      "fingerprint": "sha256:0ac44e2f3e217d2a0ed142766c9ee4eb9b34cdff43435889a124ca8aa46564d5",
       "module_sha256": "sha256:ce8f3461a5fe21b209972af3e2a2f7e6a455e400ea2bd67e99a415eb4d694415",
       "passed": false
     },
     "us-or/policies/cms/oregon-chip-eligibility.yaml": {
-      "fingerprint": "sha256:7052f2fa1588aa1d301bee4015fd478aa1d232332d01adfc1e02ed29b39541b6",
+      "fingerprint": "sha256:c53f6be9e6bae04d490d7bb9081a4940ac7332825f138f06fa6415db6d96ad76",
       "module_sha256": "sha256:ca859f0914402b8e19da889f3d69533f7c573cbf18c102cced10243287a1d626",
       "passed": false
     },
@@ -10032,7 +10042,7 @@
       "passed": false
     },
     "us-pa/policies/cms/pennsylvania-chip-eligibility.yaml": {
-      "fingerprint": "sha256:2a20bfd272631113d99dac5ca6222ad561a6f687614321d9dbac908724311f9a",
+      "fingerprint": "sha256:cbcf3dc081873765dc5905fd67e883d188438070819af68557d5834786c9284c",
       "module_sha256": "sha256:4b63c78ef7013cf9652552f7eb7b1b2e683781aa4891c54f86ccc0a5e67ae534",
       "passed": false
     },
@@ -10054,6 +10064,11 @@
     "us-sc/policies/dss/snap-policy-manual/page-125.yaml": {
       "fingerprint": "sha256:b135dc74bc279292cdd7ab5ca577e934d1f841037027cd3a629ee2660153ac24",
       "module_sha256": "sha256:b7053a89c0f9c61eb21538914ff277a1f8c41e8508493fe3572cac3d19a9115b",
+      "passed": false
+    },
+    "us-sc/policies/dss/snap-policy-manual/page-163.yaml": {
+      "fingerprint": "sha256:997c3df8a2cfa7df0d41bfab98b2628ea99891318d1b31492d5435e61f5fc3d8",
+      "module_sha256": "sha256:c9bcd297050aecc9ea14448d6229a00ac8398532670f7383e86d822131ea3a29",
       "passed": false
     },
     "us-sc/policies/dss/snap-policy-manual/page-314.yaml": {
@@ -10097,12 +10112,12 @@
       "passed": false
     },
     "us-sd/policies/cms/south-dakota-chip-eligibility.yaml": {
-      "fingerprint": "sha256:ce6920a61808bfe777afebcc6ff775ab4588e212d6d3b42ff733436e95f2a5cc",
+      "fingerprint": "sha256:edda51dd4a7c79132e53025fd79a8b438567e5212434541bed9ea1ae003599e7",
       "module_sha256": "sha256:b1d13e93afcdccf679838f456e017f122c39b6c398c55d33faf893bcc09d1e5b",
       "passed": false
     },
     "us-tn/policies/cms/tennessee-chip-eligibility.yaml": {
-      "fingerprint": "sha256:b11432f5c92a2d75b1fb65b74b3feda3c50d786a8647c07d30ff06af4cb09121",
+      "fingerprint": "sha256:ab32cfa445bd4da92855597cd60d75f6d9f32ee35399502c5d753ab9e40bf565",
       "module_sha256": "sha256:e622a45007355637345f658479a88c07fe95f2862ef962b952d13d1c62e21141",
       "passed": false
     },
@@ -10677,7 +10692,7 @@
       "passed": false
     },
     "us-tx/policies/cms/texas-chip-eligibility.yaml": {
-      "fingerprint": "sha256:3e41ca4c486b67e89cb645b21b0de4f9518a8ac3c3debb81db08995d7bd0f306",
+      "fingerprint": "sha256:fc1601d57e9c617076561712fd7dc33dc9177ac51653c0fe2a07a2ae49a3bf82",
       "module_sha256": "sha256:14d7b5dc663003a85e70a6e97f923bef6951e67a2ad5b873cbb93c23caceb3f4",
       "passed": false
     },
@@ -10697,7 +10712,7 @@
       "passed": false
     },
     "us-ut/policies/cms/utah-chip-eligibility.yaml": {
-      "fingerprint": "sha256:068d9a21bb29148035009e608474035436a6268c252562c0b0a221801ef322fa",
+      "fingerprint": "sha256:d673885e920d920b2757546a727bff8489e02e2bf9c81c43af23b59795d55c0f",
       "module_sha256": "sha256:e2b235e6bb448f3d052e597125368ae4000e368ed6879dfd16a86ab11804fc24",
       "passed": false
     },
@@ -10737,12 +10752,12 @@
       "passed": false
     },
     "us-va/policies/cms/virginia-chip-eligibility.yaml": {
-      "fingerprint": "sha256:b93f9902e529a540cc02893d431e376561725f3f39a2ea1fb357990462d1a516",
+      "fingerprint": "sha256:855af1f9bcf1891942208131c349716d6e819985b7bf26668296cfc66f1f58c6",
       "module_sha256": "sha256:b9b034ff72d2a9fb3b7ad5199631fc0e405512fd6001bdd740eb8e2de768c6cc",
       "passed": false
     },
     "us-va/policies/income_tax/pilot_liability_pipeline.yaml": {
-      "fingerprint": "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f",
+      "fingerprint": "sha256:a816b0e03c62e9b0dc75691544164e8c22f1f1623f1ab29eb70c21c32e882e7b",
       "module_sha256": "sha256:19a7fe2019d573aa49e9657d3190beebb460e24b4bd8e1a4ecbcf4b6a6620efc",
       "passed": false
     },
@@ -10772,7 +10787,7 @@
       "passed": false
     },
     "us-wa/policies/cms/washington-chip-eligibility.yaml": {
-      "fingerprint": "sha256:582673cbaad3691e48f4751d8c834bbd18e324e0b8f3fc5015cdebbf72b96b2f",
+      "fingerprint": "sha256:733844590160aa0b57fdf2930ab866e80079ce80e6e7414880d0219c25d3e5dd",
       "module_sha256": "sha256:8dc6d708242fa419bafef495bb923ca3ef44ce504d547ae39b0b89ac74a36455",
       "passed": false
     },
@@ -10797,7 +10812,7 @@
       "passed": false
     },
     "us-wa/statutes/82/82.87/82/87/040.yaml": {
-      "fingerprint": "sha256:8dd002405b930fe6d251403c89c87578673d79cdbf0291dedc9f20d1bba52e22",
+      "fingerprint": "sha256:8dd0613918d269b39b33748c622138cde0fd6f241f1e284274274f3871547895",
       "module_sha256": "sha256:e7018a7d47f2886e7cbd9c9ac61df9de3acddd4416a892374fa600fcce36a08a",
       "passed": false
     },
@@ -10812,12 +10827,12 @@
       "passed": false
     },
     "us-wi/policies/cms/wisconsin-chip-eligibility.yaml": {
-      "fingerprint": "sha256:44eaae27d672fba5f6a9d8ca05fb02dd127d7ae5b2ba277d99cfd20f42b8eacd",
+      "fingerprint": "sha256:e6c0c6dbd3f6ddf4e09655b3a6c74d4ede042c5cb04a7d9f987a58b61382bb7f",
       "module_sha256": "sha256:3900cde3cf87a7f86cd8f591474ad7188f24f7aef182d1fd9b94d97718a15632",
       "passed": false
     },
     "us-wv/policies/cms/west-virginia-chip-eligibility.yaml": {
-      "fingerprint": "sha256:200710e4d9ad33b486d4e3c21bfec956cee9e6d280a7fccf701c6b779106f288",
+      "fingerprint": "sha256:84320fdca59f094bce1db772fb9470c48b683c69f6b9dcee1fcf4f41f15736db",
       "module_sha256": "sha256:0db52ba68e367d709a2504012973a0a246775a032430ad13d6869e173a690f56",
       "passed": false
     },
@@ -10837,7 +10852,7 @@
       "passed": false
     },
     "us-wv/statutes/11-21-23.yaml": {
-      "fingerprint": "sha256:4c80a5ed2290ab1aab94606490b0b7ca462ec513962d09947b2fe3090ac9d067",
+      "fingerprint": "sha256:a7afbf376d622629ee410da3ddd101f56ccf7c034de8026c6af672628d788274",
       "module_sha256": "sha256:677d44410fb87140857809618c9401ddc9319c2c034e03ec27da1fee0421114c",
       "passed": false
     },
@@ -11332,7 +11347,7 @@
       "passed": false
     },
     "us/regulations/47-cfr/54/403.yaml": {
-      "fingerprint": "sha256:3b0fb4d480d177343d3b0ce22f452e6493a8d6f4edde9c72b394ca589def633c",
+      "fingerprint": "sha256:1ce1de57dba05d341a69e2bbff88429874d6712fa51b6c4eafffb719c67c7e2a",
       "module_sha256": "sha256:32ac24918104018755c5155cc5d6c9ba40c1a5eb2ad76cdae23eb7da828ce324",
       "passed": false
     },
@@ -11607,7 +11622,7 @@
       "passed": false
     },
     "us/statutes/26/213.yaml": {
-      "fingerprint": "sha256:2fd0e404e15739a9ba1a69e12cf8f03c6f2657169f8d30e71880554d28fdff96",
+      "fingerprint": "sha256:0c870c8850f96b5db867804c61696d8f010e430e7c5ab69e149e27f3ec9d8cb9",
       "module_sha256": "sha256:22c43dec61eb4c48f2f6185c7a961abcbd263e695d565e10bcad42cabcf64197",
       "passed": false
     },
@@ -11647,7 +11662,7 @@
       "passed": false
     },
     "us/statutes/26/24/d.yaml": {
-      "fingerprint": "sha256:988da5c59a8fe5c15fe1349922433c3504c553b0374af92dc1c20220a60c6494",
+      "fingerprint": "sha256:0e7b209649ff6cedf46b5f75e4d84adb23054fde3ed991637cac9e1c7f33a277",
       "module_sha256": "sha256:eaacb8c883ea2c08daa7e0af850a1f40913f10243ed17d06ddda24d25ce8c3cd",
       "passed": false
     },
@@ -11662,7 +11677,7 @@
       "passed": false
     },
     "us/statutes/26/25D.yaml": {
-      "fingerprint": "sha256:52ba77c8989b8c8ca9d4cadb7938c1d7de4e4583f9c402409d246eeb3fb7efcd",
+      "fingerprint": "sha256:0014c403378ef09fc97a56b53ff50468f8ba0e00342ef79b42f54990d2b7512b",
       "module_sha256": "sha256:d3a719c9bc673f033b1941fcb0dc5b588c64f92b16ea2e3205b6fe3ee5ed2372",
       "passed": false
     },
@@ -12402,7 +12417,7 @@
       "passed": false
     },
     "us/statutes/26/3241/b.yaml": {
-      "fingerprint": "sha256:cc9a7543bbdd9015d5891ced3aed3503f1651a2df02f6363dbf1de0f1b580827",
+      "fingerprint": "sha256:2d83e77ed1f4c63d4c62f7a2a93f75ef3003b9943b0eee877a478b87d8496b1f",
       "module_sha256": "sha256:92e19c92a35668c208e398950a3418b2584b8c66477c71eb5c08e308756ffe79",
       "passed": false
     },
@@ -13177,7 +13192,7 @@
       "passed": false
     },
     "us/statutes/26/85.yaml": {
-      "fingerprint": "sha256:cdca8c323ca786230651c1490cd83515fbc500fce190042973dab4ae6b68855d",
+      "fingerprint": "sha256:b70047dc5585ce256faadaa9b8f8b87608e800cda84af863a78b6602072851f9",
       "module_sha256": "sha256:c5fa101230f23c26e444ea00c05dd518ba485a2786aa9b0ee9da735f0d12d805",
       "passed": false
     },
@@ -13377,13 +13392,23 @@
       "passed": false
     },
     "us/statutes/42/402/w.yaml": {
-      "fingerprint": "sha256:c1b6095fb67c91e04bfaa2915f6fb4fe4ea0ebd7176e9d0eaae1b1da51b70264",
+      "fingerprint": "sha256:3d74a83cd3ac065203e821049d12d0799fb10dfa18600d62c883c1788dcb6771",
       "module_sha256": "sha256:44fd75d7331f338e3a8d9eb474b557780407707a8591e322efeff76aa375e62d",
       "passed": false
     },
+    "us/statutes/42/415/a.yaml": {
+      "fingerprint": "sha256:37d5c40c7e68cfe5dba65872ab88251539ce83fab0c09e7b57f8e15348f6c3ee",
+      "module_sha256": "sha256:bf244b9460ead81724d135bb1f806a1ffb45ebc2e04bfdc33f1175ea28357221",
+      "passed": false
+    },
     "us/statutes/42/415/b.yaml": {
-      "fingerprint": "sha256:5d10d3dd3e1cefd2f3e50875a4e079b6688c48876127ee3b4ca3bd9d0a4c3a7d",
+      "fingerprint": "sha256:21a750174ef9449d0e620c06751be36ec3a60a2a8d884cadec257fd5d53d7e97",
       "module_sha256": "sha256:27fa5eb3bb8e437cfdf12283d133bca9241c321e7b50f6fc46e66ca3a147ea98",
+      "passed": false
+    },
+    "us/statutes/42/415/i.yaml": {
+      "fingerprint": "sha256:eecdb934f18f1e00ece0ead72500b0fb2b64bac1da10d69c6d081ef9b7c5bd54",
+      "module_sha256": "sha256:6414eeaed24d55cb39390bc690113aacff850a573ac6b4967cbc83805356b7bd",
       "passed": false
     },
     "us/statutes/42/416/l.yaml": {
@@ -13687,7 +13712,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-12-103.yaml": {
-      "fingerprint": "sha256:63e3a9fe6eb6d54972016074a14db92d5554c1e1ab7cefaa4e6d03866c44c1e1",
+      "fingerprint": "sha256:e0da5da659bb4db545281211e80d06abcb080e226c378d5c69e92a3e2a1395f3",
       "module_sha256": "sha256:3ad4fa0e2ac8c4386fac70f1a360d2434f4a23c592033ff07241e7871d383e48",
       "passed": false
     },
@@ -13697,7 +13722,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-13-102.yaml": {
-      "fingerprint": "sha256:1544d883d384cd36a9ca7f7fc6a66701c7affc6aa9df09bf0ea23d89eb5b0ab8",
+      "fingerprint": "sha256:5aeb8e7e93ab402fec8c685a122e16e4ea10cf511470a641ca526d8bb30919f5",
       "module_sha256": "sha256:b079876669a78b6ddeac0fd8c5f3e8f4a23b1df34b9c7055e28a307990d1b9a4",
       "passed": false
     },
@@ -13897,7 +13922,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-517.yaml": {
-      "fingerprint": "sha256:a95c95089d54c0472a40efe2ea058452460fb7c15d40e22690046e24509f0a48",
+      "fingerprint": "sha256:1c9a5e04131a1a729d7031b05d2e6d82a867f93eb64344c8f08be21e049666f7",
       "module_sha256": "sha256:c924e2e2f194ad120ca47131fc1011a309b4732c5c32e97ed6dca50d0b4306d5",
       "passed": false
     },
@@ -13962,7 +13987,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-555.yaml": {
-      "fingerprint": "sha256:7635f20e5038cb6e5ef26b677a680928a2764731081da839e1b03c4fe75e331d",
+      "fingerprint": "sha256:8afd265f8b26a0eae204b9a37c4e90c0b9643b9b1a69978b796beb52d89db3dd",
       "module_sha256": "sha256:c6a73da3ce363e6780aa8b6be113d601d393516a17ea8603194d81bf482054be",
       "passed": false
     },
@@ -13987,7 +14012,7 @@
       "passed": false
     },
     "us-co/statutes/39/39-22-608.yaml": {
-      "fingerprint": "sha256:f27fd9805c8a304aecebdd02894995adc468d297451e25f3b0a34c94011c3616",
+      "fingerprint": "sha256:0e472f40c0413fe3e1ca470410c8a4c46974ba9db0d25308cd2683edee5ee03f",
       "module_sha256": "sha256:cafce6dbb600dead0bd914e2f86390910b71968f5027c55f36336c40afe3703d",
       "passed": false
     },
@@ -14327,7 +14352,7 @@
       "passed": false
     },
     "us-ia/policies/income_tax/2026_full_year_resident_core.yaml": {
-      "fingerprint": "sha256:84c9ec43289d6468decc606f145eef327906026bdce5fe1ace535e66f844c3d9",
+      "fingerprint": "sha256:500e52ff70266ccdbcb5d50520692120470ac09ad1ec7ae2e48ad3bdddc47fdd",
       "module_sha256": "sha256:31b2787f00144f04bf5dc6faaa49483ab159888b0a01bfa0dc161679dcdbdc0c",
       "passed": false
     },
@@ -15162,7 +15187,7 @@
       "passed": false
     },
     "us/statutes/26/32.yaml": {
-      "fingerprint": "sha256:d92dec59e652a0a291e74a4eea582730ca7e3d5dc8e9f6863b776085603128f2",
+      "fingerprint": "sha256:4a64e025c631740b465bd5729a1083d58e7be0fb484cd44379185bc6d48bee9b",
       "module_sha256": "sha256:979e101eb20ac9f43fd37884e7241f3afc1abb7f3eea5abc93cc1b67067d8179",
       "passed": false
     },
@@ -15272,7 +15297,7 @@
       "passed": false
     },
     "us/statutes/42/1484.yaml": {
-      "fingerprint": "sha256:52556cb3f24fb17da239186935650658c261bbfcda006ea998e9eca1fc3ba36f",
+      "fingerprint": "sha256:ffdcea312f536a7ab14cc66bcaf8160d0ca799acacf906ea6841d7d5e60e431d",
       "module_sha256": "sha256:bf026f56beb6754017ff013bc1d32cb18e92d119d3a84986137767c880cb0ff8",
       "passed": false
     },


### PR DESCRIPTION
## Summary

- refresh the remaining 128 fingerprint-evidence rows from authenticated partition audit run 31643900892
- record the complete 130-row drift census (including the two rows already registered in #1295)
- add five evidence rows that were absent from the prior ledger
- leave known-validation-gaps.yaml unchanged; this PR grants no waiver approval

## Provenance

- workflow run: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31643900892
- workflow head: `fd98e8b5fda081f84d879da18464fbbf5e0d1537`
- validated merge checkout: `72232e72e06f2353a02633a38bb8e679b1de7a34`
- canonical targets: `6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5`
- encoder: `40009d295e74784f45bb98e3d3f0f20b73df7561` (`0.2.1683`)

## Checks

- exact 130/130 audit-fingerprint match
- exact current/validated-tree module SHA-256 match for all 130 rows
- JSON parse and `git diff --check`
- `python -m pytest -q tests/test_bulk_applied_artifacts.py` (34 passed)
- independent review: no actionable correctness issue