### PR TITLE
Add signed encoding manifest for us/statute/7/2015/f

### DIFF
--- a/.axiom/encoding-manifests/us/statutes/7/2015/f.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2015/f.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2015/f.yaml",
+      "sha256": "5fd99b1337fb0897613b64112c8295ed856bc590eadd877bfd0ec6c45c8162e6"
+    },
+    {
+      "path": "us/statutes/7/2015/f.test.yaml",
+      "sha256": "3993faedc7daec5c96d7ba2b303f95d5b5a39317f47931000e027bf7afda5920"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "1daadad265dc9eaa1ab737df87b453a5e5e0cb46",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1764",
+    "version_commit": "1daadad265dc9eaa1ab737df87b453a5e5e0cb46"
+  },
+  "axiom_encode_version": "0.2.1764",
+  "backend": "openai",
+  "citation": "us/statute/7/2015/f",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-sol/us-statute-7-2015-f/workspace/context-manifest.json",
+  "context_manifest_sha256": "c3d3b64cd69300ade9fd475554a55d6d35b7b516243b274c1a0e4a1ca7dbd296",
+  "generated_at": "2026-09-07T21:50:29.223481+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-sol/statutes/7/2015/f.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "5fd99b1337fb0897613b64112c8295ed856bc590eadd877bfd0ec6c45c8162e6",
+  "generation_prompt_sha256": "f06bc720359548e41e6ef5ba7383b97f17ebb11da96c8fa6029052b7e70b26ca",
+  "model": "gpt-5.6-sol",
+  "run_id": "a553c223",
+  "runner": "openai-gpt-5.6-sol",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "SRG5BhvXeNcJV7UA2ThPfdqEmSRYmzdK1NxAp1fsT/omtQ/xbLc/RYPJwtpwBFBX7+yQjS+z1n0Tm7nyZ3yKAg=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_corpus_citation_path": "us/statute/7/2015/f",
+    "resolved_text_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+    "row": {
+      "body_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2",
+      "citation_path": "us/statute/7/2015/f",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 197,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "51527d3a-7ce2-5d09-bdb0-681309bae9e8",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-sol/us-statute-7-2015-f.json",
+  "trace_sha256": "4e196b42d18f4c2daf9287b2446a0e4d4a04571ac7ee0770b6d0146d8cf2fb6a",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "1daadad265dc9eaa1ab737df87b453a5e5e0cb46",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1764"
+    },
+    "axiom_rules_engine": {
+      "commit": "d142c645917817cf590e036fb99f99b2d4780e1a",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "e51134a13b0a8f5076fb6311341293e843d364201cf9cbaa4c202502257b193c",
+      "pre_apply_file_count": 2709,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/us/statutes/7/2015/f.test.yaml
+++ b/us/statutes/7/2015/f.test.yaml
@@ -1,0 +1,152 @@
+- name: lawful_permanent_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: citizen_nonresident_is_ineligible_on_effective_day
+  period:
+    period_kind: custom
+    name: day
+    start: '2025-07-04'
+    end: '2025-07-04'
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: resident_citizen_member_is_not_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: resident_citizen_nonmember_is_not_ineligible
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: false
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: cuban_and_haitian_entrant_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: compact_of_free_association_resident_qualifies
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: true
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+- name: refugee_and_asylee_are_not_independent_qualifying_categories
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+- name: ineligible_individual_income_and_resources_are_fully_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_applies_pro_rata_share_of_individual_income: false
+    us:statutes/7/2015/f#input.pro_rata_share_of_individual_income: 30
+    us:statutes/7/2015/f#input.individual_financial_resources: 50
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+    us:statutes/7/2015/f#individual_income_considered_for_household_eligibility_and_allotment: 100
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 50
+- name: optional_proration_and_negative_resources_are_clamped
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: false
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_applies_pro_rata_share_of_individual_income: true
+    us:statutes/7/2015/f#input.pro_rata_share_of_individual_income: 30
+    us:statutes/7/2015/f#input.individual_financial_resources: -5
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: not_holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: holds
+    us:statutes/7/2015/f#individual_income_considered_for_household_eligibility_and_allotment: 70
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 0
+- name: resident_citizen_is_not_ineligible_and_money_is_not_considered
+  period: 2025-08
+  input:
+    us:statutes/7/2015/f#input.individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.individual_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_citizen_or_national_of_united_states: true
+    us:statutes/7/2015/f#input.individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.individual_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:statutes/7/2015/f#input.individual_income: 100
+    us:statutes/7/2015/f#input.state_applies_pro_rata_share_of_individual_income: false
+    us:statutes/7/2015/f#input.pro_rata_share_of_individual_income: 0
+    us:statutes/7/2015/f#input.individual_financial_resources: 200
+  output:
+    us:statutes/7/2015/f#citizenship_or_nationality_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#citizenship_or_permitted_alien_status_qualifies_for_snap_participation: holds
+    us:statutes/7/2015/f#individual_ineligible_for_snap_participation_under_alien_status_rule: not_holds
+    us:statutes/7/2015/f#individual_income_considered_for_household_eligibility_and_allotment: 0
+    us:statutes/7/2015/f#individual_financial_resources_considered_for_household_eligibility_and_allotment: 0

--- a/us/statutes/7/2015/f.yaml
+++ b/us/statutes/7/2015/f.yaml
@@ -1,0 +1,226 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/7/2015/f
+    source_sha256: 239cc65999d115055d13b7b3a72ef1a4c83da4fdbab9ab71d0ea33536d2b96c2
+  summary: No otherwise eligible household member may participate unless the individual
+    is a United States resident and is a citizen or national, a lawful permanent resident,
+    a Cuban and Haitian entrant, or an individual lawfully residing under a Compact
+    of Free Association. The income, less an optional pro rata share, and financial
+    resources of an individual rendered ineligible are considered for household eligibility
+    and allotment.
+rules:
+- name: citizenship_or_permitted_alien_status_qualifies_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)-(D)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (A) a citizen or national of the United States
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (B) an alien lawfully admitted for permanent residence as an immigrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (C) an alien who has been granted the status of Cuban and Haitian
+            entrant
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (D) an individual who lawfully resides in the United States in
+            accordance with a Compact of Free Association
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'citizenship_or_nationality_qualifies_for_snap_participation
+
+      or individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant
+
+      or individual_has_been_granted_status_of_cuban_and_haitian_entrant
+
+      or individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association'
+- name: citizenship_or_nationality_qualifies_for_snap_participation
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(2)(A)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: predicate
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: a citizen or national of the United States
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: individual_is_citizen_or_national_of_united_states
+- name: individual_ineligible_for_snap_participation_under_alien_status_rule
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 U.S.C. 2015(f)(1)-(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: No individual who is a member of a household otherwise eligible
+            to participate in the supplemental nutrition assistance program under
+            this section shall be eligible
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (1) a resident of the United States; and
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: (2) either—
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section\n\
+      and (\n  not individual_is_resident_of_united_states\n  or not citizenship_or_permitted_alien_status_qualifies_for_snap_participation\n\
+      )"
+- name: individual_income_considered_for_household_eligibility_and_allotment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: The income (less, at State option, a pro rata share) and financial
+            resources of the individual rendered ineligible
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if individual_ineligible_for_snap_participation_under_alien_status_rule:\n\
+      \  max(0, individual_income - (if state_applies_pro_rata_share_of_individual_income:\
+      \ pro_rata_share_of_individual_income else: 0))\nelse: 0"
+- name: individual_financial_resources_considered_for_household_eligibility_and_allotment
+  kind: derived
+  entity: Person
+  dtype: Money
+  unit: USD
+  period: Month
+  source: 7 U.S.C. 2015(f)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2015/f
+          excerpt: financial resources of the individual rendered ineligible to participate
+            in the supplemental nutrition assistance program under this subsection
+            shall be considered
+      - path: versions[0].effective_from
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3
+          excerpt: Section 10108 of the OBBB was effective upon enactment, July 4,
+            2025.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "if individual_ineligible_for_snap_participation_under_alien_status_rule:\n\
+      \  max(0, individual_financial_resources)\nelse: 0"
+inputs:
+- name: individual_is_member_of_household_otherwise_eligible_to_participate_under_this_section
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_resident_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_citizen_or_national_of_united_states
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_has_been_granted_status_of_cuban_and_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_refugee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_is_asylee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: state_applies_pro_rata_share_of_individual_income
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: pro_rata_share_of_individual_income
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD
+- name: individual_financial_resources
+  entity: Person
+  dtype: Money
+  period: Month
+  unit: USD


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/statute/7/2015/f`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `n/a`
Base commit: `adc9fbaa8a6e61244b8f00295c7cde3d58858adb`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/34162766530

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.