### PR TITLE
Approve encoder 0.2.1690 unwaived validation census

### DIFF
--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -2,6 +2,786 @@
 # time — see https://github.com/TheAxiomFoundation/rulespec-us/issues/396 for the per-jurisdiction burn-down (vendor corpus slices
 # per the rulespec-uk data/corpus pattern, then remove entries).
 validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/396
+  "us/policies/cbp/us-tariff-schedule/generated/ch01/ch01.yaml":
+    pending:
+      fingerprint: "sha256:8040c22ec0071938252745203a1e9aa4f8681e53e6fb7dfc440dcd24637f9ff9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch02/ch02.yaml":
+    pending:
+      fingerprint: "sha256:c11b7b25a6d15e19f74a52eacb36e190dd0d5b3c70cf49a3eb587bfe3d4e9d13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch03/ch03.yaml":
+    pending:
+      fingerprint: "sha256:761b9642ae7d0d3329454e520c1df84536e82902378ae839d0eead89dd9b3a3f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch04/ch04.yaml":
+    pending:
+      fingerprint: "sha256:30aef8a7416b45315c07f206981e2a72f4eb7a859a89725cd6c7087cd0cf547b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch05/ch05.yaml":
+    pending:
+      fingerprint: "sha256:082bcb98cb27c75ec05338f3dd33a734df44db6a08701d80d391c71901773a98"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch06/ch06.yaml":
+    pending:
+      fingerprint: "sha256:6ee516eb036771ac8587568946e729f79a44829cba1cf34fdc08eb7de3cee339"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch07/ch07.yaml":
+    pending:
+      fingerprint: "sha256:b2447f97ec02e6c1c146e1231b28ca090aee24717004c7ad3c02e9c8daf7748d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch08/ch08.yaml":
+    pending:
+      fingerprint: "sha256:8bb16a1e9097fc74503c2de618af6d9054084efec204677a708f66a2189ed804"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch09/ch09.yaml":
+    pending:
+      fingerprint: "sha256:3dd0ea118e8e59b8fdd87e64c75dcd27242f0f11694bdd6e601219b0551f1603"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch10/ch10.yaml":
+    pending:
+      fingerprint: "sha256:d51a18e9a18c772e60b19277ebc87425877a9f92a777fc8b53226221b8e14fab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch11/ch11.yaml":
+    pending:
+      fingerprint: "sha256:d7caaf66d598711ee3ed5a6348efcb9fa7f0b2ca73c18e49f407424dd84aad6b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch12/ch12.yaml":
+    pending:
+      fingerprint: "sha256:9bd60a4f0ab5336b1449b072589ed8ce2840005e1eab8ef6af7b75b817ebfc37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch13/ch13.yaml":
+    pending:
+      fingerprint: "sha256:df2049cc1eb3f2a31a4484abb72cb0685bfee74ab318c3acd368813058288f92"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch14/ch14.yaml":
+    pending:
+      fingerprint: "sha256:cfaf4cd358e3161b04dec1d547d9fba4b8d188e70df4ff6fd2a9ec7727179dc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch15/ch15.yaml":
+    pending:
+      fingerprint: "sha256:8b05f2ab5c6b60cd76285c9c65a0e2844eb1a7994ba675fda0eb23d45dece514"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch16/ch16.yaml":
+    pending:
+      fingerprint: "sha256:78caddf6930873650b3a2a1fd6e73a8ceb5f20e47f8b2610332765083ec392f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch17/ch17.yaml":
+    pending:
+      fingerprint: "sha256:b7365c9c6193f029b3f30f242f8cff1e2f478890e2a2f4c49780c5bb2ee4c070"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch18/ch18.yaml":
+    pending:
+      fingerprint: "sha256:7492671129b671e5e47787f95f7d39de94dca3bb5807cfbf023a2f42428fe60e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch19/ch19.yaml":
+    pending:
+      fingerprint: "sha256:64fbd18d9470532b4088445ea09e8df7fa7bc63208adccbefafd90ef50cec5ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch20/ch20.yaml":
+    pending:
+      fingerprint: "sha256:705f2e5bbd38d94d5ed27dc0fad5dd396ee1071f1505302abcc953074d16cbce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch21/ch21.yaml":
+    pending:
+      fingerprint: "sha256:f6998be6751bfb9d9b9a5781fb90aa3d0bb8af86f9b531c828f28c830b2439e2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch22/ch22.yaml":
+    pending:
+      fingerprint: "sha256:0ceeb78a477c705bfd203294432de13eedb2df927ee843c3d03de148186e511b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch23/ch23.yaml":
+    pending:
+      fingerprint: "sha256:7d149f9f0cc0972b020a4c8efd2448239315fe869562e02e5d6a9b606ac3006f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch24/ch24.yaml":
+    pending:
+      fingerprint: "sha256:af2c3f35c2ea9c8ebe6da22b23dc7b40c09142b2f3fab84c8541bb4e7a460faf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch25/ch25.yaml":
+    pending:
+      fingerprint: "sha256:4746f570db792ff250d8dc99537eeeda3aa87050c6e7176d2cc90c3cc8d9e648"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch26/ch26.yaml":
+    pending:
+      fingerprint: "sha256:a4ca0244b566eda2437930db0d029392072f1b010f4a365181ef9ea812c23af8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch27/ch27.yaml":
+    pending:
+      fingerprint: "sha256:4b4b1cc0bd06e6f29510848009873e4b694e4edf05cc2db46d71f9abe979ab14"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch28/ch28.yaml":
+    pending:
+      fingerprint: "sha256:5078d01fa7762a58c5eeac5be58e2f40a28c193d72162dcd3f664a07e10aed15"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch29/ch29.yaml":
+    pending:
+      fingerprint: "sha256:e6139ab234823014ebcdaafc3fe8da6c2a5fb2f2d93bb8ebc50ab04b95e65272"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch30/ch30.yaml":
+    pending:
+      fingerprint: "sha256:ffac5f443078d85f0a56e6993be7be5c12205a7ef93f44ad726f6e223500a23b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch31/ch31.yaml":
+    pending:
+      fingerprint: "sha256:0f1fea2a972b35e599125815f862143f01a6a619c5a5c962bde3cf4cbdecfd21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch32/ch32.yaml":
+    pending:
+      fingerprint: "sha256:dd6473f0dca15f01dd1acb7674d3992dcddef1f5de9517d74f3c70d334c1cdd0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch33/ch33.yaml":
+    pending:
+      fingerprint: "sha256:6bd6c4fdca07e7ee444b34915e209c1c55ae8b166f72f321c0e716b1d09474dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch34/ch34.yaml":
+    pending:
+      fingerprint: "sha256:53d42a411038cfd8653e8f7e3fd7ec0bf5eea1a5e757baab44d43e6ba3657601"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch35/ch35.yaml":
+    pending:
+      fingerprint: "sha256:404375245726a217164089c5ff4812653bb547bb7d6ee9d78ad6873fd87e4e96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch36/ch36.yaml":
+    pending:
+      fingerprint: "sha256:586dfcfc7126844de219490573689e3a0ffc228e85e688188347e8efb69df3c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch37/ch37.yaml":
+    pending:
+      fingerprint: "sha256:c38b9ba915b7a3c7856e73edb32d7703ac7187d6ea1797cc5363c914cc246c03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch38/ch38.yaml":
+    pending:
+      fingerprint: "sha256:90d92eedecb13a0fb73c7c5c918c1e2073998f9ac2a816219dbfb029abb1b896"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch39/ch39.yaml":
+    pending:
+      fingerprint: "sha256:736701ec469f8d2faed82bddaeadd7d6a2197cf38ae330d4a5ebb7adb135e686"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch40/ch40.yaml":
+    pending:
+      fingerprint: "sha256:82483f11241fc5c33238b5f6b947f1983ab42171eaf35a2063f88b26c4939ebb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch41/ch41.yaml":
+    pending:
+      fingerprint: "sha256:72d07acc865f905145fc2a77fbe2a2654b0ac63d271c50bc4b32c13e2b5fb893"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch42/ch42.yaml":
+    pending:
+      fingerprint: "sha256:56cf694ba7bdbebf780521f16100a9bafc5d630841a7337cfc5cd4628d673386"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch43/ch43.yaml":
+    pending:
+      fingerprint: "sha256:47953891572d4c23cf9bb6b85bfbb1013595088df1227da2a50bb57ec9a4613e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch44/ch44.yaml":
+    pending:
+      fingerprint: "sha256:ff710470a228a2b0b255536639057a95d1038be5cafaad23ba87f079b284c13d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch45/ch45.yaml":
+    pending:
+      fingerprint: "sha256:2707f43f8f15fd673b82303b42eab7008833d6ba39a7e7a06ab683d11b65b331"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch46/ch46.yaml":
+    pending:
+      fingerprint: "sha256:0af9be0f2e864473f2dd528e0c162084f8581b69e36d3aa2318c0a87519e42cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch47/ch47.yaml":
+    pending:
+      fingerprint: "sha256:82e5cb516f27426d3de37099ccd37e66a9673a772df2aaa001d15316e012be9e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch48/ch48.yaml":
+    pending:
+      fingerprint: "sha256:3d5a6d5f4d3578226490f692a3c51580933316a9edb19aa62aa4b67704af2f3a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch49/ch49.yaml":
+    pending:
+      fingerprint: "sha256:d342062ca4933769d4f994348e6ed02d2c29884f2bb2247ce75cd74b4f24f141"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch50/ch50.yaml":
+    pending:
+      fingerprint: "sha256:b3effc2b480dcfe98e431f8ed18b1ec6878e21f1394b2d303c0d6aff81b5db5b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch51/ch51.yaml":
+    pending:
+      fingerprint: "sha256:0651fa59247a8773cd6eeea9f23a940815ddb7eaa346910dc6018bc6427f2af1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch52/ch52.yaml":
+    pending:
+      fingerprint: "sha256:3bc415a0e1ba06181b6146a14c867083051b7389edaf98199c9c71afdda7d089"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch53/ch53.yaml":
+    pending:
+      fingerprint: "sha256:93e6a91dc102446985737eb2d1fa5b2fb8047e3d16d34c996ff39d88facc9602"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch54/ch54.yaml":
+    pending:
+      fingerprint: "sha256:8bee2b51431b868cf84c219eada0fec8e5a2408b80c75ea498d86a100440b0c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch55/ch55.yaml":
+    pending:
+      fingerprint: "sha256:2c410c9099ffc5081873ae4701c9ccef752a463480b2e5ce4414c9df77a611e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch56/ch56.yaml":
+    pending:
+      fingerprint: "sha256:98503e1bed2a73cc4511d17b0734774a19695cfe90a968fb21b68c15126d8a59"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch57/ch57.yaml":
+    pending:
+      fingerprint: "sha256:cfa0e6ccb4c65c4d2b03045f92575bb74e646074faa98f08d6fc2b5f9069f79e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch58/ch58.yaml":
+    pending:
+      fingerprint: "sha256:9085758589c465e72b0c67fad3d670ca76e668a6f20d4c1d784ee25f23eaceee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch59/ch59.yaml":
+    pending:
+      fingerprint: "sha256:0a1cfd26aaec300ba3eb038de3f1943226030e723e373dc018cb0ec5a49a0af9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch60/ch60.yaml":
+    pending:
+      fingerprint: "sha256:75c3cdd6d145b5b89042414b361c7e93656855f225375e24a04fcd693f4c8564"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch61/ch61.yaml":
+    pending:
+      fingerprint: "sha256:d071137284c7a254c0afa52e1ee3c9e8ccd9868010b36fc9442b19ad3bf00943"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch62/ch62.yaml":
+    pending:
+      fingerprint: "sha256:2739fb5120236b1b7cd708e0a2a63af42f70a879a04f99c7731bd66c32ef5c52"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch63/ch63.yaml":
+    pending:
+      fingerprint: "sha256:3feb6494ccf7f1288c60442f8d0b223a66ae38833cd099f8474c75fa2810c4e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch64/ch64.yaml":
+    pending:
+      fingerprint: "sha256:46f0a50e4935247d60876d49712c290f69d7fa061bcd2cd70d0b14c9534ac60e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch65/ch65.yaml":
+    pending:
+      fingerprint: "sha256:9dca204d1ef939db449d39eaf1c48f148023d1fe31145a9aac60998dab8b011a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch66/ch66.yaml":
+    pending:
+      fingerprint: "sha256:66c81301284dbf24fc5bc4927fde64224f6783fde8fe491bb0812999faecc61d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch67/ch67.yaml":
+    pending:
+      fingerprint: "sha256:b645c03a1866b987e409c8c3c1cee314243f6cde2403564adf7c96613dbcc35b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch68/ch68.yaml":
+    pending:
+      fingerprint: "sha256:3cf94a11e86a5d4bac69d53b8500b71e95504d609ab7d222f722bff14bdcdd64"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch69/ch69.yaml":
+    pending:
+      fingerprint: "sha256:f0f505a40f5b51b21a3588ec8129b4d4a5db376608e63938247278a1b5cff9d1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch70/ch70.yaml":
+    pending:
+      fingerprint: "sha256:65cd6e5eb0a7a7b1d3194f59db4a16383777bea050dde377856336de138ec67a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch71/ch71.yaml":
+    pending:
+      fingerprint: "sha256:a7cffbf5b428db4fca557160243f839387246b42c91cfe82126f0649db09fb22"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch72/ch72.yaml":
+    pending:
+      fingerprint: "sha256:508c47e8953dd389e44d8225944501c2846ebdd1700e8424d42430e6710d1777"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch73/ch73.yaml":
+    pending:
+      fingerprint: "sha256:1012245184d569fa3b95a970bb3a66ac0f33ed56f98e39643dee62c38da5392d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch74/ch74.yaml":
+    pending:
+      fingerprint: "sha256:fecd3b3e6ba7709f15d500bb3098ede01eb79e0f3de9e0e07629149ee88bec6f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch75/ch75.yaml":
+    pending:
+      fingerprint: "sha256:77bab4008786d9d5d6388a0176d58e6caad16996c705d9182fc76b8c20099f75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch76/ch76.yaml":
+    pending:
+      fingerprint: "sha256:9bc0dc9e7f8d816ed7c2852b7293eb56b4ea9ff14296e32896ba51addac38f3f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch78/ch78.yaml":
+    pending:
+      fingerprint: "sha256:bddba1ad93b205a061636c0ecaa40417106777a6fcfd603dbc254983eeb0ab03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch79/ch79.yaml":
+    pending:
+      fingerprint: "sha256:801b6a81194f8335d3655e788cf274af940f85fc3c423815a3b472df3c09e23c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch80/ch80.yaml":
+    pending:
+      fingerprint: "sha256:5ea14e1a4125e23b18b67acfb043ca56cc46a1ddc7b2819a0b6b9192fee696a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch81/ch81.yaml":
+    pending:
+      fingerprint: "sha256:e29ee9871af4d3bba811c03853fa71c847fbf94ce29a8ad8ece3aed243f982d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch82/ch82.yaml":
+    pending:
+      fingerprint: "sha256:8b1fb1c432f22724544d1cf234dc4bb8059b1ee647bab21f6b0fcafcdef52fd4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch83/ch83.yaml":
+    pending:
+      fingerprint: "sha256:baa7cb3189cd01b5b453ead91ee8a2f59cd798bbdea038d4ffd23219cc53cd7c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch84/ch84.yaml":
+    pending:
+      fingerprint: "sha256:9484fda92aed05f853223bce9399d4307833217af212f474fbeb0bdb6b4a0140"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch85/ch85.yaml":
+    pending:
+      fingerprint: "sha256:609d24913c48af1df98fe12b2d8ed2a8c92805a7de976510451b67ed5ec37ae6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch86/ch86.yaml":
+    pending:
+      fingerprint: "sha256:051837f8140fd3885913231513c1c0e5b622cedabfeffa19bbbc020046d23f85"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch87/ch87.yaml":
+    pending:
+      fingerprint: "sha256:fc6eeadb5334eef9b00d1b219ef3a2e992aba3ba507b4623536e1790fe1d6b0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch88/ch88.yaml":
+    pending:
+      fingerprint: "sha256:2d4c8448d40c08697d6e62ac49bea3e70bb670d45311764f50ef3207fa7548a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch89/ch89.yaml":
+    pending:
+      fingerprint: "sha256:f7a794e0c63aedee2586106424fd0d21ad1d6b797a8770c7a5970657cdbffce7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch90/ch90.yaml":
+    pending:
+      fingerprint: "sha256:b50fc77f3633ee73d6efface2a650da968c2892695e01c4fbed3a4264c95464f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch91/ch91.yaml":
+    pending:
+      fingerprint: "sha256:df153dd7e8e4a21071384be5b7df07bbe98df2b8e3d1043931322f04e5e574c6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch92/ch92.yaml":
+    pending:
+      fingerprint: "sha256:c6bdc50f6ea39f7292ea3ddd18f195a23d63a5ae62b3606670d2b67db9add415"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch93/ch93.yaml":
+    pending:
+      fingerprint: "sha256:f8f1a9908aa96e5c087a14bbe5a42776ee8ec47f492f0fd66a080fc4838ebb67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch94/ch94.yaml":
+    pending:
+      fingerprint: "sha256:7c7492b714427ffb77a3b13e5f8ee0431fb323b3e59c19277d6f266f4a47c3c2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch95/ch95.yaml":
+    pending:
+      fingerprint: "sha256:f17d997f207ac832b46695a8f86d69431b639e92949f3a71d8e0571f7747ee13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch96/ch96.yaml":
+    pending:
+      fingerprint: "sha256:5533b24b0169412516ce640eb7c566c1b33cf8e6477b102cd0ab9b990478df0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch97/ch97.yaml":
+    pending:
+      fingerprint: "sha256:8dbab890cfd1c49c0897f6afa208816018b99d7d9cf8e7c01c5dac22ab005c80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch98/ch98.yaml":
+    pending:
+      fingerprint: "sha256:7fd878bfbc2a9d2782ee33fe3b4211b09433ffbc1027ed67312bae5351dd7caf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch99a/ch99a.yaml":
+    pending:
+      fingerprint: "sha256:700dde54d49194bc3ec471232da04494fcb046903709ce7e0488b74dc4554479"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch99b/ch99b.yaml":
+    pending:
+      fingerprint: "sha256:5f92376975161ff79d315a03fc554e8d7dfc100823fad7f6e5cbd7834ab14dac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/cbp/us-tariff-schedule/generated/ch99c/ch99c.yaml":
+    pending:
+      fingerprint: "sha256:cd923c62ab3d1d103e019285b5a7f90b1c05b34c8e3a19efed715edf8fb9d87a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch76.yaml":
+    pending:
+      fingerprint: "sha256:58cbf650a239f289124b5b5a2905d4163e852ad053f8a282b324d26cf1f8b325"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch78.yaml":
+    pending:
+      fingerprint: "sha256:8a9d201d8e6fe63eb5daaf5139f4effa5873dc62363932da1b925f6ddde1ec9b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch79.yaml":
+    pending:
+      fingerprint: "sha256:2ac567ba0cd087884209a1c56d6f278b9e141545d662d30cd58a5ccd72952265"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch80.yaml":
+    pending:
+      fingerprint: "sha256:e5191c86ee68553509b3e1542a19b627a4abd7b6e24441fa5d7b485dac13c390"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch81.yaml":
+    pending:
+      fingerprint: "sha256:e8670d07d6753460c852fcbd4c33b48cd7d4561706e60e652b64a767ad44e8ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch82.yaml":
+    pending:
+      fingerprint: "sha256:0ad426126f3a225b1212a52d7a180941ccc5fba446ebb6ff464ba7b8ef24a432"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch83.yaml":
+    pending:
+      fingerprint: "sha256:532ccaca8b43668b29ed4a6970f4cdc0b1b2ec092a6f744339521969fe5dcdb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch84.yaml":
+    pending:
+      fingerprint: "sha256:3f814fc3b6f4863d1c9a920c92b9121b40cc30c65c89b92d6396fdbe8165457d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch85.yaml":
+    pending:
+      fingerprint: "sha256:d7fc99f109619ca127fd9cd56f7c0acaf07154940a0a7867d80579ec74dd550a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch86.yaml":
+    pending:
+      fingerprint: "sha256:6f873116488479a08d1fb24873e712d4120f86694aa7de36786ff60f9d75aa66"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch87.yaml":
+    pending:
+      fingerprint: "sha256:c2a13391430ba7f15901af6d8900ffb450c68def7946abf86adb005f5b4a25e6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch88.yaml":
+    pending:
+      fingerprint: "sha256:fb5e92f6d6b556007cad6db6343f1783871cebf9a4c33d7c65dddfcfd7c99146"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch89.yaml":
+    pending:
+      fingerprint: "sha256:d14823155de5d0c6d6a72fd6736a8578dfd89dacf2c8d4d215b5df8db3f442a1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch90.yaml":
+    pending:
+      fingerprint: "sha256:aab35066c16f33895e511eaefa0a94c1961e5adfe1bbc9fe20f8403346c0ed8f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch91.yaml":
+    pending:
+      fingerprint: "sha256:359b695551b18f2469c402f6c1a249e6160b47ef5798e2a8de6ee7f4fc91c095"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch92.yaml":
+    pending:
+      fingerprint: "sha256:5c01e35e7e939e7615b1e4f6146a7956c68f2cbe16b97ef0c127094675453342"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch93.yaml":
+    pending:
+      fingerprint: "sha256:70a07f3a5a7d963edd2e9eec9a3b22a5927a823e1ab8cd93be1bf46599272a81"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch94.yaml":
+    pending:
+      fingerprint: "sha256:8f0672c4c02bbf1f45d79022cf14241b95aa5c89503e831116d0c6d0778e48c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch95.yaml":
+    pending:
+      fingerprint: "sha256:2679c9c0298de277325e4784163d0ff9a5c3f36b2a698032a82d1f26e93d212f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch96.yaml":
+    pending:
+      fingerprint: "sha256:72b95d2e973699713ef84f3ed61720659bdf4c38f961c8777c6c03110c42e6f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch97.yaml":
+    pending:
+      fingerprint: "sha256:8e9ced092890322d18432dbf63a7946cae0666fb3c87dd2527a6f905623bd58e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch98.yaml":
+    pending:
+      fingerprint: "sha256:58fb1f045d00624c30e59656163c14cf5a6b582eff7110188d0fad6ff13cee75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch99a.yaml":
+    pending:
+      fingerprint: "sha256:74a0123ff1c5f9c13546b6994419ae6ad3c2aa7b1fe31f55efa8fbf063ae80f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch99b.yaml":
+    pending:
+      fingerprint: "sha256:d3af3b1ef488ebdbed2ccbd4fd1f977384723bc455f8baf12c11085ec32b0d68"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-duty/lines/generated/ch99c.yaml":
+    pending:
+      fingerprint: "sha256:8b37cb5824db93f34a125436f10de12d1f701671d65905363230cef82bf30158"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-incidence/generated/note16-232-steel.yaml":
+    pending:
+      fingerprint: "sha256:1d283baace2e4cbc3fe58e0b658900e9b75ffabc1ae05c2c2354de32ef56f234"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-incidence/generated/note18-201-solar.yaml":
+    pending:
+      fingerprint: "sha256:c62af58b2cbdf6b806c5cc4c4743ae9bf52c5945ac240158b37e0e0e8f1c9bd7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-incidence/generated/note19-232-aluminum.yaml":
+    pending:
+      fingerprint: "sha256:433ff922cd38bc67e6703e1bee6958bce61a1be7cf0f45e54e9e9b59f3bbf937"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-incidence/generated/note20-china-301.yaml":
+    pending:
+      fingerprint: "sha256:0d3799302f0db0f97df2f17d67a6bddb006d1160e95aa132024be972244fd738"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us/policies/usitc/us-tariff-incidence/generated/note2aa-122-exemptions.yaml":
+    pending:
+      fingerprint: "sha256:2cf6b9a57e2fa3d61700574e2436df1b7a43d2b52a73a2c9ccc088f37799a17c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/statutes/42/415/a.yaml":
     active:
       fingerprint: "sha256:1b2eefed0f9acb3ec685e1aee7deb0e778bdfc873e3d150c429e517b52e6dd29"
@@ -4744,6 +5524,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-ak/policies/income_tax/2026_resident_zero_liability.yaml":
+    pending:
+      fingerprint: "sha256:45bf6c3f16c4d31b0738762b78da15ce6ff410f76fb0f0213ca3e81295f6b849"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us-ak/regulations/aac/title-7/chapter-45/45-280-resource-limit.yaml":
     pending:
       fingerprint: "sha256:4cd6b2539ea8ec41ca14035ce235435a6b70e9df6b3fa8440f487a8688a34461"
@@ -19810,6 +20596,18 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-21-109.yaml":
+    pending:
+      fingerprint: "sha256:22d1d4065935a4fdb875a8e04ae4f2b2a8cf499574b1f60b6e4fdb97dbf96930"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us-co/statutes/39/39-21-110.5.yaml":
+    pending:
+      fingerprint: "sha256:9789e2878d88e073659260b6a4032309706045a7695ef88c1229885d83aa9e88"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us-co/statutes/39/39-21-114.yaml":
     pending:
       fingerprint: "sha256:3835ca6c7d6a9f8515bcadea92a3eecf1fcd2972ac4919f5e5d876f2db9ed743"
@@ -20068,12 +20866,24 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-22-557.yaml":
+    pending:
+      fingerprint: "sha256:5663c0c895a2c52d67400753132b69674c8d5959f961981ae930e0b34aa39b56"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us-co/statutes/39/39-22-562.yaml":
     pending:
       fingerprint: "sha256:250e65bd0c2b2c0e47ae5964f70a7fa57edfa26ec906b182218131d1c7f5af2b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-22-568.yaml":
+    pending:
+      fingerprint: "sha256:0b968cbd66532fe4b4f591b25351434cfd692eb0f892b22a415a1e8b7717fb47"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us-co/statutes/39/39-22-605.yaml":
     pending:
       fingerprint: "sha256:cfd058805c45f28cdf9eaa87c3b6dc32a792f543fade3a07f4b72db4ba11641d"
@@ -20134,6 +20944,18 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-co/statutes/39/39-28-107.yaml":
+    pending:
+      fingerprint: "sha256:492b88b50a4bdbd81ccfae613e2a456c76426e00fe74a7ce5e4b90531503ef62"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+  "us-co/statutes/39/39-28-108.yaml":
+    pending:
+      fingerprint: "sha256:6ee278d7988a4fb350908c3c7cada67007c7415eb027eb3ee92c264036d22548"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us-co/statutes/39/39-28-112.yaml":
     pending:
       fingerprint: "sha256:20c56bbd769331151273297a81ccf9ed3848e68b5f29d6ec737ab30bc7d4da80"


### PR DESCRIPTION
## Summary

- adds pending approvals for the 137 exact failures registered by evidence PR #1304
- covers 1 Alaska, 6 Colorado, and 130 federal modules exposed by the encoder 0.2.1690 hardened migration census
- does not promote any entry to active; the migration PR will consume these pending approvals only after this PR is independently reviewed and merged

## Governance

- owner: `@MaxGhenis`
- issue: https://github.com/TheAxiomFoundation/rulespec-us/issues/1080
- expiry: `2026-11-14`
- evidence dependency: #1304

## Checks

- all 137 pending fingerprints mechanically match the evidence registry
- YAML parsed successfully
- `uv run pytest -q` (87 passed; one existing manifest-coverage warning)
- `git diff --check`

Draft pending evidence merge, independent review, and hosted CI.
