### PR TITLE
Approve current encoder 0.2.1690 waiver drift

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -291,11 +291,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-402/11.yaml":
     active:
-      fingerprint: "sha256:74973ef4897fdf502b4475a0c9d58e37c491b77537a083bdd7a1e9d637643576"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
       fingerprint: "sha256:56238ac40e10d4ce3cae0fdfe2e0c85683a86a04e9292f400d154dc595d04fec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -456,11 +451,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-407/241.yaml":
     active:
-      fingerprint: "sha256:c7d8c0b27fcb96dad46b504fdefc57b91f89cb8970bb1c4578fba9a3e09ac0af"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
       fingerprint: "sha256:281960277ccb40c278bc339be7ad1743f4e37d874af2a2c5c46dbf5ebe2e1012"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -643,11 +633,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/6.yaml":
     active:
-      fingerprint: "sha256:150fa6018167a9c273dfe9907928dc1e7cefd40a1e44a6f7d4e93e1421b6bcfa"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
       fingerprint: "sha256:605ef3b745375c5b8a518269ebded4577b95d99654c907bda1a61c7fe40dd024"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -2633,12 +2618,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us-ma/regulations/106-cmr/366/300/block-1.yaml":
-    active:
-      fingerprint: "sha256:a1b15d2566360051e5409c4b723f5743011b2f7d6f79be5d496190f140932bf2"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us-ma/regulations/106-cmr/366/320/block-1.yaml":
     active:
       fingerprint: "sha256:a5eb92de4feb1d6cb0e2c9bea036752ed8a6f0214b6569085c21b626067c1a86"
@@ -4475,11 +4454,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-5-temporary-cash-assistance-income-standards/page-1.yaml":
     active:
-      fingerprint: "sha256:d27849908eddd0987bcf31d6c499f0b10e86b23f4d651ba809e9e1ad5206da75"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
       fingerprint: "sha256:e94778664870df9506ac2618c7a4e3ea7d3cc623a8b06f78f2246e6e516b52ea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -4573,11 +4547,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       expires: "2026-10-08"
   "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-05-cash-assistance-100-percent-income-standards.yaml":
     active:
-      fingerprint: "sha256:8f72bcc7b637b099d5dd2f7d9de34f3873daef77cbaa13bc3484c7777f47e157"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
-    pending:
       fingerprint: "sha256:36058ec19f9c1017dc5858a79bfd25715f239ff544c780d96e3ff573fc7aebd7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -5519,7 +5488,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/policies/cms/california-chip-eligibility.yaml":
-    pending:
+    active:
       fingerprint: "sha256:47b7407bbd50109d3cfb1621d32070bd89d87bd10067f2e7f642fb362f67c3e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -8051,7 +8020,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-104/3/n.yaml":
-    pending:
+    active:
       fingerprint: "sha256:fa523bf27c897e0a468c27ca137a93a0abe7adcf4828c347c95b959421199d90"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -10733,7 +10702,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ma/regulations/106-cmr/705/600/block-1.yaml":
-    pending:
+    active:
       fingerprint: "sha256:5b0fd45c167c673530ed8e529b0dfca62fcca8464aa9109ad5ec66d7eab5c807"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -11009,7 +10978,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-mo/policies/cms/missouri-chip-eligibility.yaml":
-    pending:
+    active:
       fingerprint: "sha256:293786957f2b481b9da64fe0194b4bee307657766e971b06541d40615012a249"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -13535,7 +13504,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ne/statutes/77/77-2715/03.yaml":
-    pending:
+    active:
       fingerprint: "sha256:6d25293faa50d61b8409ff4f91f1a1c88b12861587db188106e820a17426dde2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -17249,7 +17218,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/26/3502.yaml":
-    pending:
+    active:
       fingerprint: "sha256:3376a89866c5ab0a33b5c6c6d90969e107a384138f5d2f1755b32e176bbfa339"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -17699,7 +17668,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/statutes/42/402/q.yaml":
-    pending:
+    active:
       fingerprint: "sha256:71efac613038c04dcfc5a9619de25a4a3d4da2c4d159d31f06e8dcd56425b36b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -18209,7 +18178,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-301/432.yaml":
-    pending:
+    active:
       fingerprint: "sha256:99cd4882edba2ccb2aff3c89c0f9a70edadce5c3160103ab7e0ad7078b56564c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -18665,7 +18634,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-405/3.yaml":
-    pending:
+    active:
       fingerprint: "sha256:54d01c2943f7c13ec04d1977c7305dcf8b16e930e23a55e9db135f152e6bf039"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -19217,7 +19186,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-ca/regulations/mpp/63-408/111.yaml":
-    pending:
+    active:
       fingerprint: "sha256:1cf97ae111a26616e5c9548c99ebb8874b49c1f350c75ca877f0860f70f08bf0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -19973,7 +19942,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-22-5104.yaml":
-    pending:
+    active:
       fingerprint: "sha256:9514c53927a288f5015be9fc29e52a3438d6241439bf72fe5907014ad48384a0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -20159,7 +20128,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-3-106.5.yaml":
-    pending:
+    active:
       fingerprint: "sha256:d72af5d6ce48c14c43546b842dc71ca56618bbdefe671b85ddee90ed0fb79f31"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -20387,7 +20356,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us-co/statutes/39/39-5-201.yaml":
-    pending:
+    active:
       fingerprint: "sha256:eb0d3a20a5d0710c83cb4aefb9b0a790a6ba6d6fe805877860f6c409a7f6600b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -20771,7 +20740,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/aca/ptc_pipeline.yaml":
-    pending:
+    active:
       fingerprint: "sha256:c1210e32ed5bab4c0b368284c8a58b5854bd54baccb98282147e8ad03fb426f1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -20927,7 +20896,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch06.yaml":
-    pending:
+    active:
       fingerprint: "sha256:f755bfdd6a75507b3395dc979d1a2db4e0314dfa1a8a1ce9dcb5decbac123d99"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
@@ -21239,7 +21208,7 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch58.yaml":
-    pending:
+    active:
       fingerprint: "sha256:913e34ade14017c7f743aed26a357c884ddf99dd9e3910fb37eaf63a65536425"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"


### PR DESCRIPTION
## Summary

- consume 21 exact protected-base pending validation fingerprints exposed by encoder 0.2.1690
- remove one stale active waiver for `us-ma/regulations/106-cmr/366/300/block-1.yaml`, which now passes
- change only `known-validation-gaps.yaml`; no new evidence, fingerprint, owner, issue, or expiry is introduced

## Evidence

- authenticated protected audit: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/31969807451
- exact validator: axiom-encode 0.2.1690 (`29b30fb7855c7306d9ead9ddba020dea40f938cc`)
- exact engine: `48797e101c093bb388be718c6f5d8fc9d9f94a7d`
- exact corpus release: `us-rulespec-2026-08-08-obbb-alien-snap` / `0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc`
- all 21 activated fingerprints already exist in `.axiom/pending-validation-fingerprints.json` and in protected-main pending records

## Checks

- protected-base transition: 21 exact pending-to-active consumptions, no transition issues
- evidence registry equality: 21/21 fingerprints match
- stale-active removal reproduced as a passing module under the exact toolchain
- `git diff --check`
- `python -m pytest -q tests/test_repository_layout.py`: 9 passed

This PR is the narrow approval prerequisite for #1279. It grants no broader waiver than the exact current strict-validator outcomes.
