### PR TITLE
Add signed encoding manifest for us/statute/7/2015/f

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/7/2015/f.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2015/f.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2015/f.yaml",
+      "sha256": "c5ab9bdf9c96b53b77a95efddc21847d66ff9505b3daf54c039e80f00440dd47"
+    },
+    {
+      "path": "us/statutes/7/2015/f.test.yaml",
+      "sha256": "439a9606ee6943230758ef0b00dc996dc3db35aa89af149129c8219562583694"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "7ec9e574155e0f674825535fd43c448d081eeb2b",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1760",
+    "version_commit": "7ec9e574155e0f674825535fd43c448d081eeb2b"
+  },
+  "axiom_encode_version": "0.2.1760",
+  "backend": "openai",
+  "citation": "us/statute/7/2015/f",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-statute-7-2015-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "87f1df25e19ea9f208dd99b9260aa5c170143e9e7dca059d6931e95fcd2c2ffe",
+  "generated_at": "2026-09-04T13:29:44.977857+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/7/2015/f.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "c5ab9bdf9c96b53b77a95efddc21847d66ff9505b3daf54c039e80f00440dd47",
+  "generation_prompt_sha256": "fdf16b1d1e8c55826d1fe1b758a12a1073754a6663cad28b95afbe41e5a73643",
+  "model": "gpt-5.6-sol",
+  "run_id": "898ade42",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "eAiGo3jBKf+71qpNyopnRybW+L9meZxEeMAm1gg3MCTbFFA80Bq3K1hgIdvtEpqSDGeksYbJ7qsT9sVk8ykRDg=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_text_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "row": {
+      "body_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+      "citation_path": "us/statute/7/2015/f",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 197,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "51527d3a-7ce2-5d09-bdb0-681309bae9e8",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-statute-7-2015-f.json",
+  "trace_sha256": "16070aa82bf7a144692c21134eb96d148bc0a978dfc43fbdbd8db48046af8ad8",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "7ec9e574155e0f674825535fd43c448d081eeb2b",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1760"
+    },
+    "axiom_rules_engine": {
+      "commit": "d142c645917817cf590e036fb99f99b2d4780e1a",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e51134a13b0a8f5076fb6311341293e843d364201cf9cbaa4c202502257b193c",
+      "pre_apply_file_count": 2709,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "7f3da0d315d84fa75257e6f07e6351d2f550da156474dadf4ae8a10c28a186af",
+      "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "55eb2c090f19806a4401e43fbad60250900a5e4f30dfbafbd2e41927c7596f38"
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -35962,6 +35962,14 @@
         ]
       }
     ],
+    "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3": [
+      {
+        "module": "us/statutes/7/2015/f.yaml",
+        "via": [
+          "proof_atom"
+        ]
+      }
+    ],
     "us/policy/cms/chip-spa/al/al-24-0031-fcep-and-al-24-0031-absc/pdf/page-2": [
       {
         "module": "us-al/policies/cms/alabama-chip-eligibility.yaml",
@@ -54893,6 +54901,15 @@
     "us/statute/7/2015/d/2": [
       {
         "module": "us/regulations/7-cfr/273/7.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
+    "us/statute/7/2015/f": [
+      {
+        "module": "us/statutes/7/2015/f.yaml",
         "via": [
           "module",
           "proof_atom"

--- a/us/statutes/7/2015/f.test.yaml
+++ b/us/statutes/7/2015/f.test.yaml
@@ -1,0 +1,177 @@
+- name: negative_financial_resources_are_directly_clamped_at_zero
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+    us:statutes/7/2015/f#input.individual_financial_resources: -10
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 0
+- name: citizen_or_national_branch_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: citizen_or_national_branch_does_not_qualify_when_false
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: citizen_nonresident_is_ineligible_on_effective_day
+  period:
+    period_kind: custom
+    name: day
+    start: '2025-07-04'
+    end: '2025-07-04'
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: citizen_resident_qualifies_in_august
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: lawful_permanent_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: true
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: cuban_haitian_entrant_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: true
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: compact_of_free_association_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : true
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: refugee_is_not_an_independent_qualifying_status
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: asylee_is_not_an_independent_qualifying_status
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: income_without_proration_is_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_applies_pro_rata_share_of_individual_income: false
+    us:statutes/7/2015/f#input.pro_rata_share_of_individual_income: 0
+    us:statutes/7/2015/f#input.individual_financial_resources: 20
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+    us:statutes/7/2015/f#individual_income_considered_for_household_eligibility_and_allotment: 100
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 20
+- name: proration_and_negative_resources_are_clamped_at_zero
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_the_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_the_united_states: false
+    us:statutes/7/2015/f#input.individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_cuban_and_haitian_entrant_status: false
+    ? us:statutes/7/2015/f#input.individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+    : false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_applies_pro_rata_share_of_individual_income: true
+    us:statutes/7/2015/f#input.pro_rata_share_of_individual_income: 150
+    us:statutes/7/2015/f#input.individual_financial_resources: -10
+  output:
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+    us:statutes/7/2015/f#individual_income_considered_for_household_eligibility_and_allotment: 0
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 0

--- a/us/statutes/7/2015/f.yaml
+++ b/us/statutes/7/2015/f.yaml
@@ -1,0 +1,227 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2015/f
+    source_sha256: 239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2
+  summary: No otherwise eligible household member may participate unless the individual
+    is a resident of the United States and is a citizen or national, lawful permanent
+    resident immigrant, Cuban and Haitian entrant, or lawful COFA resident. The ineligible
+    individual's income less an optional pro rata share and financial resources are
+    considered for household eligibility and allotment value.
+rules:
+- name: individual_financial_resources_considered_for_household_eligibility_and_allotment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: financial resources of the individual rendered ineligible
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: shall be considered in determining the eligibility and the value
+            of the allotment
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if individual_ineligible_for_snap_participation_under_alien_status_rule:\n\
+      \  max(0, individual_financial_resources)\nelse: 0"
+- name: citizenship_or_nationality_qualifies_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a citizen or national of the United States
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: individual_is_citizen_or_national_of_the_united_states
+- name: citizenship_or_permitted_alien_status_qualifies_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: either— (A) a citizen or national of the United States
+      - path: versions[0].formula
+        kind: definition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: granted the status of Cuban and Haitian entrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: lawfully resides in the United States in accordance with a Compact
+            of Free Association
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'citizenship_or_nationality_qualifies_for_snap_participation
+
+      or individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant
+
+      or individual_has_been_granted_cuban_and_haitian_entrant_status
+
+      or individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association'
+- name: individual_ineligible_for_snap_participation_under_alien_status_rule
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a resident of the United States
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: unless he or she is
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+
+      and
+
+      (not individual_is_resident_of_the_united_states
+
+      or not citizenship_or_permitted_alien_status_qualifies_for_snap_participation)'
+- name: individual_income_considered_for_household_eligibility_and_allotment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: The income (less, at State option, a pro rata share)
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: rendered ineligible to participate in the supplemental nutrition
+            assistance program under this subsection
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if individual_ineligible_for_snap_participation_under_alien_status_rule:\n\
+      \  max(0, individual_income - (if state_applies_pro_rata_share_of_individual_income:\
+      \ pro_rata_share_of_individual_income else: 0))\nelse: 0"
+inputs:
+- name: individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_resident_of_the_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_citizen_or_national_of_the_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_lawfully_admitted_for_permanent_residence_as_an_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_has_been_granted_cuban_and_haitian_entrant_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_lawfully_resides_in_the_united_states_in_accordance_with_a_compact_of_free_association
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: state_applies_pro_rata_share_of_individual_income
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: pro_rata_share_of_individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: individual_financial_resources
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/statute/7/2015/f`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `d58cc0ce67ad891fde4c9061c86a2091bfdd524f`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/33876220153

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.