### PR TITLE
H.R. 1 modules: retain amendment history and fix effective dates (#1310, #1319, #1320, #1321)

### DIFF
--- a/.axiom/encoding-manifests/statutes/26/24.json
+++ b/.axiom/encoding-manifests/statutes/26/24.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/26/24.yaml",
-      "sha256": "77b2f1231813f3321fae607588eaa840f103243067725aa08a4517d91d7d87a2"
+      "sha256": "c822c98ef54d5e159fe0989c8d09682f96d25a51cdef15c421254aa66a050697"
     },
     {
       "path": "statutes/26/24.test.yaml",
@@ -15,23 +15,27 @@
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
   },
   "axiom_encode_version": "0.2.68",
-  "backend": "deterministic",
+  "backend": "manual",
   "citation": "26 USC 24",
   "context_manifest_file": "/tmp/axiom-encode-26-24-root-rerun5/_eval_workspaces/openai-gpt-5.5/26-USC-24/workspace/context-manifest.json",
   "context_manifest_sha256": "e0bc086a4baf35535137b364fad9c7fec8fe479a4d2b5b2a9f87771c126f44a6",
-  "generated_at": "2026-05-22T01:44:39.511398+00:00",
+  "generated_at": "2026-09-01T23:06:45.370087+00:00",
   "generated_output_file": "/tmp/axiom-encode-26-24-root-rerun5/openai-gpt-5.5/statutes/26/24.yaml",
   "generated_output_root": "/tmp/axiom-encode-26-24-root-rerun5",
-  "generated_output_sha256": "8d23b96bb966cf5671d870a437a2d8f03effdb9703aa4d411278c8c6b0449165",
+  "generated_output_sha256": "c822c98ef54d5e159fe0989c8d09682f96d25a51cdef15c421254aa66a050697",
   "generation_prompt_sha256": "1540fa446a46af64717398ff208b26556f988646ef945d70a06ae35cab54a37f",
-  "model": "manual-repair-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "0a35ec823de9cd18ce40436dcd5948df255b4096828803fbfe6b81bd8b791d07"
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-05-22T01:44:39.511398+00:00",
+    "generation_prompt_sha256": "1540fa446a46af64717398ff208b26556f988646ef945d70a06ae35cab54a37f",
+    "manifest_sha256": "7f46f33a9f1d5f2dce6ca866dd63bc8a16a4e34ac394fc3a6f7161249b9dd8e6",
+    "prior_signature": "0a35ec823de9cd18ce40436dcd5948df255b4096828803fbfe6b81bd8b791d07",
+    "run_id": "deterministic-repair",
+    "supersedes": null
   },
   "tool": "axiom-encode deterministic/manual repair",
   "trace_file": "/tmp/axiom-encode-26-24-root-rerun5/traces/openai-gpt-5.5/26-USC-24.json",

--- a/.axiom/encoding-manifests/statutes/26/24.json
+++ b/.axiom/encoding-manifests/statutes/26/24.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "statutes/26/24.test.yaml",
-      "sha256": "2a1f62c01155abd8524f1e3fb0f2233fe9f5e57d18b0aae14616d6e058158a5e"
+      "sha256": "c427a6b180afb7da228b4ac43a2f671eff2dbc04a7604842f3544ac55f92c208"
     }
   ],
   "axiom_encode_git": {
@@ -19,7 +19,7 @@
   "citation": "26 USC 24",
   "context_manifest_file": "/tmp/axiom-encode-26-24-root-rerun5/_eval_workspaces/openai-gpt-5.5/26-USC-24/workspace/context-manifest.json",
   "context_manifest_sha256": "e0bc086a4baf35535137b364fad9c7fec8fe479a4d2b5b2a9f87771c126f44a6",
-  "generated_at": "2026-09-01T23:06:45.370087+00:00",
+  "generated_at": "2026-09-02T02:10:28.653973+00:00",
   "generated_output_file": "/tmp/axiom-encode-26-24-root-rerun5/openai-gpt-5.5/statutes/26/24.yaml",
   "generated_output_root": "/tmp/axiom-encode-26-24-root-rerun5",
   "generated_output_sha256": "c822c98ef54d5e159fe0989c8d09682f96d25a51cdef15c421254aa66a050697",

--- a/.axiom/encoding-manifests/statutes/26/24/h.json
+++ b/.axiom/encoding-manifests/statutes/26/24/h.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "statutes/26/24/h.yaml",
-      "sha256": "80d253ad020aaf460588e169963b2d126ea532359124436c2905c343b7dbc103"
+      "sha256": "b7526dc526900ad5e85bc856989d091c7d2520eaf02216a7e332f2b618f640cf"
     },
     {
       "path": "statutes/26/24/h.test.yaml",
-      "sha256": "e8d675c81ca3ba3af2ee45e57013381c59ecea8a1fa7605796f4cac6728faf42"
+      "sha256": "5db290c1a4304d612a972b706acfea7ec58d39ea138c5fed103cec010ca6a4b1"
     }
   ],
   "axiom_encode_git": {
@@ -15,23 +15,27 @@
     "root": "/Users/maxghenis/TheAxiomFoundation/axiom-encode"
   },
   "axiom_encode_version": "0.2.68",
-  "backend": "deterministic",
+  "backend": "manual",
   "citation": "26 USC 24(h)",
   "context_manifest_file": "/tmp/axiom-encode-24h-clean-apply-5/_eval_workspaces/openai-gpt-5.5/26-USC-24-h/workspace/context-manifest.json",
   "context_manifest_sha256": "23e8a931aaea4275fa0edf6dbd528f2a756883681f48b2261bca822ae536afbb",
-  "generated_at": "2026-05-20T18:26:46.497380+00:00",
+  "generated_at": "2026-09-01T21:52:06.149485+00:00",
   "generated_output_file": "/tmp/axiom-encode-24h-clean-apply-5/openai-gpt-5.5/statutes/26/24/h.yaml",
   "generated_output_root": "/tmp/axiom-encode-24h-clean-apply-5",
-  "generated_output_sha256": "6589226170a8d201d0b5e035f00ac12530f7043ed31779cb3c1cbdb553a23fd9",
+  "generated_output_sha256": "b7526dc526900ad5e85bc856989d091c7d2520eaf02216a7e332f2b618f640cf",
   "generation_prompt_sha256": "a7d6d7738f7add1dc07064c6838921deb55f20130d2b388cb92f28b73039ea18",
-  "model": "manual-repair-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "0cbeb9aaae706e9ce459c75f9b908877e91ea2357fc0aa17e390cb7324b44f5d"
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-05-20T18:26:46.497380+00:00",
+    "generation_prompt_sha256": "a7d6d7738f7add1dc07064c6838921deb55f20130d2b388cb92f28b73039ea18",
+    "manifest_sha256": "583690e8535e7b6ff43e1e90558f2a56f2618c58d5620d6ba73a14989d34cb78",
+    "prior_signature": "0cbeb9aaae706e9ce459c75f9b908877e91ea2357fc0aa17e390cb7324b44f5d",
+    "run_id": "deterministic-repair",
+    "supersedes": null
   },
   "tool": "axiom-encode deterministic/manual repair",
   "trace_file": "/tmp/axiom-encode-24h-clean-apply-5/traces/openai-gpt-5.5/26-USC-24-h.json",

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/11/c.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "us/regulations/7-cfr/273/11/c.yaml",
-      "sha256": "6827c4cc35619aa8780e53f85ddcc79454e17813bb2a5d5294e73f07e08d9b55"
+      "sha256": "c98e5d97cb607e23cd4e79676db9bce8a087600fd7b51a7484f5a8c02cca1ff1"
     },
     {
       "path": "us/regulations/7-cfr/273/11/c.test.yaml",
@@ -17,41 +17,44 @@
     "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
   },
   "axiom_encode_version": "0.2.1200",
-  "backend": "deterministic",
+  "backend": "manual",
   "citation": "us:regulations/7-cfr/273/11/c",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-04T13:06:38.839699+00:00",
+  "generated_at": "2026-09-01T23:06:45.366671+00:00",
   "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1rvd7o7c/deterministic-repair/us/regulations/7-cfr/273/11/c.yaml",
   "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp1rvd7o7c",
-  "generated_output_sha256": "6827c4cc35619aa8780e53f85ddcc79454e17813bb2a5d5294e73f07e08d9b55",
+  "generated_output_sha256": "c98e5d97cb607e23cd4e79676db9bce8a087600fd7b51a7484f5a8c02cca1ff1",
   "generation_prompt_sha256": null,
-  "model": "proof-import-hash-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "afdabcb6c02ef2636759914a3394fe079e40c5b8e047175d655deb58d961ed5b"
-  },
   "supersedes": {
-    "backend": "manual",
-    "generated_at": "2026-08-04T12:45:04.960215+00:00",
+    "backend": "deterministic",
+    "generated_at": "2026-08-04T13:06:38.839699+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "367c9942d3aa6ee27419a15c89158cf6ed27c8ecd66d8311debfc31eb9105221",
-    "prior_signature": "3f18bb2adcc06a70e4f20fcc42b069f1875422a1c3935eaed3dd93ae7bb15989",
-    "run_id": null,
+    "manifest_sha256": "3125fd9a833624a5119047433a7545c29f3eedd927c2e46cba5042dc6d0b9bf1",
+    "prior_signature": "afdabcb6c02ef2636759914a3394fe079e40c5b8e047175d655deb58d961ed5b",
+    "run_id": "deterministic-repair",
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-07T04:55:32.784640+00:00",
+      "generated_at": "2026-08-04T12:45:04.960215+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "5fed24423c9d0e8d768b9edcb8e47cc7c78967250fa4693b5eea2cc8fdd70c3a",
-      "prior_signature": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8",
+      "manifest_sha256": "367c9942d3aa6ee27419a15c89158cf6ed27c8ecd66d8311debfc31eb9105221",
+      "prior_signature": "3f18bb2adcc06a70e4f20fcc42b069f1875422a1c3935eaed3dd93ae7bb15989",
       "run_id": null,
+      "supersedes": {
+        "backend": "manual",
+        "generated_at": "2026-07-07T04:55:32.784640+00:00",
+        "generation_prompt_sha256": null,
+        "manifest_sha256": "5fed24423c9d0e8d768b9edcb8e47cc7c78967250fa4693b5eea2cc8fdd70c3a",
+        "prior_signature": "c1fefee85452f15c510121011e6333459f9b5cc9b914cd3ffe3fab463e5f06b8",
+        "run_id": null,
+        "tool": "axiom-encode sign-applied-files"
+      },
       "tool": "axiom-encode sign-applied-files"
-    },
-    "tool": "axiom-encode sign-applied-files"
+    }
   },
   "tool": "axiom-encode repair-proof-import-hashes",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/24.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "us/regulations/7-cfr/273/24.yaml",
-      "sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec"
+      "sha256": "380030d6f724c002d45dd33aeb5d1899d9f5d03b2eb7f9d73867e1a8a34e523d"
     },
     {
       "path": "us/regulations/7-cfr/273/24.test.yaml",
-      "sha256": "24711e988cabe22cac37fdb5e71adef7ace18d208ed7281cea80305bce17d9b9"
+      "sha256": "074b1e18237e40b28970c1db6abed3d333dcc9b8ee9ca7694849bae27fc09216"
     }
   ],
   "axiom_encode_git": {
@@ -21,46 +21,49 @@
   "citation": "us:regulations/7-cfr/273/24",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-08-04T13:37:30.005014+00:00",
+  "generated_at": "2026-09-01T21:52:06.149485+00:00",
   "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6/sign-applied-files/us/regulations/7-cfr/273/24.yaml",
   "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp3maau3j6",
-  "generated_output_sha256": "089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec",
+  "generated_output_sha256": "380030d6f724c002d45dd33aeb5d1899d9f5d03b2eb7f9d73867e1a8a34e523d",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "f77afc88d0826a97b45b008e2116fb950b55aae9e459967f653a7fa60e89c601"
-  },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-08-04T13:37:02.774033+00:00",
+    "generated_at": "2026-08-04T13:37:30.005014+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "a6bc0b7bd681a63bfc4944733d29c969e497a999bff998437e7483f27ac81cf8",
-    "prior_signature": "bf5ba3d089d2ce1d79a38346dac1d5235973a2a3ef7d93034434e81d024fe585",
+    "manifest_sha256": "c311ac133412d642fd235baa0de0ea64753511ae53436cf973aece170691e9d3",
+    "prior_signature": "f77afc88d0826a97b45b008e2116fb950b55aae9e459967f653a7fa60e89c601",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-08-04T12:45:04.962148+00:00",
+      "generated_at": "2026-08-04T13:37:02.774033+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "b177f6a3a3747fc6d161dc4d256f7224f38844aadfa8d6c1e869d45258983d36",
-      "prior_signature": "47bef9c7b2e312421f43ae70d6b490a644a77a758e55649f2079ed6f59f2118c",
+      "manifest_sha256": "a6bc0b7bd681a63bfc4944733d29c969e497a999bff998437e7483f27ac81cf8",
+      "prior_signature": "bf5ba3d089d2ce1d79a38346dac1d5235973a2a3ef7d93034434e81d024fe585",
       "run_id": null,
       "supersedes": {
-        "backend": "deterministic",
-        "generated_at": "2026-06-29T02:54:01.996017+00:00",
+        "backend": "manual",
+        "generated_at": "2026-08-04T12:45:04.962148+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "2cd1b3cb2d7b38fb7984440f055d9463e84fdd7ca07211aa0aa97025b5542d2b",
-        "prior_signature": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6",
-        "run_id": "deterministic-repair",
-        "tool": "axiom-encode repair-embedded-scalar-literals"
+        "manifest_sha256": "b177f6a3a3747fc6d161dc4d256f7224f38844aadfa8d6c1e869d45258983d36",
+        "prior_signature": "47bef9c7b2e312421f43ae70d6b490a644a77a758e55649f2079ed6f59f2118c",
+        "run_id": null,
+        "supersedes": {
+          "backend": "deterministic",
+          "generated_at": "2026-06-29T02:54:01.996017+00:00",
+          "generation_prompt_sha256": null,
+          "manifest_sha256": "2cd1b3cb2d7b38fb7984440f055d9463e84fdd7ca07211aa0aa97025b5542d2b",
+          "prior_signature": "bb2d6e15eff222b55448fabda033a5238afbd443c6582251aa364e3fd09092a6",
+          "run_id": "deterministic-repair",
+          "tool": "axiom-encode repair-embedded-scalar-literals"
+        },
+        "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"
-    },
-    "tool": "axiom-encode sign-applied-files"
+    }
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/encoding-manifests/us/statutes/42/1396a/xx.json
+++ b/.axiom/encoding-manifests/us/statutes/42/1396a/xx.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "us/statutes/42/1396a/xx.yaml",
-      "sha256": "b387ca2b62e96b93cb4e7c2f6277a2c83b2dc311327c318e10142d281c4ea047"
+      "sha256": "0849267981ace8d3077ab6168137b9fc2c3a98c478fb718ce4f56a85c355ebed"
     }
   ],
   "axiom_encode_git": {
@@ -21,63 +21,67 @@
   "citation": "us:statutes/42/1396a/xx",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-20T17:29:04.484275+00:00",
+  "generated_at": "2026-09-01T21:52:06.149485+00:00",
   "generated_output_file": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3/sign-applied-files/us/statutes/42/1396a/xx.yaml",
   "generated_output_root": "/var/folders/t5/1q_n2l7d1ndddzm52gy9n93w0000gn/T/tmpe4jcw7m3",
-  "generated_output_sha256": "b387ca2b62e96b93cb4e7c2f6277a2c83b2dc311327c318e10142d281c4ea047",
+  "generated_output_sha256": "0849267981ace8d3077ab6168137b9fc2c3a98c478fb718ce4f56a85c355ebed",
   "generation_prompt_sha256": null,
   "model": "",
   "run_id": null,
   "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "d5313a53c4adc1157f74266e81ab16fc9658f1a7b65a8300fea57337e3aa03e8"
-  },
   "supersedes": {
     "backend": "manual",
-    "generated_at": "2026-07-20T17:25:29.328264+00:00",
+    "generated_at": "2026-07-20T17:29:04.484275+00:00",
     "generation_prompt_sha256": null,
-    "manifest_sha256": "10bf4ed915db639b65eb0489f598a1607e61c0889aa1aac80bf3645d14f9d7a4",
-    "prior_signature": "175f4fa072f6404589696e149a792d99221bfffd3eadd8c58113f56009614f77",
+    "manifest_sha256": "1dc8bf23d55ae3bc49cd1a4509a53adf7fc2168e795eda80eb37867d770bb5b2",
+    "prior_signature": "d5313a53c4adc1157f74266e81ab16fc9658f1a7b65a8300fea57337e3aa03e8",
     "run_id": null,
     "supersedes": {
       "backend": "manual",
-      "generated_at": "2026-07-20T17:24:35.443786+00:00",
+      "generated_at": "2026-07-20T17:25:29.328264+00:00",
       "generation_prompt_sha256": null,
-      "manifest_sha256": "20caf78d507f42cf7066f901a33854fe41185403f11ddf64a4c65493fbb93958",
-      "prior_signature": "5430048690f4efe9b26c1bcf2bf3ad5f020bcd8888a7363822d00cb3285affab",
+      "manifest_sha256": "10bf4ed915db639b65eb0489f598a1607e61c0889aa1aac80bf3645d14f9d7a4",
+      "prior_signature": "175f4fa072f6404589696e149a792d99221bfffd3eadd8c58113f56009614f77",
       "run_id": null,
       "supersedes": {
         "backend": "manual",
-        "generated_at": "2026-07-20T17:22:55.239835+00:00",
+        "generated_at": "2026-07-20T17:24:35.443786+00:00",
         "generation_prompt_sha256": null,
-        "manifest_sha256": "2df72a4c8984bf02b9516f8801803416358e2507fbdec5be7beac960b9597a2f",
-        "prior_signature": "fb9482398795d8f978efb8705d6c4b2ea5aba44f46252ed052564bc9c936238a",
+        "manifest_sha256": "20caf78d507f42cf7066f901a33854fe41185403f11ddf64a4c65493fbb93958",
+        "prior_signature": "5430048690f4efe9b26c1bcf2bf3ad5f020bcd8888a7363822d00cb3285affab",
         "run_id": null,
         "supersedes": {
           "backend": "manual",
-          "generated_at": "2026-07-20T17:21:52.087705+00:00",
+          "generated_at": "2026-07-20T17:22:55.239835+00:00",
           "generation_prompt_sha256": null,
-          "manifest_sha256": "5ccfbb83f90eec26c12f4b8545061c3a524e2276b31e47e8cb8594d063287977",
-          "prior_signature": "9175dcf95707b0cfc97afcbd95cb79227185fbedb39d3034f0099d5bb2449f18",
+          "manifest_sha256": "2df72a4c8984bf02b9516f8801803416358e2507fbdec5be7beac960b9597a2f",
+          "prior_signature": "fb9482398795d8f978efb8705d6c4b2ea5aba44f46252ed052564bc9c936238a",
           "run_id": null,
           "supersedes": {
             "backend": "manual",
-            "generated_at": "2026-07-20T17:18:52.874327+00:00",
+            "generated_at": "2026-07-20T17:21:52.087705+00:00",
             "generation_prompt_sha256": null,
-            "manifest_sha256": "143ed0e5ffbea6de1cd6426d39b2bbd6895cdf851806019a6a2da4b76890b910",
-            "prior_signature": "595b085cb966e20e5f875af9ee6f7d9814dd7ddc893e5a89298c3444afb5f725",
+            "manifest_sha256": "5ccfbb83f90eec26c12f4b8545061c3a524e2276b31e47e8cb8594d063287977",
+            "prior_signature": "9175dcf95707b0cfc97afcbd95cb79227185fbedb39d3034f0099d5bb2449f18",
             "run_id": null,
             "supersedes": {
-              "backend": "deterministic",
-              "generated_at": "2026-06-29T10:38:25.722651+00:00",
+              "backend": "manual",
+              "generated_at": "2026-07-20T17:18:52.874327+00:00",
               "generation_prompt_sha256": null,
-              "manifest_sha256": "8414d31ab6b244bb77420d65e40845b12ca87b257da2cf7e4475cabeb4c5564b",
-              "prior_signature": "7ee34c4f4d0206f60b27ff8dcd9ca972f9e93900479b3c0a0fcb35728e36ae10",
-              "run_id": "deterministic-repair",
-              "tool": "axiom-encode repair-source-child-corpus-paths"
+              "manifest_sha256": "143ed0e5ffbea6de1cd6426d39b2bbd6895cdf851806019a6a2da4b76890b910",
+              "prior_signature": "595b085cb966e20e5f875af9ee6f7d9814dd7ddc893e5a89298c3444afb5f725",
+              "run_id": null,
+              "supersedes": {
+                "backend": "deterministic",
+                "generated_at": "2026-06-29T10:38:25.722651+00:00",
+                "generation_prompt_sha256": null,
+                "manifest_sha256": "8414d31ab6b244bb77420d65e40845b12ca87b257da2cf7e4475cabeb4c5564b",
+                "prior_signature": "7ee34c4f4d0206f60b27ff8dcd9ca972f9e93900479b3c0a0fcb35728e36ae10",
+                "run_id": "deterministic-repair",
+                "tool": "axiom-encode repair-source-child-corpus-paths"
+              },
+              "tool": "axiom-encode sign-applied-files"
             },
             "tool": "axiom-encode sign-applied-files"
           },
@@ -86,8 +90,7 @@
         "tool": "axiom-encode sign-applied-files"
       },
       "tool": "axiom-encode sign-applied-files"
-    },
-    "tool": "axiom-encode sign-applied-files"
+    }
   },
   "tool": "axiom-encode sign-applied-files",
   "trace_file": null,

--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
 axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
-validation_waiver_set_sha256 = "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+validation_waiver_set_sha256 = "967815adede0ce291f65a0d64f35d34165de5319978432837b8653a37f9f9ce6"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,30 @@ This repo stores US federal RuleSpec encodings and source registry metadata.
 - Add singular rule roots, separate parameter/test fixture files, or generated formula artifacts.
 - Put unrelated jurisdiction materials here.
 - Add generated source payloads to Git.
+
+## Versions and effective dates
+
+- A rule's `versions[]` is the history of the law, not the history of the file.
+  When an amendment changes a rule, **append a version** and close the previous
+  one with `effective_to`. Never edit an existing version's `formula`, `values`,
+  or `effective_from` to reflect a change in the law (#1310).
+- Editing a version in place is correct only to fix an *encoding* error — a date
+  or value that was always wrong. Say so in the commit, and name the rule.
+- `effective_from` is the date the *provision as written* began to apply, not:
+  - the date the surrounding subsection was enacted (an amended value inside a
+    long-lived subsection has its own, later date — #1319);
+  - a compliance or implementation deadline;
+  - the date you encoded it.
+- `effective_from` and `effective_to` are **inclusive**. Statutory language of the
+  form "after December 31, 2026" means `effective_from: 2027-01-01` (#1320).
+  "The first day of the first quarter that begins after December 31, 2026" is
+  January 1, 2027, not April 1.
+- Prefer a real date to a placeholder. Do not write `0001-01-01` for "unknown" —
+  it makes the rule answer as in force for all of history (#1322).
+- Cite the amending instrument on the version it produced (`source:` on the
+  version; the key parses today and the API reads it as version-level
+  provenance), and anchor a proof atom on each `versions[i].formula`.
+- Derived rules cannot yet carry more than one version
+  (axiom-rules-engine#133, #64). When an amendment changes a derived rule's
+  logic, date the new version from the amendment and let earlier periods stay
+  unresolved — a fail-closed answer is preferable to a confidently wrong one.

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -6698,12 +6698,6 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
-  "us/statutes/42/1396a/e/14.yaml":
-    active:
-      fingerprint: "sha256:4b7ea0f8c1defa6c515e771873d5900fe0199c2fcce56e833b38aacbc580c191"
-      owner: "@MaxGhenis"
-      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
-      expires: "2026-10-08"
   "us/statutes/42/1396a/f.yaml":
     active:
       fingerprint: "sha256:d9f5f5e37b7400f3123a786100f0005ee138452b22071bde49f4d2e0b17ced28"

--- a/us/.axiom/encoding-manifests/statutes/42/1396a/a/10.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1396a/a/10.json
@@ -2,7 +2,7 @@
   "applied_files": [
     {
       "path": "statutes/42/1396a/a/10.yaml",
-      "sha256": "4b0ab9425c5064a50c8584fb7b5a1a854bd280290e032dc6ca6c1c18fecee46b"
+      "sha256": "758e7d5216c90513088212c0ca505b4e106f76b922da2e30d961b565547818ec"
     },
     {
       "path": "statutes/42/1396a/a/10.test.yaml",
@@ -17,23 +17,27 @@
     "version_commit": "1d8aff2ffbccc999d1835c42fed0358dee9d3d6a"
   },
   "axiom_encode_version": "0.2.1028",
-  "backend": "deterministic",
+  "backend": "manual",
   "citation": "us:statutes/42/1396a/a/10",
   "context_manifest_file": null,
   "context_manifest_sha256": null,
-  "generated_at": "2026-07-01T03:42:38.700347+00:00",
+  "generated_at": "2026-09-01T23:06:45.375850+00:00",
   "generated_output_file": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8q4dpdo9/deterministic-repair/statutes/42/1396a/a/10.yaml",
   "generated_output_root": "/var/folders/9l/_wztzgbx7mgc7l1r0416cy7m0000gn/T/tmp8q4dpdo9",
-  "generated_output_sha256": "4b0ab9425c5064a50c8584fb7b5a1a854bd280290e032dc6ca6c1c18fecee46b",
+  "generated_output_sha256": "758e7d5216c90513088212c0ca505b4e106f76b922da2e30d961b565547818ec",
   "generation_prompt_sha256": null,
-  "model": "medicaid-community-engagement-effective-date-v1",
-  "run_id": "deterministic-repair",
-  "runner": "deterministic-repair",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "1fb60ac45edf8622ce4c0392085358f9d6363ddb128785708cca40f1426569fb"
+  "supersedes": {
+    "backend": "deterministic",
+    "generated_at": "2026-07-01T03:42:38.700347+00:00",
+    "generation_prompt_sha256": null,
+    "manifest_sha256": "773be9f3899d099d671da230ffc9a59e811c06762bf3b821206588daa371defb",
+    "prior_signature": "1fb60ac45edf8622ce4c0392085358f9d6363ddb128785708cca40f1426569fb",
+    "run_id": "deterministic-repair",
+    "supersedes": null
   },
   "tool": "axiom-encode repair-medicaid-community-engagement-effective-date",
   "trace_file": null,

--- a/us/.axiom/encoding-manifests/statutes/42/1396a/e/14.json
+++ b/us/.axiom/encoding-manifests/statutes/42/1396a/e/14.json
@@ -2,11 +2,11 @@
   "applied_files": [
     {
       "path": "statutes/42/1396a/e/14.yaml",
-      "sha256": "17c6a72e09072273dfeda63802408c7154b760cd38d4e64b08c74121350d1250"
+      "sha256": "f4872b4595da986af60c5e9a9235911b36fa66cee1abad7ecc4d2ebe9e96e953"
     },
     {
       "path": "statutes/42/1396a/e/14.test.yaml",
-      "sha256": "2bc9d1a6055f3eb546d10e11782f4719f735a2218e9651acafd9e3d71d044cb9"
+      "sha256": "05464d49aea234efcd470b60346b3e256d30a83a1eae30e80db1808570b7a58e"
     }
   ],
   "axiom_encode_git": {
@@ -17,23 +17,27 @@
     "version_commit": "c618cf13820bebf8c3a2b0cd55fd0dc677d85dfb"
   },
   "axiom_encode_version": "0.2.890",
-  "backend": "codex",
+  "backend": "manual",
   "citation": "42 USC 1396a(e)(14)",
   "context_manifest_file": "/tmp/axiom-encode-encodings/_eval_workspaces/codex-gpt-5.5/42-USC-1396a-e-14/workspace/context-manifest.json",
   "context_manifest_sha256": "7783edbd9f28615c29045494352ea200f8bc66e1515f4c93c87e31dd04907f76",
-  "generated_at": "2026-06-27T03:43:38.199658+00:00",
+  "generated_at": "2026-09-01T21:53:02.691244+00:00",
   "generated_output_file": "/tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/42/1396a/e/14.yaml",
   "generated_output_root": "/tmp/axiom-encode-encodings",
-  "generated_output_sha256": "17c6a72e09072273dfeda63802408c7154b760cd38d4e64b08c74121350d1250",
+  "generated_output_sha256": "f4872b4595da986af60c5e9a9235911b36fa66cee1abad7ecc4d2ebe9e96e953",
   "generation_prompt_sha256": "a555490c263b9431af2aa03ad710fc8bda52e7a52e072b2b35080db4f7e6765a",
-  "model": "gpt-5.5",
-  "run_id": "6baf65cb",
-  "runner": "codex-gpt-5.5",
+  "model": "",
+  "run_id": null,
+  "runner": "manual-attestation",
   "schema_version": "axiom-encode/applied-rulespec/v1",
-  "signature": {
-    "algorithm": "hmac-sha256",
-    "key_id": "axiom-encode-apply-v1",
-    "value": "d8b8e39cd9e3be8a528999d62683d24af306cfa81435139b295ebd193c8ce9a3"
+  "supersedes": {
+    "backend": "codex",
+    "generated_at": "2026-06-27T03:43:38.199658+00:00",
+    "generation_prompt_sha256": "a555490c263b9431af2aa03ad710fc8bda52e7a52e072b2b35080db4f7e6765a",
+    "manifest_sha256": "cfcd77c5666397267ffcbd09c6f4e4d07fe862c08f47fb6642715d9ca46bf6cb",
+    "prior_signature": "d8b8e39cd9e3be8a528999d62683d24af306cfa81435139b295ebd193c8ce9a3",
+    "run_id": "6baf65cb",
+    "supersedes": null
   },
   "tool": "axiom-encode encode --apply",
   "trace_file": "/tmp/axiom-encode-encodings/traces/codex-gpt-5.5/42-USC-1396a-e-14.json",

--- a/us/regulations/7-cfr/273/11/c.yaml
+++ b/us/regulations/7-cfr/273/11/c.yaml
@@ -102,7 +102,7 @@ rules:
             import:
               target: us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_eligible
               output: snap_member_abawd_time_limit_eligible
-              hash: sha256:089c5b53ea87db26e71d7e24bb63331b561a12d35ae303fd1d154170837e88ec
+              hash: sha256:380030d6f724c002d45dd33aeb5d1899d9f5d03b2eb7f9d73867e1a8a34e523d
     versions:
       - effective_from: '2008-10-01'
         formula: |-

--- a/us/regulations/7-cfr/273/24.test.yaml
+++ b/us/regulations/7-cfr/273/24.test.yaml
@@ -576,3 +576,20 @@
   output:
     us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies: holds
     us:regulations/7-cfr/273/24#snap_member_abawd_time_limit_inapplicable: holds
+# Version history of the upper age bound (rulespec-us#1310): the Fiscal
+# Responsibility Act band (55 and older excepted) is retained for
+# 2024-10-01 through 2025-07-03 and the post-P.L. 119-21 band (65) applies
+# from 2025-07-04. Only the parameter is asserted for June 2025: the derived
+# exception rule carries no version before 2025-07-04 (a second derived
+# version is blocked by axiom-rules-engine#133), so the pre-enactment
+# judgment stays unresolved rather than answering with the new criteria.
+- name: abawd_upper_age_bound_fra_era_june_2025
+  period: 2025-06
+  input: {}
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies_scalar_limit_2: 55
+- name: abawd_upper_age_bound_post_hr1
+  period: 2026-07
+  input: {}
+  output:
+    us:regulations/7-cfr/273/24#snap_member_abawd_exception_applies_scalar_limit_2: 65

--- a/us/regulations/7-cfr/273/24.yaml
+++ b/us/regulations/7-cfr/273/24.yaml
@@ -59,6 +59,11 @@ module:
         cited only for what the statute text does not settle: the operational
         reading of "under 18, or over 65" as ages 18-64 subject with 65 and
         older excepted, and the upon-enactment July 4, 2025 effective date.
+        The unconformed eCFR text is cited for exactly one thing: the
+        superseded Fiscal Responsibility Act upper age bound ("Under 18 or
+        55 years of age or older") retained as a closed version through
+        2025-07-03, so the amendment history of that parameter is encoded
+        rather than deleted.
 imports:
 - us:regulations/7-cfr/273/7
 rules:
@@ -139,32 +144,68 @@ rules:
   versions:
   - effective_from: '2025-07-04'
     formula: '18'
-# Upper age bound of the post-P.L. 119-21 exception. The enacted text reads
-# "under 18, or over 65, years of age"; read literally, "over 65" would leave
-# age exactly 65 subject. USDA operationalizes the band as ages 18-64 subject
-# and 65 and older excepted (FNS OBBBA ABAWD exceptions implementation
-# memorandum, 2025-10-03, page 1), and this encoding follows the USDA
-# operational reading: member_age >= 65 excepts. The memorandum, not the
-# statutory phrase, is the authority for the inclusive boundary.
+# Upper age bound of the exception, in two versions (rulespec-us#1310):
+#
+# versions[0] - the Fiscal Responsibility Act of 2023 (P.L. 118-5 section
+# 311) band as the still-unconformed regulation text reads it: "Under 18 or
+# 55 years of age or older" (7 CFR 273.24(c)(1)), i.e. ages 18-54 subject
+# ("individuals aged 18 to 54 were subject to the ABAWD time limit", FNS
+# OBBBA ABAWD exceptions implementation memorandum, page 1). The 55 step
+# took effect October 1, 2024 under FRA section 311; the earlier steps (51
+# from 2023-09-01, 53 from 2023-10-01) have no provision in the corpus and
+# are not encoded, so months before 2024-10-01 stay unresolved. The version
+# closes 2025-07-03, the day before P.L. 119-21 section 10102(a) struck the
+# paragraph. The engine selects a version by period start, so the July 2025
+# Month period still resolves this parameter to 55; the derived rules below
+# carry no version before 2025-07-04, so no exception judgment resolves to
+# the repealed criteria (us-ca MPP 63-410.321 chose 2025-06-30 for the same
+# reason at the judgment level).
+#
+# versions[1] - the post-P.L. 119-21 band. The enacted text reads "under 18,
+# or over 65, years of age"; read literally, "over 65" would leave age
+# exactly 65 subject. USDA operationalizes the band as ages 18-64 subject
+# and 65 and older excepted (memorandum page 1), and this encoding follows
+# the USDA operational reading: member_age >= 65 excepts. The memorandum,
+# not the statutory phrase, is the authority for the inclusive boundary.
 - name: snap_member_abawd_exception_applies_scalar_limit_2
   kind: parameter
   dtype: Count
-  source: 7 U.S.C. 2015(o)(3)(A) as amended by P.L. 119-21 section 10102(a) and FNS OBBBA ABAWD exceptions implementation memorandum (2025-10-03)
+  source: 7 CFR 273.24(c)(1) through 2025-07-03; 7 U.S.C. 2015(o)(3)(A) as amended by P.L. 119-21 section 10102(a) and FNS OBBBA ABAWD exceptions implementation memorandum (2025-10-03) from 2025-07-04
   metadata:
     proof:
       atoms:
       - path: versions[0].formula
         kind: parameter
         source:
-          corpus_citation_path: us/statute/7/2015/o/3
-          excerpt: under 18, or over 65, years of age
+          corpus_citation_path: us/regulation/7/273/24
+          excerpt: Under 18 or 55 years of age or older
       - path: versions[0].formula
         kind: parameter
         source:
           corpus_citation_path: us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1
+          excerpt: individuals aged 18 to 54 were subject to the ABAWD time limit
+      - path: versions[1].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2015/o/3
+          excerpt: under 18, or over 65, years of age
+      - path: versions[1].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-1
           excerpt: Therefore, individuals aged 18 to 64 are now subject to the time limit, unless they meet another exception.
+      - path: versions[1].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-abawd-exceptions-implementation-memo/page-4
+          excerpt: These changes were effective upon enactment, July 4, 2025.
   versions:
+  - effective_from: '2024-10-01'
+    effective_to: '2025-07-03'
+    source: 7 CFR 273.24(c)(1) (Fiscal Responsibility Act of 2023, P.L. 118-5 section 311; 55-and-older band in force from October 1, 2024)
+    formula: '55'
   - effective_from: '2025-07-04'
+    source: 7 U.S.C. 2015(o)(3)(A) as amended by P.L. 119-21 section 10102(a)
     formula: '65'
 - name: snap_member_abawd_exception_dependent_child_age_scalar_limit
   kind: parameter

--- a/us/statutes/26/24.test.yaml
+++ b/us/statutes/26/24.test.yaml
@@ -31,11 +31,70 @@
   output:
     us:statutes/26/24#ctc_qualifying_child: not_holds
     us:statutes/26/24#ctc_child_identification_requirement_satisfied: holds
+# Tax year 2018 composes the P.L. 115-97 amount in subsection (h)(2): $2,000
+# per child (rulespec-us#1319). The $2,200 amount applies to taxable years
+# beginning after December 31, 2024 and is pinned by the 2025 twin below.
 - name: post_2017_joint_credit_composes_subsection_h_and_phaseout
   period:
     period_kind: tax_year
     start: '2018-01-01'
     end: '2018-12-31'
+  input:
+    us:statutes/26/24#input.adjusted_gross_income: 401000
+    us:statutes/26/24#input.ctc_foreign_earned_income_exclusion_adjustment: 0
+    us:statutes/26/24#input.ctc_possession_income_exclusion_adjustment: 0
+    us:statutes/26/24#input.ctc_puerto_rico_income_exclusion_adjustment: 0
+    us:statutes/26/24#input.ctc_phaseout_joint_threshold_applies: true
+    us:statutes/26/24#input.ctc_phaseout_separate_threshold_applies: false
+    us:statutes/26/24#input.ctc_subsection_h_special_rules_apply: true
+    us:statutes/26/24#input.taxpayer_identification_number_issued_after_return_due_date: false
+    us:statutes/26/24#input.taxable_year_months: 12
+    us:statutes/26/24#input.taxable_year_closed_by_reason_of_taxpayer_death: false
+    us:statutes/26/24#input.ctc_fraud_disallowance_period_applies: false
+    us:statutes/26/24#input.ctc_reckless_or_intentional_disregard_disallowance_period_applies: false
+    us:statutes/26/24#input.prior_deficiency_denial_without_required_eligibility_information: false
+    us:statutes/26/24#input.ctc_advance_payments_received: 100
+    us:statutes/26/24#relation.ctc_qualifying_child_of_tax_unit:
+    - us:statutes/26/24#input.ctc_child_satisfies_dependency_rules: true
+      us:statutes/26/24#input.age: 16
+      us:statutes/26/24#input.ctc_child_deduction_allowed: true
+      us:statutes/26/24#input.certain_noncitizen_exception_applies: false
+      us:statutes/26/24#input.ctc_child_missing_identification: false
+    us:statutes/26/24/h#input.filing_status: 1
+    us:statutes/26/24/h#relation.dependent_of_tax_unit:
+    - us:statutes/26/24/h#input.ctc_person_satisfies_dependency_rules: true
+      us:statutes/26/24/h#input.ctc_child_satisfies_subsection_c: true
+      us:statutes/26/24/h#input.noncitizen_exception_to_other_dependent_credit_under_subsection_h: false
+      us:statutes/26/24/h#input.taxpayer_or_spouse_ssn_included_on_return: true
+      us:statutes/26/24/h#input.qualifying_child_ssn_included_on_return: true
+      us:statutes/26/24/h#input.taxpayer_or_spouse_ssn_is_valid_for_subsection_h: true
+      us:statutes/26/24/h#input.qualifying_child_ssn_is_valid_for_subsection_h: true
+  output:
+    us:statutes/26/24#ctc_child_amount_base: 1000
+    us:statutes/26/24#ctc_phaseout_reduction_per_increment: 50
+    us:statutes/26/24#ctc_phaseout_increment: 1000
+    us:statutes/26/24#ctc_joint_threshold_base: 110000
+    us:statutes/26/24#ctc_unmarried_threshold_base: 75000
+    us:statutes/26/24#ctc_separate_threshold_base: 55000
+    us:statutes/26/24#ctc_full_taxable_year_months: 12
+    us:statutes/26/24#ctc_fraud_disallowance_years: 10
+    us:statutes/26/24#ctc_reckless_disallowance_years: 2
+    us:statutes/26/24#ctc_modified_adjusted_gross_income: 401000
+    us:statutes/26/24#ctc_qualifying_children_count: 1
+    us:statutes/26/24#ctc_taxpayer_identification_requirement_satisfied: holds
+    us:statutes/26/24#ctc_full_taxable_year_requirement_satisfied: holds
+    us:statutes/26/24#ctc_prior_claim_restriction_satisfied: holds
+    us:statutes/26/24#ctc_phaseout_threshold_base: 110000
+    us:statutes/26/24#ctc_phaseout_threshold: 400000
+    us:statutes/26/24#ctc_maximum_before_phaseout: 2000
+    us:statutes/26/24#ctc_phaseout_amount: 50
+    us:statutes/26/24#ctc_before_advance_payments: 1950
+    us:statutes/26/24#ctc_after_advance_payments: 1850
+- name: post_2024_joint_credit_composes_amended_subsection_h_and_phaseout
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
   input:
     us:statutes/26/24#input.adjusted_gross_income: 401000
     us:statutes/26/24#input.ctc_foreign_earned_income_exclusion_adjustment: 0

--- a/us/statutes/26/24.yaml
+++ b/us/statutes/26/24.yaml
@@ -427,7 +427,7 @@ rules:
             import:
               target: us:statutes/26/24/h#ctc_phase_out_threshold_under_subsection_h
               output: ctc_phase_out_threshold_under_subsection_h
-              hash: sha256:80d253ad020aaf460588e169963b2d126ea532359124436c2905c343b7dbc103
+              hash: sha256:b7526dc526900ad5e85bc856989d091c7d2520eaf02216a7e332f2b618f640cf
     versions:
       - effective_from: '2018-01-01'
         formula: |-
@@ -456,7 +456,7 @@ rules:
             import:
               target: us:statutes/26/24/h#ctc_maximum_before_phase_out_under_subsection_h
               output: ctc_maximum_before_phase_out_under_subsection_h
-              hash: sha256:80d253ad020aaf460588e169963b2d126ea532359124436c2905c343b7dbc103
+              hash: sha256:b7526dc526900ad5e85bc856989d091c7d2520eaf02216a7e332f2b618f640cf
     versions:
       - effective_from: '2018-01-01'
         formula: |-

--- a/us/statutes/26/24/h.test.yaml
+++ b/us/statutes/26/24/h.test.yaml
@@ -1,8 +1,17 @@
+# Subsection (h) as amended by P.L. 119-21 section 70104, applicable to taxable
+# years beginning after December 31, 2024: the $2,200 amount in (h)(2) and the
+# rewritten taxpayer-and-child social security number test in (h)(7). The
+# derived cases below therefore run in tax year 2025.
+# ctc_child_ssn_requirement_satisfied_under_subsection_h carries no version
+# before 2025-01-01 (the pre-amendment (h)(7) required only the child's number
+# and cannot be a second derived version until axiom-rules-engine#133), so
+# derived outputs for tax years 2018-2024 are unresolved. The parameter
+# history is pinned by the tax-year-2024 case at the end (rulespec-us#1319).
 - name: other_dependent_positive_path
   period:
     period_kind: tax_year
-    start: '2018-01-01'
-    end: '2018-12-31'
+    start: '2025-01-01'
+    end: '2025-12-31'
   input:
     us:statutes/26/24/h#input.ctc_person_satisfies_dependency_rules: true
     us:statutes/26/24/h#input.ctc_child_satisfies_subsection_c: false
@@ -19,8 +28,8 @@
 - name: other_dependent_noncitizen_exception_path
   period:
     period_kind: tax_year
-    start: '2018-01-01'
-    end: '2018-12-31'
+    start: '2025-01-01'
+    end: '2025-12-31'
   input:
     us:statutes/26/24/h#input.ctc_person_satisfies_dependency_rules: true
     us:statutes/26/24/h#input.ctc_child_satisfies_subsection_c: false
@@ -34,8 +43,8 @@
 - name: qualifying_child_with_required_social_security_numbers
   period:
     period_kind: tax_year
-    start: '2018-01-01'
-    end: '2018-12-31'
+    start: '2025-01-01'
+    end: '2025-12-31'
   input:
     us:statutes/26/24/h#input.ctc_person_satisfies_dependency_rules: true
     us:statutes/26/24/h#input.ctc_child_satisfies_subsection_c: true
@@ -52,8 +61,8 @@
 - name: joint_return_aggregate_credit_and_refundable_cap
   period:
     period_kind: tax_year
-    start: '2018-01-01'
-    end: '2018-12-31'
+    start: '2025-01-01'
+    end: '2025-12-31'
   input:
     us:statutes/26/24/h#input.filing_status: 1
     us:statutes/26/24/h#relation.dependent_of_tax_unit:
@@ -90,3 +99,12 @@
     us:statutes/26/24/h#ctc_phase_out_threshold_under_subsection_h: 400000
     us:statutes/26/24/h#ctc_maximum_before_phase_out_under_subsection_h: 3200
     us:statutes/26/24/h#ctc_refundable_maximum_under_subsection_h: 1400
+- name: child_amount_before_hr1_tax_year_2024
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us:statutes/26/24/h#ctc_child_amount_under_subsection_h: 2000
+    us:statutes/26/24/h#ctc_refundable_per_child_cap_under_subsection_h: 1400

--- a/us/statutes/26/24/h.yaml
+++ b/us/statutes/26/24/h.yaml
@@ -28,6 +28,14 @@ rules:
         - TaxUnit
         - Person
 
+  # (h)(2) has carried two amounts. P.L. 115-97 section 11022(a) (TCJA) wrote
+  # "$2,000" for taxable years beginning after December 31, 2017; P.L. 119-21
+  # section 70104(a)(2) struck "$2,000" and inserted "$2,200", applicable to
+  # taxable years beginning after December 31, 2024 (section 70104(f)). The
+  # subsection's own opening date (2018-01-01) is NOT the effective date of
+  # the amended amount. The corpus serves current text only, so the
+  # pre-amendment value is attested by the amending act rather than by a
+  # live excerpt (rulespec-us#1319).
   - name: ctc_child_amount_under_subsection_h
     kind: parameter
     dtype: Money
@@ -40,9 +48,25 @@ rules:
             kind: amount
             source:
               corpus_citation_path: us/statute/26/24
-              text: Subsection (a) shall be applied by substituting "$2,200" for "$1,000".
+              text: >-
+                Pre-amendment (h)(2), as enacted by P.L. 115-97 section 11022(a):
+                Subsection (a) shall be applied by substituting "$2,000" for
+                "$1,000". Struck by P.L. 119-21 section 70104(a)(2) ("by striking
+                '$2,000' and inserting '$2,200'"), applicable to taxable years
+                beginning after December 31, 2024 (section 70104(f)).
+          - path: versions[1].formula
+            kind: amount
+            source:
+              corpus_citation_path: us/statute/26/24
+              excerpt: Subsection (a) shall be applied by substituting “$2,200” for “$1,000”.
     versions:
       - effective_from: '2018-01-01'
+        effective_to: '2024-12-31'
+        source: 26 USC 24(h)(2) as enacted by P.L. 115-97 section 11022(a)
+        formula: |-
+          2000
+      - effective_from: '2025-01-01'
+        source: 26 USC 24(h)(2) as amended by P.L. 119-21 section 70104(a)(2)
         formula: |-
           2200
 
@@ -136,6 +160,14 @@ rules:
         formula: |-
           2500
 
+  # (h)(7) was rewritten by P.L. 119-21 section 70104(b), applicable to taxable
+  # years beginning after December 31, 2024: the credit now also requires the
+  # taxpayer's (or one spouse's) social security number. The pre-amendment
+  # paragraph (P.L. 115-97) required only the qualifying child's number. That
+  # earlier logic cannot be retained as a second version of a derived rule
+  # until axiom-rules-engine#133 lands, so this rule starts at 2025-01-01 and
+  # taxable years 2018-2024 stay unresolved rather than answering with the
+  # post-amendment test (rulespec-us#1319).
   - name: ctc_child_ssn_requirement_satisfied_under_subsection_h
     kind: derived
     entity: Person
@@ -156,7 +188,8 @@ rules:
               corpus_citation_path: us/statute/26/24
               text: social security number means a social security number issued to an individual by the Social Security Administration, but only if issued to a citizen of the United States or pursuant to the cited Social Security Act provisions and before the due date for such return
     versions:
-      - effective_from: '2018-01-01'
+      - effective_from: '2025-01-01'
+        source: 26 USC 24(h)(7) as amended by P.L. 119-21 section 70104(b)
         formula: |-
           taxpayer_or_spouse_ssn_included_on_return
           and qualifying_child_ssn_included_on_return

--- a/us/statutes/42/1396a/a/10.yaml
+++ b/us/statutes/42/1396a/a/10.yaml
@@ -501,7 +501,7 @@ rules:
             import:
               target: us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
               output: demonstrated_community_engagement_for_month
-              hash: sha256:48ae645b26d1e6987bbf379424d1a96db6871830473d4671eb786cc3fad6c75c
+              hash: sha256:0849267981ace8d3077ab6168137b9fc2c3a98c478fb718ce4f56a85c355ebed
           - path: versions[0].formula
             kind: import
             import:

--- a/us/statutes/42/1396a/e/14.test.yaml
+++ b/us/statutes/42/1396a/e/14.test.yaml
@@ -47,3 +47,14 @@
     us:statutes/42/1396a/e/14#input.individual_exempt_under_subsection_xx_9_A_ii_II: false
   output:
     us:statutes/42/1396a/e/14#six_month_redetermination_required: holds
+- name: six_month_redetermination_required_from_first_quarter_of_2027
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/e/14#input.redetermination_scheduled_on_or_after_applicable_start_date: true
+    us:statutes/42/1396a/e/14#input.state_is_one_of_50_states_or_district_of_columbia: true
+    us:statutes/42/1396a/e/14#input.enrolled_under_adult_expansion_group: true
+    us:statutes/42/1396a/e/14#input.enrolled_under_equivalent_minimum_essential_coverage_waiver_for_adult_expansion_group: false
+    us:statutes/42/1396a/e/14#input.individual_exempt_under_subsection_xx_9_A_ii_II: false
+  output:
+    us:statutes/42/1396a/e/14#six_month_redetermination_required: holds
+    us:statutes/42/1396a/e/14#redetermination_interval_months_for_certain_adult_expansion_individuals: 6

--- a/us/statutes/42/1396a/e/14.yaml
+++ b/us/statutes/42/1396a/e/14.yaml
@@ -227,13 +227,20 @@ rules:
         kind: exception
         source:
           corpus_citation_path: us/statute/42/1396a/e/14
-          excerpt: shall continue to be eligible ... denial ... would cause an undue
-            medical or financial hardship
+          excerpt: the denial of eligibility of the individual would cause an undue medical
+            or financial hardship
   versions:
   - effective_from: '2018-01-01'
     formula: 'income_exceeds_applicable_eligibility_threshold_by_application_of_lottery_lump_sum_rule
 
       and state_determines_denial_would_cause_undue_medical_or_financial_hardship'
+# Effective date of subparagraph (L), added by P.L. 119-21 section 71107
+# (rulespec-us#1320): redeterminations "scheduled on or after the first day
+# of the first quarter that begins after December 31, 2026". That quarter
+# begins January 1, 2027 (quarters start January 1, April 1, July 1,
+# October 1), so both (L) rules start 2027-01-01, not 2027-04-01. (L) is new
+# text with no pre-amendment counterpart: there is no earlier version to
+# retain, and the ACA-era rules above are separate symbols.
 - name: redetermination_interval_months_for_certain_adult_expansion_individuals
   kind: parameter
   dtype: Count
@@ -247,7 +254,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/e/14
           excerpt: once every 6 months
   versions:
-  - effective_from: '2027-04-01'
+  - effective_from: '2027-01-01'
     formula: '6'
 - name: six_month_redetermination_required
   kind: derived
@@ -264,8 +271,14 @@ rules:
           corpus_citation_path: us/statute/42/1396a/e/14
           excerpt: scheduled on or after the first day of the first quarter that begins
             after December 31, 2026
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/42/1396a/e/14
+          excerpt: scheduled on or after the first day of the first quarter that begins
+            after December 31, 2026
   versions:
-  - effective_from: '2027-04-01'
+  - effective_from: '2027-01-01'
     formula: 'redetermination_scheduled_on_or_after_applicable_start_date
 
       and state_is_one_of_50_states_or_district_of_columbia

--- a/us/statutes/42/1396a/xx.yaml
+++ b/us/statutes/42/1396a/xx.yaml
@@ -6,10 +6,10 @@ module:
     required: true
   source_verification:
     corpus_citation_path: us/statute/42/1396a/xx
-  summary: 42 USC 1396a(xx) requires States, beginning not later than the first quarter
-    after December 31, 2026 unless a special implementation exemption applies, to
-    condition Medicaid eligibility for applicable individuals on demonstrating community
-    engagement. An applicable individual demonstrates engagement for a month by work,
+  summary: 42 USC 1396a(xx) requires States, beginning not later than the first day
+    of the first quarter that begins after December 31, 2026 (January 1, 2027) unless
+    a special implementation exemption applies, to condition Medicaid eligibility for
+    applicable individuals on demonstrating community engagement. An applicable individual demonstrates engagement for a month by work,
     community service, a work program, half-time education, a qualifying combination
     totaling not less than 80 hours, qualifying income based on the applicable minimum
     wage multiplied by 80 hours, or qualifying seasonal-worker average income over
@@ -28,6 +28,14 @@ module:
       Medicaid eligibility, other insurance affordability programs, and fair-hearing
       procedure under subsection (a)(3), which are not provided as executable RuleSpec
       dependencies.
+# Effective date (rulespec-us#1320): paragraph (1) applies "beginning not later
+# than the first day of the first quarter that begins after December 31,
+# 2026". Quarters begin on January 1, April 1, July 1 and October 1, so the
+# first quarter that begins after that date starts January 1, 2027.
+# effective_from is inclusive; December 31, 2026 is the exclusive boundary
+# named in the statute, not a day on which the requirement applies. A State
+# may elect an earlier start under a section 1115 waiver or its plan; that
+# election is not encoded here.
 rules:
 - name: monthly_activity_hours_requirement
   kind: parameter
@@ -42,7 +50,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: not less than 80 hours
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: '80'
 - name: seasonal_worker_income_lookback_months
   kind: parameter
@@ -57,7 +65,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: average monthly income over the preceding 6 months
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: '6'
 - name: hardship_unemployment_rate_threshold
   kind: parameter
@@ -72,7 +80,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: 8 percent
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: '0.08'
 - name: hardship_national_unemployment_rate_multiplier
   kind: parameter
@@ -87,7 +95,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: 1.5 times the national unemployment rate
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: '1.5'
 - name: community_engagement_met_by_activity_or_income
   kind: derived
@@ -104,7 +112,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: meets 1 or more of the following conditions
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'monthly_work_hours >= monthly_activity_hours_requirement
 
       or monthly_community_service_hours >= monthly_activity_hours_requirement
@@ -139,7 +147,7 @@ rules:
           output: institution_of_higher_education
           hash: sha256:86fc1e04b86968a3fea7737fce53a8297bc20be9c7896e4527512caed95bff86
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'institution_of_higher_education
 
       or enrolled_in_career_and_technical_education_program'
@@ -157,7 +165,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'was_specified_excluded_individual_for_part_or_all_of_month
 
       or was_under_age_19_for_part_or_all_of_month
@@ -181,7 +189,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'received_high_acuity_services_for_part_or_all_of_month
 
       or county_has_presidential_emergency_or_disaster_for_part_or_all_of_month
@@ -204,7 +212,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'state_plan_provides_optional_short_term_hardship_deeming
 
       and short_term_hardship_event
@@ -226,7 +234,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'mandatory_community_engagement_deeming_applies
 
       or optional_hardship_deeming_applies'
@@ -245,7 +253,7 @@ rules:
           corpus_citation_path: us/statute/42/1396a/xx
           excerpt: may elect to not require an individual to verify information resulting in such deeming
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'state_elects_not_to_require_verification_for_deemed_community_engagement
 
       and deemed_to_have_demonstrated_community_engagement'
@@ -262,8 +270,13 @@ rules:
         kind: formula
         source:
           corpus_citation_path: us/statute/42/1396a/xx
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/42/1396a/xx
+          excerpt: beginning not later than the first day of the first quarter that begins after December 31, 2026
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'community_engagement_met_by_activity_or_income
 
       or deemed_to_have_demonstrated_community_engagement'
@@ -281,7 +294,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'described_in_subsection_a_10_A_i_IX
 
       or is_indian_urban_indian_california_indian_or_ihs_eligible_indian
@@ -313,7 +326,7 @@ rules:
         source:
           corpus_citation_path: us/statute/42/1396a/xx
   versions:
-  - effective_from: '2026-12-31'
+  - effective_from: '2027-01-01'
     formula: 'not specified_excluded_individual
 
       and (eligible_or_enrolled_under_subsection_a_10_A_i_VIII or (eligible_or_enrolled_under_equivalent_minimum_essential_coverage_waiver


### PR DESCRIPTION
Fixes the version/effective-date defects filed against the four H.R. 1 (P.L. 119-21) modules, one commit per issue, plus the consequential repairs CI asked for.

## What changes

**7 CFR 273.24 — #1310.** `snap_member_abawd_exception_applies_scalar_limit_2` gets its Fiscal Responsibility Act version back: `55` from `2024-10-01` (FRA §311 step) closed at `2025-07-03`, then `65` from `2025-07-04`. The restored version cites text that is in the corpus today — the still-unconformed eCFR (`"Under 18 or 55 years of age or older"`) and the FNS memorandum (`"individuals aged 18 to 54 were subject to the ABAWD time limit"`). Proof atoms are re-anchored per version and a per-version `source:` names the instrument. The earlier FRA steps (51 from 2023-09-01, 53 from 2023-10-01) have no corpus provision and are deliberately not encoded; months before 2024-10-01 stay unresolved. Companion cases pin 55 at 2025-06 and 65 at 2026-07.

**26 USC 24(h) — #1319.** `ctc_child_amount_under_subsection_h` now has two versions: `$2,000` (P.L. 115-97, `2018-01-01`–`2024-12-31`) and `$2,200` (P.L. 119-21 §70104(a)(2), from `2025-01-01` per §70104(f)). The `$2,200` atom is a live excerpt; the `$2,000` value is attested by the amending act in a `text:` atom because the corpus serves current text only. The audit the issue asked for found one more defect: §70104(b) rewrote (h)(7) to require the *taxpayer's* SSN too. `ctc_child_ssn_requirement_satisfied_under_subsection_h` cannot carry the pre-amendment logic as a second derived version (axiom-rules-engine#133), so it now starts `2025-01-01`: tax years 2018–2024 are unresolved for SSN-dependent outputs instead of answering with the post-amendment test. Companion cases move to tax year 2025; a new tax-year-2024 case pins `$2,000`. The composing module's `26/24.test.yaml` had inherited the same wrong-law expectation ($2,200 in 2018); its 2018 case now expects the $2,000-based amounts and a 2025 twin pins the $2,200 path.

**42 USC 1396a(xx) and (e)(14) — #1320.** Both provisions key off "the first day of the first quarter that begins after December 31, 2026", i.e. **2027-01-01**. `xx.yaml` moves all 14 versions from `2026-12-31` (exclusive boundary read as inclusive); `e/14.yaml` moves both (L) rules from `2027-04-01`. Each gets an `effective_period` atom quoting the statute. Both are new text with no pre-amendment counterpart, so there is nothing earlier to retain — the issue's point 2 on (e)(14) resolves as "not applicable". The ellipsis excerpt on `hardship_exemption_preserves_medical_assistance` is replaced with the real (K)(iii) text; with that, CI reports (e)(14) **passes validation**, so its `known-validation-gaps` record is dropped (started-passing rule) and the waiver-set pin in `.axiom/toolchain.toml` follows the file.

**CLAUDE.md — #1321.** Adds the "Versions and effective dates" section (append-and-close, inclusive bounds, no `0001-01-01`, per-version `source:`, derived rules fail closed until #133).

**Consequential:** proof import atoms pin the sha256 of the imported module file, so `7-cfr/273/11/c` (imports 273.24), `26/24` (imports 24(h)) and `42/1396a/a/10` (imports 1396a(xx)) carry the new digests — the repair the encoder applies to dependents on apply. (a)(10)'s pin was already stale on `main`.

## Verified

Locally on the pinned toolchain (engine `48797e1`, encoder `29b30fb`): all modules compile; companion tests pass (38 cases on the four modules, 10 on `26/24` + `24(h)`, plus the three importers); proof trees and money-atom obligations pass through the harness API against the corpus; `tests/test_encoding_manifests.py` and `tests/test_repository_layout.py` pass; reverse index unchanged.

In CI (`validate (us)`, full-toolchain mode because the pin moved): 660 of 662 `us/` modules validated clean, including `1396a/e/14` without its waiver; the only two failures were the stale importer hashes, fixed in the next commit.

## What remains — needs a maintainer

1. **Sign the manifests.** Seven encoding manifests (`273/24`, `26/24/h`, `1396a/xx`, `1396a/e/14`, `273/11/c`, `26/24`, `1396a/a/10`) carry refreshed sha256s but no signature; the pinned guard expects `applied-rulespec/v5` manifests produced by the encoder under the apply-signing supervisor, which I cannot run. `generated-guard` (in the `us-ak` audit leg) rejects them as "not an encoder apply manifest" until then.
2. **Approve the waiver drift.** `273/24`, `26/24/h` and `1396a/a/10` remain waived-failing (their pre-existing failures are unchanged in kind — 273.24's plural corpus paths, etc. — but the failure *text* changed with the edits), so their `active` fingerprints drift. The bridge only lets a changed `active` record consume a protected-base `pending` record, so this needs the usual sequence: evidence PR from the hardened fingerprint workflow run against this branch's tree (as #1297/#1304), then the waiver-only approvals PR adding `pending` records (as #1299/#1308), which this PR then consumes. I could not compute the fingerprints locally (broker); CI's audit legs report the new values: `273/24` → `sha256:208d49f26b4f8d098266b6c5f20a0280bf7840ee9450e9957ca9f4f0911ee85d`, `26/24/h` → `sha256:a716230d09f1b27d9241dedea5239a25e994306aa8cf1b425462529588caf243`, `a/10` → `sha256:cbc78618caa25f932d44d64a8edfd30610d261bd27fdcff24652c2e5309e7163` (final head 5046be06; the first two are unchanged since the initial push).
3. The pinned engine emits artifact format v1, where `effective_to` is not executable; selection by latest `effective_from` still yields the right value for every period the tests cover. The closed windows become executable on the v2 engine.

## Not in this PR

- Item 2 of #1310 (a CI retention guard) and #1322 (the `0001-01-01` sentinel) — separate changes.
- Amendment history for derived rules, blocked on axiom-rules-engine#133 / #64.
- A pre-amendment version for `snap_member_abawd_exception_dependent_child_age_scalar_limit`: the pre-H.R. 1 exception ((c)(3)–(4), parent of / residing with a member under 18) was a different structure, not an earlier value of this parameter.
- Fixing 273.24's plural `corpus_citation_paths` (its long-standing waived failure) — that is a module split, not a version fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
