### PR TITLE
Approve complete encoder 0.2.1683 waiver drift

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -8,6 +8,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:37d5c40c7e68cfe5dba65872ab88251539ce83fab0c09e7b57f8e15348f6c3ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/415/b.yaml":
     active:
       fingerprint: "sha256:b701558fc8f6a779070f14b09b7731d761596c6f29e92caa0f291e7cd0f15da7"
@@ -15,13 +20,18 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:5d10d3dd3e1cefd2f3e50875a4e079b6688c48876127ee3b4ca3bd9d0a4c3a7d"
+      fingerprint: "sha256:21a750174ef9449d0e620c06751be36ec3a60a2a8d884cadec257fd5d53d7e97"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/415/i.yaml":
     active:
       fingerprint: "sha256:02ccbb5f461d70876b3493dcfe2e8390e7f33894f2aabd5e5f43e57b84bb8e73"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:eecdb934f18f1e00ece0ead72500b0fb2b64bac1da10d69c6d081ef9b7c5bd54"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1106,7 +1116,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:3d812a02cedc20a5fee110a59660c251a77cdee3692e1bae2d1bf77b6435121c"
+      fingerprint: "sha256:5b54a5ccd5fe81b016a66fc11fa7cfb5d176f67e6ab59806f65b399c825cec3d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1117,7 +1127,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:2dab9532f756c49907cf74ad4ffafc7bfedc146b28858b03455d06361b80552a"
+      fingerprint: "sha256:5cc864823c87aab941ee172905669d9c0c95e1692181e4ac00f689d760304921"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1128,7 +1138,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:9a63a2bebd4eae18977fed1bb899c2512997362969ec5c0c8c9d878d58b038be"
+      fingerprint: "sha256:63ee6ac9d2c04ecb2c145d94b9f08ff4a310a0d1d836bd02acf98cd47ce1f90b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1201,7 +1211,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:40297939f335ef39f3cdb97741361f50d6eebb25961094589f35451226841bf2"
+      fingerprint: "sha256:ec8b4135ee9a318410f56efa803ff56feda02c382c65103fd2a50baef4bb0eda"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1326,7 +1336,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:988da5c59a8fe5c15fe1349922433c3504c553b0374af92dc1c20220a60c6494"
+      fingerprint: "sha256:0e7b209649ff6cedf46b5f75e4d84adb23054fde3ed991637cac9e1c7f33a277"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1819,7 +1829,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:7afa9bd42436a651ce0bfab0b8409e3ddb67163c8a9148438d59e8e7a9efa970"
+      fingerprint: "sha256:6400b43993f2676cf65fc41b10019367b1f4fe5218b297505d74fe697b1142fa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1830,7 +1840,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:e631e7d2f5e1e23f6c5a41a216d6f41657d8316424eb7f925d4672a8e410c356"
+      fingerprint: "sha256:02cbb30ee17236234b834f5e5b1715d6e6d7f050203e8190bbb862e0fddc7d78"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1841,7 +1851,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:12c41c302d5c4a2a2e137b60e5d6ffc2f2f3611467858d7b85b06cc5408d3232"
+      fingerprint: "sha256:cba44b1395f9f30a97ce413a4deeda672cc06cdffd7c7ae3c6f021fb65a01b7a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3408,7 +3418,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:cea24e9a1a7645daf26ceb37e1036a85eceebf811e7a0d309d00255d3cf9a1ce"
+      fingerprint: "sha256:3b9e9acaa5ee9f987ba0e533a54f0c5a7ee532d356bf7b9584c7d0d4d0206a9f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3419,7 +3429,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:b7a69436fc2161c2947b3aebe804992c4ce7e463a6c17fd2b2d0f8f86fdd7b76"
+      fingerprint: "sha256:aeae923fed952d4562e322f4abc7610a34392c300021d02b7cca667c1efda049"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3430,7 +3440,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:988847e32cca202fa902b17c81ac23591b53be14664b2b5f670dc065f23ea070"
+      fingerprint: "sha256:c44346ff79acce3723c819ae88dd1f020d9e43d1eb13968bf72f92d0c8fdc1c2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3452,7 +3462,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
     pending:
-      fingerprint: "sha256:bc8de961b79da8d6351c11eb04f490531a4aab51144de4299263afc835a4d157"
+      fingerprint: "sha256:194b38dbe26ffe48a8b30ab2c630effd4199c03cd44f09eaf801c8f40b3e4fde"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3536,6 +3546,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-sc/policies/dss/snap-policy-manual/page-163.yaml":
     active:
       fingerprint: "sha256:6cc3430c3e3d5c4394d8900a7407d893e9c4f9a3acf457ba920903853abe7d34"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:997c3df8a2cfa7df0d41bfab98b2628ea99891318d1b31492d5435e61f5fc3d8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4167,6 +4182,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bf6baec0883005cdc6afca8eca029efd0edeaedb9cf22a0bcf34a3d154ba3d76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/policies/cdss/calworks/countable-non-exempt-motor-vehicle-equity-value.yaml":
     active:
       fingerprint: "sha256:4fd9430bf97b35ceb0480e9fddf2eb3406b9ae694954ff3053b841160dc50e1e"
@@ -4557,6 +4577,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:36058ec19f9c1017dc5858a79bfd25715f239ff544c780d96e3ff573fc7aebd7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/policies/dfr/snap-tanf-program-policy-manual/3050-10-cash-assistance-maximum-benefits.yaml":
     active:
       fingerprint: "sha256:f68e74daae667e5231239e3aa310b1cc7f3b1df53653ec6ea1bf874484be96d9"
@@ -4745,7 +4770,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-al/policies/cms/alabama-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:d52a750541f767040650e6346868b6963d6a600a9c126ef843273872c1cff40d"
+      fingerprint: "sha256:fb7faaebb01c9bb45d844175c426670f79f142b85582f035893d6b0998be5ac5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5093,7 +5118,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-al/policies/dhr/public-assistance-payment-manual/appendix-n/section-2/payment-computation.yaml":
     pending:
-      fingerprint: "sha256:bfd76eb9b27478619131f2eef6b0f37a085886b1578ac25ee4e62030fa423a82"
+      fingerprint: "sha256:8e016476c4173f5168145a12d81f02fcc03bb3ce21823fa822c076ea62d7ab01"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5249,7 +5274,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ar/policies/cms/arkansas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:6c9894f3c587f3580fbcd238464445854950b827eb2b164090207d9c5934c6a4"
+      fingerprint: "sha256:b3429291c9bea3cb0ee084cd4f602c45792138b4156658f0bec5ffb8fa071b6b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5261,7 +5286,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/cms/arizona-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:0b40725f2ab06768efd34a40fbba62d467872dd82706b73f577ce8633b99f0d5"
+      fingerprint: "sha256:47e3aac62f4ce656aa54f6d31002a7fda0dde8f6b2f71e384dff48cf8f9a369a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5273,7 +5298,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/policies/des/faa5/ca-benefit-determination/payment-standard-test.yaml":
     pending:
-      fingerprint: "sha256:d99acf79580ebdcd41bae15fd6f88bfa0f98fcf449e1026db3e0ee75abfbb82d"
+      fingerprint: "sha256:32d8387abf9b96f21e4b26a5ba427ae2e749d4b533f11b0319268d2b64fb93da"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5429,7 +5454,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-az/statutes/43-1041.yaml":
     pending:
-      fingerprint: "sha256:f88233370d200d58ec6df00c1a79644b661cf7a2c04e942826e8f4ff20725120"
+      fingerprint: "sha256:a8672397310e350a5005786df193c1ab113004ce3f2321697feb5a6fbb8c1cd0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5495,13 +5520,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/policies/cms/california-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:8444cdddaa2c5f7cda562d8bdd0b06aa4c32fef233fa65e6045a6dfd26126365"
+      fingerprint: "sha256:47b7407bbd50109d3cfb1621d32070bd89d87bd10067f2e7f642fb362f67c3e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:b156021da63599575025a5a768fb7d484ba833b5f8808703914de84a7903a476"
+      fingerprint: "sha256:3d6e0d52cbfadeb61efe39411cacd24c9206c59eef6f2d3a70c5bfc4c3b982f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5615,7 +5640,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/policies/cms/colorado-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:23944cb9c34904e01113f246b5f58cea3b42df20421464fcaa2a993674c243e1"
+      fingerprint: "sha256:abd7df7554d0ed54e21282b91af5fd786abde45240312df444eb596e6b32db6c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8795,7 +8820,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-104.yaml":
     pending:
-      fingerprint: "sha256:074b7b631e8a1d6abf9c636ee05a80486b8aa8f2c744b024f941a2788b51330d"
+      fingerprint: "sha256:ab63248987f8ebc5894bb09643b2b6f6d08a85badc0cd12b4af371190841b536"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8807,7 +8832,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-106.yaml":
     pending:
-      fingerprint: "sha256:e9b9c2dd130e47faf074c888a0e5284184ac9bb0a4adb4afdd8fa8ccd47dd8c8"
+      fingerprint: "sha256:152705fce15ee61c86aa83c17ccde6282ce2e95ca6039f8f4f2f8034d7e00974"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8873,7 +8898,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-29-115.yaml":
     pending:
-      fingerprint: "sha256:6cdacc5669b27163917c8618f28403e34d69ead6f65d18276cc8ec85e9b62ff6"
+      fingerprint: "sha256:e443dfda26fef125f9a1046f48dfeae53f8d8abac388bf9fcdb95d1a648bce4e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8963,7 +8988,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ct/policies/cms/connecticut-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:983bfdd236e763735a6670e3a1ca9f5993038f2a4afc6b6a7fe4d47bf3b16823"
+      fingerprint: "sha256:4e3b8d335a71bcd27d7c2cfdb83bb330d2a0eab9287cd4460835d005af5d4ad5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9023,13 +9048,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ct/statutes/17b-104.yaml":
     pending:
-      fingerprint: "sha256:49f4ea201b3867c2b2d24551d69c3ebdaed2d02bc0378442982904e08a46e8c5"
+      fingerprint: "sha256:5b958b4ec199bc18b2b25f290eef98e037feb1e2bab5851ba5a424459381b8d3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ct/statutes/17b-112.yaml":
     pending:
-      fingerprint: "sha256:2ddd17796f0d1532cbabbdcb8377dd513699ae2bb28ad5396d1cf92b0563934b"
+      fingerprint: "sha256:3ec2db61a00ad8e47a52dc402c7ad2dbce60c44537fc173aeeb2ff7f3480bb6f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9119,13 +9144,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-de/statutes/30/1117.yaml":
     pending:
-      fingerprint: "sha256:6d427e9ecded2dc602254fee8afc05745e5b9459fa3237ce3e4da0881e4f3af2"
+      fingerprint: "sha256:b861d72db13edb55e8b899e579e9dc417c2cfc8a19816fc892176683faf82199"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-fl/policies/cms/florida-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:77d7e41c59ffc066c0087e31c32905aae0f9975326d96a84414453e6d4694c6b"
+      fingerprint: "sha256:6a329e1327d4172b9735b2404f3b9840cdbb1467b088490b33c1f08be312c065"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9605,7 +9630,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ga/policies/cms/georgia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:202dab1602b63d439bb069bcbe8c9ba050bfbf43cd738e447e0c0f8ec1896074"
+      fingerprint: "sha256:d011dc8dabdf1efaeaca67e18f12f68c776be12671f0edc7afc97cfc0660df13"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9635,7 +9660,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ga/policies/dfcs/snap/standard-utility-allowances.yaml":
     pending:
-      fingerprint: "sha256:e516ba057f68e2410e58fd4e2468204f206edbeaf460504cfc459cd4345cde14"
+      fingerprint: "sha256:11f089a25d3663dc4d06a30d64e507f2926b199ab1074408236bbdb5af2de3f0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9647,7 +9672,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-hi/regulations/har/17/680/17-680-12.yaml":
     pending:
-      fingerprint: "sha256:30df6025e52afff121ee0701db1d665c879e99705cf230fbaacc0ac4fc2d234c"
+      fingerprint: "sha256:5dc6574917304d05933c304f4e0b4b3991e2ac781459c595c465c97a11760572"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9677,13 +9702,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ia/policies/cms/iowa-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:29c75315d77a6f04fc0da21e97fa398aff39a8b6b2116b2ecaf2fdbc88e62e62"
+      fingerprint: "sha256:19d31a903a27d959d18766bdfb2d9ec4b91020b8cec99b7efb5416192f5086f4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ia/regulations/iac/441/41/41/28.yaml":
     pending:
-      fingerprint: "sha256:297f4e353ebff26ecc0c6e7fa3955c31e43e21bc3d1d55b43b0e08c5ad3da32b"
+      fingerprint: "sha256:397a47d3c45078ce09ff8777d82d4d2c4324888859b641c05ad7de3abb06ab27"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9707,7 +9732,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/policies/cms/idaho-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:0f5bbcc56b42a0c5e41f209306e0eaaada8d69af8686a4d4e5c4de8d88283132"
+      fingerprint: "sha256:88105b96ece2d70053e5da23461075ede5ffc81cc6afec3ead6353bda585e30e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9719,7 +9744,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:6ca089b2f0ced2adb339b6684dc655e50d478bd82d52c84e07339b4972cde5fc"
+      fingerprint: "sha256:047107a3d04219fd1eda20c84dd391ad48d8929c377c4e2d94b5a0ff431bf13c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9839,13 +9864,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-id/statutes/63-3024.yaml":
     pending:
-      fingerprint: "sha256:ca9683f4cdd253b1aff76f70c85c35b34425ce2710e3ec8ed43b1cfe5d932822"
+      fingerprint: "sha256:6c6a967648656991da1196cb04f6d0d052991d9da53525ed5ed300c2f9f0bbef"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-id/statutes/63-3024A.yaml":
     pending:
-      fingerprint: "sha256:353f17baab59363920c29851390ec45e95653cdb5cad64bc8d802fecdb2bc2ce"
+      fingerprint: "sha256:73e01766b0c4d6ccd55278570d0c68d082f67eb11fc4a3725cbc3f9a78a7f658"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9857,7 +9882,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-il/policies/cms/illinois-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:28aeacc70e26818c36c65851581da5ea17cfbe18414c18bc989d1d6957a6793b"
+      fingerprint: "sha256:208243bce9a4dd564301ddc0c6bb94184f67efa95aedd80dd8ff7b25c2f3d831"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10001,7 +10026,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/policies/cms/indiana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:19cc449233bec72f5034d7e8faadb2f12fc374642ba1c830bc60370b51ce6b99"
+      fingerprint: "sha256:bb4a2b4f81d3b956f1e271e035b1b57aeb4c31eeb7bbff6da04b031d1a729970"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10085,7 +10110,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ks/policies/cms/kansas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:06d48e81dd5a712b8af45ff2d9316b3da5c6b814d80b63b5d0bb51eb4228f2ea"
+      fingerprint: "sha256:27ff5fb08a396a0cb009c451efbfacb035ba818137299f0fe2d456dc15232cf1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10121,37 +10146,37 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-la/policies/cms/louisiana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:aa25a8f48d4bf46e067dcf3cbef4cb9f8495eaf17e5e315d846584aaf63a98c1"
+      fingerprint: "sha256:749f09a92602ab4c11e90836900f2b4cfc0067796692b69b22310ba24f3bb064"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-la/statutes/47:294.yaml":
     pending:
-      fingerprint: "sha256:95f9824e34d0164cc571a8f15aa9f4a8664e4b4450cf87f0de9391b72037d907"
+      fingerprint: "sha256:acf7b3c922e39cb7d9f9900c78d23c7bc0ef1c5549f73261b53b72029fa1a3be"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-la/statutes/47:295.yaml":
     pending:
-      fingerprint: "sha256:cd34a64600107eede6f8d9ffe58ddb886627bdac1fda0667a34e79a0e4ff292d"
+      fingerprint: "sha256:a1054bbed22003e7272993c691aeb04250122c093e3adcfd63e5564f9d882b79"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-la/statutes/47:297/4.yaml":
     pending:
-      fingerprint: "sha256:bf597a272c1736ae2564a841c4b6ef6cd92142e59ebe8e218efa6b7ceb8c8c7e"
+      fingerprint: "sha256:e30f8976d8d763993252f35708b73276796d417309beadcdf135bb6b7bb9d7f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-la/statutes/47:297/8.yaml":
     pending:
-      fingerprint: "sha256:c445ef7df5f66ffcde86a567872a60de534b0f2b3c4b31656f19424f66a71db7"
+      fingerprint: "sha256:6a7c9fa90c562839ab9f8f6e7131b3a015cd4a0fc5804e1a35cbde9846d50db2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ma/policies/cms/massachusetts-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:107cc1a620ad112089f2e93b84e6ec431f10c7d3110f2bca63470fa60fb94d4c"
+      fingerprint: "sha256:ce9ef693d3c3a7c3be04ff91cdd13df9ea05e1cc3b5cba1d84fd8fb079bd6106"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10169,13 +10194,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/policies/dta/snap-cola/2025-10-01/standard-utility-allowances/heating-cooling.yaml":
     pending:
-      fingerprint: "sha256:63988ec7c07a416301f46aaf3fef7f7d9a7a9a8268108b9b3ad4750c6d9aa832"
+      fingerprint: "sha256:0e41165edf5c09fba976ce61cf508f4cbf55d78ea29e39d0642abb2424495259"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ma/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:caa362d34ec667700697f2d495b3ffcb0b9a193cf2d1fd0cfe65ca523efb508a"
+      fingerprint: "sha256:0a9bc84b5af07aa08f76694137f106b4b7b3f83e3adeca3f04dc0477646a4631"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10745,7 +10770,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ma/statutes/62/4.yaml":
     pending:
-      fingerprint: "sha256:24c26da31b62a11345f31fe7ec030e1bec611d3e13026b3292232701cedbeed7"
+      fingerprint: "sha256:c5822b9ce764e9787a7993fef14f6146fed0900ec78506e8e2f7ffb2e31ec570"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10787,7 +10812,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-md/policies/cms/maryland-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:5143b2945206f1bbfb5095a4929f26562f753ab61bb430ecd6876f79b214403b"
+      fingerprint: "sha256:82eab885665e1cb9689abb3f5ad0822cbcd0f3c738233cdeb493a3b6eea990fb"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10799,7 +10824,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-md/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:1b4d7acca34a3c9d03c1b8b2deac31011054bea42b7e3a36ec423926ecc3d314"
+      fingerprint: "sha256:108c236be3aef44c4dcca1beacf28450d8c403247460af8b3d23695fa17f6635"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10817,13 +10842,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-me/policies/cms/maine-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:f810361994fb23061931a82b0c6509e1c48a0b189d5ef1db4e0cc33f28c0d597"
+      fingerprint: "sha256:e0d21464d1b7807f91adb749a9b34bcb1020e495958b59f715b09e4cc74179f2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-me/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:fd34302a6cf7596cba8149ef9c8dff4983049781dfc933bb89f56c60a55c1192"
+      fingerprint: "sha256:34dcdb0a007e6c3b0c2fe52039931a2f3aafd8720f4293e64226da26dcb21cd0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10931,13 +10956,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mi/statutes/206/272.yaml":
     pending:
-      fingerprint: "sha256:b7224cb5fcf34cf248d985f30a3117acecfeac3b21572a892c713929272ab282"
+      fingerprint: "sha256:ffeb887443d379ea47a750f7bd82e292bd22723d4de29634976be1303e9eceec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/policies/cms/minnesota-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:24290720b90dfa81612c9a34869d1b248dde2e499593dd62086439de771143ae"
+      fingerprint: "sha256:f1e758f263fe144795b1d310179a5ce989b4959a2596864b20f5b69abb2edc3b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10949,13 +10974,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mn/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:e71b0de04947fdc750303f74101ce7cd0585cabae6c5f407b55bfda3ae58dd35"
+      fingerprint: "sha256:4be73e357a287db74d10d83d7de3b2d7affc4ffa80419621be592aa59eab8ca3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mn/statutes/290/0121.yaml":
     pending:
-      fingerprint: "sha256:757312db07924c40384f1c506855c059c0680a4ff89c92a9f3280943bbd97e6b"
+      fingerprint: "sha256:a04c6b54b22d1d09ac72e210c7a0f748340c633b67f7c709acd75997e4b07917"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10985,19 +11010,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mo/policies/cms/missouri-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:68623d8668b95af9939a49199baf31fbc65878ca9814d28797247def6b9c0a0f"
+      fingerprint: "sha256:293786957f2b481b9da64fe0194b4bee307657766e971b06541d40615012a249"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml":
     pending:
-      fingerprint: "sha256:5db3072a51b7b98e70de62aa9faa599e954fa1fb081a3c910c814b3278e6578b"
+      fingerprint: "sha256:f45be004d7e73ebf37f1e5c3e9f07acf8f082e2086ab80377c9c52e123e381b1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-10/block-1.yaml":
     pending:
-      fingerprint: "sha256:096dbcaaa6416de45c236f2bc99479ab914fc52e7eef9038c3c86c3d0740c555"
+      fingerprint: "sha256:d0ab845ddd6d2af1e6c5d336ecee39be37eaad0b47fb48e35065e90e934a5855"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11009,19 +11034,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-mo/policies/dss/snap/1105-000-00/1105-015-00/block-1.yaml":
     pending:
-      fingerprint: "sha256:ab1a6ee4a2010bc2c7a2fc7ae55355f064d2a7e6a6b4a22e0ea27d20f9f95653"
+      fingerprint: "sha256:de3104f5e1bbb2ac19b5565c0bdd1ddfe2afed8ef3e3609677e2426d568aad0c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ms/policies/cms/mississippi-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:ee0eb1420e1b3391b8a46eae209d9c0fb978abc2a264055e8d69a5dacc59e91a"
+      fingerprint: "sha256:9dbd0a814489767ca654c3a4a66c65bab7768d6028a17c045ce7ec5986805e5e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mt/policies/cms/montana-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:fe6ca2ea7b257f33a846c9c4a376b55a121f6e9ab4e5d0aaf621bf5ef8218727"
+      fingerprint: "sha256:4a0d66ec09150fcdf28cb9e7c16f5a4547cd62857fd79badf0cc4459cc8954b7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11069,13 +11094,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/appendix-3300-glossary/page-12.yaml":
     pending:
-      fingerprint: "sha256:19671fc8d874ae6816e3b73b8e887769be21771ee0cf06c4d934f1bd24df6f56"
+      fingerprint: "sha256:37be4acbbb659e18b9ad06b5b35d41dc9681b83cfea8ae57c4e2b403b04bb2db"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/appendix-3300-glossary/page-13.yaml":
     pending:
-      fingerprint: "sha256:3432bf868a7491f15d7c6a9f56c0e140da55f4a924e36a4228c8454190c78439"
+      fingerprint: "sha256:37affe026c13fa8fe73d21ea80ea65f04ad69db16908fbe79b29bc3d3e984244"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11375,7 +11400,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-170-notices/page-7.yaml":
     pending:
-      fingerprint: "sha256:b8afdc6e92ed2a43e8a84c938eca2bd597de1065decc15c25f652e15c7413807"
+      fingerprint: "sha256:b86c3bf811624edd623be0d2095b321e282012a4d96e9a8e2b2f1c7d5c803be9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11735,7 +11760,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-230-social-security-enumeration/page-5.yaml":
     pending:
-      fingerprint: "sha256:d17014f6c7f9753a116fb0cc11c377e5732662a20c8dbfe4b8cb85cafbcea887"
+      fingerprint: "sha256:8fdbe65abd980cf936cf3196c26430ff63edba5a83f320a6b1a5aa5018875820"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11843,7 +11868,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-250-workfare/page-7.yaml":
     pending:
-      fingerprint: "sha256:3f105c8605c5f6e06c167d6f7e279144ee0d54560a9039e310fca4da394cecc9"
+      fingerprint: "sha256:f506a5fd01cdc3b8c072fb5960cd00b19a9810979925623e4eb01e13af9e8b75"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11867,7 +11892,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-255-voluntary-quit-and-voluntary-reduction/page-4.yaml":
     pending:
-      fingerprint: "sha256:5719bcbdfde82dfe4f761716e476c42ba0acc70eceedb28370e200deb9c893a4"
+      fingerprint: "sha256:0b4590f6cfb71403e0f2eeb75b345383d98417220a4cd924e5fa28e1faff536c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -11927,7 +11952,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-260-able-bodied-adults-without-dependents/page-21.yaml":
     pending:
-      fingerprint: "sha256:ca3c6962381e3f49a3f36e45207c5d41c2f31912aa9174bcc5c2dc6afe998f02"
+      fingerprint: "sha256:0634fa65d1a6fa4703cb1edde56b78bb8ef42ad20a5a0bca41a2cdee68dd65f2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12179,7 +12204,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-10.yaml":
     pending:
-      fingerprint: "sha256:1a438f6ca8c400016390ecbf5cf93fd25b879edd35f42452fb4ba2725e740acc"
+      fingerprint: "sha256:bde7759ce30de0dc4c238cb4d3ead6fe407f1b09a691d1502a1e3a41db2e013d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12239,7 +12264,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-27.yaml":
     pending:
-      fingerprint: "sha256:d1de098c930689878e4db29b625f8547f1f4a870687b5ba2ee3109dbec0690f3"
+      fingerprint: "sha256:f1e6064d75adc8d1f1debb9f07bdc654b82a66d4be75ed288ba7738415129c82"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -12263,7 +12288,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-8.yaml":
     pending:
-      fingerprint: "sha256:62899d5485fe503aeb9e38399597f7d351af3d63f7397ee4464e6d82d5f670b7"
+      fingerprint: "sha256:5a2ea12484e0d7db71da0e76963d1e49de659c954a043244cbae307f56f47097"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13253,7 +13278,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-4.yaml":
     pending:
-      fingerprint: "sha256:a8b28d567f0f4adb347f696d4c5e3ad30d3c005bdc67e7b53bf8e8827b6d5741"
+      fingerprint: "sha256:c7d92b8f63c60423a690e0f5e7610e63b806b468757ee956394c1ddca7f6c008"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13331,7 +13356,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-845-treasury-offset-program-top/page-1.yaml":
     pending:
-      fingerprint: "sha256:dd1f1768393fdd0288277f0e0558bb1162e5e966df16ca1c27981df6d0d9e56a"
+      fingerprint: "sha256:7f6da63c39b7096b59a43fa9dffbeb3ff3b3dea47f90971ef2e37b6b79e8c73f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13505,7 +13530,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ne/policies/cms/nebraska-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:e0529fad790b3b3f4dcf6af6b98f891464782e9ed9fdfbcc274e56d303d008b4"
+      fingerprint: "sha256:2c9170a512429e892e51fac3b28ac1cab00be152641febf020ff5457ae84c36c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13535,7 +13560,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nh/regulations/he-w-700/742/02/standard-utility-allowances.yaml":
     pending:
-      fingerprint: "sha256:538f9056b0714e200f3abf010827e198a9fb824a53f58355554b15836e2bdb12"
+      fingerprint: "sha256:506d2bafcb3ef975f3165f66c04cfcceb45d342572b5b91c5b79af063a31e16f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13565,7 +13590,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nj/policies/cms/new-jersey-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:cf65846332e30ea8d40a3a92651cfbe5fb0ea9cf797f4ecfaa7eddc4d8c19d28"
+      fingerprint: "sha256:e1c4adfc35cd700e0cdc9393e4a7dbdb3a1db06f2cd0edc4814e9112c4f1b005"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13607,7 +13632,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nj/statutes/54a:4-7.yaml":
     pending:
-      fingerprint: "sha256:871759062002193ec88a1deca9a5fdad34677db67382c2a0f882f8b9d96de20e"
+      fingerprint: "sha256:23224c7ea1b2c1cc2a2d7f9d883eae66e99121713b6be6d1a7b1144c90e480a1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13631,19 +13656,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-nv/policies/cms/nevada-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:98a57a01dd8d840d9cd02b7fddbbc5a917dff52145d0d902eb8da291d1d56f02"
+      fingerprint: "sha256:1a71f714a9a24e8d4bc533dfb0585f705ed2ec4a76564e2c210c51d4dc828063"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/policies/cms/new-york-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:dffc89bf089e62eee8997a902ac57ef68e3ffc2d6973993579123a8d018068d6"
+      fingerprint: "sha256:2078477b9e0007b479b0d88337d5457c37948e29ef1a430d658f4678f2a73588"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/policies/income_tax/nyc_composed_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:107c6999f7522eab5912336130cb99e2e1740a40200765c5e0a5058ed16f46dc"
+      fingerprint: "sha256:6775fd7bf90cb7103b5fe4792a408a039c73742dd647f9ed1c2b2d1c8cd70b38"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13667,13 +13692,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/9/a/2.yaml":
     pending:
-      fingerprint: "sha256:b76db6e9b1e4a2b4a4739f156f05d6ee586319cf529eb72401779cd66585cad5"
+      fingerprint: "sha256:f9fa246a24b950c1a52c4ef8964cba557acc96e001b2164ca911cca7ce1965a3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/601-A.yaml":
     pending:
-      fingerprint: "sha256:81209afbe41752ca14110f9057ebc2f13e451ce1cea6c8c05a3576927878eae8"
+      fingerprint: "sha256:93ed4a1dbaeb3f01153a6cfba097eeb4d74fbd46770f3629f467a319c02350f1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13697,13 +13722,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/614.yaml":
     pending:
-      fingerprint: "sha256:bddf348d7f1e2c82ae251386cd57842f4a3402d6a2b6bd612545814854c786f3"
+      fingerprint: "sha256:809a4695d9f55933b3b7c6d7ef00b5024f8877f8b22e5b9be5d312d7b1a8c648"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/616.yaml":
     pending:
-      fingerprint: "sha256:7f870613e4322bffa42d37651fe168376fb1647d17f159202d3d8f8529cc98e6"
+      fingerprint: "sha256:c066d57865ec6764a3cad7750896e1041613b1f19a7f44ad7eef6d48c8d5bf8c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13715,13 +13740,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/618.yaml":
     pending:
-      fingerprint: "sha256:b538691cc3d7c5940af879aaa3392d5302413b348e6e236fe4567b4a9dc306e7"
+      fingerprint: "sha256:2840df3601ec834ee48be20848c8d4628411f3a9b092d4e21be48289867591a0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/620-A.yaml":
     pending:
-      fingerprint: "sha256:2df0768eaee157c1606909c5af6b87b871a58aba049e501e26a33703fd548ca1"
+      fingerprint: "sha256:d07271d0dbfdeada85bfcb8316469fd726c5182747e633237a16254e1f59c660"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13733,19 +13758,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ny/statutes/TAX/672.yaml":
     pending:
-      fingerprint: "sha256:cf1af855b5bf94c12a8498583fbc867f6992a19b2750b7ab5dc70b1a3b7a6434"
+      fingerprint: "sha256:e2acb8fa3961050429c8a6a672872761acafb530e9cfe618e29016f20a387c91"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/673.yaml":
     pending:
-      fingerprint: "sha256:29df80d86a9ff2b5de548d7a382d01210dcf9df0c5a9e18775b84393c37b319f"
+      fingerprint: "sha256:d9650a532b73db83c5cffbd97833cc2d7d8a3e318de7e287f0690224812023c2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ny/statutes/TAX/674.yaml":
     pending:
-      fingerprint: "sha256:41e053ef0f870f37301b0bd9146abd739a192df2347fbe6bed0abb5651d76587"
+      fingerprint: "sha256:f7459a12cfcbe37f8f60666dc85894d4b26ecc136995a0af5e18a11c199fecfe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13769,7 +13794,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-oh/statutes/5747/025.yaml":
     pending:
-      fingerprint: "sha256:64acfe3ab816885471f3f71434bc394755feb365aa5157064890e99bd2692f74"
+      fingerprint: "sha256:04e93c5b129018dfd40faae09b61ee260f4f8d1bf250039cf9f5f2d72643a696"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13781,13 +13806,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ok/policies/cms/oklahoma-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:c41c81f3bd0ea88c6f4b46bbd7045fbfaa6d37e0aa9f54f6cc7271bc9e6bd407"
+      fingerprint: "sha256:0ac44e2f3e217d2a0ed142766c9ee4eb9b34cdff43435889a124ca8aa46564d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-or/policies/cms/oregon-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:7052f2fa1588aa1d301bee4015fd478aa1d232332d01adfc1e02ed29b39541b6"
+      fingerprint: "sha256:c53f6be9e6bae04d490d7bb9081a4940ac7332825f138f06fa6415db6d96ad76"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13811,7 +13836,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-pa/policies/cms/pennsylvania-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:2a20bfd272631113d99dac5ca6222ad561a6f687614321d9dbac908724311f9a"
+      fingerprint: "sha256:cbcf3dc081873765dc5905fd67e883d188438070819af68557d5834786c9284c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -13877,13 +13902,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-sd/policies/cms/south-dakota-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:ce6920a61808bfe777afebcc6ff775ab4588e212d6d3b42ff733436e95f2a5cc"
+      fingerprint: "sha256:edda51dd4a7c79132e53025fd79a8b438567e5212434541bed9ea1ae003599e7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-tn/policies/cms/tennessee-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:b11432f5c92a2d75b1fb65b74b3feda3c50d786a8647c07d30ff06af4cb09121"
+      fingerprint: "sha256:ab32cfa445bd4da92855597cd60d75f6d9f32ee35399502c5d753ab9e40bf565"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14567,7 +14592,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-tx/policies/cms/texas-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:3e41ca4c486b67e89cb645b21b0de4f9518a8ac3c3debb81db08995d7bd0f306"
+      fingerprint: "sha256:fc1601d57e9c617076561712fd7dc33dc9177ac51653c0fe2a07a2ae49a3bf82"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14591,7 +14616,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ut/policies/cms/utah-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:068d9a21bb29148035009e608474035436a6268c252562c0b0a221801ef322fa"
+      fingerprint: "sha256:d673885e920d920b2757546a727bff8489e02e2bf9c81c43af23b59795d55c0f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14627,13 +14652,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-va/policies/cms/virginia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:b93f9902e529a540cc02893d431e376561725f3f39a2ea1fb357990462d1a516"
+      fingerprint: "sha256:855af1f9bcf1891942208131c349716d6e819985b7bf26668296cfc66f1f58c6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
     pending:
-      fingerprint: "sha256:d3441951b0347448610e1d0a8566d15263286452c99f58caea02140373fcca0f"
+      fingerprint: "sha256:a816b0e03c62e9b0dc75691544164e8c22f1f1623f1ab29eb70c21c32e882e7b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14669,7 +14694,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wa/policies/cms/washington-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:582673cbaad3691e48f4751d8c834bbd18e324e0b8f3fc5015cdebbf72b96b2f"
+      fingerprint: "sha256:733844590160aa0b57fdf2930ab866e80079ce80e6e7414880d0219c25d3e5dd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14699,7 +14724,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wa/statutes/82/82.87/82/87/040.yaml":
     pending:
-      fingerprint: "sha256:8dd002405b930fe6d251403c89c87578673d79cdbf0291dedc9f20d1bba52e22"
+      fingerprint: "sha256:8dd0613918d269b39b33748c622138cde0fd6f241f1e284274274f3871547895"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14717,13 +14742,13 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wi/policies/cms/wisconsin-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:44eaae27d672fba5f6a9d8ca05fb02dd127d7ae5b2ba277d99cfd20f42b8eacd"
+      fingerprint: "sha256:e6c0c6dbd3f6ddf4e09655b3a6c74d4ede042c5cb04a7d9f987a58b61382bb7f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-wv/policies/cms/west-virginia-chip-eligibility.yaml":
     pending:
-      fingerprint: "sha256:200710e4d9ad33b486d4e3c21bfec956cee9e6d280a7fccf701c6b779106f288"
+      fingerprint: "sha256:84320fdca59f094bce1db772fb9470c48b683c69f6b9dcee1fcf4f41f15736db"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -14747,7 +14772,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-wv/statutes/11-21-23.yaml":
     pending:
-      fingerprint: "sha256:4c80a5ed2290ab1aab94606490b0b7ca462ec513962d09947b2fe3090ac9d067"
+      fingerprint: "sha256:a7afbf376d622629ee410da3ddd101f56ccf7c034de8026c6af672628d788274"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15269,7 +15294,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/regulations/47-cfr/54/403.yaml":
     pending:
-      fingerprint: "sha256:3b0fb4d480d177343d3b0ce22f452e6493a8d6f4edde9c72b394ca589def633c"
+      fingerprint: "sha256:1ce1de57dba05d341a69e2bbff88429874d6712fa51b6c4eafffb719c67c7e2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15575,7 +15600,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/213.yaml":
     pending:
-      fingerprint: "sha256:2fd0e404e15739a9ba1a69e12cf8f03c6f2657169f8d30e71880554d28fdff96"
+      fingerprint: "sha256:0c870c8850f96b5db867804c61696d8f010e430e7c5ab69e149e27f3ec9d8cb9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -15635,7 +15660,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/25D.yaml":
     pending:
-      fingerprint: "sha256:52ba77c8989b8c8ca9d4cadb7938c1d7de4e4583f9c402409d246eeb3fb7efcd"
+      fingerprint: "sha256:0014c403378ef09fc97a56b53ff50468f8ba0e00342ef79b42f54990d2b7512b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -16517,7 +16542,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/3241/b.yaml":
     pending:
-      fingerprint: "sha256:cc9a7543bbdd9015d5891ced3aed3503f1651a2df02f6363dbf1de0f1b580827"
+      fingerprint: "sha256:2d83e77ed1f4c63d4c62f7a2a93f75ef3003b9943b0eee877a478b87d8496b1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17447,7 +17472,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/85.yaml":
     pending:
-      fingerprint: "sha256:cdca8c323ca786230651c1490cd83515fbc500fce190042973dab4ae6b68855d"
+      fingerprint: "sha256:b70047dc5585ce256faadaa9b8f8b87608e800cda84af863a78b6602072851f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -17681,7 +17706,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/402/w.yaml":
     pending:
-      fingerprint: "sha256:c1b6095fb67c91e04bfaa2915f6fb4fe4ea0ebd7176e9d0eaae1b1da51b70264"
+      fingerprint: "sha256:3d74a83cd3ac065203e821049d12d0799fb10dfa18600d62c883c1788dcb6771"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -19703,7 +19728,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-12-103.yaml":
     pending:
-      fingerprint: "sha256:63e3a9fe6eb6d54972016074a14db92d5554c1e1ab7cefaa4e6d03866c44c1e1"
+      fingerprint: "sha256:e0da5da659bb4db545281211e80d06abcb080e226c378d5c69e92a3e2a1395f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -19715,7 +19740,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-13-102.yaml":
     pending:
-      fingerprint: "sha256:1544d883d384cd36a9ca7f7fc6a66701c7affc6aa9df09bf0ea23d89eb5b0ab8"
+      fingerprint: "sha256:5aeb8e7e93ab402fec8c685a122e16e4ea10cf511470a641ca526d8bb30919f5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -19955,7 +19980,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-517.yaml":
     pending:
-      fingerprint: "sha256:a95c95089d54c0472a40efe2ea058452460fb7c15d40e22690046e24509f0a48"
+      fingerprint: "sha256:1c9a5e04131a1a729d7031b05d2e6d82a867f93eb64344c8f08be21e049666f7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -20033,7 +20058,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-555.yaml":
     pending:
-      fingerprint: "sha256:7635f20e5038cb6e5ef26b677a680928a2764731081da839e1b03c4fe75e331d"
+      fingerprint: "sha256:8afd265f8b26a0eae204b9a37c4e90c0b9643b9b1a69978b796beb52d89db3dd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -20063,7 +20088,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-608.yaml":
     pending:
-      fingerprint: "sha256:f27fd9805c8a304aecebdd02894995adc468d297451e25f3b0a34c94011c3616"
+      fingerprint: "sha256:0e472f40c0413fe3e1ca470410c8a4c46974ba9db0d25308cd2683edee5ee03f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -20465,7 +20490,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ga/statutes/48/48-7-27.yaml":
     pending:
-      fingerprint: "sha256:16757f1b8df8d6436274f244a3dbb1c18a3fee7b001d5c5d1884408185f44b7e"
+      fingerprint: "sha256:cb68de4b514bf9531bfa7bce50e1bb818846b576994e16f60f6a033c5f9c6737"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -20495,7 +20520,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ia/policies/income_tax/2026_full_year_resident_core.yaml":
     pending:
-      fingerprint: "sha256:84c9ec43289d6468decc606f145eef327906026bdce5fe1ace535e66f844c3d9"
+      fingerprint: "sha256:500e52ff70266ccdbcb5d50520692120470ac09ad1ec7ae2e48ad3bdddc47fdd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -21539,7 +21564,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/26/32.yaml":
     pending:
-      fingerprint: "sha256:d92dec59e652a0a291e74a4eea582730ca7e3d5dc8e9f6863b776085603128f2"
+      fingerprint: "sha256:4a64e025c631740b465bd5729a1083d58e7be0fb484cd44379185bc6d48bee9b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -21671,7 +21696,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us/statutes/42/1484.yaml":
     pending:
-      fingerprint: "sha256:52556cb3f24fb17da239186935650658c261bbfcda006ea998e9eca1fc3ba36f"
+      fingerprint: "sha256:ffdcea312f536a7ab14cc66bcaf8160d0ca799acacf906ea6841d7d5e60e431d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Summary

- promote the remaining 128 authenticated encoder 0.2.1683 validation fingerprints from protected-base pending evidence to active waivers
- preserve the prior active fingerprint as pending for the five records that already had active-only entries
- complete the 130-record audit together with the two fingerprints approved in #1296

## Provenance and sequence

Evidence merged in #1297 and remains attributed to encoder 0.2.1683. This approval does not rewrite historical provenance to the newer generation toolchain. The infrastructure-only #1279 must follow this approval because the new strict validator correctly rejects these failures while their evidence remains pending.

## Review cycle and checks

- waiver-only diff
- local waiver suite: 35 passed
- hosted protected-base waiver ratchet: passed
- every state shard and all non-federal guards: passed
- independent review of the exact unchanged approval subset in the consolidated diff: no actionable findings
- MaxGhenis review requested; Nikhil is not requested
- legacy federal validation remains the sole running check
