### PR TITLE
Add signed encoding manifest for us/statute/7/2015/f

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/7/2015/f.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2015/f.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2015/f.yaml",
+      "sha256": "a7363be5a9cd1d50f993a770f7622321e7b9c4ee2bbdd5cb612d4a944e7c4af1"
+    },
+    {
+      "path": "us/statutes/7/2015/f.test.yaml",
+      "sha256": "a6c5ec7fc3d763963d92afa642f3703749440241d99b71eafdc20421e6a5eaaa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7ec9e574155e0f674825535fd43c448d081eeb2b",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1760",
+    "version_commit": "7ec9e574155e0f674825535fd43c448d081eeb2b"
+  },
+  "axiom_encode_version": "0.2.1760",
+  "backend": "openai",
+  "citation": "us/statute/7/2015/f",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-statute-7-2015-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "e474aef89966a3be3f124e71d341298befc269620cb66e2221a7ef71fadb3b6d",
+  "generated_at": "2026-09-04T10:59:46.200268+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/7/2015/f.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "a7363be5a9cd1d50f993a770f7622321e7b9c4ee2bbdd5cb612d4a944e7c4af1",
+  "generation_prompt_sha256": "b350183588d2fc8d0652ee047a0de57dae1b6450e8e662acb28404e0b2ef2c99",
+  "model": "gpt-5.6-sol",
+  "run_id": "354ee5ae",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "YHMvUYO6wIO/LMZeAhFgLeOVoxUwaS6FrYboHYwaaeFUmE+nyRVa6V+0woCuBh6gTQJSryCvdnDFEM1LUkGrBA=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_text_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "row": {
+      "body_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+      "citation_path": "us/statute/7/2015/f",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 197,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "51527d3a-7ce2-5d09-bdb0-681309bae9e8",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-statute-7-2015-f.json",
+  "trace_sha256": "2a40e2a47a9b26a2e4a88479ed8150728db8c28cbe109425bf0cdaaa58e2cf7a",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ec9e574155e0f674825535fd43c448d081eeb2b",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1760"
+    },
+    "axiom_rules_engine": {
+      "commit": "d142c645917817cf590e036fb99f99b2d4780e1a",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e51134a13b0a8f5076fb6311341293e843d364201cf9cbaa4c202502257b193c",
+      "pre_apply_file_count": 2709,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/us/statutes/7/2015/f.test.yaml
+++ b/us/statutes/7/2015/f.test.yaml
@@ -1,0 +1,317 @@
+- name: resident_citizen_satisfies_both_structural_branches
+  period:
+    period_kind: custom
+    name: day
+    start: '2025-07-04'
+    end: '2025-07-04'
+  input:
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: nonresident_citizen_fails_residence_branch
+  period:
+    period_kind: custom
+    name: day
+    start: '2025-07-04'
+    end: '2025-07-04'
+  input:
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: not_holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: resident_non_citizen_fails_citizen_branch_and_all_statuses
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+- name: lawful_permanent_resident_is_a_qualifying_status
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: cuban_haitian_entrant_is_a_qualifying_status
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: compact_of_free_association_resident_is_a_qualifying_status
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: otherwise_eligible_resident_without_qualifying_status_is_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+- name: qualifying_status_changes_only_the_unless_condition
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: not_holds
+- name: household_membership_changes_only_the_chapeau_condition
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: not_holds
+- name: ineligible_income_without_state_pro_rata_option_is_considered_in_full
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: false
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 100
+- name: state_pro_rata_option_reduces_ineligible_income
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: true
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 60
+- name: pro_rata_share_greater_than_income_and_negative_resources_are_clamped
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 20
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: true
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+    us:statutes/7/2015/f#input.individual_financial_resources: -10
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 0
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered: 0
+- name: positive_resources_of_ineligible_individual_are_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_financial_resources: 75
+  output:
+    us:statutes/7/2015/f#united_states_residence_requirement_satisfied: holds
+    us:statutes/7/2015/f#citizen_or_national_status_qualifies: not_holds
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered: 75
+- name: citizen_resident_is_not_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: not_holds
+- name: lawful_permanent_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: cuban_haitian_entrant_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: compact_of_free_association_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+- name: no_qualifying_status_makes_otherwise_eligible_member_ineligible
+  period:
+    period_kind: custom
+    name: day
+    start: '2025-07-04'
+    end: '2025-07-04'
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+- name: nonresident_otherwise_eligible_member_is_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+- name: person_not_in_otherwise_eligible_household_is_not_ineligible_under_this_subsection
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: not_holds
+- name: ineligible_income_without_pro_rata_exclusion_is_considered_in_full
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: false
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 100
+- name: ineligible_income_is_reduced_by_optional_pro_rata_share
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: true
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 60
+- name: income_and_resources_are_clamped_at_zero
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_cuban_and_haitian_entrant_status: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_under_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 20
+    us:statutes/7/2015/f#input.state_option_to_exclude_pro_rata_share: true
+    us:statutes/7/2015/f#input.pro_rata_share: 40
+    us:statutes/7/2015/f#input.individual_financial_resources: -10
+  output:
+    us:statutes/7/2015/f#alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#alien_ineligible_for_snap_participation: holds
+    us:statutes/7/2015/f#ineligible_individual_income_considered: 0
+    us:statutes/7/2015/f#ineligible_individual_financial_resources_considered: 0

--- a/us/statutes/7/2015/f.yaml
+++ b/us/statutes/7/2015/f.yaml
@@ -1,0 +1,221 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2015/f
+    source_sha256: 239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2
+  summary: No individual who is a member of a household otherwise eligible to participate
+    shall be eligible unless the individual is a resident of the United States and
+    is a citizen or national, lawful permanent resident immigrant, Cuban and Haitian
+    entrant, or lawful COFA resident. The income, less at State option a pro rata
+    share, and financial resources of an ineligible individual shall be considered
+    for household eligibility and allotment value.
+inputs:
+- name: person_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_resident_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_citizen_or_national_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_lawfully_admitted_for_permanent_residence_as_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_has_cuban_and_haitian_entrant_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_lawfully_resides_under_compact_of_free_association
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: individual_financial_resources
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: state_option_to_exclude_pro_rata_share
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: pro_rata_share
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+rules:
+- name: united_states_residence_requirement_satisfied
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (1) a resident of the United States
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_is_resident_of_united_states
+- name: citizen_or_national_status_qualifies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (A) a citizen or national of the United States
+  versions:
+  - effective_from: '2025-07-04'
+    formula: person_is_citizen_or_national_of_united_states
+- name: alien_status_qualifies_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (A) a citizen or national of the United States
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (B) an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (C) an alien who has been granted the status of Cuban and Haitian
+            entrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (D) an individual who lawfully resides in the United States in
+            accordance with a Compact of Free Association
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'citizen_or_national_status_qualifies
+
+      or person_is_lawfully_admitted_for_permanent_residence_as_immigrant
+
+      or person_has_cuban_and_haitian_entrant_status
+
+      or person_lawfully_resides_under_compact_of_free_association'
+- name: alien_ineligible_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+            to participate
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+            to participate in the supplemental nutrition assistance program under
+            this section shall be eligible to participate in the supplemental nutrition
+            assistance program as a member of that or any other household unless he
+            or she is—
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (1) a resident of the United States
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (2) either
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "person_is_member_of_household_otherwise_eligible_to_participate_under_this_section\n\
+      and\n(\n  not united_states_residence_requirement_satisfied\n  or\n  not alien_status_qualifies_for_snap_participation\n\
+      )"
+- name: ineligible_individual_income_considered
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: The income (less, at State option, a pro rata share)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: of the individual rendered ineligible to participate
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if alien_ineligible_for_snap_participation:\n  max(0, individual_income\
+      \ - (if state_option_to_exclude_pro_rata_share: pro_rata_share else: 0))\nelse:\
+      \ 0"
+- name: ineligible_individual_financial_resources_considered
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: financial resources of the individual rendered ineligible
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: shall be considered in determining the eligibility and the value
+            of the allotment
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if alien_ineligible_for_snap_participation:\n  max(0, individual_financial_resources)\n\
+      else: 0"


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/statute/7/2015/f`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `d58cc0ce67ad891fde4c9061c86a2091bfdd524f`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/33864233136

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.