### PR TITLE
Stage encoder 0.2.1764 validation drift waivers

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
 axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
-validation_waiver_set_sha256 = "7ca0b83e06647d3498548e74163c55a315e6abae8b4903d72f1110745a4ebded"
+validation_waiver_set_sha256 = "f3aadc46ea6342ea560a83b80a036148f743232ce253fe3f2de60998bb64e9e1"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -6105,6 +6105,18 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-md/policies/dhs/fia/snap/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:90a35e6eee464f18c0e7d0cd047df3ee375364f2379a065e9ba4eee9bca0c794"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-md/policies/dhs/fia/snap/standard-utility-allowances.yaml":
+    pending:
+      fingerprint: "sha256:00d975686104408798d10a8915b7647ad709c19d9799c42f41c76b3835cd45b1"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
   "us-md/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:108c236be3aef44c4dcca1beacf28450d8c403247460af8b3d23695fa17f6635"
@@ -12825,3 +12837,855 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-az/policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:1cc909eccd416877df51af886cecb8d78bbbd73594563738e4ec80eef97213f3"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-az/policies/des/faa6/utility-allowance-current-amount.yaml":
+    pending:
+      fingerprint: "sha256:6f97f3fb30de4316b6bfa12b7c253eef30ea489a76c9af99b5b3e637b07b9851"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ca/policies/cdss/snap/standard-utility-allowance.yaml":
+    pending:
+      fingerprint: "sha256:28baaee3db7345c408723e165fe89b92e1800f420f40a13ab62e31560e8c2104"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ca/statutes/rtc/17038.yaml":
+    pending:
+      fingerprint: "sha256:23b99a48cbc783c4db3a4a55906d51639e70ca7ff4d05342db5bffe2a2683099"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ga/policies/dfcs/snap/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:a963ac2c3cf5b48586954414aadb988ee5fbe87ddaf42234d188ead2c8ca0728"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-la/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:3190320bb0307fe546f4b07b0a3df44097d91010af4e1a44a6c08ee68e9b1fba"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-la/statutes/47:32.yaml":
+    pending:
+      fingerprint: "sha256:b28ba3babf4987bb7fcbda08d29d6ac901599f3b834c8252add689961a77350a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ny/policies/otda/snap/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:5c12e283215fd081e0e72b1717ad8783321dec685336ded06bf1da409102e306"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ny/regulations/18-nycrr/387/12/a.yaml":
+    pending:
+      fingerprint: "sha256:af67fb3de51e7cd7d51c3ac4751cc9200b927c5d61398edd1cdc891b1de554cf"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-ny/regulations/18-nycrr/387/12/f/3/v/c.yaml":
+    pending:
+      fingerprint: "sha256:de8cda226ddcdbea681528f765cf39c5ba22c54db90f45b5e2867a2cae92e122"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels.yaml":
+    pending:
+      fingerprint: "sha256:41cfd88da3755cfd7877677e9ddafc717191b33393184357a5c4a457dce09f0d"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-dc/policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations.yaml":
+    pending:
+      fingerprint: "sha256:32467d3fbe0498266b8dae007dc5a141002161be6904ddbc69d4b87a361bd3c5"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-de/policies/ssa/poms/si-01415-058/2026/de-ssp-individual-state-supplement-levels.yaml":
+    pending:
+      fingerprint: "sha256:0d9b8005bf51be29cc85ea9833381956c34ef871d6f5d7f1b0a287b082e21843"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-de/policies/ssa/poms/si-01415-058/2026/de-ssp-living-arrangement-variations.yaml":
+    pending:
+      fingerprint: "sha256:32a59d989628858b9a1fcae59d197dab7a91dde6a857cb6d4b55d67a0deb6b14"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-sc/policies/dss/snap-policy-manual/page-159.yaml":
+    pending:
+      fingerprint: "sha256:144736d97de44f12afa0d9a1e580ac8dd22f7fd6d2a0f2a0eda83482c930cc23"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-sc/policies/dss/snap-policy-manual/page-369.yaml":
+    pending:
+      fingerprint: "sha256:8e3bb2d748eb82cd393d1064a4937c5dd1fd779d993183180e7ea452237ac6b8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-200-eligibility-requirements-overview/page-1.yaml":
+    pending:
+      fingerprint: "sha256:7d930ff9fbb12e4d9f47d1056dff22f102449fe54d46db639f7a51cc67e69948"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-205-identity/page-1.yaml":
+    pending:
+      fingerprint: "sha256:3e3f8002cfbc78f2c9b621bd3822748d245ccc0f528d9c803f26a328317ccf05"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-205-identity/page-2.yaml":
+    pending:
+      fingerprint: "sha256:de33012ec71541e16d638c41cbea86ef6b113fcca96cfb376c30f56e36d72783"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-225-citizenship/page-1.yaml":
+    pending:
+      fingerprint: "sha256:daecb7bf94291317cdebab9fb0ba5c322e934c18167e6aafa7be81281d758cdc"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-225-citizenship/page-2.yaml":
+    pending:
+      fingerprint: "sha256:747c5499a4b4f1420290451c06dc255b7e0dc4418c0c840e6f9572345aaaed4b"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-225-citizenship/page-4.yaml":
+    pending:
+      fingerprint: "sha256:68960a11c5aff5d4d42f4631baeaa74b08e20ddf7585bd7836a483e7cfaad9df"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-22.yaml":
+    pending:
+      fingerprint: "sha256:a02a756fb325cc038643b7442bdaa70bd9d4eda5e668316bb678fca78c035a1b"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-31.yaml":
+    pending:
+      fingerprint: "sha256:b79cd5caf160b6c98a273591c1bed335be119beac5547eec5af6d32597cdbdbb"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-35.yaml":
+    pending:
+      fingerprint: "sha256:c4ba4d2686212a986a27115c306823c7780722c021d284bc79669de324bfa233"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-4.yaml":
+    pending:
+      fingerprint: "sha256:13ec866124fb10d91cc00c8c3bf8afd098c51334e502a9d505d8b7ae7013154e"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-6.yaml":
+    pending:
+      fingerprint: "sha256:89629d3bff0c748d847f53c136aa2edc3ba458955b7b27ce09a83d307c4d00ae"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-227-non-citizen-requirements/page-8.yaml":
+    pending:
+      fingerprint: "sha256:a5ffc719b8c5a83b51a775ae3b27a6d7aba3feca13d7a1c9e76e8287a2d6e866"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-19.yaml":
+    pending:
+      fingerprint: "sha256:5d2d626e0d604c00af180b661b6d55776d696f866b05036269e39bf2bb7a64ee"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-2.yaml":
+    pending:
+      fingerprint: "sha256:22901232a3496b9ed8c92f82fee012399564be7de7766ba9fc10893f14faa31f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-28.yaml":
+    pending:
+      fingerprint: "sha256:d2efd41bb4223ea11a184b2c20d120f01c0d6273cdc6adeb8c9d7d7da51bcc59"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-29.yaml":
+    pending:
+      fingerprint: "sha256:a794a89156219f5f5bb7f3c8cc68922d04120022f9dc38fe960229f334d29626"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-305-rules-for-budgeting-income/page-5.yaml":
+    pending:
+      fingerprint: "sha256:ce4c5a1a1cbfc0af6ed20804ded7acd0da83499ff4e994aac86f63f2c30b650f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-450-social-security-administration-application/page-5.yaml":
+    pending:
+      fingerprint: "sha256:ecc794654cad69f2ff4f068fcb93664fbc9d27b5cbe7d5b118bf30e525eb4f41"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-4.yaml":
+    pending:
+      fingerprint: "sha256:db3965ec35b1feb411eaaccfb466cceeef0e71a28a0ba9224fd7b273e1d2905d"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-3.yaml":
+    pending:
+      fingerprint: "sha256:5b40ea82d91a71ea6bdb421daea925000e5242fdc81cff7464c262d467e07259"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-nc/policies/dhhs/fns/fns-910-cancellation-of-benefits/page-1.yaml":
+    pending:
+      fingerprint: "sha256:dcae86bd933ce9948189c490ae9a836db24c4e70dd36ee2834ab0482f83d6e8e"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/irs/rev-proc-2025-32/capital-gains.yaml":
+    pending:
+      fingerprint: "sha256:4638f1536ea732714349e9af99f70794f886f57fd42f14c214fed2f675876aa6"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/irs/rev-proc-2025-32/child-tax-credit.yaml":
+    pending:
+      fingerprint: "sha256:da210d0b2407bc176146dce4fd988c5bc82aafe2a9c4a8f194990da83ed63c76"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usda/snap/state-plan-composition.yaml":
+    pending:
+      fingerprint: "sha256:07054d7ce2d3d9385aaf4ef7782c0e0f921caa158b9ce977095e63936a99b59a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-afghanistan-9903-02-02.yaml":
+    pending:
+      fingerprint: "sha256:25eacfe83a326d0e26cab4e8e21faa5c9ecdaa11f07ddfbf9600b1a962ef676c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-algeria-9903-02-03.yaml":
+    pending:
+      fingerprint: "sha256:beb34d1a2b857feed843dafa2f4345123c498be85cdd41b7c51d016ee3a9664d"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-angola-9903-02-04.yaml":
+    pending:
+      fingerprint: "sha256:818da44c978f97a405a78d0b4a24882d350ea53ff36d5799e0422e2fe8301f01"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-bangladesh-9903-02-05.yaml":
+    pending:
+      fingerprint: "sha256:4c431476edaf50e0be89d327c085b3ff5bb4d599320264915560fe2c342af68c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-bosnia-and-herzegovina-9903-02-07.yaml":
+    pending:
+      fingerprint: "sha256:bbef959b87e762875562eabe045ec087612d744f730313cccb7387d3d0b57d4e"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-botswana-9903-02-08.yaml":
+    pending:
+      fingerprint: "sha256:313f044cdea93684b313e10408cf408901aff3b1237effd4f847bb9bc27e0411"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-brazil-9903-02-09.yaml":
+    pending:
+      fingerprint: "sha256:d379a273cb129199f9656ffac5cedd2bb71cc32e5ba5ead72b2e084302f2d198"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-brunei-9903-02-10.yaml":
+    pending:
+      fingerprint: "sha256:5232af2dd4f24f1a2bd134da2f598bee3ca2353fbba41c7a804b774fc6b787a4"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-cambodia-9903-02-11.yaml":
+    pending:
+      fingerprint: "sha256:4943fba791090d84428ee972c49e4ea69f9f5c13549af9d4507aa7a2badd6e12"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-cameroon-9903-02-12.yaml":
+    pending:
+      fingerprint: "sha256:ec0c0c669bff31e036edf0f214a30821737d7412994742cd645846f671218980"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-chad-9903-02-13.yaml":
+    pending:
+      fingerprint: "sha256:2e4099f72c906c08c590f01a1f3bc38e3304613e787e234e025d44c91d4853a7"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-costa-rica-9903-02-14.yaml":
+    pending:
+      fingerprint: "sha256:3f8e7ce54e3a355f35aa6148e6a037ab31dc66c99cf7f6d302154c00b43637b2"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-cote-d-ivoire-9903-02-15.yaml":
+    pending:
+      fingerprint: "sha256:8b5b06b6095a7e41646f0f99d8f1195570d0a1010e70e8bb134fa9b396d5b122"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-democratic-republic-of-the-congo-9903-02-16.yaml":
+    pending:
+      fingerprint: "sha256:4cefdb860e057f3625598b932b1f85fee698b3158ba22803cdd2ed3852b16399"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-ecuador-9903-02-17.yaml":
+    pending:
+      fingerprint: "sha256:26c37f22cc555fe8095cb626320312e48439750c8cbdc6b15efd1512bbf6426e"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-equatorial-guinea-9903-02-18.yaml":
+    pending:
+      fingerprint: "sha256:ed432beb0049ec2ec0ab19eff711aabdb3b8746212736aed7f64cadbe9fb61ef"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-eu-9903-02-19.yaml":
+    pending:
+      fingerprint: "sha256:946e12f877b25d223f5d2de581682fd79f7e967a540d061edc8739cba5891fd0"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-eu-9903-02-20.yaml":
+    pending:
+      fingerprint: "sha256:a479d9f3ef1a8cfac9cb7a3ddee0682acd4ac73c6a713eafb2fa864ae8366995"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-falkland-islands-9903-02-21.yaml":
+    pending:
+      fingerprint: "sha256:fbe4da324ed4e5818e89a11c565f20936fee840c79e3f64c776e69fc36a9cefe"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-fiji-9903-02-22.yaml":
+    pending:
+      fingerprint: "sha256:c9e5ece0608a314078bb51a1b5ca3f96ce0e00fbb80e63db89afe07d2f1f9593"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-ghana-9903-02-23.yaml":
+    pending:
+      fingerprint: "sha256:b56869989608c7af1d8a0129e7ac37e740ef1a08ccd16fb4caa85ebe5781c440"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-guyana-9903-02-24.yaml":
+    pending:
+      fingerprint: "sha256:83c60a695079fb72f4a7c8587e357d86c22471ec7b3eb846e7f47bb343946310"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-iceland-9903-02-25.yaml":
+    pending:
+      fingerprint: "sha256:d95b53919a3ebadb28acf6e7e7e633f7903db13e3cd5f36542da7bd55290a5f0"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-india-9903-02-26.yaml":
+    pending:
+      fingerprint: "sha256:6f609fdd3557cf6a29b51e27f790d9a88d5dc147cb66c7023d86f9381d80db48"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-indonesia-9903-02-27.yaml":
+    pending:
+      fingerprint: "sha256:d5f85edf74d9e17e8191e814d6f2a664ea9118e3c7418c9bcf319726ad343748"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-iraq-9903-02-28.yaml":
+    pending:
+      fingerprint: "sha256:ddd2fe5461c3b18e9259ae8ac7159bf98c2b75a9637923eeaea8590d8d313da8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-israel-9903-02-29.yaml":
+    pending:
+      fingerprint: "sha256:774f0f9e0c531a70833beb2a8ca44befa2e767a1f19ed650aba34ccd8607e883"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-japan-9903-02-72.yaml":
+    pending:
+      fingerprint: "sha256:87cdc99203ae1f1092a83a85224af852a28ea764a38028058978b7b649a6ea7f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-japan-9903-02-73.yaml":
+    pending:
+      fingerprint: "sha256:7ef555d4c26447d0602dbc13bbf231c4fe0ed160c366255ff71048fb82ca4365"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-jordan-9903-02-31.yaml":
+    pending:
+      fingerprint: "sha256:c0fccd57c3ad3ed41f7e8879dd082a7734286c21d6a76e48931631ccb187d711"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-kazakhstan-9903-02-32.yaml":
+    pending:
+      fingerprint: "sha256:481355e46fb97862c36051249e340d314382b6c2f14c49d72fb48326c134a06c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-laos-9903-02-33.yaml":
+    pending:
+      fingerprint: "sha256:ed235452dc202c2866625797d762fe567f0f1bb913ef40e963c88134da324832"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-lesotho-9903-02-34.yaml":
+    pending:
+      fingerprint: "sha256:8a315406275e5269c62738eebff64817551b2af51655d62e946412a3d7299af4"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-libya-9903-02-35.yaml":
+    pending:
+      fingerprint: "sha256:288229e719987bac37be5da980b4e09518a9d02c5528cd84b00f24ce54905984"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-madagascar-9903-02-37.yaml":
+    pending:
+      fingerprint: "sha256:692dc3c5d53a6a9dde6016864eb64357819eadccfebd95b00cef055db48bdb97"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-malawi-9903-02-38.yaml":
+    pending:
+      fingerprint: "sha256:3386f912848c2edb1b2767bf0cd47b6d047039cfe6ca1c466f995584a99f832c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-malaysia-9903-02-39.yaml":
+    pending:
+      fingerprint: "sha256:b68207ef1f94c2490bd218ac52a3b007615b730492ba1fa4bfd09da91ec636fd"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-mauritius-9903-02-40.yaml":
+    pending:
+      fingerprint: "sha256:20f7b416657f441cbe607841c150145a17f49e2fe33832a54f3ee0bc12258bee"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-moldova-9903-02-41.yaml":
+    pending:
+      fingerprint: "sha256:887af3e170b91f7fedba7a940c488c800afec19c28e3c59617814858512ccab8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-mozambique-9903-02-42.yaml":
+    pending:
+      fingerprint: "sha256:4e9a2954a9348eaa5bc7b0a69d34b2f9179502e9912cd22e54281e281ceb46f0"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-myanmar-9903-02-43.yaml":
+    pending:
+      fingerprint: "sha256:589f047680616be2fcc60429c85851c17b8a2efd07432671f305a6435abf0e29"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-namibia-9903-02-44.yaml":
+    pending:
+      fingerprint: "sha256:6cfe09e7527d4b10324b079ca1858f0aaa44c8267662eadc7c838c7002d9dfdd"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-nauru-9903-02-45.yaml":
+    pending:
+      fingerprint: "sha256:8213cd206dd14dd1639f256bba392c6534310b14c9115cc324cc0c353d3ea139"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-new-zealand-9903-02-46.yaml":
+    pending:
+      fingerprint: "sha256:92716815f4f17e8ca2b66318825368c8f787600dad85b95895a307fa3a541ee4"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-nicaragua-9903-02-47.yaml":
+    pending:
+      fingerprint: "sha256:d6621cab9bc056755cd1b079b007d3b3aba2836313b44a2dcdc3d5a3ea30c51a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-nigeria-9903-02-48.yaml":
+    pending:
+      fingerprint: "sha256:ab0a391c2e7eb9341af200e7935b0a9e9c453c76c8ff2acd18ee90356d34bb9b"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-north-macedonia-9903-02-49.yaml":
+    pending:
+      fingerprint: "sha256:adc3d2f211dd1ef199fb93c737f1e52f6de418472ccbe95a7a374889585b6536"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-norway-9903-02-50.yaml":
+    pending:
+      fingerprint: "sha256:80e46b03b491eca8dd806467d9de9735bcdaf13ff3ba1bbef338986ee89634ea"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-pakistan-9903-02-51.yaml":
+    pending:
+      fingerprint: "sha256:357c9f731b8e1f8e97502bfaad6a04907185d8d00e465083fc123255981a4447"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-papua-new-guinea-9903-02-52.yaml":
+    pending:
+      fingerprint: "sha256:29cc910124c2744ef3b20c1c6b255afeceeb664552d72b759f03c3aad4436e92"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-philippines-9903-02-53.yaml":
+    pending:
+      fingerprint: "sha256:8402055bc45a7218ab3dc7b1e70b01fe5968d74406f8296f74f7ae4b66ed8044"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-serbia-9903-02-54.yaml":
+    pending:
+      fingerprint: "sha256:f05f40d050c36e423e42b6da73bc385ad2b00592920dd5438fa857afb0bb5038"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-africa-9903-02-55.yaml":
+    pending:
+      fingerprint: "sha256:de1f31c5d84b5d3e57c8c340a597d36b5f2c38fcb2ecf09121afb61e5980928c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-south-korea-9903-02-56.yaml":
+    pending:
+      fingerprint: "sha256:574b829ee7cf9631170c29e7ada5828e13b843bf8e5b7d1840c2e095cd20afb9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-sri-lanka-9903-02-57.yaml":
+    pending:
+      fingerprint: "sha256:1057b8613fa9b1504d37ed3401d54f85582d22924c29ec44385a980d34456fd0"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-syria-9903-02-59.yaml":
+    pending:
+      fingerprint: "sha256:b62ee07e24d099cd0a9d3e25e031639a20e004b9bb2dc15eb4d664971ecf01c9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-taiwan-9903-02-60.yaml":
+    pending:
+      fingerprint: "sha256:0909c6fe06409e06ed8e7bdd5f5f5fcd0203d527efe93043fffda8e610a1266f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-thailand-9903-02-61.yaml":
+    pending:
+      fingerprint: "sha256:3b9c9415c16fb307093d7b19a9bdaea171830c3145d942381cecd163b1d28fa9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-trinidad-and-tobago-9903-02-62.yaml":
+    pending:
+      fingerprint: "sha256:97101c845b9c4f9788ad60dddc7369dfb00c3366f4336bd6fdd203a43c26f9a3"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-tunisia-9903-02-63.yaml":
+    pending:
+      fingerprint: "sha256:5f9a79e38a473c7fe872d033552744288af6a6d706f201b08f9a0bc579317402"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-turkiye-9903-02-64.yaml":
+    pending:
+      fingerprint: "sha256:68f6d69c657f4c89a452a458b46539949e915e7987e500caed3552528afaefd3"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-uganda-9903-02-65.yaml":
+    pending:
+      fingerprint: "sha256:26f79f898328cf7b47c851f55ab0b30ac95ad111441b190c753916bf9e5f0a02"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-uk-9903-02-66.yaml":
+    pending:
+      fingerprint: "sha256:3a6efc9208fd5cfdc0d7ba7b529d260b98ba380c71c05251384069bdb7086553"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-vanuatu-9903-02-67.yaml":
+    pending:
+      fingerprint: "sha256:1fda26c5df552beb0088f475c6bb6133ef40192ef57db02003d49844e59ba6e8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-venezuela-9903-02-68.yaml":
+    pending:
+      fingerprint: "sha256:ecb4fa6f53ad361c9785d4eed4d4e738c40fdbe3c477474e683d3a3a6bff6283"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-vietnam-9903-02-69.yaml":
+    pending:
+      fingerprint: "sha256:5b695353b69da4d3f24b8a9390e39f37e0e990dd5333b4f08f5cd19988be0ed5"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-zambia-9903-02-70.yaml":
+    pending:
+      fingerprint: "sha256:c1567579a5ee3bbdde65a6f4f059a9d913fd5b8c7795865180c5a163cb78f375"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/policies/usitc/us-tariff-duty/overlays/ieepa/reciprocal-zimbabwe-9903-02-71.yaml":
+    pending:
+      fingerprint: "sha256:ebb08ca0c6cdaa44f1b245a5e360c157e70057cbbefe5142166d93317a0d90b9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/regulations/7-cfr/273/11/c.yaml":
+    pending:
+      fingerprint: "sha256:97254fd7190dfcd737231dd14719d265a30c0d8ccb643f0ef563304fa4557c12"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/regulations/7-cfr/273/8.yaml":
+    pending:
+      fingerprint: "sha256:e2448ac9a83d3d23bd460600a1e138a9ced984644a76edc3129bba0dee3c7a3f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/regulations/7-cfr/273/9.yaml":
+    pending:
+      fingerprint: "sha256:aa83eaa98915745650c3c979118e207b77c98cb00d84d64f8adeccffb5692b23"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/26/1/j.yaml":
+    pending:
+      fingerprint: "sha256:7c864effeb649250115bc01f93f4c50be3f904e7604c4e4fea7e7a68251bedc8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/26/25B.yaml":
+    pending:
+      fingerprint: "sha256:cc6f1977ea0cf1320d68fc3e9750fde201e50da8cb4147f0ed44f8f38be44572"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/26/6012.yaml":
+    pending:
+      fingerprint: "sha256:8a6fc95f09b1f9fa582893939815d63484e172527a525fe165ddd79616367aed"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/26/63/c.yaml":
+    pending:
+      fingerprint: "sha256:2cae41a811cccdf14bd1e006692363db6be3b342e156f511c6bb79c94053b3bb"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/42/1396a/xx.yaml":
+    pending:
+      fingerprint: "sha256:18452e4045de1ad6baeba03934891ff283dc302598debfae2879a484ad6d5878"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/42/1396b/v.yaml":
+    pending:
+      fingerprint: "sha256:5462de23b2b480446bb97790a961b02fd69b9dc1070de42dca5ca1c1a5dbe7a9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/42/1437c–1.yaml":
+    pending:
+      fingerprint: "sha256:d173315e724efba8329371916e4bafd254a2d684149915d98f2a585f2941c2f1"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/42/4822.yaml":
+    pending:
+      fingerprint: "sha256:f8c236fb5adbe72824f9e8283e33cca00302bb30b17f191feaba69d54a3f60cb"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/7/2014/c.yaml":
+    pending:
+      fingerprint: "sha256:966819b9be35ce33dfce7e57762fdc44b34d33686195a46ecb7a4acab2e12d87"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/7/2014/e/6/A.yaml":
+    pending:
+      fingerprint: "sha256:7b28484bc82e4b0aa69acfe8d98ea9e13ce562c7620cec01afe3279d9dbbcae8"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us/statutes/7/2017/a.yaml":
+    pending:
+      fingerprint: "sha256:b9b227f831221d9d8dc5727a4e0f291db37a85f13113370dd3180a033271d161"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/policies/cdhs/colorado-works/basic-cash-assistance.yaml":
+    pending:
+      fingerprint: "sha256:7f6e9c7db9c59227759574646704ff580f931c9722c1e85c234f7914d7ec2f8c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/policies/cdhs/snap/fy-2026-benefit-calculation.yaml":
+    pending:
+      fingerprint: "sha256:ea0daee303a37cf18bf4ebb27ea9a506572fcc75525f6999337331be039a16dd"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.205.1.yaml":
+    pending:
+      fingerprint: "sha256:2cafef5a889223b57001215cb47ac92fae34c8a04a1f95d3535e3fe4fef115e7"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.205.32.yaml":
+    pending:
+      fingerprint: "sha256:f82f2b9cc00df2acb1920d20bc322bca4987dc55e8081c66899281b0e46780da"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.207.2.yaml":
+    pending:
+      fingerprint: "sha256:9ca42188a3a19fd336b6e017244837ca4017f878940d8d1041d4734fae09f42f"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.207.3.yaml":
+    pending:
+      fingerprint: "sha256:dda33dea83f31e23c8f61a4cca4c753ea888425992712f6acb134f4d0b8736a9"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.305.2.yaml":
+    pending:
+      fingerprint: "sha256:790f85680cc0ed8f5cc5f1bd664357b7b24e177d742c4540e14db2552dabcdaf"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.310.yaml":
+    pending:
+      fingerprint: "sha256:4aee479ecdcbe926fc53f8a3c4752334fc6f1fd4d55ca853f7ca262fb95c8473"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.401.1.yaml":
+    pending:
+      fingerprint: "sha256:3678fbdae24c0e0f24b9fa7d231a4cd77a283f8599502b77787f237ed861bfc1"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.401.2.yaml":
+    pending:
+      fingerprint: "sha256:f3a13bdbe9421a83cbc9e731cdba2c995b81c1a31cbc940201ea6df7ddd1a99a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.401.yaml":
+    pending:
+      fingerprint: "sha256:f680d86c4fb5f001892aaf9eb0126a87f9f86d1cec6f42fa6273826e799ebafd"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.407.1.yaml":
+    pending:
+      fingerprint: "sha256:8ec317074b64e59ea8d2a1483a69e5bdf0c6e97e6a9baee7fb3b6bedf854ed83"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.407.3.yaml":
+    pending:
+      fingerprint: "sha256:666ac2f4ae7a064f7adbf46baf83e7e18cf12b541d1fc94a818c90eedd77b229"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.408.2.yaml":
+    pending:
+      fingerprint: "sha256:107cfa0ede1b2bf24308113936af04e718c5fdc4d5457049dddf5ca36bdcc742"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/regulations/10-ccr-2506-1/4.408.yaml":
+    pending:
+      fingerprint: "sha256:9f8472390ee550850aa925b7234b210ba1792806d602b663ff47a78142e0f102"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/statutes/39/39-11-153.yaml":
+    pending:
+      fingerprint: "sha256:b7b536211ad3a51e0fc29e8f8d53f2ec7beedc99fcb3b22cadea8b56c87cb68a"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/statutes/39/39-22-304.yaml":
+    pending:
+      fingerprint: "sha256:57a22b87dbf6158f1697c6bbcb71f7568242ff4eb5fb0f5ed904c908b002a30b"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/statutes/39/39-22-343.yaml":
+    pending:
+      fingerprint: "sha256:a2d217d0c9a387fb9b7fb4742ce39346e4ae2faa5a892858cc80bb8b9f5a7199"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/statutes/39/39-22-564.yaml":
+    pending:
+      fingerprint: "sha256:4cda1d775ce65cf5d1ef9809b337b75e0719d26502b0c80392f35d86005a970c"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+  "us-co/statutes/39/39-3-211.yaml":
+    pending:
+      fingerprint: "sha256:6b99282290ddafa9875e4d7cb14f7794d5398b8b7a3e47981e72c700b35bbbf5"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"


### PR DESCRIPTION
## Summary

Stage 144 exact pending validation fingerprints exposed by the encoder 0.2.1764 toolchain migration in #1332.

- add pending-only records for the legacy modules reproduced under encoder `1daadad`, engine `d142c645`, and corpus `620527d7`
- preserve every existing active waiver and every policy module unchanged
- bind the ledger to its exact toolchain digest
- link the temporary records to #1248 because they block the immigration toolchain upgrade; all expire 2026-12-06

The complete census comprises 18 initial jurisdiction failures, 21 North Carolina failures, 85 federal CI-target failures, and 20 Colorado failures. Dependency-only modules found by local probing but not selected as CI validation targets are intentionally excluded. These are migration staging records: #1332 will consume the exact fingerprints into active state when the upgraded toolchain lands.

## Verification

- exact authenticated CI path membership: NC 21/21, federal 85/85, Colorado 20/20
- toolchain digest: `f3aadc46ea6342ea560a83b80a036148f743232ce253fe3f2de60998bb64e9e1`
- focused repository checks: `47 passed in 291.62s`
- protected-base transition issues: 0
- toolchain digest companion issues: 0
- `git diff --check`: clean
- independent review cycle: CLEAN on exact head `ede0f78950e5eef90b7f694cf027e66ef87685d8`; no actionable findings

Auto-merge will be armed only after required CI is green.