### PR TITLE
Register encoder 0.2.1690 unwaived validation evidence

### DIFF
--- a/.axiom/pending-validation-fingerprints.json
+++ b/.axiom/pending-validation-fingerprints.json
@@ -45,6 +45,30 @@
       "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",
       "refreshed_rows": 130
     },
+    "encoder_1690_unwaived_validation_census": {
+      "method": "hosted hardened repository validation; the federal job reached the six-hour hosted limit, so its exact 791 unwaived targets were recovered from the authenticated job log and exhaustively reproduced in four deterministic local partitions using public signed-release trust roots",
+      "workflow_run": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/32046607086",
+      "workflow_head_ref": "7c632b2daffaed56fd33e70da51738d79342ba62",
+      "validated_rules_repository_ref": "7c632b2daffaed56fd33e70da51738d79342ba62",
+      "canonical_targets_ref": "6bbb9bd3e49e75b66f378ff71cdb40addfa0b6c5",
+      "axiom_encode_ref": "29b30fb7855c7306d9ead9ddba020dea40f938cc",
+      "axiom_encode_version": "0.2.1690",
+      "axiom_rules_engine_ref": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "axiom_corpus_ref": "60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a",
+      "axiom_corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+      "axiom_corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+      "registered_rows": 137,
+      "federal_hosted_job": "https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/32046607086/job/95435966012",
+      "federal_targets": 791,
+      "federal_partitions": 4,
+      "federal_result_sha256": [
+        "sha256:9a2c64328e0e8d2a54fa5862129e9c54a6a097e8da22025eaf2e60bf2f27e512",
+        "sha256:a059b5f04fd548fdbba0020b1adf19a5329f74835639ca7a2d3f379b09d6b3cd",
+        "sha256:5429ae6d44664405d8d9202ad3942b3b9963a4ac122788daa5742cdf44b575d8",
+        "sha256:5d12197f8a30dc06621154b923974fefee9034e34df3bd53359f12873efd8918"
+      ],
+      "federal_failing_modules": 130
+    },
     "hard_cut_residual_census": {
       "method": "authenticated isolated validation-waiver fingerprint census; module_sha256 attests protected-main bytes",
       "rulespec_ref": "436fad35d2724375ba2831082a2ef00bf166f781",
@@ -84,6 +108,11 @@
     "us-ak/policies/dpa/atap/standards/2026/adult-included.yaml": {
       "fingerprint": "sha256:9b04604fa3cf9ca672d1928ea9a4d9d5f4aaec0aa34d60bb4247c0c2ade98535",
       "module_sha256": "sha256:de93ce34dc325ae8bb4e7799a0f82ca10a1507db9641cb638ecd221604de2213",
+      "passed": false
+    },
+    "us-ak/policies/income_tax/2026_resident_zero_liability.yaml": {
+      "fingerprint": "sha256:45bf6c3f16c4d31b0738762b78da15ce6ff410f76fb0f0213ca3e81295f6b849",
+      "module_sha256": "sha256:2a89c1c1f2b18373367098d0d054217fe6923f931dab683634edb065303d8cda",
       "passed": false
     },
     "us-ak/regulations/aac/title-7/chapter-45/45-280-resource-limit.yaml": {
@@ -10866,6 +10895,506 @@
       "module_sha256": "sha256:3f693e5251b03aa9f5a9e56b19f2e98c6ae91d4c0b16eaff44aecf584bb2d884",
       "passed": false
     },
+    "us/policies/cbp/us-tariff-schedule/generated/ch01/ch01.yaml": {
+      "fingerprint": "sha256:8040c22ec0071938252745203a1e9aa4f8681e53e6fb7dfc440dcd24637f9ff9",
+      "module_sha256": "sha256:889fc60e0b04dc206d4aa343948d050e73f126235b1a32847bf771001818b2f6",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch02/ch02.yaml": {
+      "fingerprint": "sha256:c11b7b25a6d15e19f74a52eacb36e190dd0d5b3c70cf49a3eb587bfe3d4e9d13",
+      "module_sha256": "sha256:b81b0d311819c32066d970ccd1594e5caf3170623846fc4a201ceea4506f42de",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch03/ch03.yaml": {
+      "fingerprint": "sha256:761b9642ae7d0d3329454e520c1df84536e82902378ae839d0eead89dd9b3a3f",
+      "module_sha256": "sha256:3ce950f390cb3f8f16f384c29f6f53b1e743d0c069ab7d07456aa7413421c7c3",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch04/ch04.yaml": {
+      "fingerprint": "sha256:30aef8a7416b45315c07f206981e2a72f4eb7a859a89725cd6c7087cd0cf547b",
+      "module_sha256": "sha256:4051925897328efec121fba7e98970ea4f3a05f337852add6da350c2e23c48c0",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch05/ch05.yaml": {
+      "fingerprint": "sha256:082bcb98cb27c75ec05338f3dd33a734df44db6a08701d80d391c71901773a98",
+      "module_sha256": "sha256:dc96b77cae87315c93a212701de5b869ba734ee7278e70d273b1cd7307b85b8c",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch06/ch06.yaml": {
+      "fingerprint": "sha256:6ee516eb036771ac8587568946e729f79a44829cba1cf34fdc08eb7de3cee339",
+      "module_sha256": "sha256:834ec1acd593f2afa13f401fd1d18e9d5c98814a3ae4a2b45e2f2a6915f6107f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch07/ch07.yaml": {
+      "fingerprint": "sha256:b2447f97ec02e6c1c146e1231b28ca090aee24717004c7ad3c02e9c8daf7748d",
+      "module_sha256": "sha256:33593c8a9f87bbb040766f5e0b32a966a14cd6724a6c417d4860f592a21bdd97",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch08/ch08.yaml": {
+      "fingerprint": "sha256:8bb16a1e9097fc74503c2de618af6d9054084efec204677a708f66a2189ed804",
+      "module_sha256": "sha256:bc33613273447ca7d6c93b3c863555a60547ffaece2bd0aa1273941be630a562",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch09/ch09.yaml": {
+      "fingerprint": "sha256:3dd0ea118e8e59b8fdd87e64c75dcd27242f0f11694bdd6e601219b0551f1603",
+      "module_sha256": "sha256:a9d3814c8c4bf1bb57f205c8f1339ffaf094d61b76dc49f47979f5cb39419b6f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch10/ch10.yaml": {
+      "fingerprint": "sha256:d51a18e9a18c772e60b19277ebc87425877a9f92a777fc8b53226221b8e14fab",
+      "module_sha256": "sha256:0cbc44478615744f1dd16486e5752def12cd815e589f65727961161415fcce84",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch11/ch11.yaml": {
+      "fingerprint": "sha256:d7caaf66d598711ee3ed5a6348efcb9fa7f0b2ca73c18e49f407424dd84aad6b",
+      "module_sha256": "sha256:79d9dc39adb1ff948032d058d39744c85469d2c020b323496757b66054b3edc4",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch12/ch12.yaml": {
+      "fingerprint": "sha256:9bd60a4f0ab5336b1449b072589ed8ce2840005e1eab8ef6af7b75b817ebfc37",
+      "module_sha256": "sha256:1d8f7f00077ceb3c017b8dcaed9094801d379f78eaa356898876e6eecaab2697",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch13/ch13.yaml": {
+      "fingerprint": "sha256:df2049cc1eb3f2a31a4484abb72cb0685bfee74ab318c3acd368813058288f92",
+      "module_sha256": "sha256:ea45ac35fcc7eb18b3977d6e95e2d845b1a68a1e343443257f36459ea776e663",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch14/ch14.yaml": {
+      "fingerprint": "sha256:cfaf4cd358e3161b04dec1d547d9fba4b8d188e70df4ff6fd2a9ec7727179dc5",
+      "module_sha256": "sha256:0cf3277da96e1500e35210e89e316a1a08229c3514f04223790f3f0045c35cdd",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch15/ch15.yaml": {
+      "fingerprint": "sha256:8b05f2ab5c6b60cd76285c9c65a0e2844eb1a7994ba675fda0eb23d45dece514",
+      "module_sha256": "sha256:cb64af02b9020f22525987aed31e2f7af3df122ce0f7203a520d2295f3bf1afc",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch16/ch16.yaml": {
+      "fingerprint": "sha256:78caddf6930873650b3a2a1fd6e73a8ceb5f20e47f8b2610332765083ec392f8",
+      "module_sha256": "sha256:930d1ca74f1875105d2ea218743e94350fef6c831205272e99a7f68bce0a5e60",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch17/ch17.yaml": {
+      "fingerprint": "sha256:b7365c9c6193f029b3f30f242f8cff1e2f478890e2a2f4c49780c5bb2ee4c070",
+      "module_sha256": "sha256:493cbe2482b84f744f847e9d3ae67dc9e2f5185796e318c87ab9462b7e991dc1",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch18/ch18.yaml": {
+      "fingerprint": "sha256:7492671129b671e5e47787f95f7d39de94dca3bb5807cfbf023a2f42428fe60e",
+      "module_sha256": "sha256:86725514ce431029d572f943833a3c21c07cab10b5443dc308ab5f6ea493c782",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch19/ch19.yaml": {
+      "fingerprint": "sha256:64fbd18d9470532b4088445ea09e8df7fa7bc63208adccbefafd90ef50cec5ff",
+      "module_sha256": "sha256:3ce1db68258a917ebb780a38ae4aabadf30cba8bb1a211603b5c6164a66a2ff8",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch20/ch20.yaml": {
+      "fingerprint": "sha256:705f2e5bbd38d94d5ed27dc0fad5dd396ee1071f1505302abcc953074d16cbce",
+      "module_sha256": "sha256:4ddd6cfdc669d38a13cbe3b14dbe6c38a5b2479b59d66639edaa2f187b7e3009",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch21/ch21.yaml": {
+      "fingerprint": "sha256:f6998be6751bfb9d9b9a5781fb90aa3d0bb8af86f9b531c828f28c830b2439e2",
+      "module_sha256": "sha256:20e54752ddd1246aff247c744b84b08975eba67b6cc339317d001953318644eb",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch22/ch22.yaml": {
+      "fingerprint": "sha256:0ceeb78a477c705bfd203294432de13eedb2df927ee843c3d03de148186e511b",
+      "module_sha256": "sha256:18d54261e90d0f3da5401fcda7c6872a42062fe49ab104eb42e562ed1dc24a0d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch23/ch23.yaml": {
+      "fingerprint": "sha256:7d149f9f0cc0972b020a4c8efd2448239315fe869562e02e5d6a9b606ac3006f",
+      "module_sha256": "sha256:adb1e5cec3eed1f02a4498a2bc9ea861a06e0c8878cfa2ea8150f2c9518fd829",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch24/ch24.yaml": {
+      "fingerprint": "sha256:af2c3f35c2ea9c8ebe6da22b23dc7b40c09142b2f3fab84c8541bb4e7a460faf",
+      "module_sha256": "sha256:c953bdd753136033ac8f863146ec3c7b42b52e8df9f4b24f54fcc1561436ecb6",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch25/ch25.yaml": {
+      "fingerprint": "sha256:4746f570db792ff250d8dc99537eeeda3aa87050c6e7176d2cc90c3cc8d9e648",
+      "module_sha256": "sha256:15f133f89a7fcb193850b28eb1580869f1001eee0b506a4c18546197c4ef84fa",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch26/ch26.yaml": {
+      "fingerprint": "sha256:a4ca0244b566eda2437930db0d029392072f1b010f4a365181ef9ea812c23af8",
+      "module_sha256": "sha256:8555df8a5c64f142437562d58de103710ac4f6a83fb68ae0c34c015b96dd039a",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch27/ch27.yaml": {
+      "fingerprint": "sha256:4b4b1cc0bd06e6f29510848009873e4b694e4edf05cc2db46d71f9abe979ab14",
+      "module_sha256": "sha256:26e56c1f58b1be7149658dc420fb6f5f1a30276e084fbbf0bcfcb2ff49bc575c",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch28/ch28.yaml": {
+      "fingerprint": "sha256:5078d01fa7762a58c5eeac5be58e2f40a28c193d72162dcd3f664a07e10aed15",
+      "module_sha256": "sha256:4202b99971dfac88b1cfeb38b2e5645bec2de4604bbb7a2808e10ae9a73f0e6f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch29/ch29.yaml": {
+      "fingerprint": "sha256:e6139ab234823014ebcdaafc3fe8da6c2a5fb2f2d93bb8ebc50ab04b95e65272",
+      "module_sha256": "sha256:6b113f3eb5d922a23ab6c366b8ea866e5aef52b622db625aa9c13e5caaede023",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch30/ch30.yaml": {
+      "fingerprint": "sha256:ffac5f443078d85f0a56e6993be7be5c12205a7ef93f44ad726f6e223500a23b",
+      "module_sha256": "sha256:5a86a1f5615b28847e752d20c93169f66765c7370fc178c72deec81c8bb964ca",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch31/ch31.yaml": {
+      "fingerprint": "sha256:0f1fea2a972b35e599125815f862143f01a6a619c5a5c962bde3cf4cbdecfd21",
+      "module_sha256": "sha256:155ef6d8d9f48d5a681d47a171702174ad66c1825ec1fb44a4e25bb8b009b630",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch32/ch32.yaml": {
+      "fingerprint": "sha256:dd6473f0dca15f01dd1acb7674d3992dcddef1f5de9517d74f3c70d334c1cdd0",
+      "module_sha256": "sha256:d96e49cd829cdd908b09aa9cd315cd6ae3cbfb1e0fb9ac3a317a2c55d1cede42",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch33/ch33.yaml": {
+      "fingerprint": "sha256:6bd6c4fdca07e7ee444b34915e209c1c55ae8b166f72f321c0e716b1d09474dc",
+      "module_sha256": "sha256:9cebae2c8f6d9162f4c4b194bf1194e5763960fabc6068ac8d4dc010f936acaa",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch34/ch34.yaml": {
+      "fingerprint": "sha256:53d42a411038cfd8653e8f7e3fd7ec0bf5eea1a5e757baab44d43e6ba3657601",
+      "module_sha256": "sha256:10d0c51bc93d60b82598a54c51c60fb3eafdd74e36e993efa9248477aa49a1a4",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch35/ch35.yaml": {
+      "fingerprint": "sha256:404375245726a217164089c5ff4812653bb547bb7d6ee9d78ad6873fd87e4e96",
+      "module_sha256": "sha256:efe5f8c3084b24baa1f5cbdea45aa070a215fa845f21a7831d0be2963c9c33cc",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch36/ch36.yaml": {
+      "fingerprint": "sha256:586dfcfc7126844de219490573689e3a0ffc228e85e688188347e8efb69df3c0",
+      "module_sha256": "sha256:46e4a6619d9775009cdb44c6b3d8e4545d64e4881c0f7ef0bf4dcdef48608ef8",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch37/ch37.yaml": {
+      "fingerprint": "sha256:c38b9ba915b7a3c7856e73edb32d7703ac7187d6ea1797cc5363c914cc246c03",
+      "module_sha256": "sha256:fe2c78e0ba29b7451fe9715e65d2501b24b3555650ff40aacdf14a6ddd87d14e",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch38/ch38.yaml": {
+      "fingerprint": "sha256:90d92eedecb13a0fb73c7c5c918c1e2073998f9ac2a816219dbfb029abb1b896",
+      "module_sha256": "sha256:9b5e0cce6369df9095f1d4066fa929d092a26a2ad568db08fd7dfe29aaf1cd7d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch39/ch39.yaml": {
+      "fingerprint": "sha256:736701ec469f8d2faed82bddaeadd7d6a2197cf38ae330d4a5ebb7adb135e686",
+      "module_sha256": "sha256:71cce18ced811161c35c7b3ddd0e0f2ae2e6eb54c93add4281641b0a550abe63",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch40/ch40.yaml": {
+      "fingerprint": "sha256:82483f11241fc5c33238b5f6b947f1983ab42171eaf35a2063f88b26c4939ebb",
+      "module_sha256": "sha256:2e4f6e7f71527fa96b49cb98c2ecb39fdf0118febd0f81ce9c7e83b53f00932d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch41/ch41.yaml": {
+      "fingerprint": "sha256:72d07acc865f905145fc2a77fbe2a2654b0ac63d271c50bc4b32c13e2b5fb893",
+      "module_sha256": "sha256:33c7607227ec295c5b4b6229e845f8711490a14e5b34b37bf4df7a6348699270",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch42/ch42.yaml": {
+      "fingerprint": "sha256:56cf694ba7bdbebf780521f16100a9bafc5d630841a7337cfc5cd4628d673386",
+      "module_sha256": "sha256:7cfc53d032b0f152a92f90366724ee30c869b4bbd870fb246e85469da4c9e229",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch43/ch43.yaml": {
+      "fingerprint": "sha256:47953891572d4c23cf9bb6b85bfbb1013595088df1227da2a50bb57ec9a4613e",
+      "module_sha256": "sha256:dff94678ae06de15c96c532b3be80bffe3b7b473a2604cb7c6073da419e4e4e6",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch44/ch44.yaml": {
+      "fingerprint": "sha256:ff710470a228a2b0b255536639057a95d1038be5cafaad23ba87f079b284c13d",
+      "module_sha256": "sha256:32497bb1c98427575c94999c059d722a94e59be06561769ffb8841af4ccf907d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch45/ch45.yaml": {
+      "fingerprint": "sha256:2707f43f8f15fd673b82303b42eab7008833d6ba39a7e7a06ab683d11b65b331",
+      "module_sha256": "sha256:144089fd18877beb3c296dfb4c1a755c5fb85012b0ff70fd53ccebb461804eb0",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch46/ch46.yaml": {
+      "fingerprint": "sha256:0af9be0f2e864473f2dd528e0c162084f8581b69e36d3aa2318c0a87519e42cf",
+      "module_sha256": "sha256:7fdc329bd30e1c865add9d626c9aa8f2b96ed5d6df031d0deb47e60fd0328f06",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch47/ch47.yaml": {
+      "fingerprint": "sha256:82e5cb516f27426d3de37099ccd37e66a9673a772df2aaa001d15316e012be9e",
+      "module_sha256": "sha256:15a9f8ad2a2c0c2548349b482e58475cf82571ba48ee1870cb2495ceb941a65d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch48/ch48.yaml": {
+      "fingerprint": "sha256:3d5a6d5f4d3578226490f692a3c51580933316a9edb19aa62aa4b67704af2f3a",
+      "module_sha256": "sha256:d7b92b1764ab8a3bd5cee9c2ca539624d14ad25344e6c751ba0a84a5495f5d00",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch49/ch49.yaml": {
+      "fingerprint": "sha256:d342062ca4933769d4f994348e6ed02d2c29884f2bb2247ce75cd74b4f24f141",
+      "module_sha256": "sha256:e7e6c539fe405cd851eea8756c0734eee2dd3f6f24b9ee13caac092a29d641a6",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch50/ch50.yaml": {
+      "fingerprint": "sha256:b3effc2b480dcfe98e431f8ed18b1ec6878e21f1394b2d303c0d6aff81b5db5b",
+      "module_sha256": "sha256:c772b75dcf33035fd63d187e12669efd746bb55e00c04fc5b93a1db8af7019f9",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch51/ch51.yaml": {
+      "fingerprint": "sha256:0651fa59247a8773cd6eeea9f23a940815ddb7eaa346910dc6018bc6427f2af1",
+      "module_sha256": "sha256:98fe1a0febc66faaa8abe25e64b6c15b26e668062e143bc23681b369ead37689",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch52/ch52.yaml": {
+      "fingerprint": "sha256:3bc415a0e1ba06181b6146a14c867083051b7389edaf98199c9c71afdda7d089",
+      "module_sha256": "sha256:942ff051c9d05a852dbe5e1be4f2b45a958541d33e7f234c18062b6cefeffaad",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch53/ch53.yaml": {
+      "fingerprint": "sha256:93e6a91dc102446985737eb2d1fa5b2fb8047e3d16d34c996ff39d88facc9602",
+      "module_sha256": "sha256:ae1258fd5313e5904760a517cd3aa6d29cf7830c8ab02bd5c4baee3e97661f1f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch54/ch54.yaml": {
+      "fingerprint": "sha256:8bee2b51431b868cf84c219eada0fec8e5a2408b80c75ea498d86a100440b0c8",
+      "module_sha256": "sha256:3fdb38f54f4690f300f40de018945e080d1314181b51c08f17f159abba40b0a6",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch55/ch55.yaml": {
+      "fingerprint": "sha256:2c410c9099ffc5081873ae4701c9ccef752a463480b2e5ce4414c9df77a611e5",
+      "module_sha256": "sha256:a1124ff9bc790b3deb0b839ea3c6bcb0765f3bfd0d133a1d34fb960c49309eda",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch56/ch56.yaml": {
+      "fingerprint": "sha256:98503e1bed2a73cc4511d17b0734774a19695cfe90a968fb21b68c15126d8a59",
+      "module_sha256": "sha256:1f79048ad28f338fff16d1fd5cbecf2c89e1db88d73c3693576c70915bc70564",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch57/ch57.yaml": {
+      "fingerprint": "sha256:cfa0e6ccb4c65c4d2b03045f92575bb74e646074faa98f08d6fc2b5f9069f79e",
+      "module_sha256": "sha256:094356dda51b84f5cb305e6cf28a2185e43c2d5b4c0801c16c2e06e612741314",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch58/ch58.yaml": {
+      "fingerprint": "sha256:9085758589c465e72b0c67fad3d670ca76e668a6f20d4c1d784ee25f23eaceee",
+      "module_sha256": "sha256:65139027229e57c1edde41a7800864ecb57c43fd4054c5e68a875330b9e6bab4",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch59/ch59.yaml": {
+      "fingerprint": "sha256:0a1cfd26aaec300ba3eb038de3f1943226030e723e373dc018cb0ec5a49a0af9",
+      "module_sha256": "sha256:4e7a9a302761032e7dd3d77b8c46403435c8350188c2da3b11ebe2a09aa920bb",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch60/ch60.yaml": {
+      "fingerprint": "sha256:75c3cdd6d145b5b89042414b361c7e93656855f225375e24a04fcd693f4c8564",
+      "module_sha256": "sha256:7e5f93efa0b35023ad6af596033e6d8e6e6b37845253dc219fa9ff80b4d56410",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch61/ch61.yaml": {
+      "fingerprint": "sha256:d071137284c7a254c0afa52e1ee3c9e8ccd9868010b36fc9442b19ad3bf00943",
+      "module_sha256": "sha256:6eac0bb84d39482c9a5cf42b0f8871e50ce833e83cde0f38b7105779ae8859e3",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch62/ch62.yaml": {
+      "fingerprint": "sha256:2739fb5120236b1b7cd708e0a2a63af42f70a879a04f99c7731bd66c32ef5c52",
+      "module_sha256": "sha256:0b8ade106330aeeccb6e779a1ef22e10f29c0fa127fcb18f4e1b0d3595122aca",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch63/ch63.yaml": {
+      "fingerprint": "sha256:3feb6494ccf7f1288c60442f8d0b223a66ae38833cd099f8474c75fa2810c4e3",
+      "module_sha256": "sha256:0974afb8bcf8be71d53d46f7b0f3a76587d7fc01b7d9584d04706e95ed7fcd3a",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch64/ch64.yaml": {
+      "fingerprint": "sha256:46f0a50e4935247d60876d49712c290f69d7fa061bcd2cd70d0b14c9534ac60e",
+      "module_sha256": "sha256:0e8283c5c53025f3d29bd0b3e7da5a2a9a10ce6340e903b44a165014a527721d",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch65/ch65.yaml": {
+      "fingerprint": "sha256:9dca204d1ef939db449d39eaf1c48f148023d1fe31145a9aac60998dab8b011a",
+      "module_sha256": "sha256:8d24fc58dc9faa577d493146f2db5c6a4ce406590069ba1bdf83507cad350005",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch66/ch66.yaml": {
+      "fingerprint": "sha256:66c81301284dbf24fc5bc4927fde64224f6783fde8fe491bb0812999faecc61d",
+      "module_sha256": "sha256:5ff7477933f283459c43cf7073a14464bbe0773c4d7469cbd631f4844060d878",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch67/ch67.yaml": {
+      "fingerprint": "sha256:b645c03a1866b987e409c8c3c1cee314243f6cde2403564adf7c96613dbcc35b",
+      "module_sha256": "sha256:110ff551b9a92c1f830bdc661c68f1aed7cd9e5034801c10ad475826b58e22db",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch68/ch68.yaml": {
+      "fingerprint": "sha256:3cf94a11e86a5d4bac69d53b8500b71e95504d609ab7d222f722bff14bdcdd64",
+      "module_sha256": "sha256:a0140bb28e5c6c2aa2cd11c0208dac89e242c658c75954a20447145bc9328298",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch69/ch69.yaml": {
+      "fingerprint": "sha256:f0f505a40f5b51b21a3588ec8129b4d4a5db376608e63938247278a1b5cff9d1",
+      "module_sha256": "sha256:8526501ca78421294d97191583dc600b306a15149dd335815613804894cdac71",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch70/ch70.yaml": {
+      "fingerprint": "sha256:65cd6e5eb0a7a7b1d3194f59db4a16383777bea050dde377856336de138ec67a",
+      "module_sha256": "sha256:226297491693946e203fc9fe7f07791fde8357f455d4cfb674e899e26139b48b",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch71/ch71.yaml": {
+      "fingerprint": "sha256:a7cffbf5b428db4fca557160243f839387246b42c91cfe82126f0649db09fb22",
+      "module_sha256": "sha256:9cc3120f3d1c56d3c4118dbd8fe4c94cf68a479bbef9d7201221f01225e10205",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch72/ch72.yaml": {
+      "fingerprint": "sha256:508c47e8953dd389e44d8225944501c2846ebdd1700e8424d42430e6710d1777",
+      "module_sha256": "sha256:000e157deae4a74f28b3a60971237d1b4c63b8f99322cdf16b09982a5b1ecd4e",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch73/ch73.yaml": {
+      "fingerprint": "sha256:1012245184d569fa3b95a970bb3a66ac0f33ed56f98e39643dee62c38da5392d",
+      "module_sha256": "sha256:728679a3d2472158d7e3a8c3329b51c0b034ba609ef97ce8efee8d54b1b9f2b7",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch74/ch74.yaml": {
+      "fingerprint": "sha256:fecd3b3e6ba7709f15d500bb3098ede01eb79e0f3de9e0e07629149ee88bec6f",
+      "module_sha256": "sha256:2a1642e354440029f8a25aaaa14585e8e443cc5af9566b9c93cccbba4400f683",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch75/ch75.yaml": {
+      "fingerprint": "sha256:77bab4008786d9d5d6388a0176d58e6caad16996c705d9182fc76b8c20099f75",
+      "module_sha256": "sha256:5424bf696e83d33035ba5d601ca5b5b076d47e1aa6b761e905de88e18d0a3581",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch76/ch76.yaml": {
+      "fingerprint": "sha256:9bc0dc9e7f8d816ed7c2852b7293eb56b4ea9ff14296e32896ba51addac38f3f",
+      "module_sha256": "sha256:d9a094a31d5bc94d6456d6b6e58e569b8a765c7304de651e5a6bbecfec1aed21",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch78/ch78.yaml": {
+      "fingerprint": "sha256:bddba1ad93b205a061636c0ecaa40417106777a6fcfd603dbc254983eeb0ab03",
+      "module_sha256": "sha256:15dddbbc38f92a35590a45f432ace2d1c8c5726ca6faa576bac37630d8a45226",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch79/ch79.yaml": {
+      "fingerprint": "sha256:801b6a81194f8335d3655e788cf274af940f85fc3c423815a3b472df3c09e23c",
+      "module_sha256": "sha256:463b936851a2abd3b9bcc2d70e8ab46f7a8b09e6474d429f53ca20e10936e5dc",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch80/ch80.yaml": {
+      "fingerprint": "sha256:5ea14e1a4125e23b18b67acfb043ca56cc46a1ddc7b2819a0b6b9192fee696a9",
+      "module_sha256": "sha256:34996b6ceb9c41c6ffe40b676544f57286f6ff25ff6be8c6a25f0d580c0783ef",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch81/ch81.yaml": {
+      "fingerprint": "sha256:e29ee9871af4d3bba811c03853fa71c847fbf94ce29a8ad8ece3aed243f982d3",
+      "module_sha256": "sha256:199acfe465f5ad50519e63fa221977d0dec866929d2a6dc8d2fdbbd20ce9bde3",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch82/ch82.yaml": {
+      "fingerprint": "sha256:8b1fb1c432f22724544d1cf234dc4bb8059b1ee647bab21f6b0fcafcdef52fd4",
+      "module_sha256": "sha256:e6d4dc8a83480fd721a4943a6dbb30a5708ec83e3767be54ce7a4d84507d408f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch83/ch83.yaml": {
+      "fingerprint": "sha256:baa7cb3189cd01b5b453ead91ee8a2f59cd798bbdea038d4ffd23219cc53cd7c",
+      "module_sha256": "sha256:3b28b0d2d50cd8010566800d85aea6511f3bb194ef98e1e58fbca24323c23199",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch84/ch84.yaml": {
+      "fingerprint": "sha256:9484fda92aed05f853223bce9399d4307833217af212f474fbeb0bdb6b4a0140",
+      "module_sha256": "sha256:6b6b500ec468654020d3ffe0513818f27e0a6936309885a83a5a942e06b0c141",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch85/ch85.yaml": {
+      "fingerprint": "sha256:609d24913c48af1df98fe12b2d8ed2a8c92805a7de976510451b67ed5ec37ae6",
+      "module_sha256": "sha256:2c2ab6ff0f8c280424a1a7ea00f3c4c855ffc857e4214dfd2512401f0c799e16",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch86/ch86.yaml": {
+      "fingerprint": "sha256:051837f8140fd3885913231513c1c0e5b622cedabfeffa19bbbc020046d23f85",
+      "module_sha256": "sha256:2ffcb67e312fd11f634e42e311e52f8534d8a4137c404c2fa1ece9506b3a6dcf",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch87/ch87.yaml": {
+      "fingerprint": "sha256:fc6eeadb5334eef9b00d1b219ef3a2e992aba3ba507b4623536e1790fe1d6b0f",
+      "module_sha256": "sha256:6f82988b649ec2b103397c67e286a69f46c00fcddee564400c1c605adf851f1e",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch88/ch88.yaml": {
+      "fingerprint": "sha256:2d4c8448d40c08697d6e62ac49bea3e70bb670d45311764f50ef3207fa7548a3",
+      "module_sha256": "sha256:c7431254a1599722d6eb7010cbf9cf50d76d5348bab185d77717338d299b91fc",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch89/ch89.yaml": {
+      "fingerprint": "sha256:f7a794e0c63aedee2586106424fd0d21ad1d6b797a8770c7a5970657cdbffce7",
+      "module_sha256": "sha256:fadae4210125dfa381d8d677cef5d17600d05d16a74ce60727a7102c2bfedcdc",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch90/ch90.yaml": {
+      "fingerprint": "sha256:b50fc77f3633ee73d6efface2a650da968c2892695e01c4fbed3a4264c95464f",
+      "module_sha256": "sha256:a609b16bc9c95dc5b319a4fdf45ce003792835f9f791fea5016353f2dd7fec65",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch91/ch91.yaml": {
+      "fingerprint": "sha256:df153dd7e8e4a21071384be5b7df07bbe98df2b8e3d1043931322f04e5e574c6",
+      "module_sha256": "sha256:6a229594fd1b02ace0f603971feba526fa31ddf26f816d507a1854dee010d3bf",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch92/ch92.yaml": {
+      "fingerprint": "sha256:c6bdc50f6ea39f7292ea3ddd18f195a23d63a5ae62b3606670d2b67db9add415",
+      "module_sha256": "sha256:f9914d7a95e1a05605d7b71d0c605883e7ad4785488cee9ba6b99bb8ab44a51e",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch93/ch93.yaml": {
+      "fingerprint": "sha256:f8f1a9908aa96e5c087a14bbe5a42776ee8ec47f492f0fd66a080fc4838ebb67",
+      "module_sha256": "sha256:682fdec4e1c6b51c62a275b70778ec65c7271cfbf292fa7497b7f868e64e6a4f",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch94/ch94.yaml": {
+      "fingerprint": "sha256:7c7492b714427ffb77a3b13e5f8ee0431fb323b3e59c19277d6f266f4a47c3c2",
+      "module_sha256": "sha256:38beb674441da532e00bb444f84e321cd8243d5e644d7167cd3cfee3b42e9eb3",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch95/ch95.yaml": {
+      "fingerprint": "sha256:f17d997f207ac832b46695a8f86d69431b639e92949f3a71d8e0571f7747ee13",
+      "module_sha256": "sha256:ff073d0dfd1168d6389fd336cb0ec0508fdfe491b54257590ad3ed38de79bd08",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch96/ch96.yaml": {
+      "fingerprint": "sha256:5533b24b0169412516ce640eb7c566c1b33cf8e6477b102cd0ab9b990478df0f",
+      "module_sha256": "sha256:89cce0ef80dc8a07dbe2152d6ca3d29e6258c0649f3212ffbaa19d746deab158",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch97/ch97.yaml": {
+      "fingerprint": "sha256:8dbab890cfd1c49c0897f6afa208816018b99d7d9cf8e7c01c5dac22ab005c80",
+      "module_sha256": "sha256:f447ebde3015985951e631d00944337ad9ff62162a04e3bccb9ffcb6ee488e03",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch98/ch98.yaml": {
+      "fingerprint": "sha256:7fd878bfbc2a9d2782ee33fe3b4211b09433ffbc1027ed67312bae5351dd7caf",
+      "module_sha256": "sha256:c372dfffc35c5e171f20127a0075eac145fd938d5e59b65bc0a20cdf23c83c4e",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch99a/ch99a.yaml": {
+      "fingerprint": "sha256:700dde54d49194bc3ec471232da04494fcb046903709ce7e0488b74dc4554479",
+      "module_sha256": "sha256:39a1f1ffc8fe0b7bf5f4f108179d821c6c2396fd741b9353219db07a35e64431",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch99b/ch99b.yaml": {
+      "fingerprint": "sha256:5f92376975161ff79d315a03fc554e8d7dfc100823fad7f6e5cbd7834ab14dac",
+      "module_sha256": "sha256:e6086ebf5bef2c92acb554a17d1a35c055108ab87062799e8b001d36b898238b",
+      "passed": false
+    },
+    "us/policies/cbp/us-tariff-schedule/generated/ch99c/ch99c.yaml": {
+      "fingerprint": "sha256:cd923c62ab3d1d103e019285b5a7f90b1c05b34c8e3a19efed715edf8fb9d87a",
+      "module_sha256": "sha256:b1982def129a9a25fb2ad9bb5211f2c9a03c1b4db6cc20cde7f900875a0dc10d",
+      "passed": false
+    },
     "us/policies/cms/medicaid-chip-bhp-eligibility-levels.yaml": {
       "fingerprint": "sha256:a707376dfce41613d6ce1d1393bd4ec4ec76a8242bf8b87941e2c065fd131f6b",
       "module_sha256": "sha256:ea0071602a4a4441e584a16bdbab3d8a3c36b40b7cea1151165533669423f5f5",
@@ -10964,6 +11493,156 @@
     "us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml": {
       "fingerprint": "sha256:707b5a2be330d73a622938d4438a519f4e691af294a86eec2bd6d4af0d92bef4",
       "module_sha256": "sha256:2e4708b8df906b506f07d091fe93dbcc6aefe603a31500502ecc270d436e9f2e",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch76.yaml": {
+      "fingerprint": "sha256:58cbf650a239f289124b5b5a2905d4163e852ad053f8a282b324d26cf1f8b325",
+      "module_sha256": "sha256:6063214e192f4d602b7a913d92985a1c243b76bb143239d486cc5eec2cc5d497",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch78.yaml": {
+      "fingerprint": "sha256:8a9d201d8e6fe63eb5daaf5139f4effa5873dc62363932da1b925f6ddde1ec9b",
+      "module_sha256": "sha256:a538f7e4d4f7b514785b1a4b513ac15435c9feba4483290dd380d18b61d13ada",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch79.yaml": {
+      "fingerprint": "sha256:2ac567ba0cd087884209a1c56d6f278b9e141545d662d30cd58a5ccd72952265",
+      "module_sha256": "sha256:2ca93d2a9fbe71d318ba073c643c499039e0239eda537f6ca2d7bfe4f57fa3f3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch80.yaml": {
+      "fingerprint": "sha256:e5191c86ee68553509b3e1542a19b627a4abd7b6e24441fa5d7b485dac13c390",
+      "module_sha256": "sha256:3e977b562e139e279190fad358f5e84ece53b90324c01bb60ee869d030c670aa",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch81.yaml": {
+      "fingerprint": "sha256:e8670d07d6753460c852fcbd4c33b48cd7d4561706e60e652b64a767ad44e8ca",
+      "module_sha256": "sha256:5dc5c8ae62b7ed8dcab94592fdcf7df072c49b84ab0b9a357274da49a2724da0",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch82.yaml": {
+      "fingerprint": "sha256:0ad426126f3a225b1212a52d7a180941ccc5fba446ebb6ff464ba7b8ef24a432",
+      "module_sha256": "sha256:92372e0ddbca110bd6663c15aa51c0ce7794a943d862253a828671c876e74837",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch83.yaml": {
+      "fingerprint": "sha256:532ccaca8b43668b29ed4a6970f4cdc0b1b2ec092a6f744339521969fe5dcdb5",
+      "module_sha256": "sha256:1db6ba26c9ab43df4482f386b99a46983ba1b2112832616d4aa4c52ca3e0cc9e",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch84.yaml": {
+      "fingerprint": "sha256:3f814fc3b6f4863d1c9a920c92b9121b40cc30c65c89b92d6396fdbe8165457d",
+      "module_sha256": "sha256:c9bc5a7df4bfadf5af6c648c736e678090b87f47d12b7f1fae9bd25a87780c64",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch85.yaml": {
+      "fingerprint": "sha256:d7fc99f109619ca127fd9cd56f7c0acaf07154940a0a7867d80579ec74dd550a",
+      "module_sha256": "sha256:054248e288cb6fe80393b57ef96ee20be048374cb89c663d43b9cabafb3990de",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch86.yaml": {
+      "fingerprint": "sha256:6f873116488479a08d1fb24873e712d4120f86694aa7de36786ff60f9d75aa66",
+      "module_sha256": "sha256:b362f1d25c06b976c661cece7a91a824f71c32ec541c2c385db55cd86df28034",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch87.yaml": {
+      "fingerprint": "sha256:c2a13391430ba7f15901af6d8900ffb450c68def7946abf86adb005f5b4a25e6",
+      "module_sha256": "sha256:79e408f42f2541d0ac9647b3a3b089f5ba2c7ccc201a0ab541fa0a23814d8146",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch88.yaml": {
+      "fingerprint": "sha256:fb5e92f6d6b556007cad6db6343f1783871cebf9a4c33d7c65dddfcfd7c99146",
+      "module_sha256": "sha256:552e3cacf0693e0820b17721d8812684b79902b04844d9ed189b7f325643894d",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch89.yaml": {
+      "fingerprint": "sha256:d14823155de5d0c6d6a72fd6736a8578dfd89dacf2c8d4d215b5df8db3f442a1",
+      "module_sha256": "sha256:818373948075984ac8b59d69b970d2ce04ec8925ac16cb8125ccba7fc9ed35ee",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch90.yaml": {
+      "fingerprint": "sha256:aab35066c16f33895e511eaefa0a94c1961e5adfe1bbc9fe20f8403346c0ed8f",
+      "module_sha256": "sha256:4a708a3116669acb4640be10e4e06a3f74588985caae93ba40c82ea1b17207e3",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch91.yaml": {
+      "fingerprint": "sha256:359b695551b18f2469c402f6c1a249e6160b47ef5798e2a8de6ee7f4fc91c095",
+      "module_sha256": "sha256:9f771476f96b1b4bfeccf9cad3c6553a1293a10997357e2972ad736c586e66e4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch92.yaml": {
+      "fingerprint": "sha256:5c01e35e7e939e7615b1e4f6146a7956c68f2cbe16b97ef0c127094675453342",
+      "module_sha256": "sha256:a4002114e144f24933b4a7f8d53ebee5f556d5aa09feada578ad6a82a7f29e07",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch93.yaml": {
+      "fingerprint": "sha256:70a07f3a5a7d963edd2e9eec9a3b22a5927a823e1ab8cd93be1bf46599272a81",
+      "module_sha256": "sha256:a60c5e12ed6fc58c149217c82aaa2813ef2b138288464a5a3d4c3d5cf0c0d995",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch94.yaml": {
+      "fingerprint": "sha256:8f0672c4c02bbf1f45d79022cf14241b95aa5c89503e831116d0c6d0778e48c8",
+      "module_sha256": "sha256:6e580417d51fa8786e68fa329ae67e7365a2d5b5d733a61ec544eb7e3cc0443f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch95.yaml": {
+      "fingerprint": "sha256:2679c9c0298de277325e4784163d0ff9a5c3f36b2a698032a82d1f26e93d212f",
+      "module_sha256": "sha256:c0e93c5df84cf68a9a1c287a44007e144cd9c90978a536655311c899c9797720",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch96.yaml": {
+      "fingerprint": "sha256:72b95d2e973699713ef84f3ed61720659bdf4c38f961c8777c6c03110c42e6f1",
+      "module_sha256": "sha256:66f70517ac898a70413f134f2efe8e78fb8be7eabd91235693b97de1398ea942",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch97.yaml": {
+      "fingerprint": "sha256:8e9ced092890322d18432dbf63a7946cae0666fb3c87dd2527a6f905623bd58e",
+      "module_sha256": "sha256:2ceaa4c8c416bfde007f9ff9b3ab531faaed2f4ad6db2476f5a58e58d17b931f",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch98.yaml": {
+      "fingerprint": "sha256:58fb1f045d00624c30e59656163c14cf5a6b582eff7110188d0fad6ff13cee75",
+      "module_sha256": "sha256:7a2559a3ae4a8757b3c32e5bd49482bfb6c8490471a3a490cda09a42c6bb1d17",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch99a.yaml": {
+      "fingerprint": "sha256:74a0123ff1c5f9c13546b6994419ae6ad3c2aa7b1fe31f55efa8fbf063ae80f1",
+      "module_sha256": "sha256:b360fd7ce0daa39c7479da0c9d2571fbb3809dc5574d32b0a1aa9b6de63ac851",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch99b.yaml": {
+      "fingerprint": "sha256:d3af3b1ef488ebdbed2ccbd4fd1f977384723bc455f8baf12c11085ec32b0d68",
+      "module_sha256": "sha256:1d00631fbb0dc510700c43cefd1575a1802d87105de02ba44948eb8213b63bd9",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-duty/lines/generated/ch99c.yaml": {
+      "fingerprint": "sha256:8b37cb5824db93f34a125436f10de12d1f701671d65905363230cef82bf30158",
+      "module_sha256": "sha256:08d4a26940219d468f28ca3b700068ec292a3af7813e29e542c5bd104924029e",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-incidence/generated/note16-232-steel.yaml": {
+      "fingerprint": "sha256:1d283baace2e4cbc3fe58e0b658900e9b75ffabc1ae05c2c2354de32ef56f234",
+      "module_sha256": "sha256:8ec8adf882321fe51240606a1d3a85322e4a9b7ecf06ef3c3e8bee19ffec21f4",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-incidence/generated/note18-201-solar.yaml": {
+      "fingerprint": "sha256:c62af58b2cbdf6b806c5cc4c4743ae9bf52c5945ac240158b37e0e0e8f1c9bd7",
+      "module_sha256": "sha256:418b3c5255b3157aff756a8bb8852b38393d31f3be19322236c40cc2b609a2ba",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-incidence/generated/note19-232-aluminum.yaml": {
+      "fingerprint": "sha256:433ff922cd38bc67e6703e1bee6958bce61a1be7cf0f45e54e9e9b59f3bbf937",
+      "module_sha256": "sha256:937bd0cb5ca030d247b09e00f75b9b8915570e3534fccbe33286ad55e1933366",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-incidence/generated/note20-china-301.yaml": {
+      "fingerprint": "sha256:0d3799302f0db0f97df2f17d67a6bddb006d1160e95aa132024be972244fd738",
+      "module_sha256": "sha256:6971e00c441f438c89069b4e18f80cf1c04e5d668b81d4cbad5faeda4402ebaf",
+      "passed": false
+    },
+    "us/policies/usitc/us-tariff-incidence/generated/note2aa-122-exemptions.yaml": {
+      "fingerprint": "sha256:2cf6b9a57e2fa3d61700574e2436df1b7a43d2b52a73a2c9ccc088f37799a17c",
+      "module_sha256": "sha256:41361233c700e0e6e697d4c83f4aac4150a57df0703db90fcaea4674bcd841d7",
       "passed": false
     },
     "us/regulations/42-cfr/431/213.yaml": {
@@ -13781,6 +14460,16 @@
       "module_sha256": "sha256:275124f4d8bd197b13074f85192bcca7936fdb6d1a0e3d4f4fbae62b43516c0f",
       "passed": false
     },
+    "us-co/statutes/39/39-21-109.yaml": {
+      "fingerprint": "sha256:22d1d4065935a4fdb875a8e04ae4f2b2a8cf499574b1f60b6e4fdb97dbf96930",
+      "module_sha256": "sha256:7caaf497a48ef5536aa05e6100ec1bc453669adc074359e0d43922b0be28c736",
+      "passed": false
+    },
+    "us-co/statutes/39/39-21-110.5.yaml": {
+      "fingerprint": "sha256:9789e2878d88e073659260b6a4032309706045a7695ef88c1229885d83aa9e88",
+      "module_sha256": "sha256:bb9939f27e27541be17d8ab8e96ea42c04e587eabf1beef3ed0e77659ced5446",
+      "passed": false
+    },
     "us-co/statutes/39/39-21-114.yaml": {
       "fingerprint": "sha256:3835ca6c7d6a9f8515bcadea92a3eecf1fcd2972ac4919f5e5d876f2db9ed743",
       "module_sha256": "sha256:d26c165129f675b64b00e019b4cb052da74ac302466e7111cc2809e39e22ccea",
@@ -13996,9 +14685,19 @@
       "module_sha256": "sha256:a2515650044d65e67a4b8a4393c58a358dea40ce5d9c77c36fe1faff78e4e249",
       "passed": false
     },
+    "us-co/statutes/39/39-22-557.yaml": {
+      "fingerprint": "sha256:5663c0c895a2c52d67400753132b69674c8d5959f961981ae930e0b34aa39b56",
+      "module_sha256": "sha256:f9a750d40c56f2ab547df85907d7b7876f973542329996c0779afcd482f6b337",
+      "passed": false
+    },
     "us-co/statutes/39/39-22-562.yaml": {
       "fingerprint": "sha256:250e65bd0c2b2c0e47ae5964f70a7fa57edfa26ec906b182218131d1c7f5af2b",
       "module_sha256": "sha256:682e53e7e8d677093f3b91296297611e9fca245782b579cc35098a488b01fdc5",
+      "passed": false
+    },
+    "us-co/statutes/39/39-22-568.yaml": {
+      "fingerprint": "sha256:0b968cbd66532fe4b4f591b25351434cfd692eb0f892b22a415a1e8b7717fb47",
+      "module_sha256": "sha256:24d3cceda26df2a2eed8761d3f0570530a18416ac5a4bb01bb137962662c4da4",
       "passed": false
     },
     "us-co/statutes/39/39-22-605.yaml": {
@@ -14049,6 +14748,16 @@
     "us-co/statutes/39/39-28-103.3.yaml": {
       "fingerprint": "sha256:12fa73513bd934b5f088b07ee1b2503b7588c77f1780d20abb0d89b84e6e5f05",
       "module_sha256": "sha256:49f4cec1deeb168ec077eefec0510181202d3121c030c0f876f7050fc5492206",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-107.yaml": {
+      "fingerprint": "sha256:492b88b50a4bdbd81ccfae613e2a456c76426e00fe74a7ce5e4b90531503ef62",
+      "module_sha256": "sha256:12af030b18fffb2c60fde5d1883f1f39d1f7bb12e6615932ce013bdc66b06950",
+      "passed": false
+    },
+    "us-co/statutes/39/39-28-108.yaml": {
+      "fingerprint": "sha256:6ee278d7988a4fb350908c3c7cada67007c7415eb027eb3ee92c264036d22548",
+      "module_sha256": "sha256:438a26ffe6a8280668d1161152c8f7eb081444588c49ecf6c4afdb5c2e0c1e47",
       "passed": false
     },
     "us-co/statutes/39/39-28-112.yaml": {


### PR DESCRIPTION
## Summary

- registers evidence only for every unwaived validation failure exposed by the encoder 0.2.1690 hardened migration census
- covers 1 Alaska, 6 Colorado, and 130 federal failures (137 rows total)
- does not modify `known-validation-gaps.yaml` or approve any waiver

## Provenance

- hosted migration run: https://github.com/TheAxiomFoundation/rulespec-us/actions/runs/32046607086
- immutable encoder: `29b30fb7855c7306d9ead9ddba020dea40f938cc` (`0.2.1690`)
- immutable corpus: `60de5efae2a1b1dd58b7c92fa9b73a86bd78f30a`
- immutable engine: `48797e101c093bb388be718c6f5d8fc9d9f94a7d`
- the hosted federal job hit GitHub's six-hour limit; its exact 791 unwaived targets were recovered from the authenticated log and reproduced exhaustively in four deterministic local partitions using public signed-release trust roots
- result artifact digests are recorded in the evidence metadata

## Checks

- exact federal coverage: 791 unique targets, no omissions or duplicates
- exact failures: 130 federal + 7 hosted Alaska/Colorado
- evidence fingerprints and module SHA-256 values mechanically verified
- `python -m json.tool .axiom/pending-validation-fingerprints.json`
- `uv run pytest -q` (87 passed; one existing manifest-coverage warning)
- `git diff --check`

Draft pending independent review and hosted CI on the final head.
