### PR TITLE
Add signed encoding manifest for us/regulation/7/273/4

### DIFF
--- a/.axiom/encoding-manifests/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.json
+++ b/.axiom/encoding-manifests/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.json
@@ -1,0 +1,251 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml",
+      "sha256": "a676143833594eb342865cde3fffb1334db385bd72c326711c41b3ca70d58b90"
+    },
+    {
+      "path": "us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml",
+      "sha256": "7346138490feae3120233bed4543277ed5305dec2287f202bec7ca3ebc421d45"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1755",
+    "version_commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a"
+  },
+  "axiom_encode_version": "0.2.1755",
+  "backend": "openai",
+  "citation": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+  "context_manifest_file": "/home/runner/work/_temp/generated/source-02/_eval_workspaces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-obbb-alien-eligibility-implementation-memo/workspace/context-manifest.json",
+  "context_manifest_sha256": "3c5e801d5f802134664d546d6981402751ed8286e12f962e34afd930284baab1",
+  "generated_at": "2026-09-02T12:50:11.973707+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/source-02/openai-gpt-5.6-terra/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/source-02",
+  "generated_output_sha256": "a676143833594eb342865cde3fffb1334db385bd72c326711c41b3ca70d58b90",
+  "generation_prompt_sha256": "cafc18e4ea88041aa3e7184e561f570bc0599499a0af28498cb5b058cd8cf0c9",
+  "model": "gpt-5.6-terra",
+  "run_id": "8ed25410",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "FP0mjFSc5Eu1KrA3eIa1j3AMm3eAE1Dr0T8ItFyMgLs2L93aLbC0f6xvRJGncP+0Hb71BSUw5Oxs+tbKGjPCDA=="
+  },
+  "source_attestation": {
+    "component_rows": [
+      {
+        "body_sha256": "49dc2ccf52a26ed453f8ddad319c99fd59085bbc01958aba89393c14e1a355dc",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-1",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 2,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "2756e2a3-6d3e-55aa-bced-4c33681b61c5",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "46c90f029882a1efb8e7a90a306d72451ded411aa6a072c95691c4256c6bba13",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-2",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 3,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "609fc487-ed49-597e-ae7b-c4a4e9e6364e",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "f72ae7092f8a2a71b3e0b3698e7fbc8ad3697c58491f3ebaac875e3d976716f1",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 4,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "f2c56943-45e4-5976-97bd-d335f9018c8c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "b000f7c5b8a08e66012566703be6b03650c9d8e05332c8165764d1b6ef228ff8",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-4",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 5,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "5fa4d7a0-2eac-5adb-9d53-ff2b7f35a41b",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "5ca41d41d4366a9a0c9a5c9bdd4b18868f6679eb47f2092c1522b931f4570b02",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-5",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 6,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "ee93060e-13bb-51e3-9f98-1abf82539252",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "6a96cbdeceecb2eebd9789424067b7a5f2ae6410e50055c8fd012a047df02041",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-6",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 7,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "72962936-fbc3-50e7-8f7a-99ac80f231ef",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "71fcfb4bd3e6500fd707b2b365bd7e28c7073344c1113eb51b793258aada2640",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-7",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 8,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "423c63bf-bf79-51aa-b368-ee862ae59ed1",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "db7f57da8d7b771eecd6e9ec3c72fc00b40d568797250882ee40a064020e510e",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-8",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 9,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "3fce701d-8dc9-515f-a084-16270112a38d",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "8e717455a887dbd8ea9663980a52c2daa7e1abac02ca6acb39e329005d793390",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-9",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 10,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "bb8b1d8b-21de-5c0b-b094-1fb18cd04334",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "5173fe1feee684bec81c19cc4b82b6e5d8d45c37d396a662e99839ea6e35a7e7",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-10",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 11,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "6809d721-f1e6-5012-9d92-fc099a24ac9c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "94a74d114be850b9d8afc970aad80087efe9c8dac2fceb3ecd7461b761f70ca5",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-11",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 12,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "a1b3b769-94a3-5650-b8ff-31e96c7baa5c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      }
+    ],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2025-10-31",
+    "generation_input_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c",
+    "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+    "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+    "requested_corpus_citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+    "resolved_corpus_citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+    "resolved_text_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c",
+    "row": {
+      "body_sha256": null,
+      "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+      "document_class": "guidance",
+      "expression_date": "2025-10-31",
+      "jurisdiction": "us",
+      "line_number": 1,
+      "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+      "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+      "record_id": "1d2b4574-ad56-513b-b993-033a6d4df27e",
+      "source_as_of": "2026-03-02",
+      "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+      "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-03-02",
+    "source_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/source-02/traces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-obbb-alien-eligibility-implementation-memo.json",
+  "trace_sha256": "ad3bd1de884f89680df31f5fcd9ed279ba2d888ac5463919c45c24f096625949",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1755"
+    },
+    "axiom_rules_engine": {
+      "commit": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "31328e9b24eba0b48e95694c94fa0a0bdb732287d4b69a84143a0f508a175d9a",
+      "pre_apply_file_count": 2711,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/4.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/4.json
@@ -1,0 +1,100 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/7-cfr/273/4.yaml",
+      "sha256": "51e5e852cdb46a07e06bf908526bb31296af0e50dce27ab9c7266799bfeed4f8"
+    },
+    {
+      "path": "us/regulations/7-cfr/273/4.test.yaml",
+      "sha256": "b700042c1f73aae8af58e4d6b90e18ffedf351fcdeafceaf3bc95d4b2710f9e1"
+    },
+    {
+      "path": "us/policies/usda/snap/state-plan-composition.test.yaml",
+      "sha256": "7c076ab917dc198bed41367b2d3f1b9b646d4595ff9069a5229e3b4c6b73d864"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1755",
+    "version_commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a"
+  },
+  "axiom_encode_version": "0.2.1755",
+  "backend": "openai",
+  "citation": "us/regulation/7/273/4",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-regulation-7-273-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "c1b0ecaa38c400ce2dd805d00c151ce606bdde5cd1045d41bbec97bf3f39dd72",
+  "generated_at": "2026-09-02T13:19:59.002891+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/regulations/7-cfr/273/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "51e5e852cdb46a07e06bf908526bb31296af0e50dce27ab9c7266799bfeed4f8",
+  "generation_prompt_sha256": "d2f06b93258c701fb32da3c87681f41ac8213d5b9a0726761a606b638423e8db",
+  "model": "gpt-5.6-terra",
+  "run_id": "3734a8ea",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "Ph/d5udTwoCU+8lki+2/Iwky4SqDU0cZkTzxqaBLS8QzcUrTwEBnfL8CoZg3qMK6FxC566eFLUKSasDvqjC0CQ=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-04-29",
+    "generation_input_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+    "provision_file": "data/corpus/provisions/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained.jsonl",
+    "provision_file_sha256": "de25d2b32f261e92405a553f65dfc90b47b032a4d1a80b1b585857b7fd342d1e",
+    "requested_corpus_citation_path": "us/regulation/7/273/4",
+    "resolved_corpus_citation_path": "us/regulation/7/273/4",
+    "resolved_text_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+    "row": {
+      "body_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+      "citation_path": "us/regulation/7/273/4",
+      "document_class": "regulation",
+      "expression_date": "2026-04-29",
+      "jurisdiction": "us",
+      "line_number": 9,
+      "provision_file": "data/corpus/provisions/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained.jsonl",
+      "provision_file_sha256": "de25d2b32f261e92405a553f65dfc90b47b032a4d1a80b1b585857b7fd342d1e",
+      "record_id": "3c7f0bf5-cc4e-5a8b-b1fd-2ee868a41be8",
+      "source_as_of": "2026-04-29",
+      "source_path": "sources/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained/official-documents/release-scope-us-regulation-2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained",
+      "version": "2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-04-29",
+    "source_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-regulation-7-273-4.json",
+  "trace_sha256": "88f4b186a04d7d0dc4baa98b637f3a007662e3020db72710821653f067e8fd2a",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1755"
+    },
+    "axiom_rules_engine": {
+      "commit": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "4ce7179f88633d1c403cb756f801a236d6a014a84cff4d2c39edabe4f4d62669",
+      "pre_apply_file_count": 2713,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/.axiom/encoding-manifests/us/statutes/7/2015/f.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2015/f.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2015/f.yaml",
+      "sha256": "fe7543305249bb91efc27d4507fef817c8847411bee01ca9ff96ca02cc9bde2f"
+    },
+    {
+      "path": "us/statutes/7/2015/f.test.yaml",
+      "sha256": "aa476595563aedc6e2fefa2ab65675dcbdba6a6e563b4f711dec1a8a322b9352"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1755",
+    "version_commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a"
+  },
+  "axiom_encode_version": "0.2.1755",
+  "backend": "openai",
+  "citation": "us/statute/7/2015/f",
+  "context_manifest_file": "/home/runner/work/_temp/generated/source-01/_eval_workspaces/openai-gpt-5.6-terra/us-statute-7-2015-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "80fd9812d5937925c72e3b7b2fff15b149cae62d35bfa911c945fefbad03bfbc",
+  "generated_at": "2026-09-02T12:36:26.592488+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/source-01/openai-gpt-5.6-terra/statutes/7/2015/f.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/source-01",
+  "generated_output_sha256": "fe7543305249bb91efc27d4507fef817c8847411bee01ca9ff96ca02cc9bde2f",
+  "generation_prompt_sha256": "1b5080242557e51402b27bd6e2cc388fc7de9580ae185c0915357ce53169db25",
+  "model": "gpt-5.6-terra",
+  "run_id": "2efbd7d2",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "GmcWbr2kJeiWxhCJ0hEoCQESQTteEKMpsg/jmPv8vE8Yu8R3TA00m/XVR7LRTy50rfDQJUVwrWAtyiq1OG28Bw=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_text_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "row": {
+      "body_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+      "citation_path": "us/statute/7/2015/f",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 197,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "51527d3a-7ce2-5d09-bdb0-681309bae9e8",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/source-01/traces/openai-gpt-5.6-terra/us-statute-7-2015-f.json",
+  "trace_sha256": "57189e6f7e1c04e74cbd1af03b94ccf7973c7255779650339facbbd22a9bbda8",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "f87ba011d0f9227ab5ad4bf65a4b12f57e0ab82a",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1755"
+    },
+    "axiom_rules_engine": {
+      "commit": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e51134a13b0a8f5076fb6311341293e843d364201cf9cbaa4c202502257b193c",
+      "pre_apply_file_count": 2709,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35962,6 +35962,15 @@
         ]
       }
     ],
+    "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo": [
+      {
+        "module": "us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/policy/cms/chip-spa/al/al-24-0031-fcep-and-al-24-0031-absc/pdf/page-2": [
       {
         "module": "us-al/policies/cms/alabama-chip-eligibility.yaml",
@@ -37268,7 +37277,8 @@
       {
         "module": "us/regulations/7-cfr/273/4.yaml",
         "via": [
-          "module"
+          "module",
+          "proof_atom"
         ]
       }
     ],
@@ -54893,6 +54903,15 @@
     "us/statute/7/2015/d/2": [
       {
         "module": "us/regulations/7-cfr/273/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/7/2015/f": [
+      {
+        "module": "us/statutes/7/2015/f.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml
+++ b/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml
@@ -1,0 +1,999 @@
+- name: qc_variance_exclusion_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: holds
+- name: non_permitted_alien_is_removed_at_recertification
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : holds
+- name: qc_variance_exclusion_applies_within_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: holds
+- name: lpr_waiting_period_exception_does_not_apply
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+- name: lpr_work_quarters_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 40
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+- name: eligible_lpr_after_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: nonpermitted_alien_removed_at_recertification
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: not_holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : holds
+- name: no_overissuance_claim_after_obbb_recertification_loss
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.benefits_were_received_after_obbb_changes_took_effect
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_not_subject_to_overissuance_claim_for_post_change_benefits
+    : holds
+- name: qc_variance_exclusion_applies_with_timely_implementation
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: holds
+- name: qc_variance_exclusion_does_not_apply_without_timely_implementation
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: not_holds
+- name: cited_cfr_title_number_snapshot
+  period: 2025-08
+  input: {}
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#cited_cfr_title_number: 7
+- name: qc_implementation_requirement_satisfied
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.qc_variance_exclusion_other_requirements_met: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#implementation_requirement_permits_qc_variance_exclusion
+    : holds
+- name: qc_implementation_requirement_not_satisfied
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.qc_variance_exclusion_other_requirements_met: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : false
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#implementation_requirement_permits_qc_variance_exclusion
+    : not_holds
+- name: qc_other_requirements_not_satisfied
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.qc_variance_exclusion_other_requirements_met: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#implementation_requirement_permits_qc_variance_exclusion
+    : not_holds
+- name: no_overissuance_claim_for_post_change_benefits
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.benefits_were_received_after_obbb_changes_took_effect
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_not_subject_to_overissuance_claim_for_post_change_benefits
+    : holds
+- name: no_overissuance_claim_rule_blocked_without_obbb_recertification_loss
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+    : false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.benefits_were_received_after_obbb_changes_took_effect
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_not_subject_to_overissuance_claim_for_post_change_benefits
+    : not_holds
+- name: no_overissuance_claim_rule_blocked_for_pre_change_benefits
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.benefits_were_received_after_obbb_changes_took_effect
+    : false
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_not_subject_to_overissuance_claim_for_post_change_benefits
+    : not_holds
+- name: conditional_entrant_with_lpr_status_may_use_lpr_path
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_conditional_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#conditional_entrant_may_use_post_obbb_lpr_eligibility_path
+    : holds
+- name: conditional_entrant_without_lpr_status_cannot_use_lpr_path
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_conditional_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#conditional_entrant_may_use_post_obbb_lpr_eligibility_path
+    : not_holds
+- name: battered_alien_with_lpr_status_may_use_lpr_path
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_battered_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#battered_alien_may_use_post_obbb_lpr_eligibility_path: holds
+- name: battered_alien_without_lpr_status_cannot_use_lpr_path
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_battered_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#battered_alien_may_use_post_obbb_lpr_eligibility_path: not_holds
+- name: trafficking_victim_or_family_member_with_lpr_status_may_use_lpr_path
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_victim_of_severe_trafficking_or_certain_family_member
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#trafficking_victim_or_family_member_may_use_post_obbb_lpr_eligibility_path
+    : holds
+- name: trafficking_victim_or_family_member_without_lpr_status_cannot_use_lpr_path
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_victim_of_severe_trafficking_or_certain_family_member
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#trafficking_victim_or_family_member_may_use_post_obbb_lpr_eligibility_path
+    : not_holds
+- name: lpr_under_age_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_under_age_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_work_quarters_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_blind_or_disabled_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_blind_or_disabled_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_older_lawful_resident_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_older_lawful_resident_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_military_connection_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_military_connection_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_amerasian_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_amerasian_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_american_indian_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_american_indian_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: lpr_hmong_or_highland_laotian_exception_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+- name: lpr_hmong_or_highland_laotian_exception_applies
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+- name: qc_variance_exclusion_blocked_by_late_implementation
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: not_holds
+- name: non_citizen_us_national_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: cuban_or_haitian_entrant_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: cofa_citizen_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: lpr_is_eligible_after_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: lpr_under_18_is_exempt_from_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: lpr_with_qualifying_work_quarters_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 40
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: blind_or_disabled_lpr_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: older_lawfully_residing_lpr_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: lpr_with_military_connection_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: amerasian_lpr_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: american_indian_lpr_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: hmong_or_highland_laotian_lpr_is_exempt
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: permitted_alien_fails_other_snap_requirements
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_qualifying_work_quarters: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_at_recertification: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_alien: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_in_obbb_permitted_alien_group: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exception_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules: not_holds
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_must_be_removed_from_household_at_recertification
+    : not_holds
+- name: qc_variance_exclusion_does_not_apply_after_period
+  period: 2025-11
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.section_10108_is_misapplied: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.misapplication_is_within_qc_variance_exclusion_period
+    : false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_implemented_new_provision_in_accordance_with_qc_rule
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#qc_variance_exclusion_applies: not_holds

--- a/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml
+++ b/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml
@@ -1,0 +1,564 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+    source_sha256: 0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c
+  summary: '“Section 10108 of the OBBB amends section 6(f) of the Food and Nutrition
+    Act of 2008 (FNA), limiting eligibility for SNAP to the following groups: U.S.
+    citizens, U.S. nationals, lawful permanent residents (LPRs), Cuban and Haitian
+    entrants, and Compact of Free Association (COFA) citizens.” “LPRs may still be
+    eligible for SNAP without a waiting period” under the listed exceptions. “A 120-day
+    variance exclusion is permitted” until November 1, 2025.'
+rules:
+- name: qc_variance_exclusion_applies
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: Quality Control and Technical Assistance, pages 3-4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: A 120-day variance exclusion is permitted for the misapplication
+            of changes in Section 10108 of the OBBB to new and ongoing SNAP households
+            until the exclusionary period end date on November 1, 2025.
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: The 120-day variance exclusion period will not apply if the State
+            agency does not implement the new provision in accordance with 7 CFR 275.12(d)(2)(vii)(D).
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'section_10108_is_misapplied
+
+      and misapplication_is_within_qc_variance_exclusion_period
+
+      and state_implemented_new_provision_in_accordance_with_qc_rule'
+- name: lpr_waiting_period_years
+  kind: parameter
+  dtype: Integer
+  period: Year
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Eligible after a 5-year waiting period
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '5'
+- name: lpr_qualifying_work_quarters_threshold
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Have 40 qualifying work quarters
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '40'
+- name: qc_variance_exclusion_period_days
+  kind: parameter
+  dtype: Count
+  period: Day
+  source: Quality Control and Technical Assistance, pages 3-4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: hold States harmless for Quality Control (QC) purposes for 120
+            days
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '120'
+- name: person_is_in_obbb_permitted_alien_group
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility, pages 1-2; Attachment 1, pages 5-8
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Post-OBBB SNAP eligible alien groups are U.S. nationals, lawful
+            permanent residents (LPRs), Cuban and Haitian entrants (CHEs), and Compacts
+            of Free Association (COFA) citizens.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_non_citizen_us_national
+
+      or person_is_cuban_or_haitian_entrant
+
+      or person_is_cofa_citizen
+
+      or person_is_lawful_permanent_resident'
+- name: lpr_waiting_period_exception_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility, page 2; Attachment 1, pages 5-7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 'LPRs may still be eligible for SNAP without a waiting period if
+            they meet one or more of the following conditions: x Are under 18 years
+            old x Have 40 qualifying work quarters x Are blind or disabled x Were
+            lawfully residing in the U.S. and 65 or older on August 22, 1996 x Have
+            a U.S. military connection Guidance documents lack the force and effect
+            of law, unless expressly authorized by statute or incorporated into a
+            contract.'
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "person_is_lawful_permanent_resident\nand (\n  lpr_is_under_18\n  or\
+      \ lpr_qualifying_work_quarters >= lpr_qualifying_work_quarters_threshold\n \
+      \ or lpr_is_blind_or_disabled\n  or lpr_was_lawfully_residing_and_older_on_prwora_enactment_date\n\
+      \  or lpr_has_us_military_connection\n  or lpr_is_admitted_as_amerasian_immigrant\n\
+      \  or lpr_is_american_indian_born_abroad\n  or lpr_is_hmong_or_highland_laotian_tribal_member\n\
+      )"
+- name: person_is_snap_eligible_under_obbb_alien_rules
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility, pages 1-2; Attachment 1, pages 5-8
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Eligible immediately, with no waiting period, as long as they meet
+            all other SNAP financial and non-financial eligibility requirements.
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Eligible after a 5-year waiting period, as long as they meet all
+            other SNAP financial and non-financial eligibility requirements.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "person_meets_other_snap_financial_and_nonfinancial_requirements\nand\
+      \ (\n  person_is_us_citizen\n  or person_is_non_citizen_us_national\n  or person_is_cuban_or_haitian_entrant\n\
+      \  or person_is_cofa_citizen\n  or (\n    person_is_lawful_permanent_resident\n\
+      \    and (\n      years_since_lpr_status >= lpr_waiting_period_years\n     \
+      \ or lpr_waiting_period_exception_applies\n    )\n  )\n)"
+- name: alien_must_be_removed_from_household_at_recertification
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Implementation, page 3
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: If an alien does not fall into one of the groups listed in section
+            6(f) of the FNA, as amended by OBBB, the alien is no longer eligible for
+            SNAP and must be removed from the household at that time.4 Changes During
+            the Certification Period The Food and Nutrition Act of 2008 requires State
+            agencies to use the Systematic Alien Verification for Entitlements (SAVE)
+            program to verify the immigration status of all aliens participating in
+            SNAP prior to certification.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'household_is_at_recertification
+
+      and person_is_alien
+
+      and not person_is_in_obbb_permitted_alien_group'
+- name: alien_not_subject_to_overissuance_claim_for_post_change_benefits
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Implementation, page 3, footnote 4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: aliens who lose SNAP eligibility at recertification due to the
+            OBBB SNAP eligibility changes, are not subject to a claim for over issuance
+            for the benefits received after the OBBB changes took effect.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+
+      and benefits_were_received_after_obbb_changes_took_effect'
+- name: cited_cfr_title_number
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Implementation and Quality Control, pages 3-4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: follow program rules for acting on changes and resolving unclear
+            information at 7 CFR 273.12(c).
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '7'
+- name: implementation_requirement_permits_qc_variance_exclusion
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: Quality Control and Technical Assistance, page 3
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: The 120-day variance exclusion period will not apply if the State
+            agency does not implement the new provision in accordance with 7 CFR 275.12(d)(2)(vii)(D).
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'qc_variance_exclusion_other_requirements_met
+
+      and state_implemented_new_provision_in_accordance_with_qc_rule'
+- name: conditional_entrant_may_use_post_obbb_lpr_eligibility_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Conditional Entrants Eligible immediately Not eligible unless an
+            LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_conditional_entrant
+
+      and person_is_lawful_permanent_resident'
+- name: battered_alien_may_use_post_obbb_lpr_eligibility_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Battered Aliens Eligible immediately Not eligible unless an LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_battered_alien
+
+      and person_is_lawful_permanent_resident'
+- name: trafficking_victim_or_family_member_may_use_post_obbb_lpr_eligibility_path
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Victims of Severe Trafficking and Certain Family Members Eligible
+            immediately Not eligible unless an LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_victim_of_severe_trafficking_or_certain_family_member
+
+      and person_is_lawful_permanent_resident'
+- name: parole_minimum_period_years
+  kind: parameter
+  dtype: Integer
+  period: Year
+  source: Attachment 2, Alien Group Descriptions, page 11
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Paroled into the U.S. under §212(d)(5) of the INA for a period
+            of at least 1 year.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '1'
+- name: cofa_associated_governments_count
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: Attachment 2, Alien Group Descriptions, page 9
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: the Federated States of Micronesia, the Republic of the Marshall
+            Islands, and the Republic of Palau
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '3'
+- name: obbb_permitted_alien_groups_count
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Alien Eligibility, page 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Post-OBBB SNAP eligible alien groups are U.S. nationals, lawful
+            permanent residents (LPRs), Cuban and Haitian entrants (CHEs), and Compacts
+            of Free Association (COFA) citizens.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '4'
+- name: food_and_nutrition_act_alien_eligibility_subsection_number
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: section 6(f) of the Food and Nutrition Act of 2008
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '6'
+- name: prwora_title_number
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 1, footnote 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 2 Aliens who were qualified aliens as defined by section 431 of
+            the Personal Responsibility and Work Opportunity Reconciliation Act (PRWORA)
+            (8 USC 1641) and aliens included in section 402(a) of PRWORA (8 USC 1612(a))
+            in addition to groups listed in section 6(f) of the FNA were eligible
+            for SNAP.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '8'
+- name: lpr_waiting_period_exception_count
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: LPRs may still be eligible for SNAP without a waiting period if
+            they meet one or more of the following conditions
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '8'
+- name: lpr_under_age_exception_age
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Are under 18 years old
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '18'
+- name: lpr_older_lawful_resident_exception_age
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Were lawfully residing in the U.S. and 65 or older on August 22,
+            1996
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '65'
+inputs:
+- name: person_is_us_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_non_citizen_us_national
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_cuban_or_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_cofa_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_lawful_permanent_resident
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: years_since_lpr_status
+  entity: Person
+  dtype: Decimal
+  period: Month
+- name: lpr_is_under_18
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_qualifying_work_quarters
+  entity: Person
+  dtype: Count
+  period: Month
+- name: lpr_is_blind_or_disabled
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_was_lawfully_residing_and_older_on_prwora_enactment_date
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_has_us_military_connection
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_admitted_as_amerasian_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_american_indian_born_abroad
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_hmong_or_highland_laotian_tribal_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_meets_other_snap_financial_and_nonfinancial_requirements
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: household_is_at_recertification
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_loses_snap_eligibility_at_recertification_due_to_obbb_changes
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: benefits_were_received_after_obbb_changes_took_effect
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: section_10108_is_misapplied
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: misapplication_is_within_qc_variance_exclusion_period
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: state_implemented_new_provision_in_accordance_with_qc_rule
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: qc_variance_exclusion_other_requirements_met
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: person_is_conditional_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_battered_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_victim_of_severe_trafficking_or_certain_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: state_implemented_before_variance_exclusion_end_date
+  entity: StateAgency
+  dtype: Boolean
+  period: Month

--- a/us/policies/usda/snap/state-plan-composition.test.yaml
+++ b/us/policies/usda/snap/state-plan-composition.test.yaml
@@ -64,9 +64,6 @@
       us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
       us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
       us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
       us:regulations/7-cfr/273/4#input.member_is_refugee: false
       us:regulations/7-cfr/273/4#input.member_is_asylee: false
@@ -140,9 +137,6 @@
     us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
     us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
     us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
     us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
     us:regulations/7-cfr/273/4#input.member_is_refugee: false
     us:regulations/7-cfr/273/4#input.member_is_asylee: false
@@ -317,9 +311,6 @@
       us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
       us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
       us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
       us:regulations/7-cfr/273/4#input.member_is_refugee: false
       us:regulations/7-cfr/273/4#input.member_is_asylee: false
@@ -404,9 +395,6 @@
       us:regulations/7-cfr/273/24#input.snap_abawd_countable_months_in_three_year_period: 0
       us:regulations/7-cfr/273/24#input.member_regained_abawd_eligibility: false
       us:regulations/7-cfr/273/24#input.member_has_additional_three_month_abawd_eligibility: false
-      us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-      us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-      us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
       us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
       us:regulations/7-cfr/273/4#input.member_is_refugee: false
       us:regulations/7-cfr/273/4#input.member_is_asylee: false

--- a/us/regulations/7-cfr/273/4.test.yaml
+++ b/us/regulations/7-cfr/273/4.test.yaml
@@ -1,30 +1,251 @@
-- name: us_citizen_member_is_status_eligible
+- name: spouse_quarters_credited_during_current_marriage_are_available
   period: 2026-01
   input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: true
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: holds
+- name: spouse_quarters_credited_during_marriage_when_spouse_deceased_are_available
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: holds
+- name: spouse_quarters_not_credited_during_marriage_are_unavailable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: true
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: spouse_quarters_credited_but_marriage_ended_without_death_are_unavailable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: citizen_member_is_citizenship_or_alien_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
     us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
     us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
   output:
     us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
     us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
-- name: trafficking_victim_alien_status_is_eligible_when_documented
+- name: spouse_quarters_credited_outside_current_marriage_without_spouse_death_are_unavailable
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
-    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: true
-    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
   output:
-    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
-- name: refugee_qualified_alien_is_immediately_eligible
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: paired_spouse_deceased_quarters_are_creditable
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: holds
+- name: paired_spouse_deceased_quarters_are_not_creditable_without_required_connection
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: spouse_quarters_not_credited_during_marriage_or_after_spouse_death_are_unavailable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: review_spouse_work_quarters_available
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: true
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: holds
+- name: review_spouse_work_quarters_unavailable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: true
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: spouse_work_quarters_during_marriage_or_after_death_are_available
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: true
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: holds
+- name: spouse_work_quarters_outside_marriage_and_without_death_are_unavailable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarters_credited_from_work_during_marriage: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_are_still_married: false
+    us:regulations/7-cfr/273/4#input.spouse_is_deceased: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_qualifying_quarter_credit_available: not_holds
+- name: paired_disabled_hmong_child_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: paired_disabled_hmong_child_is_blocked_without_disability_dependency
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: paired_qualified_alien_immediate_criterion_satisfies_chapeau
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
     us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
     us:regulations/7-cfr/273/4#input.member_is_refugee: true
     us:regulations/7-cfr/273/4#input.member_is_asylee: false
@@ -35,17 +256,31 @@
     us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
     us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
     us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: holds
     us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
-- name: qualified_alien_after_five_year_wait_is_eligible
+- name: paired_qualified_alien_immediate_criterion_does_not_satisfy_chapeau
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
     us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
     us:regulations/7-cfr/273/4#input.member_is_refugee: false
     us:regulations/7-cfr/273/4#input.member_is_asylee: false
@@ -56,23 +291,5245 @@
     us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
     us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
     us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: true
-    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
-    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
   output:
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_after_wait_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
-- name: missing_alien_documentation_bars_alien_status
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: not_holds
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: not_holds
+- name: paired_divorce_continuation_before_recertification
   period: 2026-01
   input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: paired_divorce_continuation_ends_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: paired_disabled_military_child_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: paired_disabled_military_child_is_blocked_without_disability_dependency
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: paired_exact_six_month_absence_does_not_presume_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: paired_more_than_six_month_absence_presumes_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: disabled_hmong_child_age_eighteen_or_older_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: disabled_hmong_child_age_eighteen_or_older_without_disability_dependency_is_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: qualified_alien_with_immediate_criterion_is_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: holds
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
+- name: qualified_alien_without_immediate_criterion_is_not_immediately_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: not_holds
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: not_holds
+- name: divorce_preserves_spouse_quarter_eligibility_until_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: divorce_does_not_preserve_spouse_quarter_eligibility_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: disabled_military_family_child_age_eighteen_or_older_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: disabled_military_family_child_without_pre_eighteen_dependency_is_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: residency_absence_exactly_six_months_does_not_trigger_presumption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: residency_absence_more_than_six_months_triggers_presumption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: review_hmong_child_under_eighteen_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: review_hmong_child_under_eighteen_variant_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: review_hmong_child_full_time_student_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: review_hmong_child_full_time_student_variant_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: review_hmong_child_disability_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: review_hmong_child_disability_variant_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: review_divorce_continuation_before_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: review_divorce_continuation_ends_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: review_military_family_student_child_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: true
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: review_military_family_student_child_variant_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: review_military_family_disabled_child_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: review_military_family_disabled_child_variant_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: review_long_absence_without_resumption_evidence_presumes_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: true
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: review_long_absence_with_resumption_evidence_rebuts_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: true
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: true
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: review_another_status_exists_after_prior_status_expiration
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_prior_eligible_alien_status_expired: true
+    us:regulations/7-cfr/273/4#input.eligibility_under_another_eligible_alien_status_exists: true
+  output:
+    us:regulations/7-cfr/273/4#eligibility_under_another_status_after_expiration: holds
+- name: review_another_status_absent_after_prior_status_expiration
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_prior_eligible_alien_status_expired: true
+    us:regulations/7-cfr/273/4#input.eligibility_under_another_eligible_alien_status_exists: false
+  output:
+    us:regulations/7-cfr/273/4#eligibility_under_another_status_after_expiration: not_holds
+- name: review_consent_failure_makes_sponsored_alien_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_failed_to_consent_to_required_information_sharing: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_for_failed_indigence_consent: holds
+- name: review_consent_given_avoids_consent_failure_ineligibility
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_failed_to_consent_to_required_information_sharing: false
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_for_failed_indigence_consent: not_holds
+- name: review_subsequent_verification_is_reported_change
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+    us:regulations/7-cfr/273/4#input.state_agency_subsequently_received_required_sponsor_information_or_verification: true
+  output:
+    us:regulations/7-cfr/273/4#subsequently_received_sponsor_information_treated_as_reported_change: holds
+- name: review_no_subsequent_verification_is_not_reported_change
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+    us:regulations/7-cfr/273/4#input.state_agency_subsequently_received_required_sponsor_information_or_verification: false
+  output:
+    us:regulations/7-cfr/273/4#subsequently_received_sponsor_information_treated_as_reported_change: not_holds
+- name: hmong_dependent_child_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: hmong_dependent_child_blocked_without_qualifying_age_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: spouse_quarter_credit_continues_before_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarter_credit_used_for_snap_eligibility: true
+    us:regulations/7-cfr/273/4#input.spouse_quarter_couple_divorced_after_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_credit_continues_until_recertification: holds
+- name: spouse_quarter_credit_stops_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarter_credit_used_for_snap_eligibility: true
+    us:regulations/7-cfr/273/4#input.spouse_quarter_couple_divorced_after_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_credit_continues_until_recertification: not_holds
+- name: disabled_hmong_child_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: disabled_hmong_child_variant_blocks_without_pre_eighteen_dependency
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: military_family_disabled_child_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: military_family_disabled_child_variant_blocks_without_pre_eighteen_dependency
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: documented_canadian_indian_status_is_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+  output:
+    us:regulations/7-cfr/273/4#american_indian_born_in_canada_status_eligible: holds
+    us:regulations/7-cfr/273/4#recognized_indian_tribe_member_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#trafficking_victim_or_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
+- name: hmong_child_under_eighteen_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: hmong_child_under_eighteen_blocks_without_age_variant
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: hmong_child_student_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: hmong_child_student_variant_blocks_without_student_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: hmong_child_disability_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: holds
+- name: hmong_child_disability_variant_blocks_without_disability_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: residency_absence_over_six_months_without_evidence_presumes_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: residency_absence_over_six_months_with_evidence_does_not_presume_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: true
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: hmong_child_without_qualifying_variant_is_not_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_legally_adopted_or_biological_child: true
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.hmong_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_child_status_eligible: not_holds
+- name: spouse_quarters_continue_before_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarter_credit_used_for_snap_eligibility: true
+    us:regulations/7-cfr/273/4#input.spouse_quarter_couple_divorced_after_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_credit_continues_until_recertification: holds
+- name: spouse_quarters_do_not_continue_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.spouse_quarter_credit_used_for_snap_eligibility: true
+    us:regulations/7-cfr/273/4#input.spouse_quarter_couple_divorced_after_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_credit_continues_until_recertification: not_holds
+- name: military_family_child_student_variant_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: true
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: holds
+- name: military_family_child_without_variant_is_not_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two: false
+    us:regulations/7-cfr/273/4#input.military_family_child_is_unmarried_disabled_and_dependent_before_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#military_family_child_connection_eligible: not_holds
+- name: residence_absence_over_six_months_without_intent_presumes_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: true
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: residence_absence_over_six_months_with_intent_does_not_presume_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: true
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: true
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: eligibility_exists_under_another_status_after_prior_status_expires
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_prior_eligible_alien_status_expired: true
+    us:regulations/7-cfr/273/4#input.eligibility_under_another_eligible_alien_status_exists: true
+  output:
+    us:regulations/7-cfr/273/4#eligibility_under_another_status_after_expiration: holds
+- name: eligibility_does_not_exist_under_another_status_after_prior_status_expires
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_prior_eligible_alien_status_expired: true
+    us:regulations/7-cfr/273/4#input.eligibility_under_another_eligible_alien_status_exists: false
+  output:
+    us:regulations/7-cfr/273/4#eligibility_under_another_status_after_expiration: not_holds
+- name: sponsored_alien_consent_failure_is_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_failed_to_consent_to_required_information_sharing: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_for_failed_indigence_consent: holds
+- name: sponsored_alien_consent_prevents_consent_ineligibility
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_failed_to_consent_to_required_information_sharing: false
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_for_failed_indigence_consent: not_holds
+- name: later_verification_is_treated_as_reported_change
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+    us:regulations/7-cfr/273/4#input.state_agency_subsequently_received_required_sponsor_information_or_verification: true
+  output:
+    us:regulations/7-cfr/273/4#subsequently_received_sponsor_information_treated_as_reported_change: holds
+- name: no_later_verification_is_not_reported_change
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+    us:regulations/7-cfr/273/4#input.state_agency_subsequently_received_required_sponsor_information_or_verification: false
+  output:
+    us:regulations/7-cfr/273/4#subsequently_received_sponsor_information_treated_as_reported_change: not_holds
+- name: sponsor_deeming_eligible_sponsored_alien_control
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: sponsor_deeming_ineligible_sponsored_alien_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: sponsor_deeming_no_organization_sponsor_control
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: sponsor_deeming_organization_sponsor_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: sponsor_deeming_sponsor_required_control
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: sponsor_deeming_no_sponsor_requirement_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: true
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: sponsor_deeming_sponsored_alien_adult_control
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: sponsor_deeming_sponsored_alien_child_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: true
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: sponsor_deeming_non_citizen_child_control
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: sponsor_deeming_citizen_child_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: indigence_boundary_uses_one_hundred_thirty_percent
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 80
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 20
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 30
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: auto_output_sponsor_payment_income_excess
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
     us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
     us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: true
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_household_gross_income_eligibility_limit: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#sponsor_payment_income_excess: 0
+- name: auto_positive_snap_member_qualified_alien_after_wait_eligible
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: true
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_after_wait_eligible: holds
+- name: indigence_exact_one_point_three_ratio_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 1.3
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 1
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: indigence_just_above_one_point_three_ratio_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 1.31
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 1
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: indigence_in_kind_assistance_at_one_hundred_thirty_percent_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 130
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: indigence_in_kind_assistance_just_above_one_hundred_thirty_percent_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 130.01
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: repaired_indigence_literal_one_point_three_boundary_holds
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 130
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: repaired_indigence_literal_above_one_point_three_boundary_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 130.01
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: repaired_immediate_criterion_selector_allows_qualified_alien
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: holds
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
+- name: repaired_immediate_criterion_selector_blocks_qualified_alien
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: not_holds
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: not_holds
+- name: repaired_divorce_selector_continues_spouse_quarter_eligibility
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: repaired_divorce_selector_absent_does_not_trigger_continuation
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: repaired_no_battered_alien_exemption_allows_sponsor_deeming
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: repaired_battered_alien_exemption_blocks_sponsor_deeming
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: indigence_exact_one_point_three_literal_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 1.3
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 1
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: indigence_above_one_point_three_literal_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 1.31
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 1
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: immediate_eligibility_criterion_selector_holds
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: holds
+- name: immediate_eligibility_criterion_selector_blocks
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion: not_holds
+- name: temporary_absence_under_six_months_without_abandonment_does_not_interrupt
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 5
+    us:regulations/7-cfr/273/4#input.temporary_absence_has_no_intention_to_abandon_us_residency: true
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#temporary_absence_does_not_interrupt_qualified_status_residency: holds
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: exactly_six_months_is_neutral
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.temporary_absence_has_no_intention_to_abandon_us_residency: true
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#temporary_absence_does_not_interrupt_qualified_status_residency: not_holds
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: over_six_months_presumes_interruption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.temporary_absence_has_no_intention_to_abandon_us_residency: true
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#temporary_absence_does_not_interrupt_qualified_status_residency: not_holds
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: spouse_quarter_credit_continues_before_recertification_repair
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: spouse_quarter_credit_stops_at_recertification_repair
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: demonstrated_multiple_sponsorship_divides_income_and_resources
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 1000
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 400
+    us:regulations/7-cfr/273/4#input.sponsor_household_gross_income_eligibility_limit: 900
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 2500
+    us:regulations/7-cfr/273/4#input.sponsored_alien_demonstrated_sponsor_is_sponsor_of_other_aliens: true
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 2
+  output:
+    us:regulations/7-cfr/273/4#deemed_sponsor_monthly_income: 300
+    us:regulations/7-cfr/273/4#multiple_sponsored_aliens_deemed_income_share: 150
+    us:regulations/7-cfr/273/4#deemed_sponsor_resources: 1000
+    us:regulations/7-cfr/273/4#multiple_sponsored_aliens_deemed_resource_share: 500
+- name: unproven_multiple_sponsorship_keeps_undivided_income_and_resources
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 1000
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 400
+    us:regulations/7-cfr/273/4#input.sponsor_household_gross_income_eligibility_limit: 900
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 2500
+    us:regulations/7-cfr/273/4#input.sponsored_alien_demonstrated_sponsor_is_sponsor_of_other_aliens: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 2
+  output:
+    us:regulations/7-cfr/273/4#deemed_sponsor_monthly_income: 300
+    us:regulations/7-cfr/273/4#multiple_sponsored_aliens_deemed_income_share: 300
+    us:regulations/7-cfr/273/4#deemed_sponsor_resources: 1000
+    us:regulations/7-cfr/273/4#multiple_sponsored_aliens_deemed_resource_share: 1000
+- name: sponsored_alien_indigence_blocks_amount_above_130_percent_selector
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 81
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 20
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 30
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: sponsored_alien_indigence_at_poverty_guideline_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 80
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 20
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 30
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: sponsored_alien_indigence_at_exact_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 80
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 20
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 30
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: sponsored_alien_indigence_above_exact_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 81
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 20
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 30
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: above_one_point_three_indigence_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 131
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: indigence_above_formula_clause_one_point_three_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 131
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: indigence_above_exact_one_point_three_poverty_guideline_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 131
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: exact_one_point_three_indigence_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 130
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: indigence_formula_clause_114_exact_one_point_three_multiplier
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 130
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: no_battered_exception_allows_sponsor_deeming
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 200
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: military_dependent_child_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_of_qualifying_military_person: false
+    ? us:regulations/7-cfr/273/4#input.military_family_member_is_unmarried_dependent_child_with_qualifying_age_student_or_disability_status
+    : true
+  output:
+    us:regulations/7-cfr/273/4#military_family_connection_eligible: holds
+- name: military_dependent_child_blocks_without_qualifying_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_of_qualifying_military_person: false
+    ? us:regulations/7-cfr/273/4#input.military_family_member_is_unmarried_dependent_child_with_qualifying_age_student_or_disability_status
+    : false
+  output:
+    us:regulations/7-cfr/273/4#military_family_connection_eligible: not_holds
+- name: residency_absence_exactly_six_months_does_not_interrupt
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: residency_absence_more_than_six_months_interrupts
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: indigence_holds_at_one_point_three_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 130
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: holds
+- name: indigence_blocks_above_one_point_three_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_household_own_income: 131
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.household_poverty_income_guideline: 100
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_indigent: not_holds
+- name: missing_documentation_classifies_alien_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+  output:
+    us:regulations/7-cfr/273/4#missing_alien_documentation_ineligible_classification: holds
+- name: available_documentation_does_not_classify_alien_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us:regulations/7-cfr/273/4#missing_alien_documentation_ineligible_classification: not_holds
+- name: exact_six_month_residency_absence_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: residency_absence_above_six_month_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: hmong_child_qualifying_variant_selected
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: hmong_child_qualifying_variant_not_selected
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+- name: spouse_quarter_divorce_rule_continues_before_recertification
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: spouse_quarter_divorce_rule_stops_at_recertification
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: parent_or_spouse_benefit_quarter_without_receipt_is_creditable
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: holds
+- name: parent_or_spouse_benefit_quarter_with_receipt_is_not_creditable
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: true
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: not_holds
+- name: military_child_relationship_selected
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: true
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: holds
+- name: military_child_relationship_not_selected
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: not_holds
+- name: documentation_available_preserves_alien_status
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
+- name: documentation_refusal_blocks_alien_status
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: not_holds
+- name: indigence_information_consent_preserves_eligibility
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_provided_consent_for_required_information_sharing: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_eligible_after_indigence_information_consent: holds
+- name: indigence_information_consent_refusal_blocks_eligibility
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_provided_consent_for_required_information_sharing: false
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_eligible_after_indigence_information_consent: not_holds
+- name: active_twelve_month_indigence_period_deems_actual_amount
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_indigence_determination_active: true
+    us:regulations/7-cfr/273/4#input.amount_actually_provided_to_indigent_sponsored_alien: 75
+  output:
+    us:regulations/7-cfr/273/4#indigent_sponsored_alien_deemed_income: 75
+- name: expired_twelve_month_indigence_period_does_not_deem_actual_amount
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_indigence_determination_active: false
+    us:regulations/7-cfr/273/4#input.amount_actually_provided_to_indigent_sponsored_alien: 75
+  output:
+    us:regulations/7-cfr/273/4#indigent_sponsored_alien_deemed_income: 0
+- name: exact_six_month_absence_does_not_presume_interruption
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: absence_over_six_months_presumes_interruption
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: hmong_child_qualifying_variant_holds
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: hmong_child_without_qualifying_variant_is_blocked
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+- name: spouse_quarter_eligibility_continues_before_recertification_pair
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: spouse_quarter_eligibility_stops_at_recertification_pair
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: fortieth_quarter_same_quarter_exception_holds
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: true
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: true
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: holds
+- name: fortieth_quarter_same_quarter_exception_absent_blocks_credit
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: true
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: not_holds
+- name: military_child_relationship_holds
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: true
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: holds
+- name: military_child_relationship_absent_blocks
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: not_holds
+- name: alternate_earlier_status_preserves_eligibility
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: true
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: true
+  output:
+    us:regulations/7-cfr/273/4#eligibility_preserved_after_subsequent_adjustment: holds
+- name: no_subsequent_limited_adjustment_does_not_trigger_preservation_rule
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: true
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+  output:
+    us:regulations/7-cfr/273/4#eligibility_preserved_after_subsequent_adjustment: not_holds
+- name: documentation_refusal_classifies_person_ineligible
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+  output:
+    us:regulations/7-cfr/273/4#missing_alien_documentation_ineligible_classification: holds
+- name: documentation_available_avoids_ineligible_classification
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us:regulations/7-cfr/273/4#missing_alien_documentation_ineligible_classification: not_holds
+- name: battered_exception_blocks_sponsor_deeming
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: sponsor_cooperation_responsibility_satisfied
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_obtained_sponsor_cooperation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_required_deeming_information_and_documentation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_reported_required_sponsor_changes: true
+  output:
+    us:regulations/7-cfr/273/4#eligible_sponsored_alien_information_responsibility_satisfied: holds
+- name: sponsor_cooperation_responsibility_not_satisfied
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_obtained_sponsor_cooperation: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_required_deeming_information_and_documentation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_reported_required_sponsor_changes: true
+  output:
+    us:regulations/7-cfr/273/4#eligible_sponsored_alien_information_responsibility_satisfied: not_holds
+- name: other_program_sponsor_income_may_be_used
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: true
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: holds
+- name: other_program_sponsor_income_blocked_by_unlimited_reductions
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: not_holds
+- name: residency_interruption_exact_six_month_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: residency_interruption_more_than_six_month_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: citizenship_chapeau_enabled_by_citizen_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
+- name: hmong_child_qualifying_age_or_student_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: hmong_child_blocked_without_qualifying_age_or_student_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+- name: deceased_hmong_child_dependent_at_death_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: deceased_hmong_child_not_dependent_at_death_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+- name: disabled_hmong_child_dependent_before_eighteen_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: disabled_hmong_child_not_dependent_before_eighteen_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+- name: qualified_alien_selector_immediate_eligibility
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
+- name: qualified_alien_selector_blocks_nonqualified_person
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: not_holds
+- name: spouse_quarters_stop_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: military_child_qualifies
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: true
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: holds
+- name: military_child_without_qualifying_relationship_blocked
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: not_holds
+- name: earlier_eligible_status_preserved_after_limited_adjustment
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: true
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: true
+  output:
+    us:regulations/7-cfr/273/4#eligibility_preserved_after_subsequent_adjustment: holds
+- name: earlier_status_not_preserved_without_limited_adjustment
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: true
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+  output:
+    us:regulations/7-cfr/273/4#eligibility_preserved_after_subsequent_adjustment: not_holds
+- name: documentation_available_allows_eligible_alien_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
+    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
+- name: documentation_refusal_blocks_eligible_alien_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
   output:
     us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
     us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: not_holds
+- name: other_program_sponsor_income_use_allowed
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: true
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: holds
+- name: other_program_sponsor_income_use_blocked_by_unlimited_reductions
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: not_holds
+- name: sponsored_alien_information_cooperation_satisfied
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_obtained_sponsor_cooperation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_required_deeming_information_and_documentation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_reported_required_sponsor_changes: true
+  output:
+    us:regulations/7-cfr/273/4#eligible_sponsored_alien_information_responsibility_satisfied: holds
+- name: sponsored_alien_information_cooperation_missing
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_obtained_sponsor_cooperation: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_required_deeming_information_and_documentation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_reported_required_sponsor_changes: true
+  output:
+    us:regulations/7-cfr/273/4#eligible_sponsored_alien_information_responsibility_satisfied: not_holds
+- name: sponsored_alien_verification_outstanding_is_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_while_awaiting_verification: holds
+- name: sponsored_alien_verification_received_ends_ineligibility
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: false
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_while_awaiting_verification: not_holds
+- name: common_sponsor_household_information_gap_blocks_household
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.same_sponsor_is_responsible_for_entire_household: true
+    us:regulations/7-cfr/273/4#input.household_needed_sponsor_information_or_verification_outstanding: true
+  output:
+    us:regulations/7-cfr/273/4#entire_household_ineligible_while_common_sponsor_information_outstanding: holds
+- name: common_sponsor_household_information_provided_unblocks_household
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.same_sponsor_is_responsible_for_entire_household: true
+    us:regulations/7-cfr/273/4#input.household_needed_sponsor_information_or_verification_outstanding: false
+  output:
+    us:regulations/7-cfr/273/4#entire_household_ineligible_while_common_sponsor_information_outstanding: not_holds
+- name: residency_interruption_presumption_exact_six_month_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: residency_interruption_presumption_above_six_month_boundary
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: eligible_sponsored_alien_satisfies_information_responsibilities
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_obtained_sponsor_cooperation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_required_deeming_information_and_documentation: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens: true
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien_reported_required_sponsor_changes: true
+  output:
+    us:regulations/7-cfr/273/4#eligible_sponsored_alien_information_responsibility_satisfied: holds
+- name: sponsored_alien_is_ineligible_while_verification_is_outstanding
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_required_information_or_verification_outstanding: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien_ineligible_while_awaiting_verification: holds
+- name: common_sponsor_information_gap_makes_entire_household_ineligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.same_sponsor_is_responsible_for_entire_household: true
+    us:regulations/7-cfr/273/4#input.household_needed_sponsor_information_or_verification_outstanding: true
+  output:
+    us:regulations/7-cfr/273/4#entire_household_ineligible_while_common_sponsor_information_outstanding: holds
+- name: participating_sponsor_is_excluded_from_snap_restitution_demand
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.restitution_demand_is_for_snap_benefits_issued_to_eligible_alien_sponsored_by_person: true
+    us:regulations/7-cfr/273/4#input.sponsor_is_participating_in_snap: true
+  output:
+    us:regulations/7-cfr/273/4#participating_sponsor_excluded_from_snap_restitution_demand: holds
+- name: sponsor_deeming_applies_when_no_exemption_holds
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: same_household_exemption_blocks_sponsor_deeming
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: organization_and_battered_alien_exemptions_block_sponsor_deeming
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: child_and_no_sponsor_requirement_exemptions_block_sponsor_deeming
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: true
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: true
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: true
+  output:
+    us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption: not_holds
+    us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#citizen_child_deeming_exemption: holds
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: six_month_absence_does_not_trigger_interruption_presumption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 6
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: not_holds
+- name: noncitizen_national_member_is_citizenship_or_alien_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: true
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
+- name: other_program_sponsor_income_may_be_used_with_limited_reductions
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: true
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: holds
+- name: other_program_sponsor_income_use_blocked_when_reductions_are_not_limited
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: true
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: true
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+  output:
+    us:regulations/7-cfr/273/4#other_assistance_program_sponsor_income_may_be_used: not_holds
+- name: spouse_quarter_eligibility_continues_before_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: true
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: holds
+- name: spouse_quarter_eligibility_does_not_continue_at_recertification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: true
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+  output:
+    us:regulations/7-cfr/273/4#spouse_quarter_eligibility_continues_until_recertification: not_holds
+- name: fortieth_quarter_earned_before_same_quarter_application_is_creditable
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: true
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: true
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: holds
+- name: post_cutoff_benefit_receipt_quarter_is_not_creditable_without_exception
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: true
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: true
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+  output:
+    us:regulations/7-cfr/273/4#benefit_receipt_quarter_creditable: not_holds
+- name: military_veteran_connection_is_immediately_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: true
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+  output:
+    us:regulations/7-cfr/273/4#qualifying_veteran_military_connection: holds
+    us:regulations/7-cfr/273/4#qualifying_active_duty_military_connection: not_holds
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: not_holds
+    us:regulations/7-cfr/273/4#military_connection_immediate_eligibility: holds
+- name: military_family_connection_requires_qualifying_relationship
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+  output:
+    us:regulations/7-cfr/273/4#qualifying_veteran_military_connection: not_holds
+    us:regulations/7-cfr/273/4#qualifying_active_duty_military_connection: not_holds
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: not_holds
+    us:regulations/7-cfr/273/4#military_connection_immediate_eligibility: not_holds
+- name: immediate_eligibility_categories_hold
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: true
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: true
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: true
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: true
+  output:
+    us:regulations/7-cfr/273/4#cuban_or_haitian_entrant_immediate_eligibility: holds
+    us:regulations/7-cfr/273/4#amerasian_immediate_eligibility: holds
+    us:regulations/7-cfr/273/4#blindness_or_disability_immediate_eligibility: holds
+    us:regulations/7-cfr/273/4#historical_residence_immediate_eligibility: holds
+- name: immediate_eligibility_categories_do_not_hold_without_status
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+  output:
+    us:regulations/7-cfr/273/4#cuban_or_haitian_entrant_immediate_eligibility: not_holds
+    us:regulations/7-cfr/273/4#amerasian_immediate_eligibility: not_holds
+    us:regulations/7-cfr/273/4#blindness_or_disability_immediate_eligibility: not_holds
+    us:regulations/7-cfr/273/4#historical_residence_immediate_eligibility: not_holds
+- name: absence_above_six_months_triggers_interruption_presumption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 7
+    us:regulations/7-cfr/273/4#input.alien_presented_evidence_of_intent_to_resume_us_residency: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_exceeds_six_months: false
+  output:
+    us:regulations/7-cfr/273/4#residency_interruption_presumed: holds
+- name: citizen_member_is_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
+- name: qualified_alien_categories_hold
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: true
+    us:regulations/7-cfr/273/4#input.member_is_asylee: true
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: true
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: true
+  output:
+    us:regulations/7-cfr/273/4#lawful_permanent_resident_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#asylee_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#refugee_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#conditional_entrant_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#battered_or_extreme_cruelty_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#cuban_or_haitian_entrant_qualified_alien_category: holds
+- name: qualified_alien_categories_do_not_hold_without_category_status
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+  output:
+    us:regulations/7-cfr/273/4#lawful_permanent_resident_qualified_alien_category: not_holds
+    us:regulations/7-cfr/273/4#asylee_qualified_alien_category: not_holds
+    us:regulations/7-cfr/273/4#refugee_qualified_alien_category: not_holds
+    us:regulations/7-cfr/273/4#conditional_entrant_qualified_alien_category: not_holds
+    us:regulations/7-cfr/273/4#battered_or_extreme_cruelty_qualified_alien_category: not_holds
+    us:regulations/7-cfr/273/4#cuban_or_haitian_entrant_qualified_alien_category: not_holds
+- name: parolee_five_year_status_path_holds
+  period: 2025-10
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: true
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 1
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
+  output:
+    us:regulations/7-cfr/273/4#parolee_qualified_alien_category: holds
+    us:regulations/7-cfr/273/4#parolee_five_year_status_path_eligible: holds
+- name: noncitizen_national_is_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: true
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
+- name: parolee_meets_minimum_qualified_period
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: true
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 1
+  output:
+    us:regulations/7-cfr/273/4#parolee_qualified_alien_category: holds
+- name: parolee_below_minimum_qualified_period
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: true
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+  output:
+    us:regulations/7-cfr/273/4#parolee_qualified_alien_category: not_holds
+- name: american_indian_canadian_blood_boundary
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+  output:
+    us:regulations/7-cfr/273/4#american_indian_born_in_canada_status_eligible: holds
+- name: minor_trafficking_victim_is_eligible_without_certification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: true
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 17
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+  output:
+    us:regulations/7-cfr/273/4#adult_trafficking_victim_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#minor_trafficking_victim_status_eligible: holds
+    us:regulations/7-cfr/273/4#younger_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#older_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#trafficking_victim_or_family_status_eligible: holds
+- name: american_indian_born_in_canada_at_blood_share_boundary_is_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.5
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+  output:
+    us:regulations/7-cfr/273/4#american_indian_born_in_canada_status_eligible: holds
+- name: american_indian_born_in_canada_below_blood_share_boundary_is_not_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: true
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0.49
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: true
+  output:
+    us:regulations/7-cfr/273/4#american_indian_born_in_canada_status_eligible: not_holds
+- name: missing_alien_documentation_produces_ineligible_classification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+  output:
+    us:regulations/7-cfr/273/4#missing_alien_documentation_ineligible_classification: holds
+- name: executed_affidavit_of_support_defines_sponsored_alien
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: true
+  output:
+    us:regulations/7-cfr/273/4#sponsored_alien: holds
+- name: indigence_explanation_and_refusal_opportunity_complete
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: true
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: true
+  output:
+    us:regulations/7-cfr/273/4#indigence_explanation_and_refusal_opportunity_provided: holds
+- name: indigence_explanation_missing
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: true
+  output:
+    us:regulations/7-cfr/273/4#indigence_explanation_and_refusal_opportunity_provided: not_holds
+- name: sponsor_deeming_applies_without_exemption
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: holds
+- name: hmong_qualifying_person_is_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: true
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: true
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_qualifying_person_status_eligible: holds
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_spouse_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_status_eligible: holds
+- name: certified_adult_trafficking_victim_is_status_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: true
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: true
+    us:regulations/7-cfr/273/4#input.member_age: 30
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+  output:
+    us:regulations/7-cfr/273/4#adult_trafficking_victim_status_eligible: holds
+    us:regulations/7-cfr/273/4#minor_trafficking_victim_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#younger_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#older_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#trafficking_victim_or_family_status_eligible: holds
+- name: minor_trafficking_victim_is_status_eligible_without_certification
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: true
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_age: 17
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+  output:
+    us:regulations/7-cfr/273/4#adult_trafficking_victim_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#minor_trafficking_victim_status_eligible: holds
+    us:regulations/7-cfr/273/4#younger_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#older_trafficking_victim_derivative_family_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#trafficking_victim_or_family_status_eligible: holds
+- name: sponsor_resources_are_reduced_by_statutory_disregard
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 2000
+  output:
+    us:regulations/7-cfr/273/4#deemed_sponsor_resources: 500
+- name: organization_sponsor_exempts_alien_from_deeming_person_outputs
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: true
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+  output:
+    us:regulations/7-cfr/273/4#sponsor_deeming_applies: not_holds
+- name: earlier_eligibility_survives_more_limited_status_adjustment
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: true
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: true
+  output:
+    us:regulations/7-cfr/273/4#eligibility_preserved_after_subsequent_adjustment: holds
+- name: auto_positive_hmong_or_highland_laotian_spouse_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_spouse_status_eligible: holds
+- name: auto_positive_hmong_or_highland_laotian_child_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: true
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: true
+  output:
+    us:regulations/7-cfr/273/4#hmong_or_highland_laotian_child_status_eligible: holds
+- name: auto_positive_younger_trafficking_victim_derivative_family_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: true
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: true
+  output:
+    us:regulations/7-cfr/273/4#younger_trafficking_victim_derivative_family_status_eligible: holds
+- name: auto_positive_older_trafficking_victim_derivative_family_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: true
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: true
+  output:
+    us:regulations/7-cfr/273/4#older_trafficking_victim_derivative_family_status_eligible: holds
+- name: auto_output_recognized_indian_tribe_member_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#recognized_indian_tribe_member_status_eligible: not_holds
+- name: auto_output_snap_member_special_nonqualified_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: not_holds
+- name: auto_output_snap_member_qualified_alien_immediately_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: not_holds
+- name: auto_output_snap_member_qualified_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: not_holds
+- name: auto_output_snap_member_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: not_holds
+- name: auto_output_snap_member_citizenship_or_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
     us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: not_holds
+- name: auto_positive_recognized_indian_tribe_member_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: true
+  output:
+    us:regulations/7-cfr/273/4#recognized_indian_tribe_member_status_eligible: holds
+- name: auto_positive_snap_member_qualified_alien_immediately_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: true
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: true
+    us:regulations/7-cfr/273/4#input.member_is_asylee: true
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: true
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: true
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
+- name: auto_positive_snap_member_qualified_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: true
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: true
+    us:regulations/7-cfr/273/4#input.member_is_asylee: true
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: true
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: true
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: true
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: holds
+- name: auto_positive_snap_member_citizenship_or_alien_status_eligible
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
+- name: auto_output_forty_qualifying_quarters_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#forty_qualifying_quarters_immediate_eligibility: not_holds
+- name: auto_output_refugee_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#refugee_immediate_eligibility: not_holds
+- name: auto_output_asylee_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#asylee_immediate_eligibility: not_holds
+- name: auto_positive_forty_qualifying_quarters_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: true
+  output:
+    us:regulations/7-cfr/273/4#forty_qualifying_quarters_immediate_eligibility: holds
+- name: auto_positive_refugee_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: true
+  output:
+    us:regulations/7-cfr/273/4#refugee_immediate_eligibility: holds
+- name: auto_positive_asylee_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: true
+  output:
+    us:regulations/7-cfr/273/4#asylee_immediate_eligibility: holds
+- name: auto_positive_qualifying_active_duty_military_connection
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: true
+  output:
+    us:regulations/7-cfr/273/4#qualifying_active_duty_military_connection: holds
+- name: auto_positive_qualifying_military_family_connection
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: true
+    us:statutes/8/1641/b#input.person_applies_for_federal_public_benefit: true
+    us:statutes/8/1641/b#input.person_receives_federal_public_benefit: false
+    us:statutes/8/1641/b#input.person_attempts_to_receive_federal_public_benefit: false
+    us:statutes/8/1641/b#input.alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act: true
+    us:statutes/8/1641/b#input.alien_granted_asylum_under_section_208_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act: false
+    us:statutes/8/1641/b#input.parole_period_years: 0
+    us:statutes/8/1641/b#input.alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions: false
+    us:statutes/8/1641/b#input.alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980: false
+    us:statutes/8/1641/b#input.alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e: false
+    ? us:statutes/8/1641/b#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+    : false
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: true
+  output:
+    us:regulations/7-cfr/273/4#qualifying_military_family_connection: holds
+- name: auto_output_withholding_qualified_alien_category
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 0
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#withholding_qualified_alien_category: not_holds
+- name: auto_output_withholding_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 0
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#withholding_immediate_eligibility: not_holds
+- name: auto_output_adult_lawful_permanent_resident_five_year_path
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 0
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#adult_lawful_permanent_resident_five_year_path: not_holds
+- name: auto_output_conditional_entrant_five_year_path
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 0
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#conditional_entrant_five_year_path: not_holds
+- name: auto_output_lawful_residing_status_for_alien_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.alien_and_spouse_divorced_after_snap_eligibility_determination: false
+    us:regulations/7-cfr/273/4#input.alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_eligibility_was_based_on_spouse_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.battered_alien_deeming_exemption_applies: false
+    us:regulations/7-cfr/273/4#input.citizen_child_of_sponsored_alien_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.current_period_is_before_next_recertification: false
+    us:regulations/7-cfr/273/4#input.eligibility_under_earlier_less_rigorous_status: false
+    us:regulations/7-cfr/273/4#input.eligible_sponsored_alien: false
+    us:regulations/7-cfr/273/4#input.ina_section_289_applies_to_member: false
+    us:regulations/7-cfr/273/4#input.member_age: 0
+    us:regulations/7-cfr/273/4#input.member_american_indian_blood_share: 0
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_alien_subjected_to_severe_form_of_trafficking: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_is_battered_or_extreme_cruelty_qualified_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_certified_by_department_of_health_and_human_services: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_honorably_discharged_qualifying_veteran: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: false
+    us:regulations/7-cfr/273/4#input.member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_on_qualifying_active_duty: false
+    us:regulations/7-cfr/273/4#input.member_is_paroled_under_ina_section_212_d_5: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian: false
+    us:regulations/7-cfr/273/4#input.member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: false
+    us:regulations/7-cfr/273/4#input.member_of_recognized_indian_tribe_eligible_for_special_programs_and_services: false
+    us:regulations/7-cfr/273/4#input.member_parole_period_years: 0
+    us:regulations/7-cfr/273/4#input.member_received_derivative_t_visa: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_born_in_canada: false
+    us:regulations/7-cfr/273/4#input.member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931: false
+    us:regulations/7-cfr/273/4#input.number_of_aliens_sponsored_by_same_sponsor: 0
+    us:regulations/7-cfr/273/4#input.other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.qualified_status_residency_absence_months: 0
+    us:regulations/7-cfr/273/4#input.quarter_is_after_statutory_cutoff: false
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_money_paid_to_alien: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_executing_spouse_total_resources: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_cash_contributions: 0
+    us:regulations/7-cfr/273/4#input.sponsor_and_other_in_kind_assistance_value: 0
+    us:regulations/7-cfr/273/4#input.sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member: false
+    us:regulations/7-cfr/273/4#input.sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program: false
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_earned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsor_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/4#input.sponsored_alien_child_under_eighteen: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_has_organization_or_group_sponsor: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_is_member_of_sponsor_snap_household: false
+    us:regulations/7-cfr/273/4#input.sponsored_alien_not_required_to_have_sponsor: false
+    us:regulations/7-cfr/273/4#input.state_agency_explained_purpose_of_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_provided_opportunity_to_refuse_indigence_determination: false
+    us:regulations/7-cfr/273/4#input.state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming: false
+    us:regulations/7-cfr/273/4#input.subsequent_adjustment_to_more_limited_status: false
+    us:regulations/7-cfr/273/4#input.tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era: false
+  output:
+    us:regulations/7-cfr/273/4#lawful_residing_status_for_alien_eligibility: not_holds
+- name: auto_positive_withholding_qualified_alien_category
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: true
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+  output:
+    us:regulations/7-cfr/273/4#withholding_qualified_alien_category: holds
+- name: auto_positive_withholding_immediate_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: true
+    us:regulations/7-cfr/273/4#input.member_is_alien: true
+  output:
+    us:regulations/7-cfr/273/4#withholding_immediate_eligibility: holds
+- name: auto_positive_adult_lawful_permanent_resident_five_year_path
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_lawfully_admitted_permanent_resident: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: true
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
+  output:
+    us:regulations/7-cfr/273/4#adult_lawful_permanent_resident_five_year_path: holds
+- name: auto_positive_conditional_entrant_five_year_path
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_is_conditional_entrant: true
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: true
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
+  output:
+    us:regulations/7-cfr/273/4#conditional_entrant_five_year_path: holds
+- name: auto_positive_lawful_residing_status_for_alien_eligibility
+  period:
+    period_kind: month
+    start: '2025-10-01'
+    end: '2025-10-31'
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_requirements: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/8/1641/b#input.person_is_alien: false
+    us:regulations/7-cfr/273/4#input.member_lawfully_resides_in_united_states: true
+  output:
+    us:regulations/7-cfr/273/4#lawful_residing_status_for_alien_eligibility: holds

--- a/us/regulations/7-cfr/273/4.yaml
+++ b/us/regulations/7-cfr/273/4.yaml
@@ -1,102 +1,2723 @@
 format: rulespec/v1
+imports:
+- us:statutes/8/1641/b#qualified_alien
+- us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status
+- us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules
 module:
-  deferred_outputs:
-    - output: us:regulations/7-cfr/273/4/c#sponsored_alien_household_income_and_resource_deeming
-      blocked_by:
-        - us:regulations/7-cfr/273/4#sponsored_alien_sponsor_deeming_context
-      reason: >-
-        Paragraph (c) governs sponsor income and resource deeming for households
-        containing sponsored alien members. This module encodes citizenship and
-        alien-status eligibility predicates; sponsored-alien household budgeting
-        and sponsor deeming are deferred until income and resource eligibility
-        composition is encoded.
-  summary: |-
-    7 CFR 273.4 makes a person eligible for SNAP only if the person is a U.S.
-    citizen, U.S. non-citizen national, an enumerated eligible noncitizen, or
-    a qualified alien satisfying the applicable immediate-eligibility or
-    five-year-status criteria. A person who cannot or will not document alien
-    status is classified as ineligible.
+  proof_validation:
+    required: true
   source_verification:
     corpus_citation_path: us/regulation/7/273/4
+    source_sha256: 846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3
+  summary: 'No person is eligible to participate in SNAP unless the person meets the
+
+    citizenship or eligible-alien status requirements; the section also governs
+
+    reporting of illegal aliens and sponsored-alien deeming.'
 rules:
-  - name: snap_member_citizen_or_national_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(1)-(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: member_is_us_citizen or member_is_us_noncitizen_national
-  - name: snap_member_special_nonqualified_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(3)-(5)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member
-          or member_is_hmong_or_highland_laotian_qualifying_person_or_family_member
-          or member_is_trafficking_victim_or_qualifying_family_member
-  - name: snap_member_qualified_alien_immediately_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)(ii)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          member_is_qualified_alien_with_forty_qualifying_quarters
-          or member_is_refugee
-          or member_is_asylee
-          or member_has_deportation_or_removal_withheld
-          or member_is_cuban_or_haitian_entrant
-          or member_is_amerasian_immigrant
-          or member_has_eligible_military_connection
-          or member_receives_blindness_or_disability_benefits
-          or member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22
-          or member_is_under_age_eighteen
-  - name: snap_member_qualified_alien_after_wait_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)(iii)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: member_is_qualified_alien_subject_to_five_year_wait and qualified_alien_five_year_status_period_met
-  - name: snap_member_qualified_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: snap_member_qualified_alien_immediately_eligible or snap_member_qualified_alien_after_wait_eligible
-  - name: snap_member_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          (
-              snap_member_special_nonqualified_alien_status_eligible
-              or snap_member_qualified_alien_status_eligible
-          )
-          and not alien_status_documentation_missing_or_unwilling
-  - name: snap_member_citizenship_or_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: snap_member_citizen_or_national_status_eligible or snap_member_alien_status_eligible
+- name: snap_member_citizenship_or_alien_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: No person is eligible to participate in the Program unless
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status
+          output: person_has_qualifying_snap_alien_or_citizenship_status
+          hash: sha256:fe7543305249bb91efc27d4507fef817c8847411bee01ca9ff96ca02cc9bde2f
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#person_is_snap_eligible_under_obbb_alien_rules
+          output: person_is_snap_eligible_under_obbb_alien_rules
+          hash: sha256:a676143833594eb342865cde3fffb1334db385bd72c326711c41b3ca70d58b90
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'snap_member_citizen_or_national_status_eligible
+
+      or snap_member_alien_status_eligible
+
+      or person_has_qualifying_snap_alien_or_citizenship_status
+
+      or person_is_snap_eligible_under_obbb_alien_rules'
+- name: spouse_qualifying_quarter_credit_available
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: quarters credited from the work of a spouse of the alien during
+            their marriage if they are still married or the spouse is deceased
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "spouse_quarters_credited_from_work_during_marriage\nand (\n  alien_and_spouse_are_still_married\n\
+      \  or spouse_is_deceased\n)"
+- name: snap_member_special_nonqualified_alien_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(3)-(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An individual who is
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#american_indian_born_in_canada_status_eligible
+          output: american_indian_born_in_canada_status_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#recognized_indian_tribe_member_status_eligible
+          output: recognized_indian_tribe_member_status_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#hmong_or_highland_laotian_status_eligible
+          output: hmong_or_highland_laotian_status_eligible
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#trafficking_victim_or_family_status_eligible
+          output: trafficking_victim_or_family_status_eligible
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'american_indian_born_in_canada_status_eligible
+
+      or recognized_indian_tribe_member_status_eligible
+
+      or hmong_or_highland_laotian_status_eligible
+
+      or trafficking_victim_or_family_status_eligible'
+- name: hmong_child_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(4)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: unmarried dependent child
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "hmong_child_is_legally_adopted_or_biological_child\nand (\n  hmong_child_is_unmarried_dependent_under_eighteen\n\
+      \  or hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two\n\
+      \  or hmong_child_is_unmarried_disabled_and_dependent_before_eighteen\n)"
+- name: residency_interruption_presumed
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: absent for more than 6 months
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: unless the alien presents evidence of his or her intent to resume
+            U.S. residency
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#residency_interruption_presumption_absence_months
+          output: residency_interruption_presumption_absence_months
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "(\n  qualified_status_residency_absence_exceeds_six_months\n  or (\n\
+      \    qualified_status_residency_absence_months\n    > residency_interruption_presumption_absence_months\n\
+      \  )\n)\nand not alien_presented_evidence_of_intent_to_resume_us_residency"
+- name: qualified_alien_meets_at_least_one_immediate_eligibility_criterion
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: meets at least one of the criteria
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_qualified_alien_with_forty_qualifying_quarters
+
+      or member_is_refugee
+
+      or member_is_asylee
+
+      or member_has_deportation_or_removal_withheld
+
+      or member_is_cuban_or_haitian_entrant
+
+      or member_is_amerasian_immigrant
+
+      or member_has_eligible_military_connection
+
+      or member_receives_blindness_or_disability_benefits
+
+      or member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22
+
+      or member_is_under_age_eighteen'
+- name: snap_member_qualified_alien_immediately_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: is eligible to receive SNAP benefits
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/8/1641/b#qualified_alien
+          output: qualified_alien
+          hash: sha256:7a98dbc72ac610e0af2df7e37d61bb8b24bfc2b8da7219ac5cdfa1f3af8986bc
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#qualified_alien_meets_at_least_one_immediate_eligibility_criterion
+          output: qualified_alien_meets_at_least_one_immediate_eligibility_criterion
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'qualified_alien
+
+      and qualified_alien_meets_at_least_one_immediate_eligibility_criterion'
+- name: snap_member_alien_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must classify that person as an ineligible alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "(\n  snap_member_special_nonqualified_alien_status_eligible\n  or snap_member_qualified_alien_status_eligible\n\
+      )\nand not alien_status_documentation_missing_or_unwilling"
+- name: snap_member_citizen_or_national_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A U.S. citizen
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A U.S. non-citizen national
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_us_citizen
+
+      or member_is_us_noncitizen_national'
+- name: snap_member_qualified_alien_after_wait_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must be in a qualified status for 5 years
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/8/1641/b#qualified_alien
+          output: qualified_alien
+          hash: sha256:7a98dbc72ac610e0af2df7e37d61bb8b24bfc2b8da7219ac5cdfa1f3af8986bc
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'qualified_alien
+
+      and member_is_qualified_alien_subject_to_five_year_wait
+
+      and qualified_alien_five_year_status_period_met'
+- name: snap_member_qualified_alien_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (6) An individual who is both a qualified alien as defined in paragraph
+            (a)(6)(i) of this section and an eligible alien as defined in paragraph
+            (a)(6)(ii) or (a)(6)(iii) of this section.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'snap_member_qualified_alien_immediately_eligible
+
+      or snap_member_qualified_alien_after_wait_eligible'
+- name: spouse_quarter_credit_continues_until_recertification
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: eligibility continues until the next recertification
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'spouse_quarter_credit_used_for_snap_eligibility
+
+      and spouse_quarter_couple_divorced_after_eligibility_determination
+
+      and current_period_before_next_recertification'
+- name: military_family_child_connection_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: unmarried dependent child
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'military_family_child_is_unmarried_dependent_under_eighteen
+
+      or military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two
+
+      or military_family_child_is_unmarried_disabled_and_dependent_before_eighteen'
+- name: eligibility_under_another_status_after_expiration
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: determine if eligibility exists under another status
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'eligibility_under_prior_eligible_alien_status_expired
+
+      and eligibility_under_another_eligible_alien_status_exists'
+- name: sponsored_alien_ineligible_for_failed_indigence_consent
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: fails to provide consent, he or she shall be ineligible
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_failed_to_consent_to_required_information_sharing
+- name: sponsored_alien_ineligible_while_awaiting_verification
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Until the alien provides information or verification
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_required_information_or_verification_outstanding
+- name: subsequently_received_sponsor_information_treated_as_reported_change
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must act on the information as a reported change in household membership
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'sponsored_alien_required_information_or_verification_outstanding
+
+      and state_agency_subsequently_received_required_sponsor_information_or_verification'
+- name: sponsored_alien_indigent
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (iv) An indigent alien that the State agency has determined is
+            unable to obtain food and shelter taking into account the alien's own
+            income plus any cash, food, housing, or other assistance provided by other
+            individuals, including the sponsor(s).
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: does not exceed 130 percent of the poverty income guideline
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#indigence_poverty_guideline_rate
+          output: indigence_poverty_guideline_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'sponsor_and_other_cash_contributions
+
+      + sponsor_and_other_in_kind_assistance_value
+
+      + sponsored_alien_household_own_income
+
+      <= household_poverty_income_guideline * indigence_poverty_guideline_rate'
+- name: indigence_poverty_guideline_rate
+  kind: parameter
+  dtype: Rate
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: does not exceed 130 percent of the poverty income guideline
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1.30'
+- name: deemed_sponsor_monthly_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 CFR 273.4(c)(2)(i)(A)-(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: total monthly earned and unearned income
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A 20 percent earned income amount
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An amount equal to the Program's monthly gross income eligibility
+            limit
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#sponsor_earned_income_deduction_rate
+          output: sponsor_earned_income_deduction_rate
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "max(\n  0,\n  sponsor_monthly_earned_income\n  + sponsor_monthly_unearned_income\n\
+      \  - (sponsor_monthly_earned_income * sponsor_earned_income_deduction_rate)\n\
+      \  - sponsor_household_gross_income_eligibility_limit\n)"
+- name: temporary_absence_does_not_interrupt_qualified_status_residency
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Temporary absences of less than 6 months from the United States
+            with no intention of abandoning U.S. residency do not terminate or interrupt
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#residency_interruption_presumption_absence_months
+          output: residency_interruption_presumption_absence_months
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'qualified_status_residency_absence_months < residency_interruption_presumption_absence_months
+
+      and temporary_absence_has_no_intention_to_abandon_us_residency'
+- name: spouse_quarter_eligibility_continues_until_recertification
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(A)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: the alien's eligibility continues until the next recertification
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'alien_eligibility_was_based_on_spouse_qualifying_quarters
+
+      and alien_and_spouse_divorced_after_snap_eligibility_determination
+
+      and current_period_is_before_next_recertification'
+- name: multiple_sponsored_aliens_deemed_income_share
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 CFR 273.4(c)(2)(v)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: If a sponsored alien can demonstrate to the State agency's satisfaction
+            that his or her sponsor is the sponsor of other aliens
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must divide the income and resources deemed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#deemed_sponsor_monthly_income
+          output: deemed_sponsor_monthly_income
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if sponsored_alien_demonstrated_sponsor_is_sponsor_of_other_aliens:
+      deemed_sponsor_monthly_income / number_of_aliens_sponsored_by_same_sponsor else:
+      deemed_sponsor_monthly_income'
+- name: multiple_sponsored_aliens_deemed_resource_share
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 CFR 273.4(c)(2)(v)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: If a sponsored alien can demonstrate to the State agency's satisfaction
+            that his or her sponsor is the sponsor of other aliens
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must divide the income and resources deemed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#deemed_sponsor_resources
+          output: deemed_sponsor_resources
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if sponsored_alien_demonstrated_sponsor_is_sponsor_of_other_aliens:
+      deemed_sponsor_resources / number_of_aliens_sponsored_by_same_sponsor else:
+      deemed_sponsor_resources'
+- name: sponsor_deeming_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(2)-(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: only in the event a sponsored alien is an eligible alien
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: The provisions of paragraph (c)(2) of this section do not apply
+            to
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#same_snap_household_deeming_exemption
+          output: same_snap_household_deeming_exemption
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#organization_sponsor_deeming_exemption
+          output: organization_sponsor_deeming_exemption
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#sponsorship_not_required_deeming_exemption
+          output: sponsorship_not_required_deeming_exemption
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#battered_alien_sponsor_deeming_exemption
+          output: battered_alien_sponsor_deeming_exemption
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#sponsored_alien_child_deeming_exemption
+          output: sponsored_alien_child_deeming_exemption
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#citizen_child_deeming_exemption
+          output: citizen_child_deeming_exemption
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'eligible_sponsored_alien
+
+      and not same_snap_household_deeming_exemption
+
+      and not organization_sponsor_deeming_exemption
+
+      and not sponsorship_not_required_deeming_exemption
+
+      and not battered_alien_sponsor_deeming_exemption
+
+      and not sponsored_alien_child_deeming_exemption
+
+      and not citizen_child_deeming_exemption'
+- name: missing_alien_documentation_ineligible_classification
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (b) Reporting illegal aliens.
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must classify that person as an ineligible alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: alien_status_documentation_missing_or_unwilling
+- name: qualified_status_wait_years
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: qualified status for 5 years
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '5'
+- name: residency_interruption_presumption_absence_months
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: absent for more than 6 months
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '6'
+- name: sponsor_earned_income_deduction_rate
+  kind: parameter
+  dtype: Rate
+  source: 7 CFR 273.4(c)(2)(i)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A 20 percent earned income amount
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0.20'
+- name: military_family_connection_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: spouse and unmarried dependent children
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_spouse_of_qualifying_military_person
+
+      or military_family_member_is_unmarried_dependent_child_with_qualifying_age_student_or_disability_status'
+- name: sponsored_alien_eligible_after_indigence_information_consent
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: If the sponsored alien fails to provide consent, he or she shall
+            be ineligible
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_provided_consent_for_required_information_sharing
+- name: indigent_sponsored_alien_deemed_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: the only amount that the State agency must deem to such an alien
+            will be the amount actually provided
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: ending 12 months after such date
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'if sponsored_alien_indigence_determination_active: amount_actually_provided_to_indigent_sponsored_alien
+      else: 0'
+- name: eligible_sponsored_alien_information_responsibility_satisfied
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: responsible for obtaining the cooperation of the sponsor
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: providing the State agency at the time of application and at the
+            time of recertification with the information and documentation necessary
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: responsible for providing the names and other identifying factors
+            of other aliens
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: responsible for reporting the required information about the sponsor
+            and sponsor's spouse
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'eligible_sponsored_alien_obtained_sponsor_cooperation
+
+      and eligible_sponsored_alien_provided_required_deeming_information_and_documentation
+
+      and eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens
+
+      and eligible_sponsored_alien_reported_required_sponsor_changes'
+- name: entire_household_ineligible_while_common_sponsor_information_outstanding
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: If the same sponsor is responsible for the entire household, the
+            entire household is ineligible until such time as the household provides
+            the needed sponsor information or verification.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'same_sponsor_is_responsible_for_entire_household
+
+      and household_needed_sponsor_information_or_verification_outstanding'
+- name: participating_sponsor_excluded_from_snap_restitution_demand
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(6)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must exclude any sponsor who is participating in the Program from
+            any demand made under 8 CFR 213a.4(a)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: for the value of SNAP benefits issued to an eligible sponsored
+            alien he or she sponsors
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'restitution_demand_is_for_snap_benefits_issued_to_eligible_alien_sponsored_by_person
+
+      and sponsor_is_participating_in_snap'
+- name: same_snap_household_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is a member of his or her sponsor's SNAP household
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_is_member_of_sponsor_snap_household
+- name: organization_sponsor_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: sponsored by an organization or group as opposed to an individual
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_has_organization_or_group_sponsor
+- name: sponsorship_not_required_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is not required to have a sponsor under the Immigration
+            and Nationality Act
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_not_required_to_have_sponsor
+- name: battered_alien_sponsor_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(v)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A battered alien spouse, alien parent of a battered child, or child
+            of a battered alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: battered_alien_deeming_exemption_applies
+- name: sponsored_alien_child_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(vi)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A sponsored alien child under 18 years of age of a sponsored alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: sponsored_alien_child_under_eighteen
+- name: citizen_child_deeming_exemption
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(vii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A citizen child under age 18 of a sponsored alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: citizen_child_of_sponsored_alien_under_eighteen
+- name: withholding_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: whose deportation is being withheld
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_has_deportation_or_removal_withheld'
+- name: withholding_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien whose deportation is withheld
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_has_deportation_or_removal_withheld'
+- name: adult_lawful_permanent_resident_five_year_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien age 18 or older lawfully admitted for permanent residence
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_lawfully_admitted_permanent_resident
+
+      and member_is_qualified_alien_subject_to_five_year_wait
+
+      and qualified_alien_five_year_status_period_met'
+- name: conditional_entrant_five_year_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is granted conditional entry
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_conditional_entrant
+
+      and member_is_qualified_alien_subject_to_five_year_wait
+
+      and qualified_alien_five_year_status_period_met'
+- name: lawful_residing_status_for_alien_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(7)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (7) For purposes of determining eligible alien status in accordance
+            with paragraphs (a)(4) and (a)(6)(ii)(I) of this section “lawfully residing
+            in the U.S.” means that the alien is lawfully present as defined at 8
+            CFR 103.12(a).
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_lawfully_resides_in_united_states
+- name: interagency_notice_federal_register_volume
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: September 28, 2000 (65 FR 58301)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '65'
+- name: other_assistance_program_sponsor_income_may_be_used
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(2)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: the State agency may use that income amount for SNAP deeming purposes
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must limit allowable reductions
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program
+
+      and state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming
+
+      and other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B'
+- name: benefit_receipt_quarter_creditable
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: if the alien earns the 40th quarter of coverage prior to applying
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'not quarter_is_after_statutory_cutoff
+
+      or not alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter
+
+      or alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter'
+- name: cuban_or_haitian_entrant_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(E)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien granted status as a Cuban or Haitian entrant
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_cuban_or_haitian_entrant'
+- name: amerasian_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An Amerasian admitted pursuant to section 584 of Public Law 100-202
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_amerasian_immigrant'
+- name: qualifying_veteran_military_connection
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A veteran who was honorably discharged for reasons other than alien
+            status
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_honorably_discharged_qualifying_veteran'
+- name: qualifying_active_duty_military_connection
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An individual on active duty in the Armed Forces of the U.S.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_on_qualifying_active_duty'
+- name: qualifying_military_family_connection
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: The spouse and unmarried dependent children of a person described
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person'
+- name: military_connection_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(G)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien with one of the following military connections
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#qualifying_veteran_military_connection
+          output: qualifying_veteran_military_connection
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#qualifying_active_duty_military_connection
+          output: qualifying_active_duty_military_connection
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#qualifying_military_family_connection
+          output: qualifying_military_family_connection
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'qualifying_veteran_military_connection
+
+      or qualifying_active_duty_military_connection
+
+      or qualifying_military_family_connection'
+- name: blindness_or_disability_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(H)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: receiving benefits or assistance for blindness or disability
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_receives_blindness_or_disability_benefits'
+- name: historical_residence_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(I)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: on August 22, 1996, was lawfully residing in the U.S.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931'
+- name: military_service_minimum_active_duty_section_number
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(G)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: 38 U.S.C. 5303A(d)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '3'
+- name: doj_interim_guidance_federal_register_volume
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a) footnote 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: 62 FR 61344
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '62'
+- name: amerasian_admission_public_law_number
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Public Law 100-202
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '100'
+- name: amerasian_admission_public_law_suffix
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Public Law 100-202
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '202'
+- name: amerasian_amending_public_law_suffix
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Public Law 100-461
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '461'
+- name: forty_qualifying_quarters_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien age 18 or older lawfully admitted for permanent residence
+            under the INA who has 40 qualifying quarters
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_is_qualified_alien_with_forty_qualifying_quarters
+- name: refugee_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien admitted as a refugee under section 207 of the INA
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_is_refugee
+- name: asylee_immediate_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(ii)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien granted asylum under section 208 of the INA
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_is_asylee
+- name: two_parent_quarter_credit_sources
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(A)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: the parent(s) or spouse of the alien
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '2'
+- name: lawful_permanent_resident_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is lawfully admitted for permanent residence under
+            the INA
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_lawfully_admitted_permanent_resident'
+- name: asylee_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is granted asylum under section 208 of the INA
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_asylee'
+- name: refugee_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A refugee who is admitted to the United States under section 207
+            of the INA
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_refugee'
+- name: parolee_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: A qualified alien is
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: paroled into the U.S. under section 212(d)(5) of the INA for a
+            period of at least 1 year
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#minimum_qualified_parole_period_years
+          output: minimum_qualified_parole_period_years
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_paroled_under_ina_section_212_d_5
+
+      and member_parole_period_years >= minimum_qualified_parole_period_years'
+- name: conditional_entrant_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(F)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: granted conditional entry pursuant to section 203(a)(7) of the
+            INA as in effect prior to April 1, 1980
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_conditional_entrant'
+- name: battered_or_extreme_cruelty_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(G)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: has been battered or subjected to extreme cruelty in the U.S.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_battered_or_extreme_cruelty_qualified_alien'
+- name: cuban_or_haitian_entrant_qualified_alien_category
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(i)(H)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (H) An alien who is a Cuban or Haitian entrant, as defined in section
+            501(e) of the Refugee Education Assistance Act of 1980.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and member_is_cuban_or_haitian_entrant'
+- name: parolee_five_year_status_path_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iii)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An alien who is paroled into the U.S. under section 212(d)(5) of
+            the INA for a period of at least 1 year
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must be in a qualified status for 5 years before being eligible
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#parolee_qualified_alien_category
+          output: parolee_qualified_alien_category
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'parolee_qualified_alien_category
+
+      and qualified_alien_five_year_status_period_met'
+- name: minimum_qualified_parole_period_years
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(i)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: for a period of at least 1 year
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1'
+- name: american_indian_born_in_canada_minimum_blood_share
+  kind: parameter
+  dtype: Rate
+  source: 7 CFR 273.4(a)(3)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: at least 50 per centum of blood
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0.50'
+- name: trafficking_victim_minor_age_limit
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(5)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: under the age of 18
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '18'
+- name: american_indian_born_in_canada_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(3)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: American Indian born in Canada who possesses at least 50 per centum
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#american_indian_born_in_canada_minimum_blood_share
+          output: american_indian_born_in_canada_minimum_blood_share
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_was_born_in_canada
+
+      and member_american_indian_blood_share >= american_indian_born_in_canada_minimum_blood_share
+
+      and ina_section_289_applies_to_member'
+- name: recognized_indian_tribe_member_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(3)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: recognized as eligible for the special programs and services
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_of_recognized_indian_tribe_eligible_for_special_programs_and_services
+- name: hmong_or_highland_laotian_qualifying_person_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(4)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Lawfully residing in the U.S. and was a member of a Hmong or Highland
+            Laotian tribe
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_lawfully_resides_in_united_states
+
+      and member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel
+
+      and tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era'
+- name: hmong_or_highland_laotian_spouse_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(4)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: The spouse, or surviving spouse of such Hmong or Highland Laotian
+  versions:
+  - effective_from: '2025-10-01'
+    formula: member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian
+- name: hmong_or_highland_laotian_child_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(4)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An unmarried dependent child of such Hmong or Highland Laotian
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian
+
+      and member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status'
+- name: hmong_or_highland_laotian_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(4)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An individual who is
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'hmong_or_highland_laotian_qualifying_person_status_eligible
+
+      or hmong_or_highland_laotian_spouse_status_eligible
+
+      or hmong_or_highland_laotian_child_status_eligible'
+- name: adult_trafficking_victim_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(5)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: subjected to a severe form of trafficking in persons and who is
+            certified
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien_subjected_to_severe_form_of_trafficking
+
+      and member_is_certified_by_department_of_health_and_human_services'
+- name: minor_trafficking_victim_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(5)(ii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: subjected to a severe form of trafficking in persons and who is
+            under the age of 18
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#trafficking_victim_minor_age_limit
+          output: trafficking_victim_minor_age_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien_subjected_to_severe_form_of_trafficking
+
+      and member_age < trafficking_victim_minor_age_limit'
+- name: younger_trafficking_victim_derivative_family_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(5)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: spouse, child, parent or unmarried minor sibling of a victim
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one
+
+      and member_received_derivative_t_visa'
+- name: older_trafficking_victim_derivative_family_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(5)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: The spouse or child of a victim of a severe form of trafficking
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older
+
+      and member_received_derivative_t_visa'
+- name: trafficking_victim_or_family_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(5)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: An individual who is
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'adult_trafficking_victim_status_eligible
+
+      or minor_trafficking_victim_status_eligible
+
+      or younger_trafficking_victim_derivative_family_status_eligible
+
+      or older_trafficking_victim_derivative_family_status_eligible'
+- name: sponsored_alien
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (c) Households containing sponsored alien members—(1) Definition.
+            A sponsored alien is an alien for whom a person (the sponsor) has executed
+            an affidavit of support (USCIS Form I-864 or I-864A) on behalf of the
+            alien pursuant to section 213A of the INA.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_is_alien
+
+      and sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member'
+- name: indigence_determination_duration_months
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: ending 12 months after such date
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '12'
+- name: trafficking_victim_younger_age_limit
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(5)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: under 21 years of age
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '21'
+- name: full_time_student_dependent_child_age_limit
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(4)(iii), 7 CFR 273.4(a)(6)(ii)(G)(3)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: if a full-time student under the age of 22
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '22'
+- name: qualifying_quarters_required
+  kind: parameter
+  dtype: Count
+  source: 7 CFR 273.4(a)(6)(ii)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: has 40 qualifying quarters
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '40'
+- name: indigence_explanation_and_refusal_opportunity_provided
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(c)(3)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Prior to determining whether an alien is indigent, the State agency
+            must explain the purpose of the determination to the alien and/or household
+            representative and provide the alien and/or household representative the
+            opportunity to refuse the determination.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'state_agency_explained_purpose_of_indigence_determination
+
+      and state_agency_provided_opportunity_to_refuse_indigence_determination'
+- name: sponsor_resource_disregard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: 7 CFR 273.4(c)(2)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: reduced by $1,500
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '1500'
+- name: deemed_sponsor_resources
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 CFR 273.4(c)(2)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: (iv) The State agency must deem as available to the eligible sponsored
+            alien the total amount of the resources of the sponsor and sponsor's spouse
+            as determined in accordance with § 273.8, reduced by $1,500.
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#sponsor_resource_disregard
+          output: sponsor_resource_disregard
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: max(0, sponsor_and_executing_spouse_total_resources - sponsor_resource_disregard)
+- name: sponsor_payment_income_excess
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 CFR 273.4(c)(2)(iii)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: only to the extent that the money exceeds the amount deemed
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:regulations/7-cfr/273/4#deemed_sponsor_monthly_income
+          output: deemed_sponsor_monthly_income
+          hash: sha256:local
+  versions:
+  - effective_from: '2025-10-01'
+    formula: max(0, sponsor_and_executing_spouse_money_paid_to_alien - deemed_sponsor_monthly_income)
+- name: eligibility_preserved_after_subsequent_adjustment
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a)(6)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: Subsequent adjustment to a more limited status does not override
+            eligibility based on an earlier less rigorous status.
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'eligibility_under_earlier_less_rigorous_status
+
+      and subsequent_adjustment_to_more_limited_status'
+inputs:
+- name: spouse_quarters_credited_from_work_during_marriage
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_and_spouse_are_still_married
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: spouse_is_deceased
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_us_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_us_noncitizen_national
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_hmong_or_highland_laotian_qualifying_person_or_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_trafficking_victim_or_qualifying_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_qualified_alien_with_forty_qualifying_quarters
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_refugee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_asylee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_deportation_or_removal_withheld
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_cuban_or_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_amerasian_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_eligible_military_connection
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_receives_blindness_or_disability_benefits
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_under_age_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_qualified_alien_subject_to_five_year_wait
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: qualified_alien_five_year_status_period_met
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_status_documentation_missing_or_unwilling
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: spouse_quarter_credit_used_for_snap_eligibility
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: spouse_quarter_couple_divorced_after_eligibility_determination
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: current_period_before_next_recertification
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_legally_adopted_or_biological_child
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_unmarried_dependent_under_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_unmarried_dependent_full_time_student_under_twenty_two
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_unmarried_disabled_and_dependent_before_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: military_family_child_is_unmarried_dependent_under_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: military_family_child_is_unmarried_dependent_full_time_student_under_twenty_two
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: military_family_child_is_unmarried_disabled_and_dependent_before_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: qualified_status_residency_absence_exceeds_six_months
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_presented_evidence_of_intent_to_resume_us_residency
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligibility_under_another_eligible_alien_status_exists
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligibility_under_prior_eligible_alien_status_expired
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_failed_to_consent_to_required_information_sharing
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_required_information_or_verification_outstanding
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: state_agency_subsequently_received_required_sponsor_information_or_verification
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_special_eligible_alien_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_meets_immediate_qualified_alien_criterion
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_subject_to_five_year_qualified_status_requirement
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_completed_five_year_qualified_status_requirement
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_household_own_income
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+- name: sponsor_and_other_cash_contributions
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+- name: sponsor_and_other_in_kind_assistance_value
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+- name: household_poverty_income_guideline
+  entity: Household
+  dtype: Money
+  unit: USD
+  period: Month
+- name: sponsor_household_gross_income_eligibility_limit
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: temporary_absence_has_no_intention_to_abandon_us_residency
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_demonstrated_sponsor_is_sponsor_of_other_aliens
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_eligible_alien_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_unmarried_dependent_and_has_qualifying_age_student_or_disability_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: hmong_child_is_legally_adopted_or_biological_child_of_qualifying_person
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: qualified_alien_immediate_criterion_met
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: spouse_quarters_were_used_for_snap_eligibility
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: current_period_is_before_next_recertification
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: military_family_member_is_unmarried_dependent_child_with_qualifying_age_student_or_disability_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_spouse_of_qualifying_military_person
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: qualified_status_residency_absence_months
+  entity: Person
+  dtype: Count
+  period: Month
+- name: sponsor_monthly_earned_income
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: sponsor_monthly_unearned_income
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: sponsor_household_gross_income_limit
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: number_of_aliens_sponsored_by_same_sponsor
+  entity: Person
+  dtype: Count
+  period: Month
+- name: sponsored_alien_provided_consent_for_required_information_sharing
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_indigence_determination_active
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: amount_actually_provided_to_indigent_sponsored_alien
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: eligible_sponsored_alien_obtained_sponsor_cooperation
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligible_sponsored_alien_provided_required_deeming_information_and_documentation
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligible_sponsored_alien_provided_identifying_information_for_other_sponsored_aliens
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligible_sponsored_alien_reported_required_sponsor_changes
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: same_sponsor_is_responsible_for_entire_household
+  entity: Household
+  dtype: Boolean
+  period: Month
+- name: household_needed_sponsor_information_or_verification_outstanding
+  entity: Household
+  dtype: Boolean
+  period: Month
+- name: restitution_demand_is_for_snap_benefits_issued_to_eligible_alien_sponsored_by_person
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: sponsor_is_participating_in_snap
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: member_was_lawfully_residing_on_statutory_date_and_is_older_eligible_person
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsor_gross_income_was_reported_to_another_state_agency_administered_assistance_program
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: state_agency_uses_other_program_sponsor_gross_income_for_snap_deeming
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: other_program_sponsor_income_reductions_are_limited_to_paragraph_c_2_i_A_and_B
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: alien_eligibility_was_based_on_spouse_qualifying_quarters
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_and_spouse_divorced_after_snap_eligibility_determination
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: quarter_is_after_statutory_cutoff
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_parent_or_spouse_received_federal_means_tested_or_snap_benefit_in_quarter
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_earned_fortieth_quarter_before_applying_for_benefit_in_same_quarter
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_honorably_discharged_qualifying_veteran
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_on_qualifying_active_duty
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_spouse_or_unmarried_dependent_child_of_qualifying_military_person
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_lawfully_admitted_permanent_resident
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_conditional_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_paroled_under_ina_section_212_d_5
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_parole_period_years
+  entity: Person
+  dtype: Count
+  period: Month
+- name: member_was_born_in_canada
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_american_indian_blood_share
+  entity: Person
+  dtype: Rate
+  period: Month
+- name: ina_section_289_applies_to_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_of_recognized_indian_tribe_eligible_for_special_programs_and_services
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_lawfully_resides_in_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_was_hmong_or_highland_laotian_tribe_member_when_tribe_assisted_us_personnel
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: tribe_assistance_to_us_personnel_was_military_or_rescue_operation_during_vietnam_era
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_spouse_or_surviving_spouse_of_qualifying_hmong_or_highland_laotian
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_legally_adopted_or_biological_child_of_qualifying_hmong_or_highland_laotian
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_unmarried_dependent_child_with_qualifying_age_or_disability_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_alien_subjected_to_severe_form_of_trafficking
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_certified_by_department_of_health_and_human_services
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_age
+  entity: Person
+  dtype: Count
+  period: Month
+- name: member_is_qualifying_family_member_of_trafficking_victim_under_twenty_one
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_received_derivative_t_visa
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_spouse_or_child_of_trafficking_victim_age_twenty_one_or_older
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_applies_for_federal_public_benefit
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_receives_federal_public_benefit
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_attempts_to_receive_federal_public_benefit
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_lawfully_admitted_for_permanent_residence_under_immigration_and_nationality_act
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_granted_asylum_under_section_208_of_immigration_and_nationality_act
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: refugee_admitted_to_united_states_under_section_207_of_immigration_and_nationality_act
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_paroled_into_united_states_under_section_212_d_5_of_immigration_and_nationality_act
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: parole_period_years
+  entity: Person
+  dtype: Count
+  period: Month
+- name: alien_deportation_or_removal_withheld_under_listed_immigration_and_nationality_act_provisions
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_granted_conditional_entry_under_section_203_a_7_as_in_effect_prior_to_april_1_1980
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: alien_is_cuban_and_haitian_entrant_as_defined_in_refugee_education_assistance_act_section_501_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association_referred_to_in_section_1612_b_2_G
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsor_executed_form_i_864_or_i_864a_on_behalf_of_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: state_agency_explained_purpose_of_indigence_determination
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: state_agency_provided_opportunity_to_refuse_indigence_determination
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: qualifying_hmong_or_highland_laotian_is_deceased_or_current_spouse
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsor_and_executing_spouse_total_resources
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: sponsor_and_executing_spouse_money_paid_to_alien
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: eligible_sponsored_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_is_member_of_sponsor_snap_household
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_has_organization_or_group_sponsor
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_not_required_to_have_sponsor
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: battered_alien_deeming_exemption_applies
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsored_alien_child_under_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: citizen_child_of_sponsored_alien_under_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: sponsor_household_size_gross_income_eligibility_limit
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+- name: eligibility_under_earlier_less_rigorous_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: subsequent_adjustment_to_more_limited_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: eligible_sponsored_alien_household_own_income
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+- name: household_size_poverty_income_guideline
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+- name: member_is_battered_or_extreme_cruelty_qualified_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_was_lawfully_residing_on_august_22_1996_and_born_on_or_before_august_22_1931
+  entity: Person
+  dtype: Boolean
+  period: Month

--- a/us/statutes/7/2015/f.test.yaml
+++ b/us/statutes/7/2015/f.test.yaml
@@ -1,0 +1,448 @@
+- name: citizen_resident_satisfies_participation_status_requirements
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: resident_without_qualifying_status_has_full_income_and_resources_considered
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: false
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 100
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: nonresident_permanent_resident_has_prorated_income_considered
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: true
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: not_holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 75
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: temporary_visitor_cannot_satisfy_permanent_resident_branch
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : true
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: cuban_and_haitian_entrant_satisfies_paragraph_2
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: compact_of_free_association_resident_satisfies_paragraph_2
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: member_outside_otherwise_eligible_household_is_not_rendered_ineligible
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: citizen_resident_is_not_ineligible_under_subsection
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: resident_without_qualifying_status_is_ineligible_without_proration
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: false
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 100
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: nonresident_permanent_resident_is_ineligible_with_proration
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: true
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: not_holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 75
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: cuban_and_haitian_entrant_resident_has_qualifying_status
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: compact_of_free_association_resident_has_qualifying_status
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: true
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: person_outside_otherwise_eligible_household_is_not_rendered_ineligible
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: resident_without_qualifying_status_is_ineligible
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: person_not_in_otherwise_eligible_household_is_not_rendered_ineligible_by_this_subsection
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: citizen_resident_satisfies_both_numbered_requirements
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: permanent_resident_nonresident_is_ineligible_with_pro_rata_income
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: true
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: not_holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 75
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: compact_resident_has_qualifying_status
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: true
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: resident_without_paragraph_2_status_is_ineligible_without_pro_rata_reduction
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: false
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#permanent_resident_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#cuban_and_haitian_entrant_status_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#compact_of_free_association_residence_satisfies_paragraph_2: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 100
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: permanent_resident_is_eligible_and_income_is_reduced_by_elected_pro_rata_share
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: true
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 0
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 0
+- name: nonresident_permanent_resident_is_ineligible_and_pro_rata_income_is_considered
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_elects_pro_rata_share_reduction_for_ineligible_individual_income: true
+    us:statutes/7/2015/f#input.ineligible_individual_income: 100
+    us:statutes/7/2015/f#input.pro_rata_share_of_ineligible_individual_income: 25
+    us:statutes/7/2015/f#input.ineligible_individual_financial_resources: 60
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered_for_household_snap_determination: 75
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered_for_household_snap_determination: 60
+- name: citizen_or_national_has_qualifying_status
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: cuban_and_haitian_entrant_has_qualifying_status
+  period: 2026-01
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_under_compact_of_free_association: false
+    ? us:statutes/7/2015/f#input.person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+    : false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds

--- a/us/statutes/7/2015/f.yaml
+++ b/us/statutes/7/2015/f.yaml
@@ -1,0 +1,245 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2015/f
+    source_sha256: 239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2
+  summary: No otherwise eligible household member may participate in SNAP unless the
+    individual is “(1) a resident of the United States” and “(2) either” a citizen
+    or national, qualifying permanent resident, Cuban and Haitian entrant, or Compact
+    of Free Association resident. Income, less an elected pro rata share, and financial
+    resources of an individual rendered ineligible are considered for household eligibility
+    and allotment value.
+rules:
+- name: united_states_residence_requirement_satisfied
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a resident of the United States
+  versions:
+  - effective_from: '2008-10-01'
+    formula: person_is_resident_of_united_states
+- name: citizen_or_national_status_satisfies_paragraph_2
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a citizen or national of the United States
+  versions:
+  - effective_from: '2008-10-01'
+    formula: person_is_citizen_or_national_of_united_states
+- name: permanent_resident_status_satisfies_paragraph_2
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: excluding, among others, alien visitors, tourists, diplomats, and
+            students
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant
+
+      and not person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence'
+- name: cuban_and_haitian_entrant_status_satisfies_paragraph_2
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: an alien who has been granted the status of Cuban and Haitian entrant
+  versions:
+  - effective_from: '2008-10-01'
+    formula: person_has_status_of_cuban_and_haitian_entrant
+- name: compact_of_free_association_residence_satisfies_paragraph_2
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: lawfully resides in the United States in accordance with a Compact
+            of Free Association
+  versions:
+  - effective_from: '2008-10-01'
+    formula: person_lawfully_resides_in_united_states_under_compact_of_free_association
+- name: person_has_qualifying_snap_alien_or_citizenship_status
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: either—
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'citizen_or_national_status_satisfies_paragraph_2
+
+      or permanent_resident_status_satisfies_paragraph_2
+
+      or cuban_and_haitian_entrant_status_satisfies_paragraph_2
+
+      or compact_of_free_association_residence_satisfies_paragraph_2'
+- name: person_ineligible_for_snap_participation_due_to_alien_status
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+            to participate
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: unless he or she is
+  versions:
+  - effective_from: '2008-10-01'
+    formula: 'person_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+
+      and
+
+      (not united_states_residence_requirement_satisfied
+
+      or not person_has_qualifying_snap_alien_or_citizenship_status)'
+- name: ineligible_individual_income_considered_for_household_snap_determination
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: The income (less, at State option, a pro rata share)
+  versions:
+  - effective_from: '2008-10-01'
+    formula: "if person_ineligible_for_snap_participation_due_to_alien_status:\n \
+      \ if state_elects_pro_rata_share_reduction_for_ineligible_individual_income:\n\
+      \    max(0, ineligible_individual_income - pro_rata_share_of_ineligible_individual_income)\n\
+      \  else: ineligible_individual_income\nelse: 0"
+- name: ineligible_individual_financial_resources_considered_for_household_snap_determination
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: financial resources of the individual rendered ineligible
+  versions:
+  - effective_from: '2008-10-01'
+    formula: "if person_ineligible_for_snap_participation_due_to_alien_status:\n \
+      \ ineligible_individual_financial_resources\nelse: 0"
+inputs:
+- name: person_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_resident_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_citizen_or_national_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_alien_visitor_tourist_diplomat_or_student_entering_temporarily_without_intention_to_abandon_foreign_residence
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_has_status_of_cuban_and_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_lawfully_resides_in_united_states_under_compact_of_free_association
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: state_elects_pro_rata_share_reduction_for_ineligible_individual_income
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: ineligible_individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+- name: pro_rata_share_of_ineligible_individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+- name: ineligible_individual_financial_resources
+  entity: Person
+  dtype: Money
+  period: Month


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/regulation/7/273/4`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `["us/statute/7/2015/f","us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo"]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `33613765722`
Base commit: `d58cc0ce67ad891fde4c9061c86a2091bfdd524f`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/33629917181

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.

Naming-contract acronym follow-up: TheAxiomFoundation/axiom.org#232
