### PR TITLE
Add federal proposal-security base rules

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -54307,6 +54307,15 @@
         ]
       }
     ],
+    "us/statute/42/19232/f": [
+      {
+        "module": "us/statutes/42/19232/f.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/42/3535": [
       {
         "module": "us/statutes/42/3535.yaml",

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -36097,6 +36097,15 @@
         ]
       }
     ],
+    "us/regulation/2/25/110": [
+      {
+        "module": "us/regulations/2-cfr/25/110/foreign-full-sam-exception.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/26/1/1401-1/d/2/i": [
       {
         "module": "us/policies/income_tax/additional_medicare_tax_pipeline.yaml",

--- a/us/.axiom/encoding-manifests/regulations/2-cfr/25/110/foreign-full-sam-exception.json
+++ b/us/.axiom/encoding-manifests/regulations/2-cfr/25/110/foreign-full-sam-exception.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/2-cfr/25/110/foreign-full-sam-exception.yaml",
+      "sha256": "b9d52b244cfe7c2988f958eb1edd183ba5714edf0c0945f80782ef891c21f1e6"
+    },
+    {
+      "path": "regulations/2-cfr/25/110/foreign-full-sam-exception.test.yaml",
+      "sha256": "e7ec813b937b0510b9da4b3f92773322c541de92f6c3e1c270afd51e60f80789"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_axiom-worktrees/nsf-pappg-toolchain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us/regulations/2-cfr/25/110/foreign-full-sam-exception",
+  "context_manifest_file": "/private/tmp/axiom-fps-110-foreign-full-v1/_eval_workspaces/codex-gpt-5.5/us-regulations-2-cfr-25-110-foreign-full-sam-exception/workspace/context-manifest.json",
+  "context_manifest_sha256": "80bb56dd558421ea20f66c8ded16ebdd8cbd5f635a30f5f8599e4bc47b08e9b8",
+  "generated_at": "2026-08-30T20:23:10.469493+00:00",
+  "generated_output_file": "/private/tmp/axiom-fps-110-foreign-full-v1/codex-gpt-5.5/regulations/2-cfr/25/110/foreign-full-sam-exception.yaml",
+  "generated_output_root": "/private/tmp/axiom-fps-110-foreign-full-v1",
+  "generated_output_sha256": "b9d52b244cfe7c2988f958eb1edd183ba5714edf0c0945f80782ef891c21f1e6",
+  "generation_prompt_sha256": "5a938dd1c831b270d9836536178195a0234973114ed79c2ef2328baf92161454",
+  "model": "gpt-5.5",
+  "run_id": "d1d669f1",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "4fbe02fab784a73a9df2a2c9f991ee3381d22a4d13b3bc0b6a0bceaa6e4094dd"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-fps-110-foreign-full-v1/traces/codex-gpt-5.5/us-regulations-2-cfr-25-110-foreign-full-sam-exception.json",
+  "trace_sha256": "21d31623ea06972470b5111cdb96b7c33e897c9b7eb16e9bd5f54f23ad71f171"
+}

--- a/us/.axiom/encoding-manifests/statutes/42/19232/f.json
+++ b/us/.axiom/encoding-manifests/statutes/42/19232/f.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "statutes/42/19232/f.yaml",
+      "sha256": "09d29d34bde4d4f1a86302afd268a5513772ded501810fef8b6c70c2a8aec69c"
+    },
+    {
+      "path": "statutes/42/19232/f.test.yaml",
+      "sha256": "5f2d39e9adee8d50c69be02959bf1a1ccff31924874649bf19e15d98043f3d63"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/maxghenis/TheAxiomFoundation/_axiom-worktrees/nsf-pappg-toolchain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us/statutes/42/19232/f",
+  "context_manifest_file": "/private/tmp/axiom-fps-19232-f-training-retry-v1/_eval_workspaces/codex-gpt-5.5/us-statutes-42-19232-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "40054d8a34141d65c9e4bc62c6bcdc52c822b00bdd6a365d3adceee76619c194",
+  "generated_at": "2026-08-30T21:30:01.428570+00:00",
+  "generated_output_file": "/private/tmp/axiom-fps-19232-f-training-retry-v1/codex-gpt-5.5/statutes/42/19232/f.yaml",
+  "generated_output_root": "/private/tmp/axiom-fps-19232-f-training-retry-v1",
+  "generated_output_sha256": "09d29d34bde4d4f1a86302afd268a5513772ded501810fef8b6c70c2a8aec69c",
+  "generation_prompt_sha256": "84b09c55c94381d1aef013003d5ceacd5b12ec206518060db5953703fbf8be50",
+  "model": "gpt-5.5",
+  "run_id": "1a7aa8f7",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "d071da92e3ebf6574f58361500ee50b0da31cd3282903bc38971ebb4ab40f8c6"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/axiom-fps-19232-f-training-retry-v1/traces/codex-gpt-5.5/us-statutes-42-19232-f.json",
+  "trace_sha256": "2168a24593d2a14671fde5788a21c9e57e1e9ce384823eff83e6979b416b1e6f"
+}

--- a/us/regulations/2-cfr/25/110/foreign-full-sam-exception.test.yaml
+++ b/us/regulations/2-cfr/25/110/foreign-full-sam-exception.test.yaml
@@ -1,0 +1,102 @@
+- name: positive_actual_foreign_full_sam_exception_below_limit
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 499999
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: true
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_applies: holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#uei_remains_required_under_foreign_full_sam_exception: holds
+- name: exact_limit_rejected_even_with_grant
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 500000
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: true
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: not_holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_applies: not_holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#uei_remains_required_under_foreign_full_sam_exception: not_holds
+- name: eligible_below_limit_without_actual_grant
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 499999
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: false
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_applies: not_holds
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#uei_remains_required_under_foreign_full_sam_exception: not_holds
+- name: subrecipient_ineligible_under_paragraph_iii
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: false
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 499999
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: true
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: not_holds
+- name: domestic_performance_ineligible
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: false
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 499999
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: true
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: not_holds
+- name: non_foreign_entity_ineligible
+  period:
+    period_kind: custom
+    name: day
+    start: '2024-10-02'
+    end: '2024-10-02'
+  input:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.applicant_or_recipient: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.entity_is_foreign_organization_or_foreign_public_entity: false
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_will_be_performed_outside_united_states: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_award_amount: 499999
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_determines_exception_case_by_case: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.agency_utilizes_risk_based_approach: true
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#input.federal_agency_granted_paragraph_iii_exception: true
+  output:
+    us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted: not_holds

--- a/us/regulations/2-cfr/25/110/foreign-full-sam-exception.yaml
+++ b/us/regulations/2-cfr/25/110/foreign-full-sam-exception.yaml
@@ -1,0 +1,104 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/2/25/110
+  summary: |-
+    2 CFR 25.110(a)(2)(iii): For applicants or recipients, a Federal agency may exempt foreign organizations or foreign public entities from completing full registration in SAM.gov for a Federal award less than $500,000 that will be performed outside the United States. Such entities must still obtain a UEI. The agency must determine the exemption case-by-case using a risk-based approach.
+rules:
+  - name: foreign_full_sam_registration_exception_award_limit
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: 2 CFR 25.110(a)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/regulation/2/25/110
+              excerpt: "Federal award less than $500,000"
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          500000
+
+  - name: foreign_full_sam_exception_may_be_granted
+    kind: derived
+    entity: FederalFinancialAssistanceExceptionDecision
+    dtype: Judgment
+    period: Day
+    source: 2 CFR 25.110(a)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/2/25/110
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_registration_exception_award_limit
+              output: foreign_full_sam_registration_exception_award_limit
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          applicant_or_recipient
+          and entity_is_foreign_organization_or_foreign_public_entity
+          and federal_award_will_be_performed_outside_united_states
+          and federal_award_amount < foreign_full_sam_registration_exception_award_limit
+          and agency_determines_exception_case_by_case
+          and agency_utilizes_risk_based_approach
+
+  - name: foreign_full_sam_exception_applies
+    kind: derived
+    entity: FederalFinancialAssistanceExceptionDecision
+    dtype: Judgment
+    period: Day
+    source: 2 CFR 25.110(a)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/regulation/2/25/110
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_may_be_granted
+              output: foreign_full_sam_exception_may_be_granted
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          foreign_full_sam_exception_may_be_granted
+          and federal_agency_granted_paragraph_iii_exception
+
+  - name: uei_remains_required_under_foreign_full_sam_exception
+    kind: derived
+    entity: FederalFinancialAssistanceExceptionDecision
+    dtype: Judgment
+    period: Day
+    source: 2 CFR 25.110(a)(2)(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/2/25/110
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/2-cfr/25/110/foreign-full-sam-exception#foreign_full_sam_exception_applies
+              output: foreign_full_sam_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2024-10-01'
+        formula: |-
+          foreign_full_sam_exception_applies

--- a/us/statutes/42/19232/f.test.yaml
+++ b/us/statutes/42/19232/f.test.yaml
@@ -1,0 +1,130 @@
+- name: agency_duty_for_award_to_recipient_institution_without_person_inputs
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: holds
+- name: recipient_duty_holds_with_actual_award_condition_and_employed_covered_individual
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: holds
+- name: recipient_duty_fails_without_actual_award_condition_while_agency_duty_holds
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: false
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: recipient_duty_fails_without_employed_covered_individual_while_agency_duty_holds
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: false
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: neither_duty_holds_when_award_is_not_to_recipient_institution
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: false
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: not_holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: neither_duty_holds_when_award_not_from_evaluated_agency
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: false
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: not_holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: neither_duty_holds_when_case_does_not_concern_award
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: false
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: not_holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: pre_enactment_all_positive_neither_duty_holds
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-08'
+    end: '2022-08-08'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: true
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#federal_research_agency_must_ensure_award_training_requirement: not_holds
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds
+- name: recipient_duty_fails_without_actual_award_condition_even_when_award_scope_holds
+  period:
+    period_kind: custom
+    name: day
+    start: '2022-08-09'
+    end: '2022-08-09'
+  input:
+    us:statutes/42/19232/f#input.case_concerns_award: true
+    us:statutes/42/19232/f#input.award_is_from_evaluated_federal_research_agency: true
+    us:statutes/42/19232/f#input.award_is_to_recipient_institution: true
+    us:statutes/42/19232/f#input.award_actually_contains_same_agency_mftrp_risk_training_requirement: false
+    us:statutes/42/19232/f#input.person_is_covered_individual_employed_at_same_recipient_institution: true
+  output:
+    us:statutes/42/19232/f#recipient_institution_must_provide_mftrp_risk_training_under_award_condition: not_holds

--- a/us/statutes/42/19232/f.yaml
+++ b/us/statutes/42/19232/f.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/19232/f
+  summary: |-
+    Each Federal research agency shall ensure that, as a requirement of an award from each such agency, recipient institutions provide training on the risks of malign foreign talent recruitment programs to covered individuals employed at such institutions.
+rules:
+  - name: federal_research_agency_must_ensure_award_training_requirement
+    kind: derived
+    entity: FederalResearchAgencyAwardRecipientInstitutionTrainingCase
+    dtype: Judgment
+    period: Day
+    source: 42 U.S.C. § 19232(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+              excerpt: as a requirement of an award from each such agency
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+              excerpt: recipient institutions provide training
+    versions:
+      - effective_from: '2022-08-08'
+        formula: |-
+          false
+      - effective_from: '2022-08-09'
+        formula: |-
+          case_concerns_award
+          and award_is_from_evaluated_federal_research_agency
+          and award_is_to_recipient_institution
+  - name: recipient_institution_must_provide_mftrp_risk_training_under_award_condition
+    kind: derived
+    entity: FederalResearchAgencyAwardRecipientInstitutionTrainingCase
+    dtype: Judgment
+    period: Day
+    source: 42 U.S.C. § 19232(f)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: effective_period
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+              excerpt: as a requirement of an award from each such agency
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+              excerpt: recipient institutions provide training on the risks of malign foreign talent recruitment programs
+          - path: versions[1].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/19232/f
+              excerpt: covered individuals employed at such institutions
+    versions:
+      - effective_from: '2022-08-08'
+        formula: |-
+          false
+      - effective_from: '2022-08-09'
+        formula: |-
+          case_concerns_award
+          and award_is_from_evaluated_federal_research_agency
+          and award_is_to_recipient_institution
+          and award_actually_contains_same_agency_mftrp_risk_training_requirement
+          and person_is_covered_individual_employed_at_same_recipient_institution


### PR DESCRIPTION
## Summary

Adds two narrow, encoder-generated federal proposal-security base modules:

- 2 CFR 25.110(a)(2)(iii): the foreign-organization/foreign-public-entity exception from full SAM registration for awards under $500,000 performed outside the United States, including case-by-case/risk-based agency discretion, an explicit grant fact, and continued UEI requirement.
- 42 U.S.C. 19232(f): the Federal research agency's award-condition duty and the recipient institution's MFTRP-risk-training obligation only when that award actually contains the same agency-imposed condition.

The modules keep agency and recipient actors separate. The research-security rule's broad covered-individual-employed predicate includes subsection-(d) participants without turning permitted international-collaboration activity into an automated classifier.

Both modules, fixtures, and signed manifests are unedited `axiom-encode` output. The only generated repository artifact is the official provisions-to-rules reverse index.

This PR does not duplicate axiom-corpus PR #631 (NSF 26-506 and PAPPG 24-1 Chapter II) and contains no NSF PAPPG/PESOSE module.

## Deliberately unshipped

The broader authority set was evaluated but is not included where the encoder/runtime could not preserve the operative rule without repair:

- 2 CFR 25.105, the remaining 25.110 exceptions, and 25.200/25.205/25.300: rejected for actor/transaction collapse, requirement-specific exception collapse, missing lead/subrecipient distinctions, or derived-rule date backdating.
- 42 U.S.C. 6605: rejected because the generated formula did not parse in the real Rust loader and collapsed disclosure/certification/update duties.
- 42 U.S.C. 19232(a), 19234(a)(1), 19235, and 19237: rejected for duty collapse, missing inherited-chapeau provenance, proof-root failure, or runtime backdating. Section 19232(e) was also withheld because clean canonical output emitted single versions that execute before the intended date.
- 31 U.S.C. 1352 and 45 CFR Part 604/Appendices A-B: rejected for missing $100,000/flow-down semantics, wrong flow-down actor, scope/date defects, or image-only form text.
- 42 U.S.C. 1862o: rejected because generated output omitted the access-to-mentors route, blurred the Director/applicant actor boundary, and backdated the duty.
- PAPPG Chapter I/Supplements 1-2 and IN 149/FAQ adapters: withheld because their prerequisite base modules did not pass; the DMSP guidance run also lacked a valid higher-authority dependency path.

No prohibited-entity list is frozen in RuleSpec. No production corpus/rule load, publication, deployment, or activation is part of this PR.

## Validation

- `axiom-encode test`: 15/15 generated fixtures (6 SAM exception; 9 training condition)
- `axiom-encode proof-validate --require-money-atoms`: 7/7 atoms for each module; SAM money atom present
- Native Rust engine `ffd821327`: direct threshold, actual-grant, agency/recipient, no-award-condition, and pre/post-date canaries pass
- Signed `guard-generated --roots us`: pass
- Reverse-index tests: 6 passed
- Full repository suite: 91 passed, 1 existing legacy-manifest warning
- Independent final diff review: SHIP, with no blocking findings

## Source dependencies

Official source ingestion is reviewed separately in axiom-corpus PRs #634, #635, and #636. PR #636 contains the scoped federal proposal-security source pack and is stacked on the two adapter PRs.
