### PR TITLE
[experiment] Legacy local-path encode of 42 CFR 435.145 (HMAC v1, not for merge)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -36215,6 +36215,15 @@
         ]
       }
     ],
+    "us/regulation/42/435/145": [
+      {
+        "module": "us/regulations/42-cfr/435/145.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/42/435/150": [
       {
         "module": "us/regulations/42-cfr/435/150.yaml",

--- a/us/.axiom/encoding-manifests/regulations/42-cfr/435/145.json
+++ b/us/.axiom/encoding-manifests/regulations/42-cfr/435/145.json
@@ -1,0 +1,41 @@
+{
+  "applied_files": [
+    {
+      "path": "regulations/42-cfr/435/145.yaml",
+      "sha256": "5f26ce07056cabcfd90eef2fc9241a398761ffd05e2e35146499683dda585b5b"
+    },
+    {
+      "path": "regulations/42-cfr/435/145.test.yaml",
+      "sha256": "d89f96d03ce87483c222a74277429b4ad95f8f2915acd045516764dd117b42fa"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3869d66d009f52258be35901edbef370e65a399c",
+    "dirty_tracked": false,
+    "root": "/Users/ziminghua/vscode/TheAxiomFoundation/_mi_fip_toolchain/axiom-encode",
+    "version": "0.2.1200",
+    "version_commit": "3869d66d009f52258be35901edbef370e65a399c"
+  },
+  "axiom_encode_version": "0.2.1200",
+  "backend": "codex",
+  "citation": "us/regulation/42/435/145",
+  "context_manifest_file": "/private/tmp/claude-501/-Users-ziminghua-vscode-TheAxiomFoundation/79e634a5-08c6-422e-8cd9-efc997184f04/scratchpad/local-encode/out-1200-apply/_eval_workspaces/codex-gpt-5.5/us-regulation-42-435-145/workspace/context-manifest.json",
+  "context_manifest_sha256": "6740dddbf5e6b036e60180c11c1acd0f065bf0be71a7819e1a52b3fb58c4bbe5",
+  "generated_at": "2026-09-08T18:30:58.352707+00:00",
+  "generated_output_file": "/private/tmp/claude-501/-Users-ziminghua-vscode-TheAxiomFoundation/79e634a5-08c6-422e-8cd9-efc997184f04/scratchpad/local-encode/out-1200-apply/codex-gpt-5.5/regulations/42-cfr/435/145.yaml",
+  "generated_output_root": "/private/tmp/claude-501/-Users-ziminghua-vscode-TheAxiomFoundation/79e634a5-08c6-422e-8cd9-efc997184f04/scratchpad/local-encode/out-1200-apply",
+  "generated_output_sha256": "5f26ce07056cabcfd90eef2fc9241a398761ffd05e2e35146499683dda585b5b",
+  "generation_prompt_sha256": "d4889ba0bc555253a177a7689ebec343a23304c29843ab7f3b8b28ca5e1fa182",
+  "model": "gpt-5.5",
+  "run_id": "92a0b08b",
+  "runner": "codex-gpt-5.5",
+  "schema_version": "axiom-encode/applied-rulespec/v1",
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "key_id": "axiom-encode-apply-v1",
+    "value": "3f9f9dc5ae1ab1a10de81fc0f9297a4ffdf0252e2d63616b7e57d8dc05027f6c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/private/tmp/claude-501/-Users-ziminghua-vscode-TheAxiomFoundation/79e634a5-08c6-422e-8cd9-efc997184f04/scratchpad/local-encode/out-1200-apply/traces/codex-gpt-5.5/us-regulation-42-435-145.json",
+  "trace_sha256": "bfebff7a8e8e4b58cf3f9c1ee4754bf596a0c399a0e002cd0798041731da1cf7"
+}

--- a/us/regulations/42-cfr/435/145.test.yaml
+++ b/us/regulations/42-cfr/435/145.test.yaml
@@ -1,0 +1,30 @@
+- name: adoption_assistance_agreement_path_confers_medicaid_eligibility
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/145#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: true
+    ? us:regulations/42-cfr/435/145#input.foster_care_or_kinship_guardianship_assistance_maintenance_payments_being_made_by_state_or_tribe_under_title_iv_e
+    : false
+  output:
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_assistance_agreement_path_eligible: holds
+    us:regulations/42-cfr/435/145#title_iv_e_foster_care_or_kinship_guardianship_payment_path_eligible: not_holds
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_foster_care_or_kinship_guardianship_medicaid_eligible: holds
+- name: foster_care_or_kinship_guardianship_payment_path_confers_medicaid_eligibility
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/145#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+    ? us:regulations/42-cfr/435/145#input.foster_care_or_kinship_guardianship_assistance_maintenance_payments_being_made_by_state_or_tribe_under_title_iv_e
+    : true
+  output:
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_assistance_agreement_path_eligible: not_holds
+    us:regulations/42-cfr/435/145#title_iv_e_foster_care_or_kinship_guardianship_payment_path_eligible: holds
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_foster_care_or_kinship_guardianship_medicaid_eligible: holds
+- name: neither_title_iv_e_path_does_not_confer_medicaid_eligibility
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/145#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+    ? us:regulations/42-cfr/435/145#input.foster_care_or_kinship_guardianship_assistance_maintenance_payments_being_made_by_state_or_tribe_under_title_iv_e
+    : false
+  output:
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_assistance_agreement_path_eligible: not_holds
+    us:regulations/42-cfr/435/145#title_iv_e_foster_care_or_kinship_guardianship_payment_path_eligible: not_holds
+    us:regulations/42-cfr/435/145#title_iv_e_adoption_foster_care_or_kinship_guardianship_medicaid_eligible: not_holds

--- a/us/regulations/42-cfr/435/145.yaml
+++ b/us/regulations/42-cfr/435/145.yaml
@@ -1,0 +1,61 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/145
+  summary: The agency must provide Medicaid to individuals for whom an adoption assistance
+    agreement is in effect with a State or Tribe under title IV-E, or for whom foster
+    care or kinship guardianship assistance maintenance payments are being made by
+    a State or Tribe under title IV-E.
+rules:
+- name: title_iv_e_adoption_assistance_agreement_path_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145
+  versions:
+  - effective_from: '2014-01-01'
+    formula: adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e
+- name: title_iv_e_foster_care_or_kinship_guardianship_payment_path_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145
+  versions:
+  - effective_from: '2014-01-01'
+    formula: foster_care_or_kinship_guardianship_assistance_maintenance_payments_being_made_by_state_or_tribe_under_title_iv_e
+- name: title_iv_e_adoption_foster_care_or_kinship_guardianship_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/145
+  versions:
+  - effective_from: '2014-01-01'
+    formula: 'title_iv_e_adoption_assistance_agreement_path_eligible
+
+      or title_iv_e_foster_care_or_kinship_guardianship_payment_path_eligible'


### PR DESCRIPTION
## Purpose

Experiment, **not for merge**. This exercises the PR-side CI for the retired local encoding path so the encoding guide can document what actually happens. It will be closed once CI has reported.

## What was done

- `axiom-encode encode us/regulation/42/435/145 --backend codex --apply` with encoder **0.2.1200** (legacy) against worktrees at the legacy pins: rulespec-us `96d5e7c1`, axiom-corpus `60de5efa`, axiom-rules-engine `ffd82132`.
- Generation on the author's Codex CLI login (gpt-5.5). The first draft failed compile; the legacy encoder auto-repaired the source-relation delegations and applied.
- Manifest is `axiom-encode/applied-rulespec/v1`, HMAC-signed with the shared apply key.
- Module, test, and manifest copied byte-for-byte onto a branch from current main (`38d5c8c5`); manifest hashes verified; reverse index regenerated with `tests/generate_reverse_index.py`.

## Known limitations

- Under the current encoder's completeness gate this module fails: paragraph (a) "Basis" is neither encoded nor precisely deferred (verified by replaying `analyze_complete_source_unit` offline). The legacy encoder has no such gate.
- The signed v5 encoding of the same section is in progress via the protected workflow (axiom-encode run 34261357382, citation `us/regulation/42/435/145/b`).

Related: rulespec-us#1306 (Head Start) took this same path in August and was asked to be replaced by a v5 encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)