### PR TITLE
Add signed encoding manifest for us/statute/7/2015/f

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/7/2015/f.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2015/f.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2015/f.yaml",
+      "sha256": "362aacb6238cd173ca7393bd5d416c3db49db715e1b1d67114de805c47a84b29"
+    },
+    {
+      "path": "us/statutes/7/2015/f.test.yaml",
+      "sha256": "0ca791b24107cc27cd34c07a9ced145ac2ffa262141301a5543f09c08cb1ed8f"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "e299d9affb046087018f2768399bb41cb4fcae90",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1759",
+    "version_commit": "e299d9affb046087018f2768399bb41cb4fcae90"
+  },
+  "axiom_encode_version": "0.2.1759",
+  "backend": "openai",
+  "citation": "us/statute/7/2015/f",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-statute-7-2015-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "cf9ef361461876926bb402444a38f6ca469670ea954fb2163e6e02de7480fdb5",
+  "generated_at": "2026-09-04T07:32:01.520696+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/7/2015/f.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "362aacb6238cd173ca7393bd5d416c3db49db715e1b1d67114de805c47a84b29",
+  "generation_prompt_sha256": "f76e278b0fa56e2e414d35cb280ea6360f808857736e03008e6d18e9b2d6d89f",
+  "model": "gpt-5.6-sol",
+  "run_id": "9b85b17b",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "ME89ERMi/HeMRq/CchDbnSgHS1Unxw7K4xKeLGj7f5kI0YMGKexz1w14mBvf0SyYeI2f8INEafEw7qB5y+o0AQ=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_text_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "row": {
+      "body_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+      "citation_path": "us/statute/7/2015/f",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 197,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "51527d3a-7ce2-5d09-bdb0-681309bae9e8",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-statute-7-2015-f.json",
+  "trace_sha256": "cb52650d5e4cfc56908ee3c25480cf580fb349386023ae78c24e06e072a19caf",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "e299d9affb046087018f2768399bb41cb4fcae90",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1759"
+    },
+    "axiom_rules_engine": {
+      "commit": "48797e101c093bb388be718c6f5d8fc9d9f94a7d",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e51134a13b0a8f5076fb6311341293e843d364201cf9cbaa4c202502257b193c",
+      "pre_apply_file_count": 2709,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -54899,6 +54899,15 @@
         ]
       }
     ],
+    "us/statute/7/2015/f": [
+      {
+        "module": "us/statutes/7/2015/f.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/statute/7/2015/o/3": [
       {
         "module": "us-ca/regulations/mpp/63-410/321.yaml",

--- a/us/statutes/7/2015/f.test.yaml
+++ b/us/statutes/7/2015/f.test.yaml
@@ -1,0 +1,384 @@
+- name: income_less_optional_pro_rata_share_is_considered
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_income: 1000
+    us:statutes/7/2015/f#input.state_option_pro_rata_share_of_person_income: 200
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_person_income_amount_considered: 800
+- name: auto_zero_ineligible_person_income_amount_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_financial_resources: 0
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_income: 0
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.state_option_pro_rata_share_of_person_income: 0
+  output:
+    us:statutes/7/2015/f#ineligible_person_income_amount_considered: 0
+- name: citizen_resident_satisfies_both_requirements
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: lawful_permanent_resident_is_a_qualifying_category
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: cuban_and_haitian_entrant_is_a_qualifying_category
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: compact_of_free_association_resident_is_a_qualifying_category
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: no_qualifying_category_renders_otherwise_eligible_resident_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: otherwise_eligible_membership_enables_alien_status_disqualification
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: absence_of_otherwise_eligible_membership_blocks_alien_status_disqualification
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: nonresident_otherwise_eligible_member_is_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: not_holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: income_less_state_optional_pro_rata_share_is_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_income: 1000
+    us:statutes/7/2015/f#input.state_option_pro_rata_share_of_person_income: 200
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_person_income_amount_considered: 800
+- name: negative_financial_resources_are_clamped_for_ineligible_person
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_financial_resources: -25
+  output:
+    us:statutes/7/2015/f#person_meets_snap_residency_requirement: holds
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_person_financial_resources_amount_considered: 0
+- name: citizen_resident_is_qualifying_and_not_alien_status_ineligible
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: lawful_permanent_resident_is_qualifying
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: cuban_haitian_entrant_is_qualifying
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: compact_of_free_association_resident_is_qualifying
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: no_qualifying_category_renders_resident_member_ineligible
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: nonresident_member_is_ineligible_despite_qualifying_status
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: otherwise_ineligible_household_member_is_not_reached_by_alien_status_rule
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: income_less_optional_pro_rata_share_is_considered_for_ineligible_person
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_income: 1000
+    us:statutes/7/2015/f#input.state_option_pro_rata_share_of_person_income: 200
+  output:
+    us:statutes/7/2015/f#person_is_snap_citizen_or_national: not_holds
+    us:statutes/7/2015/f#person_is_snap_lawful_permanent_resident_immigrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_cuban_and_haitian_entrant: not_holds
+    us:statutes/7/2015/f#person_is_snap_compact_of_free_association_resident: not_holds
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_person_income_amount_considered: 800
+- name: citizen_has_qualifying_status_and_is_not_ineligible
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: not_holds
+- name: lawful_permanent_resident_immigrant_has_qualifying_status
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: cuban_and_haitian_entrant_has_qualifying_status
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: compact_of_free_association_resident_has_qualifying_status
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+- name: nonresident_otherwise_eligible_person_is_ineligible
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+- name: negative_financial_resources_are_clamped_and_alien_status_ineligibility_is_resolved
+  period: 2025-07
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.person_financial_resources: -25
+  output:
+    us:statutes/7/2015/f#person_has_qualifying_snap_alien_or_citizenship_status: not_holds
+    us:statutes/7/2015/f#person_ineligible_for_snap_participation_due_to_alien_status: holds
+    us:statutes/7/2015/f#ineligible_person_financial_resources_amount_considered: 0

--- a/us/statutes/7/2015/f.yaml
+++ b/us/statutes/7/2015/f.yaml
@@ -1,0 +1,286 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2015/f
+    source_sha256: 239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2
+  summary: “No individual who is a member of a household otherwise eligible to participate”
+    may participate unless the individual is “a resident of the United States” and
+    is a citizen or national, lawful permanent resident immigrant, Cuban and Haitian
+    entrant, or COFA resident. “The income (less, at State option, a pro rata share)
+    and financial resources” of an individual rendered ineligible shall be considered.
+rules:
+- name: ineligible_person_income_amount_considered
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: The income (less, at State option, a pro rata share) and financial
+            resources of the individual rendered ineligible
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'if person_ineligible_for_snap_participation_due_to_alien_status: max(0,
+      person_income - state_option_pro_rata_share_of_person_income) else: 0'
+- name: person_meets_snap_residency_requirement
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a resident of the United States
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_is_resident_of_united_states
+- name: person_is_snap_citizen_or_national
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a citizen or national of the United States
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_is_citizen_or_national_of_united_states
+- name: person_is_snap_lawful_permanent_resident_immigrant
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(B)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_is_lawfully_admitted_for_permanent_residence_as_immigrant
+- name: person_is_snap_cuban_and_haitian_entrant
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: an alien who has been granted the status of Cuban and Haitian entrant
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_has_been_granted_status_of_cuban_and_haitian_entrant
+- name: person_is_snap_compact_of_free_association_resident
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: lawfully resides in the United States in accordance with a Compact
+            of Free Association
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association
+- name: person_has_qualifying_snap_alien_or_citizenship_status
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: either— (A) a citizen or national of the United States
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (B) an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (C) an alien who has been granted the status of Cuban and Haitian
+            entrant
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (D) an individual who lawfully resides in the United States in
+            accordance with a Compact of Free Association
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_snap_citizen_or_national
+
+      or person_is_snap_lawful_permanent_resident_immigrant
+
+      or person_is_snap_cuban_and_haitian_entrant
+
+      or person_is_snap_compact_of_free_association_resident'
+- name: person_ineligible_for_snap_participation_due_to_alien_status
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+            to participate
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: unless he or she is— (1) a resident of the United States; and (2)
+            either—
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+
+      and
+
+      (not person_meets_snap_residency_requirement
+
+      or not person_has_qualifying_snap_alien_or_citizenship_status)'
+- name: ineligible_person_financial_resources_amount_considered
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: financial resources of the individual rendered ineligible to participate
+            in the supplemental nutrition assistance program under this subsection
+            shall be considered
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'if person_ineligible_for_snap_participation_due_to_alien_status: max(0,
+      person_financial_resources) else: 0'
+inputs:
+- name: person_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_resident_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_citizen_or_national_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_lawfully_admitted_for_permanent_residence_as_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_has_been_granted_status_of_cuban_and_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_income
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: state_option_pro_rata_share_of_person_income
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+- name: person_financial_resources
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/statute/7/2015/f`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `d58cc0ce67ad891fde4c9061c86a2091bfdd524f`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/33842787010

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.