### PR TITLE
Pin reviewed pending waiver workflow

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -55,7 +55,7 @@ jobs:
 
   validate:
     needs: workflow-toolchain
-    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@7a1eb2439d4cbb3b129811adef7554a2d798bef2
+    uses: TheAxiomFoundation/.github/.github/workflows/validate-rulespec.yml@0effa6a5b05e7fac53902df7d523e909bd7fc48a
     secrets: inherit
     with:
       axiom-encode-ref: ${{ needs.workflow-toolchain.outputs.axiom_encode_ref }}


### PR DESCRIPTION
## Summary
- pins the reviewed reusable validation workflow from TheAxiomFoundation/.github#108
- enables the existing hash-pinned validation-waiver pending protocol without changing any RuleSpec, waiver, or toolchain data

## Checks
- workflow YAML parse
- `tests/test_repository_layout.py` (4 passed)
- `git diff --check`

Upstream workflow review: TheAxiomFoundation/.github#108 (clean and merged).