### PR TITLE
Approve pending encoder 0.2.1764 validation fingerprints

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
 axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
-validation_waiver_set_sha256 = "7180b7a9ed28b649b0f56afe4b24847c40746b4bad6a65b3fa8fd9238a667960"
+validation_waiver_set_sha256 = "7ca0b83e06647d3498548e74163c55a315e6abae8b4903d72f1110745a4ebded"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -8,9 +8,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:29499e30cb4114a148d812671dfb57cc184d28e037bdcdb8d5b48502298b43d2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch02/ch02.yaml":
     active:
       fingerprint: "sha256:c11b7b25a6d15e19f74a52eacb36e190dd0d5b3c70cf49a3eb587bfe3d4e9d13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8e80b7da6468d981a438932cc73d6922cb657dc2308fd22221054663ef63137e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -20,9 +30,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:7a24a93d8c41d1276c7700f7ad16dfb01ec92730ab3990248cd88790bcf01f36"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch04/ch04.yaml":
     active:
       fingerprint: "sha256:30aef8a7416b45315c07f206981e2a72f4eb7a859a89725cd6c7087cd0cf547b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:28dd2cde6ae5230a4f4a01f966923f5c28ccebb3d1ed90b3d0f32eb2b433b1e6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -32,9 +52,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:19534368501c0337df7e8ee70ddec43a860a7bdaac8908585ee5dffd8a7e9047"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch06/ch06.yaml":
     active:
       fingerprint: "sha256:6ee516eb036771ac8587568946e729f79a44829cba1cf34fdc08eb7de3cee339"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6cfb0217125b006192322141a571496bc501a8ef7565ce3f26671d51f9a525d7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -44,9 +74,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f65b3e5689ab9801c834a1f15ed1cc41a72ab318b0ccb095f81a95520acc8f6b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch08/ch08.yaml":
     active:
       fingerprint: "sha256:8bb16a1e9097fc74503c2de618af6d9054084efec204677a708f66a2189ed804"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:502b0ad519c042214c8692279cab2f6c956b3e0c4d72095c406cebb88bd3c5e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -56,9 +96,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6c3b7b4eb31ebedd1ae606b549543ec92e147d4adc4eb85a44a61427e88f18c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch10/ch10.yaml":
     active:
       fingerprint: "sha256:d51a18e9a18c772e60b19277ebc87425877a9f92a777fc8b53226221b8e14fab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:28dcd04d777810bfd50338186a5e532a739250d45c73d2c4bdb35f91e7a03f9b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -68,9 +118,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:17f511ac2459b48ba5fa2bdd61823ddd3c030b745987f5f853eb813f6af34a20"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch12/ch12.yaml":
     active:
       fingerprint: "sha256:9bd60a4f0ab5336b1449b072589ed8ce2840005e1eab8ef6af7b75b817ebfc37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:e8fa9445461b76a808db4eb6e883e6c88578271a58df12dc6ed34587c4bfb8cc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -80,9 +140,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f6b75af9e992d69dafae84ab3a7787344911649c6af3c069b9acf09adc927f80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch14/ch14.yaml":
     active:
       fingerprint: "sha256:cfaf4cd358e3161b04dec1d547d9fba4b8d188e70df4ff6fd2a9ec7727179dc5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f89ced6e8cf86eac8870b148463beff0490e8c30861e0e06deee4122afd972a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -92,9 +162,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:e80acb67fde244f1cf7945868ad6fd9ac4ab7a9c6129719b50a0266e63cbb091"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch16/ch16.yaml":
     active:
       fingerprint: "sha256:78caddf6930873650b3a2a1fd6e73a8ceb5f20e47f8b2610332765083ec392f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:cb510ad25c54b3614e603887c4a44fcd69130b9382963bef3f4f2a6adbfb28a5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -104,9 +184,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:dd00fe65f0854cc385a10d7ecbe5ab0801745609433f8fa84e95ddf76bfa0292"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch18/ch18.yaml":
     active:
       fingerprint: "sha256:7492671129b671e5e47787f95f7d39de94dca3bb5807cfbf023a2f42428fe60e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:9e515552ab1d363d64187cd8c6c126c2279c2e71e46e2c7f0a79cb829b0e3ee9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -116,9 +206,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:843f830d981b4ede408be70a95311d15ea9fbe4cd8de1f22d788220ba96ffa32"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch20/ch20.yaml":
     active:
       fingerprint: "sha256:705f2e5bbd38d94d5ed27dc0fad5dd396ee1071f1505302abcc953074d16cbce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:9686447736f51f567a03b3dc60cae7cf8a14250d2872c2463acd0ccd6f611660"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -128,9 +228,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:48b8cff2eb1d49b3d22d3505dad1769cff7f023cd97ee1c527929568cf4e4ec2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch22/ch22.yaml":
     active:
       fingerprint: "sha256:0ceeb78a477c705bfd203294432de13eedb2df927ee843c3d03de148186e511b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6657bbab10ac7115d1deb8585a9ce65dd502b86a1c12a89d53cf5c76022dd29a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -140,9 +250,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f6d240329088d35761afaa421f6547d10a295f8bec0fb7de866b641f71f75739"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch24/ch24.yaml":
     active:
       fingerprint: "sha256:af2c3f35c2ea9c8ebe6da22b23dc7b40c09142b2f3fab84c8541bb4e7a460faf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:7396a8e81acce8ffd03cc26ed08c6a02801519ec54f17ed40fa427f7a3b93f8c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -152,9 +272,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:109b571e9024045e42a4ecb10493e4272d8b626abc03aa411bd3ef0f48414559"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch26/ch26.yaml":
     active:
       fingerprint: "sha256:a4ca0244b566eda2437930db0d029392072f1b010f4a365181ef9ea812c23af8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:616ea9a050c495c3d9c2baa8c3d0de4146fc7e6d362625171e8e3416e0ab3096"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -164,9 +294,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:c63d91b53445e5678d7189586bc3b7c8a6cca076f803633f3b72e21bbb39a357"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch28/ch28.yaml":
     active:
       fingerprint: "sha256:5078d01fa7762a58c5eeac5be58e2f40a28c193d72162dcd3f664a07e10aed15"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:7003389cd37a6726bf55c5ce0a0c096ce303f27f06fb06e2fae463c2e75f2681"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -187,9 +327,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1681763f3494f98260191b89928b15da065c2698d65d86c7883dceefd8d0f6f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch31/ch31.yaml":
     active:
       fingerprint: "sha256:0f1fea2a972b35e599125815f862143f01a6a619c5a5c962bde3cf4cbdecfd21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:b9ebbc6f1000420c66f74b21e445648f7ac4762b8e9cfd97896dba6ca5cb71b1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -199,9 +349,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6093cdfbe26018bc502b42acf3a4a044d699ccd4a74323ce48bdf079ac772b3e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch33/ch33.yaml":
     active:
       fingerprint: "sha256:6bd6c4fdca07e7ee444b34915e209c1c55ae8b166f72f321c0e716b1d09474dc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d5573bd589e271e4cf4319e89d5828c302d0290a8b45cbe16d3a38cebb4e0e55"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -211,9 +371,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f43fd937709f01e7a88418ba7f0cd9d10d53979c8b044f139d5bfbd766fd9703"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch35/ch35.yaml":
     active:
       fingerprint: "sha256:404375245726a217164089c5ff4812653bb547bb7d6ee9d78ad6873fd87e4e96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:5322d18ccf32db13ec14187fdfd612af6bd2510faf43311b9b881451c6531664"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -223,9 +393,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d214c1209f35c9a4126d8aed5125908444173fe61a575e275719f84c0873ac09"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch37/ch37.yaml":
     active:
       fingerprint: "sha256:c38b9ba915b7a3c7856e73edb32d7703ac7187d6ea1797cc5363c914cc246c03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1008a82c504b8760f4726fcc938f34f744ddd46ddfa89ab8ad77b9fbccae64af"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -235,9 +415,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6ee26d7142e5e5e8e1748236c9f59a314342984b5153fb5bfc4dc9a22cbad484"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch39/ch39.yaml":
     active:
       fingerprint: "sha256:736701ec469f8d2faed82bddaeadd7d6a2197cf38ae330d4a5ebb7adb135e686"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:34408ca14a6bec26531fe8b127f5e316773811b57c06a90fb0a64fa959777865"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -247,9 +437,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a56cbd5e09ded180217ee0fcc758910bef9a092247bd4af0fb1ba518d18cc3d2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch41/ch41.yaml":
     active:
       fingerprint: "sha256:72d07acc865f905145fc2a77fbe2a2654b0ac63d271c50bc4b32c13e2b5fb893"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1d0754ee05b8eac466f9b5c988abace0e2db2fa09a8bdf7264e27519ed84fa99"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -259,9 +459,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:72013ac8be4e338c624e6afd5e18de348de1dfb7741cf73cd3dbe1f18ee56bb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch43/ch43.yaml":
     active:
       fingerprint: "sha256:47953891572d4c23cf9bb6b85bfbb1013595088df1227da2a50bb57ec9a4613e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:85999deb002a7dfdaa26d77bb79a8c3746df1320b91db4a15c50851d016f7b4e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -271,9 +481,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:af9e286e808c65e7f65d48de15e8ff75cd2240035b69cb98cc23018e855404d7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch45/ch45.yaml":
     active:
       fingerprint: "sha256:2707f43f8f15fd673b82303b42eab7008833d6ba39a7e7a06ab683d11b65b331"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a97f2beb2fe72e699c40bf46492673a93dc2ae1a62b0169b1312be91957c7e87"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -283,9 +503,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:c162988a7fe981d4aac22818761813ec1f8384397aad358d21b9e060d8c6ad4f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch47/ch47.yaml":
     active:
       fingerprint: "sha256:82e5cb516f27426d3de37099ccd37e66a9673a772df2aaa001d15316e012be9e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:0c7619770bba71d520d65c7f9dec6f42e1f2ba153020b47d731a41869b1a4877"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -295,9 +525,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:739ec7e37db75c58b722ce379c38a27778f294dbe5849bd2567befcb68842ad4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch49/ch49.yaml":
     active:
       fingerprint: "sha256:d342062ca4933769d4f994348e6ed02d2c29884f2bb2247ce75cd74b4f24f141"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:52725dff78a2e2f3f73f6a5bf5f63f9f970567d3a138b09d645f36d09712b1d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -307,9 +547,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:2eb4a06df1379956126cbfbbcccccafa4183ef28fba669e2fb4c51ff611ef66d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch51/ch51.yaml":
     active:
       fingerprint: "sha256:0651fa59247a8773cd6eeea9f23a940815ddb7eaa346910dc6018bc6427f2af1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:fa21b5750a6916745676800168fa8db56370319faf0345698bc060bcfb9bdc3c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -319,9 +569,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:5b5482dc691b9d9f62b51aaba71f1e5dbd7655a5d8ff67ed17dcaa496cc836f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch53/ch53.yaml":
     active:
       fingerprint: "sha256:93e6a91dc102446985737eb2d1fa5b2fb8047e3d16d34c996ff39d88facc9602"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:cf54de02720f0c5884b1bd32d02b73c87fdbb404d0be4d482b35db2044f4bcec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -331,9 +591,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3d13b63e027de5c3dd818f5fd0a7d7aaaf4447419e3aa54c7a2165c7faeb41f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch55/ch55.yaml":
     active:
       fingerprint: "sha256:2c410c9099ffc5081873ae4701c9ccef752a463480b2e5ce4414c9df77a611e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3f1fc63ecbceca5dc3540672b9f6634a1c5981f9bc304a0c7cece34a68e82937"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -343,9 +613,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:04b2476e8ae71c88bc53c7533b922a25ccbd0b4277ebb55ade06ec7c567a9755"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch57/ch57.yaml":
     active:
       fingerprint: "sha256:cfa0e6ccb4c65c4d2b03045f92575bb74e646074faa98f08d6fc2b5f9069f79e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:2be0e4e8a8a040ccb3483b67ea91a227c02cbeaf825ecf424e314424197fae74"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -355,9 +635,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:543755805f52957cf8e862a4853fbe5f3950c5445180e51b18ec0814e0c84bd3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch59/ch59.yaml":
     active:
       fingerprint: "sha256:0a1cfd26aaec300ba3eb038de3f1943226030e723e373dc018cb0ec5a49a0af9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1010928ef98693b13907230e3ab00f3e5d2a4c8e5f9fdea15ce0a1c7e9c029c5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -367,9 +657,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:6bdbcd0175278d2138d97f49c37e314c8272dc252a961cda37f1949b4c3ce517"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch61/ch61.yaml":
     active:
       fingerprint: "sha256:d071137284c7a254c0afa52e1ee3c9e8ccd9868010b36fc9442b19ad3bf00943"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a2c9702ed7d2b6f17d21acb5eb367b09949e53fe9d41b561aaad12b0519bc101"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -379,9 +679,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:72f9f2429c4970ba6fe68a854998535bf58dd2d451a5078952da931fc6ab6180"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch63/ch63.yaml":
     active:
       fingerprint: "sha256:3feb6494ccf7f1288c60442f8d0b223a66ae38833cd099f8474c75fa2810c4e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:ebfb02c83e8f22e3d5964d0f5fc9e172566acdd2777c927c968ccabd11592ef4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -391,9 +701,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8c8faf34a98a48be772148ad7394ef70cd413974c6bf9dd1b49d47aa3bb36cbb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch65/ch65.yaml":
     active:
       fingerprint: "sha256:9dca204d1ef939db449d39eaf1c48f148023d1fe31145a9aac60998dab8b011a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3c7315fdf45257922f5035f22ee26a8d5e43022fc8ff49e8896a9de9affc8658"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -403,9 +723,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:baf6dd5dff3013bd0a49f1fbf5bab489575299e72c72d2a37a66ace1cff83901"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch67/ch67.yaml":
     active:
       fingerprint: "sha256:b645c03a1866b987e409c8c3c1cee314243f6cde2403564adf7c96613dbcc35b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:61a0ca3ad553525e63b4db016a17adaf254867cd58e79183e0ec12e689f082aa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -415,9 +745,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:7704a86c096f1dfb376b5ccbd36560255a8cbc47b860c265e155df05a4aaaf59"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch69/ch69.yaml":
     active:
       fingerprint: "sha256:f0f505a40f5b51b21a3588ec8129b4d4a5db376608e63938247278a1b5cff9d1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:c8c85c2cabd35742f3d2643bb223797c57a4eccc835d5a295c13c06109c02ce7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -427,9 +767,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:112fc71dfda5d8604ba019bdab1827788ea5d1d0cac4956a3f9a415396e302e6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch71/ch71.yaml":
     active:
       fingerprint: "sha256:a7cffbf5b428db4fca557160243f839387246b42c91cfe82126f0649db09fb22"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8a517ee15eef0c24d1857e2a4c8d74eb16195ddc7fb68fac2659b3863862843e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -439,9 +789,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:5d35ceac84264dbcffa277680cb460209f42da91aa4b76312b93fb4d01afd335"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch73/ch73.yaml":
     active:
       fingerprint: "sha256:1012245184d569fa3b95a970bb3a66ac0f33ed56f98e39643dee62c38da5392d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:7a64bb0239a01ced6a8701fb4b065af173cf779f9b11bbb07b55d3f0e0f4ef3c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -451,9 +811,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:dcfdb2952d5f2e4bc004c91f6d42ac4d18acfccc37c400a9597dc9df5fcf02f0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch75/ch75.yaml":
     active:
       fingerprint: "sha256:77bab4008786d9d5d6388a0176d58e6caad16996c705d9182fc76b8c20099f75"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d946a40219421ecde569b00128d5b65290f1f4f3e2410488c8df51d13726b8d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -463,9 +833,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:315c5a08d1d9c8e84d8da580f0a83bc0ce1856ab00f6b1733e38ac679fd3815e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch78/ch78.yaml":
     active:
       fingerprint: "sha256:bddba1ad93b205a061636c0ecaa40417106777a6fcfd603dbc254983eeb0ab03"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:943ae94c2c0313aa463e096f130906f7e230f026bf4a5a1691b4edba820591f1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -475,15 +855,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a9cc94c2b24a985860410b4d56a3ac2ce222c98df7fba75fa2b361e9ff02090f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch80/ch80.yaml":
     active:
       fingerprint: "sha256:5ea14e1a4125e23b18b67acfb043ca56cc46a1ddc7b2819a0b6b9192fee696a9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:52bb32a2a4775d06562a99713308880377659a4dbf6a645dbb9f8c3da773e5aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch81/ch81.yaml":
     active:
       fingerprint: "sha256:e29ee9871af4d3bba811c03853fa71c847fbf94ce29a8ad8ece3aed243f982d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:c308e4ed09206b136d1ccf1798f762a1a10c8d24b6677081f1872e30b5018fd2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -504,9 +899,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d98bd663911987c55e56cd70acca5da1e709ecb636ba95704278397cb990419c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch84/ch84.yaml":
     active:
       fingerprint: "sha256:9484fda92aed05f853223bce9399d4307833217af212f474fbeb0bdb6b4a0140"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:c30d44f3f9b3de2828413bc42d0f91d813fa899f25ca06e72b77dc26d28dfa1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -516,9 +921,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:cf7eea2fe883d8496b32e42f8e5c53652e6578c21c689af58ec0cd6b08521f1c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch86/ch86.yaml":
     active:
       fingerprint: "sha256:051837f8140fd3885913231513c1c0e5b622cedabfeffa19bbbc020046d23f85"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1fac8fa31f8c271e1381398ed5ce6e22dc958baec9c5f718f957c3e0a7089eaf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -528,9 +943,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:632c75a188cd710b268ba0470b6d05a23c67975a2fd92313602d428582497f11"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch88/ch88.yaml":
     active:
       fingerprint: "sha256:2d4c8448d40c08697d6e62ac49bea3e70bb670d45311764f50ef3207fa7548a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3d60eb313a10f541d75909e2d111a723053e48d2434552af521db8b176c92a35"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -540,9 +965,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8e2630c471f39f8fa06d461ee53868a70ce11f56f5edd1dacfb7611fd67689d0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch90/ch90.yaml":
     active:
       fingerprint: "sha256:b50fc77f3633ee73d6efface2a650da968c2892695e01c4fbed3a4264c95464f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3122353361693fa483ddad8acadd63bec4b2592893998aa17cd9ecdf736de26e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -552,9 +987,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:97ba4e588f6b2706aa516b0098f5aeb395aaa823bd8b5dda5b1fbfeef7f12ac0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch92/ch92.yaml":
     active:
       fingerprint: "sha256:c6bdc50f6ea39f7292ea3ddd18f195a23d63a5ae62b3606670d2b67db9add415"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d116a3a4142241c3c94f42237b14b2883dbc13efce2278c44e59fbf29c732fb3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -564,9 +1009,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:4203bf7b1c1c6e38028498a4ab8d91257e636a236cae52968357955e3a129c19"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch94/ch94.yaml":
     active:
       fingerprint: "sha256:7c7492b714427ffb77a3b13e5f8ee0431fb323b3e59c19277d6f266f4a47c3c2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:b7024f9da0868b1ef52585c8158f2b07106dcb446e6c38cbf2949cb021b8b3f9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -576,9 +1031,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:fc3115b05a13d373ac720a2596870e6ea5bd83fc7f2aec746634569ae3e6f550"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch96/ch96.yaml":
     active:
       fingerprint: "sha256:5533b24b0169412516ce640eb7c566c1b33cf8e6477b102cd0ab9b990478df0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:311031eb397dd33a9962b6910341a7f1a9877ceaa24d6572e60e34679ad99720"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -588,9 +1053,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:0672246b340174cd19bab761b9dfa684023e099915eeae2d95ed6c42d194ee83"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch98/ch98.yaml":
     active:
       fingerprint: "sha256:7fd878bfbc2a9d2782ee33fe3b4211b09433ffbc1027ed67312bae5351dd7caf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:770a8af9c96bbf4c8a04ea3aeff1fb078db5e70fbeb913aef273deccceb2faac"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -600,9 +1075,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:b05012b9e892e777c70a7339ded6121e66ffa792eb633d71f74c26f1e0a7e648"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/cbp/us-tariff-schedule/generated/ch99b/ch99b.yaml":
     active:
       fingerprint: "sha256:5f92376975161ff79d315a03fc554e8d7dfc100823fad7f6e5cbd7834ab14dac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:28cf7e5cd9205c979659d432c981cc42e4eb34a540df330e7493cba0fafb4a7a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -612,9 +1097,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:936cfb4b53ff2c8e9648f53a4eb52fb0115945644276723ce05270eb819368db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch76.yaml":
     active:
       fingerprint: "sha256:58cbf650a239f289124b5b5a2905d4163e852ad053f8a282b324d26cf1f8b325"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:050eb04cb3e8060c09c1d25ee71fde8d9b4614a994324cd085e3daf96787ff1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -624,9 +1119,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:4b8817fe80ceaeffd442ec95a8713c8b4aa9d739abdad3dfd9a790d24055e8d7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch79.yaml":
     active:
       fingerprint: "sha256:2ac567ba0cd087884209a1c56d6f278b9e141545d662d30cd58a5ccd72952265"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a6ce25bcfe5297d95f1901ded3b1b42ddd9c53fe6341368f0e861bc3bdf89028"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -636,9 +1141,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:a8ca6768578060547c8761b7c8b02629080ecc430db5759ac543493f204d9219"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch81.yaml":
     active:
       fingerprint: "sha256:e8670d07d6753460c852fcbd4c33b48cd7d4561706e60e652b64a767ad44e8ca"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1234a9b939af7cf01990455dca437cf1d20d83e8e0eea7ef790258962d451154"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -648,9 +1163,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:72fd37c89a40210997a2ba9ed20d4733a4bc29ebb1f0b23014e9203a84b32587"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch83.yaml":
     active:
       fingerprint: "sha256:532ccaca8b43668b29ed4a6970f4cdc0b1b2ec092a6f744339521969fe5dcdb5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:ba354ef6256b5deeefb92c2bcefc6f9c4c4df2cb1a114ff8026fc2190fe6e695"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -660,9 +1185,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:b05928c6c272a7ea43d6181dcec45d813c7a7c3078323f3da4f737e86a8c6c98"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch85.yaml":
     active:
       fingerprint: "sha256:d7fc99f109619ca127fd9cd56f7c0acaf07154940a0a7867d80579ec74dd550a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:48f5c46b18cc281bcd97624ccfa64804d6ab08db4396a59be14ef7954b5551ad"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -672,9 +1207,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:78bc48692529fe20105c373d236faa733c62e675768359a751820a8d355e12aa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch87.yaml":
     active:
       fingerprint: "sha256:c2a13391430ba7f15901af6d8900ffb450c68def7946abf86adb005f5b4a25e6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:5186ea5bf9439e4a8f2e40bbb0149ef3bb5f3c77c40a221136a68577c89d214e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -684,9 +1229,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8315976a3a0fbd181fba4ce0022907aa0b1a21753697168b8f96adef0bf543bb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch89.yaml":
     active:
       fingerprint: "sha256:d14823155de5d0c6d6a72fd6736a8578dfd89dacf2c8d4d215b5df8db3f442a1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:9a2cc3d49d01f7df7af8f703896001fd6f35266f655fd03e7a59b025cd7d7d20"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -696,9 +1251,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8730fcfc3a761a26ebf454d104cfb7f7ecdbace27e84d31e620d7184f6480d79"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch91.yaml":
     active:
       fingerprint: "sha256:359b695551b18f2469c402f6c1a249e6160b47ef5798e2a8de6ee7f4fc91c095"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:3ecb06394302c8d2b833b7ed8c30d6692e91bc06032c6d548c1a7b60b4a71fb4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -708,9 +1273,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:8aa191d4124b10d96826aefb04180da011d026edc5268099a3c0248972ad7d35"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch93.yaml":
     active:
       fingerprint: "sha256:70a07f3a5a7d963edd2e9eec9a3b22a5927a823e1ab8cd93be1bf46599272a81"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:24a1313bc91633078da4dfc0fc6e8c33c13d426a552f3723fe586b68f1addc0d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -720,9 +1295,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1af563fe2b5470e9437ca7b16cfd7ee0196e54d3a9492a3207cdd62fd82d2605"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch95.yaml":
     active:
       fingerprint: "sha256:2679c9c0298de277325e4784163d0ff9a5c3f36b2a698032a82d1f26e93d212f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:f3ffafb48a3c51873b2760a738dce2c12566c282c68ae1b92ad6061cbfbe167d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -732,9 +1317,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:87434defa45739d43cac73a9d284df6975a8c05bde05ece2702a45a4f2de0079"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch97.yaml":
     active:
       fingerprint: "sha256:8e9ced092890322d18432dbf63a7946cae0666fb3c87dd2527a6f905623bd58e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:d48c737d46d4ccbc212fbae56da2c9127b9c36d244cfa900384814932b910701"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -744,9 +1339,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:2d80f79a8f3cda0a05affc029516947e5d860f0468ee6811c1bc384533f3c201"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch99a.yaml":
     active:
       fingerprint: "sha256:74a0123ff1c5f9c13546b6994419ae6ad3c2aa7b1fe31f55efa8fbf063ae80f1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:ec22bb039473f202f8287346057c7ae7afd6fc6909fdf5f10a5427cfbf8e72cd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -767,9 +1372,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:59374b986259ab6cb3cc03bd182582f31af4d825c1847a93a5531e1c880ee18e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-incidence/generated/note16-232-steel.yaml":
     active:
       fingerprint: "sha256:1d283baace2e4cbc3fe58e0b658900e9b75ffabc1ae05c2c2354de32ef56f234"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:89498286e7bf6b66029061ffcf34ff9108a595eec2ef5b302bb3e169ef4c96ec"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -779,9 +1394,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:743ce8d36d34f2e6e19f019157ed104dbfaa13c07ff8885a099476f70d1cdc4b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-incidence/generated/note19-232-aluminum.yaml":
     active:
       fingerprint: "sha256:433ff922cd38bc67e6703e1bee6958bce61a1be7cf0f45e54e9e9b59f3bbf937"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:5ea1c4ad8a663979471392db3c1736cda066ed6a7f4dd6032eed01f84b3657d3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -791,9 +1416,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:2c98317572e7d8dec881571d64387f2c899d06631530c7d7a9a9bdbda534d4de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
   "us/policies/usitc/us-tariff-incidence/generated/note2aa-122-exemptions.yaml":
     active:
       fingerprint: "sha256:2cf6b9a57e2fa3d61700574e2436df1b7a43d2b52a73a2c9ccc088f37799a17c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:1e08ce02f7370bc307e8bc3d067b4d71b656225c39f8604ff3a0984c7e1b0067"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -803,15 +1438,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f336c0926a45a314e6e0308c20e9318585dc3038ef9a670a2b8a8187c06b68ef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/415/b.yaml":
     active:
       fingerprint: "sha256:21a750174ef9449d0e620c06751be36ec3a60a2a8d884cadec257fd5d53d7e97"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ca774322850a01c0fa8ac7864ef71a9831c7d3c5b853f0db86c91893c9ee4d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/415/i.yaml":
     active:
       fingerprint: "sha256:eecdb934f18f1e00ece0ead72500b0fb2b64bac1da10d69c6d081ef9b7c5bd54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a6b369d934e4478bfe233099d037be70eb82f1bd66a87efe02e030af74b72667"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1325,6 +1975,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c39be708f861f00f11c8096d4a20a4129ee1b2eb602d2655d8356f41b8343131"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/regulations/9-ccr-2503-6/3.606.1/E.yaml":
     active:
       fingerprint: "sha256:d9375b14930a8362f5db779f54d5843eeb2570792add02fd87207d93a58ad3cf"
@@ -1358,6 +2013,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ga/policies/dfcs/snap/3617.yaml":
     active:
       fingerprint: "sha256:e780526d7b9e99db1961f97950df412bee42a8398e449a53ecc1b27f20082eb3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b63344dfb73a8c1b060574ca4922b7d2aa4f4ac9c295a3e6592b00ee891b37c4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1409,9 +2069,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b751274e37fd7ba55ddb9fab93e41e23743893f2d09a91738ed780e2d2e1c724"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/10.yaml":
     active:
       fingerprint: "sha256:63ee6ac9d2c04ecb2c145d94b9f08ff4a310a0d1d836bd02acf98cd47ce1f90b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4d84b79653a4fe5170b9f10ef8090e21ec154f4d3b07454016959b24593e9257"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1421,9 +2091,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ec69dd8943ba17ba96b95eb2c4da5cfeaaf53bce09806e3a89e86ed2fb68e6cb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/12/f/3/v/b.yaml":
     active:
       fingerprint: "sha256:bd3d8da1a7d42623f070d259989982e2eced637247b7655c7da81516e2c82c30"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4f1a94a57b941320cec4ce54bf6233f76990cdc3939783ce23006c75f55e9de4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1433,9 +2113,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:16f6f2154daf68befad57ffb39ffa70363acf2bc8b70ea8a05dd9213cf6b42ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/387/14/a/5.yaml":
     active:
       fingerprint: "sha256:ec8b4135ee9a318410f56efa803ff56feda02c382c65103fd2a50baef4bb0eda"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:434021675bde44d69c2b756be47e6a2efd9fb9ad4f2948da38a570e44ecfa372"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1472,6 +2162,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/regulations/7-cfr/273/10.yaml":
     active:
       fingerprint: "sha256:be5d6a73152eb3d146fbf55e0c3d19e25423713060f66902860592a64907ef51"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:59ce03cf5366602cc2470165d906f32ad81a7ca88ba7b7f6ae05b52893e0f15a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -1523,6 +2218,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:86df284b44fb5915a8717d9adda7ebf66807b139639462867ade90ab92e7ddbd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/24/h.yaml":
     active:
       fingerprint: "sha256:4131f1d832bed539a791952aeb313bc2d1a830fe05f9cbc33a0e34e7e0f5e8cd"
@@ -1532,6 +2232,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/25A.yaml":
     active:
       fingerprint: "sha256:33697f39bd8c1cf0406052c529deb1c73b39d812b1e1cc41b11b3ea948023bf6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:46c6077469ff9eb1508de6d5e5a95355ff1f335471d8872c0db25e4ff0b7320c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2330,6 +3035,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml":
     active:
       fingerprint: "sha256:7b6aef13d7d22b60ee668a49c69cc56890be2635b60bb6c7df65e6b01a86a06a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ee12aa36f58e197a6981f5dfb29769e57a708e44376a4a0816db73cafd49bf33"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3359,6 +4069,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3a7e3d33ca706ef824a6492ee0060538f9c4fe631748cfd43c11169a4a2307c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-tn/regulations/1240-01/14/09/block-1.yaml":
     active:
       fingerprint: "sha256:c1dbccc62213d4a54a2b4721aa7358c38f19f9de7c5ddbab6ec06caa0f2cd219"
@@ -3653,6 +4368,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bdc2e3e9e544eb2fe01d54246ae62b4b2a4eb4d64998b04b1225c8dfd87cac01"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-fl/policies/dcf/ess-program-policy-manual/appendix-a-12-state-funded-programs-eligibility-standards/page-1.yaml":
     active:
       fingerprint: "sha256:3572b1c5d5237ca5984d7ccf66f5ec37c14df7f1c0a1f03266957bb402944a2f"
@@ -3668,6 +4388,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ga/policies/decal/caps/appendix-c-payment-zones.yaml":
     active:
       fingerprint: "sha256:56d1760be5b422a9028e4043f619cb919b00371b0a717e0f6496f9dd8ed9a21a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d2506c9a431e496655060e4ed58beec6024185cd1195e235403988d8dd0ddb68"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3845,6 +4570,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4103101541c534a4291f6c4407ff1639209a03cc534570b8b75b7e9fa63c4add"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ak/policies/dpa/atap/standards/2026/adult-included-gross-income-limit.yaml":
     active:
       fingerprint: "sha256:6cd4ca6e3bd6cf93424bfbb6fe6c22cf0575e06f2ef82e7c92ef2a7851c9b0fa"
@@ -3866,6 +4596,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ak/policies/income_tax/2026_resident_zero_liability.yaml":
     active:
       fingerprint: "sha256:45bf6c3f16c4d31b0738762b78da15ce6ff410f76fb0f0213ca3e81295f6b849"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
+      expires: "2026-11-14"
+    pending:
+      fingerprint: "sha256:befb9d0101bec277e7b1ed0ef15f2cae85269b112016ce202111dc27eb9e5643"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1080"
       expires: "2026-11-14"
@@ -3899,6 +4634,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a9ccb6b815a7caef6b33499822c56fb01dfef59a18a416f3bd000ec6ca4ecf49"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-al/policies/dhr/public-assistance-payment-manual/appendix-n/section-2/payment-computation.yaml":
     active:
       fingerprint: "sha256:8e016476c4173f5168145a12d81f02fcc03bb3ce21823fa822c076ea62d7ab01"
@@ -3929,6 +4669,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:aed297353b835d7d95fd3b6be84884445b1fe8a41a6e3272b2a49cb724c8f37a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ar/policies/dhs/tea/manual/2024/payment-levels.yaml":
     active:
       fingerprint: "sha256:8a2b6c225df81e667a865d5cdf04c2025b720ba8f0a27b5f6192711f4f2aba5b"
@@ -3938,6 +4683,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-az/policies/cms/arizona-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:47e3aac62f4ce656aa54f6d31002a7fda0dde8f6b2f71e384dff48cf8f9a369a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:984df47241f156e58cf925fa5fe64672c494feaf7f5784f41dac5f8b4c8c022a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4037,9 +4787,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:eece991e7ec5ccae814d851c53a5606b18d0feec42b327adf51ce53f2fd8849c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:3d6e0d52cbfadeb61efe39411cacd24c9206c59eef6f2d3a70c5bfc4c3b982f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:efa1b71852f522fd7c0cdcad9971e80672491bc0ef642244c42bbf752a314387"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4085,6 +4845,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2cfb6dcd3e985f129b06c618954657953d8ddf879b61eefa444d90d39de82629"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/regulations/10-ccr-2506-1/4.130.yaml":
     active:
       fingerprint: "sha256:91f6c3068dab2eb6df55ff43b9e2c4749f5fd66067071a59f1ce49ce797b33d5"
@@ -4094,6 +4859,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-co/regulations/10-ccr-2506-1/4.206.yaml":
     active:
       fingerprint: "sha256:5f766951776f604566abdefa2c6078fc4092b8d81be1f26688b9ab5453f694f7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b94f2322d5def36198506a6763c7303f25748964307132dc949931ce56d37653"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4709,6 +5479,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f8c64d598e1d9483b27f2e5a612cd57457de150f0fd0ee8e40708968d7444206"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-31-101.yaml":
     active:
       fingerprint: "sha256:f7af6b6e976a8dc4b869e09c8c52453f36720adc05a5bcf93271e197c4e67199"
@@ -4724,6 +5499,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ct/policies/cms/connecticut-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:4e3b8d335a71bcd27d7c2cfdb83bb330d2a0eab9287cd4460835d005af5d4ad5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5fd4ef7376dba4c01a6e015c4f96e07edfebcdb450ccc42feafa74438327825a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4805,9 +5585,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b7a74b79982aca66c95dfe072c3149177d3062e4d384c3a16c9be3f1092260bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-couple-state-supplement-levels.yaml":
     active:
       fingerprint: "sha256:0695f50b6b422271619cd7d1798372ae2f5e21ec9755f167dcd5b82b6ca97e57"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f72e788d89509ede67216aa8143c18bc27c67a0b14ac4899135e159ceeaa304a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4823,9 +5613,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7c96d29b7f38baead52d7ab0a8d8e2bdc46049b0fc3dd0560e91100976d0f6e3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-de/policies/ssa/poms/si-01415-058/2026/de-ssp-couple-state-supplement-levels.yaml":
     active:
       fingerprint: "sha256:a3fbf8126341ecef5a25984f596ccbbb0c9cb4e451064f61755ce342c577d584"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b4ad162e1801f5e568edd1ada92cb7f8d49c9625ae3db086a7afffc293f0f72a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4871,9 +5671,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:546feae9d51e1f181155cc49bab09175fc8db8bd6847104b27fd01b12cfd47ab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/cms/georgia-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:d011dc8dabdf1efaeaca67e18f12f68c776be12671f0edc7afc97cfc0660df13"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7db73665c8beb5515fb37228d413abab0a2ec1a2236d120c9d6ebfa602c970d5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4883,15 +5693,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:51e51abdb5b3d0c3d10b0cce27189347eec1bf90c360bb5d32482d3a60877444"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-hi/policies/cms/hawaii-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:21286587552db9da37b9be290ebbb24319bcdcb5a9ac550120aeb5ff2a9efab8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e4403e8317a3d39d3807d180093c1cf1c3ce9f8545f6be5017bb97145ec9db55"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-hi/regulations/har/17/680/17-680-12.yaml":
     active:
       fingerprint: "sha256:5dc6574917304d05933c304f4e0b4b3991e2ac781459c595c465c97a11760572"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:49581524abaaadf20ee7ebaf4420742f3f249a92f7bdf6ae8504abcb1d683f3a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4925,6 +5750,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b97c5098175b20d639404b0538d6e230b5e2410d2f6fe8d7dc61418e10bc0e96"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ia/regulations/iac/441/41/41/28.yaml":
     active:
       fingerprint: "sha256:397a47d3c45078ce09ff8777d82d4d2c4324888859b641c05ad7de3abb06ab27"
@@ -4949,9 +5779,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e793151f753c077681a56bbc2eb5cf8da7f712440b1a4494e455bdf427735f71"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-id/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:047107a3d04219fd1eda20c84dd391ad48d8929c377c4e2d94b5a0ff431bf13c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:af115a778ac93dfee6ccebdf46d02b76d4ac95e4502454adb912febf72337122"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4976,6 +5816,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-il/policies/cms/illinois-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:208243bce9a4dd564301ddc0c6bb94184f67efa95aedd80dd8ff7b25c2f3d831"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f01d44bd794f0b7196c338a873a7504a9ab569dbcf9975d8ad42b6eba86c6c45"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5015,6 +5860,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a3967eb9a3adac9dfceed7b020f6130df743de1c00a399f60a2ac6da75fc785d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/statutes/12-15-32-6/5.yaml":
     active:
       fingerprint: "sha256:b2d0f16e1bd33fc45d1a7387f810d7e9ff7200130cf7cf029b70669e2637106b"
@@ -5045,15 +5895,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e2f6a6925c1d4439954aaf49a3321d2a00488c8d12ea68dd9e46822689e23464"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ks/policies/khpa/policy-memo/2007-05-01/state-supplemental-payment-program.yaml":
     active:
       fingerprint: "sha256:b51d581046187a800863913c2f2ebad6b06e5272d3222a9d9ed03fef20f14d19"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5accb2265bfc351cc729445670d3d8bc4cd3fcde6f2dceed863ad853032747ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ky/policies/cms/kentucky-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:ba5d1016a8a3998ffc926465be525cffd36358da6c84d89ca56bd850c4bec722"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c4ddd232949369a4f745dd2ba81daa65506f0292f66e010f4bfa45b10a7ade2a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5081,9 +5946,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c8d2cba2818b60a62428bf96431f8e052748e9eb27eb21abac91608d3888e253"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-la/statutes/47:294.yaml":
     active:
       fingerprint: "sha256:acf7b3c922e39cb7d9f9900c78d23c7bc0ef1c5549f73261b53b72029fa1a3be"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:759c54e4e5685fa0da1234c99e911eba49855b44da17ac344fbcd95a9c772739"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5093,9 +5968,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:015219d042e29cabdbd819593db1c377690d6963792447ca91c45abbe7c3da58"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-la/statutes/47:297/4.yaml":
     active:
       fingerprint: "sha256:e30f8976d8d763993252f35708b73276796d417309beadcdf135bb6b7bb9d7f3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:01028b0fdc4838f7874ebf773306d184462a2b6f261ae8f297c047bbacfca86c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5105,9 +5990,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5f28d62ac66b4bc34dc5c44cb57732db008d9e54c88d569fa159dd947b06a7b0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/policies/cms/massachusetts-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:ce9ef693d3c3a7c3be04ff91cdd13df9ea05e1cc3b5cba1d84fd8fb079bd6106"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d65d0163ef040c8467c2f4edca28a3edc6c00e57c1bb8f5481fd528ffdd421ae"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5117,9 +6012,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e6643304e0d698d3be8d5fc8362196dd8cf1bd6fe8aac717a850cf0d6ca2beb3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ma/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:0a9bc84b5af07aa08f76694137f106b4b7b3f83e3adeca3f04dc0477646a4631"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:153c710d9825c798d56f2290cb16e156cd77f26831933320c6b7e45aed00e8b7"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5189,6 +6094,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dfbdf2f28f7b3534a2a0b8497e0438cb6df7d0b340ce1e28db27668eff5295a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-md/policies/dhs/fia/im-26-13/2026-tca-tdap-benefit-increase/allowable-tca-monthly-payment.yaml":
     active:
       fingerprint: "sha256:9dbd467c895e84c469c85985f7602f61e3a56cdc1bff578cb6613e735e6b1cfd"
@@ -5219,9 +6129,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:748c3992c6a0a5658a6b42137ebb601ba5b8229a4ff891ec9db0d85bc1cceaa0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-me/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:34dcdb0a007e6c3b0c2fe52039931a2f3aafd8720f4293e64226da26dcb21cd0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:93ec98d2dcdb17d7a0afd0bc7958fb7b753fc19de4a2a6d9da36eb1c6c520106"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5270,6 +6190,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-mi/policies/cms/michigan-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:d836d4f47b86b7908c893c7de9dfda57b21998448e1790fd1d58a4d496a661b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:568e2e104f65002bf5e4b87c5075b4e9f0b9bc1f513030bf07c041b6b81adb6a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5333,9 +6258,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cda0281826242f144f3f446675421150d78c6f5b9544c6e76388893a4f207b76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mn/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:4be73e357a287db74d10d83d7de3b2d7affc4ffa80419621be592aa59eab8ca3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3cc2d6732de1e5fb9aabecc56dc39e703615e7bd795e31d79f474764c48744ea"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5375,9 +6310,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:690f93f790fa831a63a2ca04cc3ee5989f55113aa98a9961ab310ad34d6edde6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mo/policies/dss/snap/1105-000-00/1105-015-00/1105-015-04/1105-015-04-05/block-1.yaml":
     active:
       fingerprint: "sha256:f45be004d7e73ebf37f1e5c3e9f07acf8f082e2086ab80377c9c52e123e381b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f78f086f3a09a9973359c784650fd738f335606e69ac700646c77afc3bfc38ab"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5387,9 +6332,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d72b1349f390a5fd3049cc48886e2f9753ce4d98fde768e49ad2ef6817614cf5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mo/policies/dss/snap/1105-000-00/1105-015-00/block-1.yaml":
     active:
       fingerprint: "sha256:de3104f5e1bbb2ac19b5565c0bdd1ddfe2afed8ef3e3609677e2426d568aad0c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d79bd97f6b5106ab017ff85a9d3726702a30dd3a74a4a6d1785169048617d4d0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5399,9 +6354,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:544365e8f8f686b6f5c7ea528cf1dadd40a87ab1cd4aed805537747bdcae7340"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mt/policies/cms/montana-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:4a0d66ec09150fcdf28cb9e7c16f5a4547cd62857fd79badf0cc4459cc8954b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bac966d5e82a8f610e2d623db545ccbc0298f3f1fee29942c67d9847169118ce"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5414,6 +6379,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/cms/north-carolina-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:9dbb12f3504fa62c49e2bad04b6c1c5cdc37f1a7f3b593af14a1aa5e7d87bb0a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3e72f07ce7bb24ca9185fbf954f826918ae91d554490b50eaefbfa5da41ca46b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5465,6 +6435,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:46ae595d471b63c5fafc5c508e1de724433e689bf8ee4d82fb87d44fbf2a564b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-315-special-budgeting-income/page-27.yaml":
     active:
       fingerprint: "sha256:f1e6064d75adc8d1f1debb9f07bdc654b82a66d4be75ed288ba7738415129c82"
@@ -5495,6 +6470,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9d9af3b41f012a5c4b1d026d38b9dbbf2bdab03dd2faa6888c104b3c673fed9f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nd/statutes/57/57-38-01/28.yaml":
     active:
       fingerprint: "sha256:2d58f6e65dbdf911d2e3c794f4c0704bed7695aeef59e94bdcb883c53df70448"
@@ -5504,6 +6484,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ne/policies/cms/nebraska-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:2c9170a512429e892e51fac3b28ac1cab00be152641febf020ff5457ae84c36c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:78465bd528cb7139d561f285d15ed86b266e40ee731db1bc31818181ec65668a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5519,15 +6504,54 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:64f082073c27470c5fbceefebd31801fcc4c4b22afa52eecce2c2a8a1d98952a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nh/regulations/he-w-700/742/02/standard-utility-allowances.yaml":
     active:
       fingerprint: "sha256:506d2bafcb3ef975f3165f66c04cfcceb45d342572b5b91c5b79af063a31e16f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b6dd36db4459ae7d37327a2794a38a682e9611866b8e4a1ce9e38d25a0a3d34e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nh/regulations/he-w-700/He-W 704/04.yaml":
+    pending:
+      fingerprint: "sha256:c6c8d230ac6c60b038104e2c14819c4194aae8bed76f75ce9b31c36fded9c02d"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nh/regulations/he-w-700/He-W 704/05.yaml":
+    pending:
+      fingerprint: "sha256:d288ac51f6fc39dc51d0ab5fea88cb24ecd735452de6fd9602818333182c068c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nh/regulations/he-w-700/He-W 709/0.yaml":
+    pending:
+      fingerprint: "sha256:9484a6d1f45b3e047b73b3d6495c92fa3032bed0eaa3ffb4056da9b9b4eb600a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nh/regulations/he-w-700/He-W 722/01.yaml":
+    pending:
+      fingerprint: "sha256:adfb14442a4bb3940d1fda64955d32ac76176de0f955ca342cd9561d92b0720e"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
   "us-nj/policies/cms/new-jersey-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:e1c4adfc35cd700e0cdc9393e4a7dbdb3a1db06f2cd0edc4814e9112c4f1b005"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ed6d4c0a8574fd186a3b1ead452c8243c350cc2a5521f223fc13be45a1596ebe"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5573,9 +6597,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:744a629577ffadbe519e98d2a0e58158f711885e1b7fbfd3032a929dc4e4b397"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nm/policies/cms/new-mexico-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:cc614425557716793feb09930318ab0070cf7df862fc4c05abb79ec87ef54686"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:24d6f2bbb47b564ccf1e764f7db6393b69ae60aff5af4234d2ba8c8165c03ac8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5591,15 +6625,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f31ef9b2dcf2ac037f8ca0a9819fc05843112ab111b3872b4b2e70302bc00c67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/policies/cms/new-york-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:2078477b9e0007b479b0d88337d5457c37948e29ef1a430d658f4678f2a73588"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fac6a7b7effa3aace72687bc5a6f3331ebaff47c1761275319cec96d5e75fcab"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/policies/income_tax/nyc_composed_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:6775fd7bf90cb7103b5fe4792a408a039c73742dd647f9ed1c2b2d1c8cd70b38"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:58685aba94da9dfdb01e7a7424c0917209fc1d3f7aad12917a1d3c3afefed56d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5675,6 +6724,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e3e45e99e5ab0ea36970afbe21b9088a4c39c60ebc07c39b59aa101a33203fe7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-oh/statutes/5747/02.yaml":
     active:
       fingerprint: "sha256:45a2b1fdcc3dacd8c78afa5fb3477b7ab89e991ce36563863015c5b7e6750fbf"
@@ -5699,9 +6753,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ea6b3c52e5a7c85d9d8894a4211cf3f9f3741726bfd62a3ed2679ccaa5fc14ed"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-or/policies/cms/oregon-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:c53f6be9e6bae04d490d7bb9081a4940ac7332825f138f06fa6415db6d96ad76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a6764fded50571a5715550c6be63bc46d00b23920a328e9e8bf9aec05be05c29"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5729,15 +6793,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2dfdfb24b9e1d68e7ee60b52d4a6976c732f66cf0f78e4865fa8fe7e08d80e9f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ri/policies/cms/rhode-island-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:92c09f9a49337b76904f4c0b9a0cfbf73eba5eb93748c68ec7d19048d7eed04c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5098513088934652cf01e5e4a2bb9b1856daba2b7c4e4d4f0437702502d37f94"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-sc/policies/cms/south-carolina-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:750407b0098328fa74246c70c68c1d1defcc5d982a992301c1bfd71444c6aaf3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ba0ef15ec7cb03ee741fc22547d1ff2f6e08aac47c0a78e7b7fd7d613509cbf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5753,15 +6832,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3571c958ce787971a91b041b75c6c3f51126473ce71749a1c13d5a7b149f91d5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-tn/policies/cms/tennessee-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:ab32cfa445bd4da92855597cd60d75f6d9f32ee35399502c5d753ab9e40bf565"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1a205e8ff5f2ac78d615ade7b3d766f2a6878c41618634208939f84ba590f282"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-tx/policies/cms/texas-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:fc1601d57e9c617076561712fd7dc33dc9177ac51653c0fe2a07a2ae49a3bf82"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:712673dd04b734fa764195f462d7573aa0504976581f0cd88d9cf01ae9d95a0d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5780,6 +6874,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ut/policies/cms/utah-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:d673885e920d920b2757546a727bff8489e02e2bf9c81c43af23b59795d55c0f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:435f89efb2f01bc58713f98c348caa8050bd16999df1a334e7e6b858dba9b0c0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5813,9 +6912,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dc338c8a48f46c905f5efda099765bd8a9e1077656d2485627b6ac723b687f80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-va/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:a816b0e03c62e9b0dc75691544164e8c22f1f1623f1ab29eb70c21c32e882e7b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ddcafe85a2ddf47155204d7aba1962b792c83fc875b061c818cdbe855e0b09fc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5854,6 +6963,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:303e3ddc1802fea668036055ff4f479e7ed7933607781aa67f743935645514d3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-wa/regulations/388/388-478/388-478-0020.yaml":
     active:
       fingerprint: "sha256:964d1b145a79f09e6e9b68751611810fe33af175518a4b7a8a0a11130a00e794"
@@ -5884,9 +6998,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d9979c8126f03d884315559ea5d9a351e1e7390939c103a3906c8e7ef4f9fadd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-wv/policies/cms/west-virginia-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:84320fdca59f094bce1db772fb9470c48b683c69f6b9dcee1fcf4f41f15736db"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d2b8d7f5be3c373c1822241660e0e15cb4c8db1e67c29c643c5c21d702239f44"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5926,9 +7050,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ef6eb962a406c386fe384922ef1beaa84e3c053d3409e66e5aed6cc198d3169c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml":
     active:
       fingerprint: "sha256:8463a2139aad273cd60cea721e08358a7f7690e07272930d2ad73d81de5fc3b7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9f0333cdaee11bbc73ac59fb6a45cb43da62e44564aeb72e2c8df17dcbb02172"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5938,9 +7072,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:17c087f80f9148afe8e7cb56334bf98dab29d12d3034dbc30f804bb265735b76"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/income-tax-brackets.yaml":
     active:
       fingerprint: "sha256:629a0520fcfe66fe8b646c9a60951a74baf57021594da565511bfb81bc1dff44"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b10927e92e631a66423c5011b881b15a9aeb21ad02376d62479e8041517cac9a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5950,9 +7094,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:648ae9331b628b969a2169f0d66ca9f7f500ec9b14b51d098ee961cd4e419d67"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/deductions.yaml":
     active:
       fingerprint: "sha256:06e24ad1a75afcc9386be8eb4c1814e7acbea57bf9554332a2fa25d9d1c6e89e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:04f2dc6dccf86372e9a26a9347905e41ebf2760d6df75a41f720d9ccfe1ef497"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5962,15 +7116,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7b4b482e9979174b21d77ed35736cc36d2a46cc029269649da75888851d931cb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usda/snap/fy-2024-cola/maximum-allotments.yaml":
     active:
       fingerprint: "sha256:b97fd841f700b750c3b059452d03e4e0ebaf813cfc59d8845d2c001fcd82031d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6a1bb669e372c9c741b7f8ca3b9e7141d7df76c24aee5ff93cddfd62353623a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usda/snap/fy-2026-cola/deductions.yaml":
     active:
       fingerprint: "sha256:2c006059146d21eff02f5950376a5f94d5ba1349ec2e1ebbfbda835decacf1ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ac3ff77f73caed4c70236d1422cd9b158a3ae7d93fc52011d82f2c8d140e0dda"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5988,6 +7157,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml":
     active:
       fingerprint: "sha256:707b5a2be330d73a622938d4438a519f4e691af294a86eec2bd6d4af0d92bef4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9f258fbe8a09f544a7787f1d2d92f923592b22399498ac6a9ab12bb7dd275596"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6069,6 +7243,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7fbc318aff31bf9ebc12601556cc25ae3d3cb277a38e68469f52ee5484521156"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/112.yaml":
     active:
       fingerprint: "sha256:bf8f5ea89e98eda61437aeedb0a48cfe515dbde8610be7488630257d2ce55dc7"
@@ -6132,6 +7311,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/199A.yaml":
     active:
       fingerprint: "sha256:4ce91fbc649d108819efa50be0fc2395e7eec5f556c542343772ff8495a520a4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7d0fe36d95d5d975407570e33e459004b8888c26b27fb12eaae8209ea886d474"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6342,6 +7526,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/26/3131/h.yaml":
     active:
       fingerprint: "sha256:42a906b3d2ea19b90afeedc2a455f5bf4b71cbbcec54cc546e60518ebd92d881"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:680fd9053fbae16a095c74b86a2085f911a9a328eec5126b33974956792e425e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6657,6 +7846,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6caf3544e49bc13720cb7b9c95fd63e82e89148f5034e81b7c90639c5b127f78"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/85.yaml":
     active:
       fingerprint: "sha256:b70047dc5585ce256faadaa9b8f8b87608e800cda84af863a78b6602072851f9"
@@ -6714,6 +7908,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us/statutes/42/1396a/a/10.yaml":
     active:
       fingerprint: "sha256:f121e2a1bf1a15fa4fee9236648f4f53024eec5de608ce9a7c666881551eef4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dee046869e46f3d7e8589c51bb39efa1db662aa8a67ab74dad45afd12205e13c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6789,9 +7988,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d0d921b0a66716f38db58bffc1713d6aefdcf3b2fee736ae8a1bd452661979e5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/402/q.yaml":
     active:
       fingerprint: "sha256:71efac613038c04dcfc5a9619de25a4a3d4da2c4d159d31f06e8dcd56425b36b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:577837a773932c1ecb0fe3a11d65bfdf68c034f6b5d30eded634f7da74472bbc"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6801,15 +8010,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:64cd423ba267296cf2f969779ea8ed70bf79b7f1f0ff21995823a759309b6302"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/416/l.yaml":
     active:
       fingerprint: "sha256:c0602781af4dfc3eb6b7b5d97b4588954e2d987e6a04c20a18fac5829191298a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:62a5622297d45995bc92c0ea92117b9b719b89229c507fd531963a28c9efef88"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/426.yaml":
     active:
       fingerprint: "sha256:303663e2e5a9e06d6c051ba543db53202ee204458f53622191843b67f9564860"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2a9ce0d608bc28ef06fa3d3fb6fae14397f265a90178b58044b679a77e182200"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6843,6 +8067,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c4671c4abc578d083748d05d50f6bec1da0a288a2ab1dd7355018e295ed70344"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/42/426/f.yaml":
     active:
       fingerprint: "sha256:c1c1eb9f16e32ccc2c22880adba96ebbdf448af9327ff9d6649d82ec900d0377"
@@ -6873,9 +8102,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c627eb3eb05dcb7153c007d55d3268f77768385f97b2502647f091f93fe7195c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ar/policies/income_tax/2026_resident_liability_source_hold.yaml":
     active:
       fingerprint: "sha256:deb3067cb5a981607d5b68d0662d13d5c77797772a29dc79f7059e09d5aac0f9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ba090db371abcaa82455a34b08523502c19c58a678fd0d479e7b5586d31f3b81"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6891,9 +8130,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:81c19a0f54ca3ab7f18c3e8139f49f912f8d078bb88b6c60b1af7fa234518fd7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/policies/cdss/snap/fy-2026-benefit-calculation.yaml":
     active:
       fingerprint: "sha256:434dbd6078fa7de26b7b361b6d747ace34ad348b18553b6277aad21b1e198fa3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b90d3f3665284fd3f351f0c63f92b45527526ce4a2e6503b02b7578f9478e216"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -6911,6 +8160,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ca/policies/income_tax/2026_resident_liability_source_hold.yaml":
     active:
       fingerprint: "sha256:757ca87b91be689003412dab974347355f24dedb0d320c89f1d899a799919d31"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c9f1f20ca061f3367b7fe28b661f75f07b60b736a61af9dc33103d50cbd5b16e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -8318,6 +9572,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:668d6f944a945b40587a955ea5d65cbdbcf2d5288fdbf7321b70b6238aeda6a2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ca/regulations/mpp/63-410/322.yaml":
     active:
       fingerprint: "sha256:f4fd3bd77272afc532e593e7f2f9b5c8c23ccddc49d970667e56fcc1592c08ac"
@@ -8576,15 +9835,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:63e12f844040fd4e04281cdd72a96aed63f9d6a2b5aad68304d118412e4b2e69"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/policies/income_tax/eitc_pilot_pipeline.yaml":
     active:
       fingerprint: "sha256:80eafe20b0f6fd5e8497ba2e7463fe14fe2da87fca584225f7c81ae4a638d4c1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cd0b2d82f0dd092d1a32581af8cb0e612a45e857f19b8ce21b2efa1a549a197d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:84dfea2ccd248c3f7adf54512460757427ab137b340c59460f243af624e36db7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f87288ff2dafd0c2eb24a72317c6636679fe17f58db3faa079996348eff545b8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9296,6 +10570,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:75843d0d3b821abfbc294148268fe74173101d421bfcd3838a1e518ba8755965"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-co/statutes/39/39-5-102.yaml":
     active:
       fingerprint: "sha256:745680a6f6ef43107363d19122db35dff32975b465087950a7cc78e235837b1e"
@@ -9428,9 +10707,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d58e2daefdf62400fd719be32505e6d08525b1ee0d6846f6c4450b8db5f4be9f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ct/policies/income_tax/2026_resident_ordinary_tax_before_personal_credit.yaml":
     active:
       fingerprint: "sha256:3c982ea5729859e0e54dd09136e038a3a46a030742ba721ff20eb79a91143e63"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:88acd036a847216e555a82e14a17d60e4e2c8b401e1bb85d8e1c6ad0dbc29e09"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9440,9 +10729,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1b8c8a04847dc310f7d230b94606b06da7da6ca774000abd84669e96562cc529"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-de/policies/income_tax/resident_core_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:4873b351f85001d4ca319a95f3d31c6002402b6498df6e83792d2d64f63d364b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b1495a922a6bf071bcd90a98246db65b7e89a1d884bb107407ca82f4b3134c16"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9452,9 +10751,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dd4d8432565a028db5fbbaf9d17b50ee0aa154213e6ea254326906fea161f1fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/income_tax/2026_annual_tax_before_nonrefundable_credits.yaml":
     active:
       fingerprint: "sha256:52aaf499b4794e21633b83d19931e3ec8e79d30b348e5a98f302c08ffe0aa31f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5349e198e3dccdda5462e3da9729fd22e534b6fe2c3217a3e823cb704e8ddfbd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9470,9 +10779,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f8f81c6cb9a045b15d9286faa0bc4d397a410f3e350c2328390e98cb42d4a0da"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/statutes/48/48-7-27.yaml":
     active:
       fingerprint: "sha256:cb68de4b514bf9531bfa7bce50e1bb818846b576994e16f60f6a033c5f9c6737"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c6bed7c78fc249e0bc125960991e9119f3a83e499c9e9b868b598e2aaf11cb15"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9482,9 +10801,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6aa3233eec2c1ff0621e4e96702a3e10f8f847a2e726ebe842a54baae2d46ecd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/statutes/48/48-7A-3.yaml":
     active:
       fingerprint: "sha256:540042a6a75a4bb806519b6047bdfdb3e7ef61a417b93892525d908d59dd4ae5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2590935e58ac709ca0ee88c03280bbca268399578817e33ee89b3e5bb7385d88"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9494,9 +10823,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d6f017800416de5976be52c0123f021796468679af50de31ac1bba9d3d8f1604"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-hi/policies/income_tax/resident_core_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:e95b8e822a5abc7c5c4919feaebd6b9d724e64a145d9caf7eb3a90799cb6b602"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9ff1add11bd27095cc92af0168396569be27560bef13c1439df444e49fcce476"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9506,9 +10845,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f8618b28495721ada342b6c2532c82d93e126c06cb6127712e5426284152d87c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-id/policies/income_tax/2026_full_year_resident_source_hold.yaml":
     active:
       fingerprint: "sha256:3d2e7e912dad73fdeaf5d31f38aa8ccb47fb3a59297821fae4ef91de5c305784"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:57162943e716c456926315ded899cbd5e4e92584eb4735ff54953e3ad45abc71"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9518,9 +10867,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ac712c968d6c29de5923f1c88db35c95ae245e017982524d07f30621c9207a29"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-in/policies/income_tax/2026_resident_liability_source_hold.yaml":
     active:
       fingerprint: "sha256:890e2f75be97ab18c048b7aa4fb6f9323b0617df433d5c45a5f27b6961b1b362"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:158bfbf0d2366a75fb375d18db3aad0eded53407178f768363c6d67bbf1c3024"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9530,9 +10889,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f9842eba2b4114aa7fa12aceb7dd2c33199f5c73f17c01216ca59670ef82333e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ks/policies/income_tax/2026_k40es_schedule_before_credits.yaml":
     active:
       fingerprint: "sha256:f2e09330010e58c532bb01d8616c3c4c44e14750955a9a5a55ea797fe8d6898a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1e5e3f6e632438d98b0afeb65576520cc228c9ddc80617ee384cf04b4e291fef"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9548,9 +10917,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6570f83eb0d9df08dce96df6bf612bdec7877d5052151af1e631ba89118d4bbd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-la/policies/income_tax/2026_resident_core.yaml":
     active:
       fingerprint: "sha256:4ab20071683ea1b7fbe865974b7aa96c2e6bf38e27a9513bd1c6ae1dda7803a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1ae883de8dd68a5008d95bbc75aa69490c2b57e6b58a4082454cad6375828547"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9560,9 +10939,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0e48f64613f5cfd2e4bbedc24c14a418771d55262a4469833726ddec9644ca9f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-md/policies/income_tax/2026_full_year_resident_source_hold.yaml":
     active:
       fingerprint: "sha256:c9ef70082bd875be90cfa4a1a8bf1b1b2e55339ed51ac831200c8f1421b4b8af"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:421efe880eec22f76d421cdf4a3de4921a94f1f387b7d83d1c23f9ca2044cff9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9572,9 +10961,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3943bdce0a732ea77cc21dd6587bb7959c9a59f46933d8ec38ba954a7bef2028"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mi/policies/income_tax/e2e_resident_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:444afce9197e74ca12f3e49e288e5db5a75291fd0cfe6846d44f07eecf160f1f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1b166d7653b41913bb609e2171f53c9a4b6933db7d82b36a0e8520c780db42cf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9595,6 +10994,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b96853a5caaea1a22f1eda9b4008c258a63ca2764df508d940980c50f84df97a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ms/policies/income_tax/2026_section_27_7_5_schedule.yaml":
     active:
       fingerprint: "sha256:f3b9a0e7b84e74bc23c9af054cb16e874b37a07b89f60e09f1875dd88615fe9d"
@@ -9604,6 +11008,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-mt/policies/income_tax/resident_core_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:66b119b761968e72537eb6f9aa27319f8cce4033c699be6fc02a8e2a20e772bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ecbdc5718a506045fa1f870a0384c3c56584b1fdd9efb4afc4bc70ce2c2e7117"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9625,9 +11034,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:13f1f0b8a3fdb49240f0842e433ac70cc019f44c85737b265790282599ac817f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ne/policies/income_tax/2026_1040n_es_estimated_schedule.yaml":
     active:
       fingerprint: "sha256:71ee8916bc7c2f10cd39286a8b66a9dbbbc07aafd74b4b4542566c5cc2632254"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e68112674c3db2c7944416cd15f3ad99f311345816aff0b19182cc80ad4dccc9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9643,6 +11062,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e4ab1cd0ed63fcad9b897e86142f1c696943095b54ab85d682284fe484377147"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nm/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:77d0f8860b544f7c967923b53cde4c7f09dc4b10319974d8f39fac0e40282b4e"
@@ -9655,15 +11079,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:50ef4b75bef17e2b6906ed134efde87be9eabb026bf2fc7f72e7ff072ed4dbfe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-oh/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:88d34d4e06d46c3b2d3489a530465e7b3596139eaf828d1cc353dab73154bb2c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cc8e67484a23097996bd1ecd9badce087b7f6f6b72974734ba69e47b3a58a6dd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ok/policies/income_tax/2026_resident_ordinary_core.yaml":
     active:
       fingerprint: "sha256:6eb1a8aede728d0db9aafedc5ce91cda242ce657e73e529a8a7975848f390634"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c76ca79c79180196afcac4d5e903a70f6742f732011388d8032ee9154316c0b6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9679,9 +11118,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:22692e440bcbb9f9b9cb4c578005b17933633e622f8586b0adbc40ece4407285"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-or/policies/income_tax/resident_core_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:e28864d814eca29e5be40eb8749d9e997b2beaccfb0a71fdfa9ecc998ec1042c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:63a781addf33e5675044871da2094ac7387d02b6b71c86d417e1bc2280b9aa96"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9691,9 +11140,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5cad309745c0bcd5ae85a951fd0b5279f1aa4a4ad1a5588d598a8e72f0362b73"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ri/policies/income_tax/resident_core_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:d75a9bb00e9d85c3b9a9f4fe456ecb5f0a35f7dccc2414d23c2f5a42000743ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a3e843de08d2400d8a9f268084703d3bf4c4f501b129a4cddd46cad1332be78b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9703,9 +11162,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:4eb76c6b5f87ef714f2f4a1bf702deca218e437717ff5de3b0100c809f98aa48"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-sd/policies/income_tax/2026_resident_zero_liability.yaml":
     active:
       fingerprint: "sha256:fa7b2897498d51aa57a2233f18202c90646d1084501bc26e0f59545d724a2a58"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e4ee905075c0beb4431dc122f5bb2d5c504fc665b6ee2b9ef5d864ac8a9068aa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9715,9 +11184,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f7f71a9301381c3c958d5fb2878308678244cb25d4208ad5da054fb69c2588d4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ut/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:8e1ee9b50c3199498a31393854cd55747d0a7023bcf696ccfddc9305ae9edebe"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:313d74f8735bf191af3cbf60f3b51c5b54cd7c2d3e7f27be99f7bef42194fd2b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9733,6 +11212,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:57115696c86e684a6b3fcad049979eb0787081a34bf61269605e5e71df08ba37"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-wi/policies/income_tax/2026_form1es_estimated_schedule.yaml":
     active:
       fingerprint: "sha256:cdb5b0c111bbdea57a0d704f220ce34f502f0df374052ae0e61722c88c514c41"
@@ -9745,9 +11229,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dd507d2c2ae54936e3177608cc130d92a46d7617cfaa259d22dc67ee8ebd7b54"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-wv/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:444ff6fcfee3aaad4cf4662b774971f6f84829f48dcecf58cf06c6dbec378080"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:11e0df8ebfdda8430fffa25f4829472840ccec525d380af6f1946669bcfa2eaf"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9757,15 +11251,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1926007a1e4fcf0415fd4758d3c228ffa4ac6070d2738fd57ec9afc65bc2abef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/aca/ptc_pipeline.yaml":
     active:
       fingerprint: "sha256:c1210e32ed5bab4c0b368284c8a58b5854bd54baccb98282147e8ad03fb426f1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:97b3ade0972b0f451a27c17f0e4b551f5f21fdceb81cac98161de9c2c696324f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/cbp/us-tariff-duty/composition.yaml":
     active:
       fingerprint: "sha256:5ae55ea895bcbe7ddcf81ca64d50685e0e2d074c48173863eba6b46e8a92a42a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c5f3a66bb05562e8283e6caa3ca516297428b0dbd84d6b720234306a69ceb3df"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9781,9 +11290,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fb8cb9be38c16b7237323998a68c4d67e433af591d0fde9230d5210f69486f83"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/income_tax/elderly_disabled_credit_pipeline.yaml":
     active:
       fingerprint: "sha256:1c06ad89c67b75db86bc54e4d8e7dccfb83d0665643ceb3dbf3868497df43137"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e849b298aa6a199e5347f4696ec549fa346acc76f424c06089ebb8a456f392a1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9793,9 +11312,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e2ef19168c65750ce461025db40890001f389ad17c9c5e7b2a9e6252a527d2c1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/income_tax/lifetime_learning_credit_pipeline.yaml":
     active:
       fingerprint: "sha256:3fc72405d75fc6a8719f6674f393d494cdfa82aa6bca83157257d0c4e12fa626"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:17247d8ffce78e750011ad1961b20c2187b9a8d0b00e2f2a971d1ddb233c0e1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9805,9 +11334,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f2608e9e2770e660ed39fc3af778eddae21d41a788f981f21d8430999541ed5d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/income_tax/qualified_business_income_deduction_pipeline.yaml":
     active:
       fingerprint: "sha256:cf1556415b319af39c1fff6ed46dd7cd5e6ff572b25382723ed383d12296099c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:07d550239469a07a5affba88cbfef9681c52ac9b9abfa31340efcc3c261abb2c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9817,9 +11356,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f8cfa01aa15d1454bbb306da6f57ed74a9db7eb7c31e059e7e9c15eb13898c0a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/income_tax/savers_credit_pipeline.yaml":
     active:
       fingerprint: "sha256:989b261c560e4b3ac53ad611933079747dd3feda50e36e84009c9474f2bee5fb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:45440023ee035bde61a7213374d79412f431e0d862e43d7c83af7d397c927571"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9829,9 +11378,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:def6535ab8f66ed80e31d5bb507ce666f38090f53b513b8b2224b823c1735a0d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/income_tax/taxable_income_pipeline.yaml":
     active:
       fingerprint: "sha256:2d30f8e72917d87470b7a8c09d2c425137455b56468881bc8b551c9bbb4cde2f"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8980e4a4598ec8d2161d6ab72f24c92e47e9d21d89be3f215fe6413244cdfe5c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9841,9 +11400,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:19238334444d3c88f7b620be689142733444d8680f23db9efd6644d0d29398ba"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/irs/rev-proc-2025-32/qualified-business-income.yaml":
     active:
       fingerprint: "sha256:304edcfa2d3b40dd4fedc97fddcd7f6b2144b39b8855db752767f6059550e18a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5dc4939bd3b10f67d44aa8ab499a7da220f3869fdbe69456f036a52824f6544c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9853,15 +11422,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8375ef3ebf874556bf40f9ca4c20788d9fa6c40a4d7a5cef26d2730b966ecef7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usda/csfp/eligibility_pipeline.yaml":
     active:
       fingerprint: "sha256:2b62ee47e52475b940adddbe3a66d6ea4a33ff3c7d7ab06b54e1a7772aa27da4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:39e307b161a495e8b2a89e2ea5c4c0eff5903ee21dffd83247c181554a049de1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usda/wic/eligibility_pipeline.yaml":
     active:
       fingerprint: "sha256:c59783f04fd493847871cf12f7628547d7d4b39a83280b15c28045df65346531"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b2530959f851b66661112ca3db58d8798c3bac9ff9a81f3252e81d6f8de9eb7a"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9889,9 +11473,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2e5e5062e7dc63ec2d3614d23651a993157a0d782f6b39d1907a6730e5a9ef4e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch02.yaml":
     active:
       fingerprint: "sha256:5366937be89bf4909953b13d38ebe6c0a856eea9a57894a61ae5eb51d895c0c0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fa7eb6e0a69acfc08f30c6b196405d181cf1f6d3b7c9d27b05e7867e7ad5ca31"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9901,9 +11495,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:671c112b4df6c05a0be78d9ec9f5656149f9825fa3e60fa6497ea5c0487eddaf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch04.yaml":
     active:
       fingerprint: "sha256:29bd583c37c24c983f6cb8434ff44d4dfc3ec25280ca0e3fe103670403d46644"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9541c4764ad0d2f13318bc9b98076f23f128ce11bbbf6eb1c18cba2f3aa7f566"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9913,9 +11517,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ff5ab5ea79503455ad8ee83d43fa6d4e321e1f41ea9de83985036c505e1f2116"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch06.yaml":
     active:
       fingerprint: "sha256:f755bfdd6a75507b3395dc979d1a2db4e0314dfa1a8a1ce9dcb5decbac123d99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:713c91057d90c6ced6ff388981bc4468d8f1da1df6969cb8da47235f77f1792f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9925,9 +11539,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c1140f8726620cdb80949e4b0aeee1f574bdef82ddc25ad744b8c4faae5e10c8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch08.yaml":
     active:
       fingerprint: "sha256:3955b1d1177381ca5ad08ebc0b9c8cacd84f2327e73b349052e7855dbd9b667c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c6f4e9aea42448e07944b33104b42942bbf4329f9bbd8363e16e6327c4b1ab2b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9937,9 +11561,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2c148b71be78c9085cf276cfffca7d7ad75a836399585605212ed873012adf8c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch10.yaml":
     active:
       fingerprint: "sha256:b5a5dc396d3ed0c414637b50f89b20289cbc64af35e8238eb8877ecf6460f1e2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e948995a8758b15169cd14ce132e9f81a15115dcf3aea9f5ba0e4c894a7a5ee8"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9949,9 +11583,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6290fd9b58f1dc932a9058b5a19ab9cecbdf2bad19a265d613b77346fa354013"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch12.yaml":
     active:
       fingerprint: "sha256:f51d4a5ad49396bcc279ce4f6a5ffe03d498f6782a461defe79715e9911542f2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e1c3e9c40dbbf810e13e79beb98b6fa89e90208837f7d5b11eb37d9cc614d620"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9961,9 +11605,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:64a23582a873e99097c991f3529127e091a4a316eccfd03ea6f75d36b3721b8a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch14.yaml":
     active:
       fingerprint: "sha256:afbe15aa19513654cbcb6cc30680d7c73d0c4bbafe0b64ec325674fac119e947"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:84b333b76b46eb3dc6188c89c0db59e344301e60efc77ad9713a926f09913116"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9973,9 +11627,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:dbb3a083393b016936ff3f2b0c64246e7ab6223f87314e1a09a50c8f70ef2617"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch16.yaml":
     active:
       fingerprint: "sha256:f32256dd4912f057d17806a46b071fac2400dc8df71ede2b53988981b6dea045"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:601c1460f3d0e6b3e4538bc4c6be3989cd3e9789fb0130bd57bfb0b445f68d33"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9985,9 +11649,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:926ab2ba15cc9faab97fb99c99c3172e41ad32bb55fbb69c0a05321af4ff5d55"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch18.yaml":
     active:
       fingerprint: "sha256:0e525c9c171b037d27080b6d57f1663ed8301c8c142ebabedbb3761c2283eb66"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2ac358ec0bd6dc1356cbe73302c98a65c76a018abc97b4dd98024fbcdddc81db"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9997,9 +11671,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:78a12f6950a53039e4d69a18e4707f1c28f79b37a64777b855995ebb90a29c8b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch20.yaml":
     active:
       fingerprint: "sha256:6bf93bb4ab7954b2fe5f494a1fe55d2b56b8cbfdd1f98a50f066621409eb9fe7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ec39fc57421fcb5c092891d338a0bda01c66fa2f450a23d261fa8f332e66c2f5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10009,9 +11693,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f865a117b543c783747a62dcc949b7e0c3735cb989211c64c3b1e9f0ec885e2d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch22.yaml":
     active:
       fingerprint: "sha256:f977e52008392187f6a8770d8cc40f3941cb2e57233dac3b241721ea56c7d740"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:05a4729d7d217f96e138d11b056d9bd74ae284a7f9a8c14e9b77685a354a0f78"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10021,9 +11715,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:615a1cfdb0bbc662f3926c758b80bb3753a6b187ca6560d72442de1a231a2368"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch24.yaml":
     active:
       fingerprint: "sha256:8fc7589742b38c4591de2343b32295663da696f9e40e4c61913918d038269130"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f581076a361cbdb1dc348cff21baa9158af0cf8934afba5aad0049d7e5092e6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10033,9 +11737,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5e8d2b4ea20b2273f1280c0e1c93129bcb95a333ab640c276ea03c70ae0a5291"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch26.yaml":
     active:
       fingerprint: "sha256:86f0f8a5d9befa34dc7f17d543fb28aebbff5c0cd88237a6b9263621f687d467"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e5ff3b224c300fd9dda4b1eb290328ae970892dc37f3d663f1ef9874f751509b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10045,9 +11759,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:71c046a5996d848736f21555e51512790c7f7bbb48a407074eae59bb2a0f8cb2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch28.yaml":
     active:
       fingerprint: "sha256:a31990bb7e6ca3aa23a5881b4812ada84c4040c19982d35eb9d7396ec03d75ce"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:20f21f7b2525039d3eaabdf93bbdf8d59ff5f5f1678111f2995c72eb5d4f3233"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10057,9 +11781,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:35db7295ddc9b59ce637506160186acc0382a2899ee889de1138e3e0989dad21"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch30.yaml":
     active:
       fingerprint: "sha256:80dbb1f4b4f0562a8c0c7142c1bc8ca00625d59abc3dd0b32eedd7767de19507"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d5de0e782bd4591aec2408f79806f90ca9b23a3b30bdd70a7b1afabab3dacdaa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10069,9 +11803,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f1e4e04848e39b34f872ac597286558ab17fd8b0160b8af4069d0174776117b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch32.yaml":
     active:
       fingerprint: "sha256:588f2b3860d4b588b6c24a7331ac495e7eb470d28421328b745b3d60837997f8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f2fd8966f7c80fe776a98be4226b2d75325a19cf93478ffe9f1711f027779e4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10081,9 +11825,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e863a85b62b4eed630ed526828091ae9c195e019c631039c78e85d06ec656544"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch34.yaml":
     active:
       fingerprint: "sha256:24e09c7c81b785e84d2701cde6ebbb7bc064fcc0436b6f19627e9361db236dcd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3ddd2f01628ad0139bcb772b472495c6a276fbe17650f15a0feba90348a27951"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10093,9 +11847,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:eff4eb1527b011173b6f4d75e5dd0f593e4766472459ee8381aba56c44a011a0"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch36.yaml":
     active:
       fingerprint: "sha256:5dd04d2a07e78c5c744cdca024361b5929a8484f622b0d4eea35d3733a8fd158"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8b59e69ec0cd64488dec960b9ba893596bc79129c03e98830e2e4bc17c589556"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10105,9 +11869,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:350ccd1b5fe29867950d4749a77f12be60d79b6e600840cc171eb84611cac5ee"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch38.yaml":
     active:
       fingerprint: "sha256:15706a80c73cf16d8734c74a869fecab7f9cc961e8969817d602bd35900bc5d9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8fd5b5d15d4178e8eb7a87e0db8c818f549a3d41e5a35b2acd9ad9011c5ba46c"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10117,9 +11891,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fd604b7580a0b73202da88240a82ba6375d964653cd45ed6f97fe58acc77d250"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch40.yaml":
     active:
       fingerprint: "sha256:615308a5f0e78f6f6d2b23507d97112d85461631442959e6d5c63a75b6204f91"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:547fdfd90ee7e56431a049725ed05d84d40244ed5d812cfa6aebd65f3a2083b0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10129,9 +11913,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:df6e56105102e683f13b82a47940394f03e9f2f9b771889c41502b2cf03aa692"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch42.yaml":
     active:
       fingerprint: "sha256:6994971a1334f51c76cece8d0d920f9638e47ee1807a33d7a7f8ef42c9d230a9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c19143947d21e63f7a3e587f288eedfa25bb9bb21c236d047d50b9b067bfab39"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10141,9 +11935,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:da69e0ea7bbbf618165ac5c39ec6e2749a10a640932c30c9d42486cf72864007"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch44.yaml":
     active:
       fingerprint: "sha256:ea130ad3881e5d6c33648998ea7a7de1e38b429bb0a73b0b29d3fe7c590fb488"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8f025cdb503ddfc44023e5e2ab70963340797dcf5248b1fa605288f8b1e17832"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10153,9 +11957,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:be8e67278044a6431353ec019eadad5a8fc4b12a78fc9256eb8930bac2e643b9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch46.yaml":
     active:
       fingerprint: "sha256:b33039a163d760538a19cb7d142aeffb280febff8ff032e05bea538a4e41a002"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5d9bd432842e2561f0c502578e00de2ec3b7249a84cb3dd4088f710813e81a9e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10176,9 +11990,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e0906abc8566cc838cf73634427ee4a3150d165cc95edac49cdde4cd6ca93e30"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch49.yaml":
     active:
       fingerprint: "sha256:28b59bb2360423c63328bb7cb51ee719c72bfab494398d39eb5d191904018757"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:199d78148b6e7675f5b4357aa19dd6eea50a671d418a19252eac7387c3d47203"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10188,9 +12012,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9dd7336daedc8b7b388fe8cf80ce18fb2eafec5dfbaa80393d60760c54d93864"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch51.yaml":
     active:
       fingerprint: "sha256:f3ce53000448f5efa3e7cefa8facc6277509fec8ef961d36e3dadedd213cf6b1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:618fbd15a025ee8c8abf4d5eadc9163c249e2f91cf7e64d8ae5bd8411a448a18"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10200,9 +12034,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6d3a7c73c1eb5fea2e6350096d987f872ef4db208ac3656d53830b6ffe3f704c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch53.yaml":
     active:
       fingerprint: "sha256:3c9c112663446bc1ff881ced46bfe19737ba65661a608742176f004c08a53a97"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9f8fb7c32e3a8a8a0b38b55d014aad151785bce17b2d3efc3168b3b1da41a02e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10212,9 +12056,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c25e7d4149bbf621bc5942aea25a1874ef53878146a30a0f57c4afd7892d82b8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch55.yaml":
     active:
       fingerprint: "sha256:bafab518b4a85bbd4ea90abe99b6e3df3e4b9e0ed170696e1a8fa2b7581d5b1a"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9f74ac29891fe1612a953ac55217e1965474416d9140f68a358ee99338a54961"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10224,9 +12078,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:3dd8bea36e491fcc236be0c9f28da548429eb9a30d0dd72d738b0d7463eaad80"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch57.yaml":
     active:
       fingerprint: "sha256:ce17e4d3c85b39ee2e365c4229d029793f8128542993fd55c0d12f297067b50d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:76043b7831f0ff843a78be100ff2c81796930abadef03ecce6f30aa584e0fa82"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10236,9 +12100,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:81cc4a952481f65061346c158c9300d052219f02c979fd7b831d5b8f477a72a8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch59.yaml":
     active:
       fingerprint: "sha256:e5078e4476ab5bd61fd38cb9380fe32f39e9ea33d73540a00ba8f9d73bd19cc8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b22f0ca55d3576c596023558f0e533bb01b1eeccbbdfd9a0808226eb1a40033d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10248,9 +12122,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d0bd730a1373f31a72621b5b407a658d714c25204582f220626ef64d257f004d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch61.yaml":
     active:
       fingerprint: "sha256:ffe9fa262cb7534d382db9c79d254b6e3266bcf16facfda0617ad09141fb750e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c3424caba118644eb15cae610ac82f60b0dbafeeffbc8ebfbd5a55c53384d5a2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10260,9 +12144,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:25df2ffe682134acb02c4c49fe31752293328ec239a1d380a31909199ea17043"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch63.yaml":
     active:
       fingerprint: "sha256:f16c9fe1ec0c01a188a866fd82e30823f94ef59a65668c257e92d772fc2e2aa9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:8099ec880894dbf479f0d271eefd05e98d7fe1243c7c2f78a94980bb0601d961"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10272,9 +12166,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b4f24c7c9463a10d3653622ce6cc73a51a10cff433d0aff17600cfa714abeaa8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch65.yaml":
     active:
       fingerprint: "sha256:c31e634fbdebcc9a61191c15ffa5f1ab8d54c2e9955ccde40c86e562baf95623"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:c055b8d091f5cb4afb878d54c9e038365dd748b14817e23990446a96b297fcab"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10284,9 +12188,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a36ed026bad21cd1a24152d13413fb61ddb9b7e67553eaa203834c62e709b57d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch67.yaml":
     active:
       fingerprint: "sha256:63a5e975e754ec7fe691f6be5966382954e51ce987e5830ff9739b14530cab99"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:31d67cbfecf3e544e641dc34975dd41e978cacab6d29f9b0cae82eebc1c8523d"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10296,9 +12210,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:62c2c258908c57a41edb7249c70bc629ce407325b83c59ca3f5ab3d499241fef"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch69.yaml":
     active:
       fingerprint: "sha256:688a0842bf11f3d64e8346c8a4157278167645464b100fc549c1d01decb7e4fd"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e53e738a3a89370096e8447130b9c8fcab825b8dccbd210e7e30466015153f64"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10308,9 +12232,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7511f21100c901feef65615822dc167fc47059a31c3ebe3e9ae6558081cedf26"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch71.yaml":
     active:
       fingerprint: "sha256:480908e683d42206985f3576742af4229fb03815412c87fcc9804ddcf87f21cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:018b011118b0c4d0c9694036fe4f0f8cce6e3b527112dc8cbc62514a2a003102"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10320,9 +12254,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:954e10834d84d780e1476370aec548d3642bc1e57d6e01cff3edd4e4499bb215"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch73.yaml":
     active:
       fingerprint: "sha256:2cd6125bee07f91e0d8050af2a604ab8747374ca5c6f99066c89f248a6ae9742"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5f95855c62787f3b54ad5155c5635b970642732eb51a29f3af8f4b7148dcb590"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10332,9 +12276,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bc028a2124118be5631d3d9ca3280d5d2c081eeb1cb2701032d051906588e1de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/lines/generated/ch75.yaml":
     active:
       fingerprint: "sha256:fcc9ec53b6e267d311f6cc8599a3195025004513ce92aea32c6012d3f2f1283d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:eba2675b86c3ded099fb97d8d3ed45675a76fe9c0a77342f9a51d05b8763a4aa"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10344,9 +12298,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:7504f02a243b246d8b829ba845656c8e7f91d73993ad618df5eb86c23b42f3bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-annex-exclusion-9903-01-32.yaml":
     active:
       fingerprint: "sha256:7cfda459a8194c36d2d396e92757225a0ed0aed8cfa2c1e30fda4bcdb253125d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fd61504f51e55b8efddb984bbdbca166d740466781693ff89a5eee5703f7bb1b"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10356,9 +12320,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a3d9ea587eaf1977a1d940830228a231b505c1d93ec62fd70073e941f82e2631"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-liechtenstein-9903-02-87.yaml":
     active:
       fingerprint: "sha256:698387c8ec7415a365d5df35780eec9e8fe690f55f1b0c6d625f25c3694e30cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ff88182a2760bec3546e3290cee9ec7df801753140ee0f1845fc026d8dc9bbcd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10368,9 +12342,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b79dc2c5ba5984c5197168e8e8d309067b5b9bda8ba87910ee14bb6367896fd6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-metals-exclusion-9903-01-33.yaml":
     active:
       fingerprint: "sha256:8a5a17e0a11db7d4a6c3daa6972a95204233f728848d866071c3827587ddd5fa"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:65a86b1cfd72db14771c89d14b9b1f8ba9ac6cf10b75ecf90f4fffdfebc950a4"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10380,9 +12364,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:49cbb194e2815eb2f3f0907f0cca57463f22705921ab77a00e1193204ad0ccd9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-80.yaml":
     active:
       fingerprint: "sha256:e000ba2a87bd3cdee5141ecd10463ba9395aa861b393eeb140f68682015cb0cc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:012488781fae8f7e9abce5878ef618b6cdf28b5bae8a536f2f897a2d3327cbd6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10392,15 +12386,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:e1cbbd340408f4da1720ec5fa2a27b09853fa5304fa8592bef23360821e8d320"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-82.yaml":
     active:
       fingerprint: "sha256:72c2709a6e2f8d00e28ead1501e1175ca4860d6ef8ffbd2631d3f829f1486314"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b1d25b87feb1becfdbeaffbb57894507da9f9b06180db6b66e3712910145ece2"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-switzerland-9903-02-83.yaml":
     active:
       fingerprint: "sha256:4485d121b855785dbeaf769fc087a44d6720f82533a5bb47279f791a664d88d6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:95d425571233f4ab81759cff0594db9499296ee57734e11b62f8f23aac6aee1f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10422,9 +12431,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:776048facf9213662206b0751ae3c0704bd350fc5c0460725649ce7107b42aa1"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-japan-9903-05-49.yaml":
     active:
       fingerprint: "sha256:0e2613a0f84d9851fdcd9f4a10f86457cd5ce4842a3f5526bedd2a7c586b6197"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:0ad8199849e8f5faa549b4ffa05f9a449c625e96bb63d2920b6ea90130c1ddf1"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10434,15 +12453,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:9c8abb35ee6b3516d60412976ccd93ee410a89d66f6bc35964ea7a673eca8416"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-switzerland-9903-05-74.yaml":
     active:
       fingerprint: "sha256:f619ccd4e6dcbe84deb75acb3764948bb2ffd6f3f1ed82411d66e61fc7234146"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f470a6538412a54a056f6ba6a56a6cb2df8bf3aa0b19a8648833feb180e8f5cf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/policies/usitc/us-tariff-duty/overlays/section-301/forced-labor-taiwan-9903-05-76.yaml":
     active:
       fingerprint: "sha256:64e7a74c211b7d2e4a4fcddd7192188ba9ea7644fbb218bfdbe439498f356ccb"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b22480c1efbc12797a42092d61fcb00db2d2337576234d1d28e81010f7e4e157"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10464,6 +12498,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5bf56d6339972dcdc4cb07a572d71a5d14a62bd130be3647b35da683dac4ab7e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/regulations/42-cfr/435/561.yaml":
     active:
       fingerprint: "sha256:61b26d921389ad3be9e81e1d7d180fa9cf5eb68c8d55340532ffa82bf4b66daa"
@@ -10476,9 +12515,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:95eb2f0e5452e82c1d2f233113dd10ec207ba4711b65615cf61700bbeab6694c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/regulations/7-cfr/273/7.yaml":
     active:
       fingerprint: "sha256:221ff92fc5f81543ca2f614d2bbe59667afd49e878fdd990378f3ab953a0c442"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ff14bcf6a9124743df1ee382418847c30433f0704b288a617ed5b43c15833922"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10560,6 +12609,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ea9c23c28364216de33d1391ac0811b1a3796ffd9e2052956e91c726f2d5b407"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/42.yaml":
     active:
       fingerprint: "sha256:320a2bd6e6e88cbc02c418ed381e91d5f0892e535b7489ff4be31956c99d1b0f"
@@ -10572,9 +12626,19 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ace8f42fc16c90663aa6c274db4cf997b21628ce93981ea2be67ce6100afe9ff"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/57.yaml":
     active:
       fingerprint: "sha256:c89bcce4f05afc48d828bcaf41bcdeedb8a7824bb41b3ff02f93a3a684a18abf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:55fe3e61b30bd20c3ecc28e2eef366f0a096f9bba6805335d10fcd0b3ff283b2"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -10584,15 +12648,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b5d1dc6f098aab56122b661b26a0b797044ae26d955d5a2031009a6ebcc091ac"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/59.yaml":
     active:
       fingerprint: "sha256:6ef556d6a917adb1a039e96e0a6facd7d2e38da44427c7a3115df4cc26550be5"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6652335c99cc5fa74e0b1217f71976cc8dda0a33841f975b68b48a7ebc97b71d"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us/statutes/26/63/c/6.yaml":
     active:
       fingerprint: "sha256:babdf988f3f47f7715f41152c0caae57f5ec32c78190b3f6a275014867fda774"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2f8d57315bbd4dc96fb919c37c88e4b90be82ca7f7558dd3cdad7c83c4627ce6"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"


### PR DESCRIPTION
## Summary

Approve 415 pending validation fingerprints required before encoder 0.2.1764 can be consumed:

- 411 exact active-fingerprint drifts authenticated by the completed 0.2.1764 waiver audit in run 34063633717
- 4 New Hampshire legacy-path failures reproduced locally against encoder `1daadad`, engine `d142c645`, corpus `620527d7`, and RuleSpec `275698e0`
- keep every active waiver and its owner/issue/expiry unchanged
- update only the waiver ledger and its exact toolchain digest companion

The four NH fingerprints preserve the hard-cut validator behavior; they temporarily waive the existing noncanonical legacy modules while their provenance-safe migration is handled. They are owned by `@PavelMakarchuk`, linked to #1248 because they block that toolchain upgrade, and expire 2026-12-06.

## Verification

- protected-base transition issues: 0
- toolchain digest companion issues: 0
- focused repository checks: `47 passed in 291.93s`
- `git diff --check`: clean
- independent review cycle: initial 411-row version clean after companion-semantics clarification; amended 415-row version re-review requested

Auto-merge remains armed and will merge only after required CI is green.