### PR TITLE
Add signed encoding manifest for us/regulation/42/435/145/b (artifact-only run, manual assembly)

### DIFF
--- a/.axiom/encoding-manifests/us/regulations/42-cfr/435/145/b.json
+++ b/.axiom/encoding-manifests/us/regulations/42-cfr/435/145/b.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/42-cfr/435/145/b.yaml",
+      "sha256": "620809250aadc714e26e6cb4a0596a3c1a4103c3fa7730c980d8b8843d1f1fbb"
+    },
+    {
+      "path": "us/regulations/42-cfr/435/145/b.test.yaml",
+      "sha256": "d2af17a5fd06110cd68aaa9e818171bf823222941b93affc37e42f558ef7dae6"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "3647566df745320b87fc24f1b18902bc63f2fae7",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1766",
+    "version_commit": "3647566df745320b87fc24f1b18902bc63f2fae7"
+  },
+  "axiom_encode_version": "0.2.1766",
+  "backend": "openai",
+  "citation": "us/regulation/42/435/145/b",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-regulation-42-435-145-b/workspace/context-manifest.json",
+  "context_manifest_sha256": "54acd3ad5bc9b2bda1f52c01086833983813768fc282d6bcb06a74deed274d96",
+  "generated_at": "2026-09-08T19:49:07.636611+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/regulations/42-cfr/435/145/b.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "620809250aadc714e26e6cb4a0596a3c1a4103c3fa7730c980d8b8843d1f1fbb",
+  "generation_prompt_sha256": "aa3766638f440d483b9743d234fdf8553b5206684daf718d4988dab1ae1351cf",
+  "model": "gpt-5.6-terra",
+  "run_id": "4a9ba015",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "9FvrHKl8//Y5uynBGP2uoiLtoIK91VTjp8YaAxu6i/zMU4Wx0eOrGMfymB2n5dUDdOaCl4qv2pzGU7Honm3PCw=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-25",
+    "generation_input_sha256": "e4fe0a24e05a8cdc589c65ed19e200d778d062f056b045acc5cc8244e611a37b",
+    "provision_file": "data/corpus/provisions/us/regulation/2026-06-25-title-42-part-435.jsonl",
+    "provision_file_sha256": "fd5fcd9d8e6b1daa6ed40ad6f5ae1f3ee3af5f20aa91cf50f38455ab8cd6dd18",
+    "requested_corpus_citation_path": "us/regulation/42/435/145/b",
+    "resolved_corpus_citation_path": "us/regulation/42/435/145",
+    "resolved_text_sha256": "e4fe0a24e05a8cdc589c65ed19e200d778d062f056b045acc5cc8244e611a37b",
+    "row": {
+      "body_sha256": "d7ee1a4b6f9111196b11abd1a3724be1e05de1ae50fd1129c1b3e77c8061aaf9",
+      "citation_path": "us/regulation/42/435/145",
+      "document_class": "regulation",
+      "expression_date": "2026-06-25",
+      "jurisdiction": "us",
+      "line_number": 33,
+      "provision_file": "data/corpus/provisions/us/regulation/2026-06-25-title-42-part-435.jsonl",
+      "provision_file_sha256": "fd5fcd9d8e6b1daa6ed40ad6f5ae1f3ee3af5f20aa91cf50f38455ab8cd6dd18",
+      "record_id": "084dee28-f9ac-5d6d-bfb4-0ad062464d66",
+      "source_as_of": "2026-06-25",
+      "source_path": "sources/us/regulation/2026-06-25-title-42-part-435/ecfr/title-42-part-435.xml",
+      "version": "2026-06-25-title-42-part-435"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-25",
+    "source_sha256": "d7ee1a4b6f9111196b11abd1a3724be1e05de1ae50fd1129c1b3e77c8061aaf9"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-regulation-42-435-145-b.json",
+  "trace_sha256": "f937d6b4056dede9e0657b049d8ca927149523a2cefd49a5c16df682aa7c8fe9",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "3647566df745320b87fc24f1b18902bc63f2fae7",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1766"
+    },
+    "axiom_rules_engine": {
+      "commit": "d142c645917817cf590e036fb99f99b2d4780e1a",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "4a431acb19c10a5fe224b641e532efc9956ac12c01c938f67190a71069f08a96",
+      "pre_apply_file_count": 2711,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -36215,6 +36215,15 @@
         ]
       }
     ],
+    "us/regulation/42/435/145/b": [
+      {
+        "module": "us/regulations/42-cfr/435/145/b.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/42/435/150": [
       {
         "module": "us/regulations/42-cfr/435/150.yaml",

--- a/us/regulations/42-cfr/435/145/b.test.yaml
+++ b/us/regulations/42-cfr/435/145/b.test.yaml
@@ -1,0 +1,47 @@
+- name: adoption_assistance_agreement_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: true
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e: false
+    ? us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+    : false
+  output:
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility: holds
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_adoption_assistance: holds
+- name: foster_care_maintenance_payment_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e: true
+    ? us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+    : false
+  output:
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility: holds
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_maintenance_payments: holds
+- name: kinship_guardianship_maintenance_payment_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e: false
+    ? us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+    : true
+  output:
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility: holds
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_maintenance_payments: holds
+- name: no_title_iv_e_eligibility_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e: false
+    ? us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+    : false
+  output:
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility: not_holds
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_adoption_assistance: not_holds
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_maintenance_payments: not_holds
+- name: adoption_assistance_agreement_not_in_effect
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e: false
+  output:
+    us:regulations/42-cfr/435/145/b#medicaid_eligibility_under_adoption_assistance: not_holds

--- a/us/regulations/42-cfr/435/145/b.yaml
+++ b/us/regulations/42-cfr/435/145/b.yaml
@@ -1,0 +1,84 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/145/b
+    source_sha256: d7ee1a4b6f9111196b11abd1a3724be1e05de1ae50fd1129c1b3e77c8061aaf9
+  summary: (b) Eligibility. The agency must provide Medicaid to individuals for whom
+    an adoption assistance agreement is in effect with a State or Tribe under title
+    IV-E of the Act, or foster care or kinship guardianship assistance maintenance
+    payments are being made by a State or Tribe under title IV-E of the Act.
+inputs:
+- name: adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+rules:
+- name: medicaid_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: The agency must provide Medicaid to individuals for whom—
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e
+
+      or foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+
+      or kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e'
+- name: medicaid_eligibility_under_adoption_assistance
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: An adoption assistance agreement is in effect with a State or Tribe
+            under title IV-E of the Act
+  versions:
+  - effective_from: '0001-01-01'
+    formula: adoption_assistance_agreement_in_effect_with_state_or_tribe_under_title_iv_e
+- name: medicaid_eligibility_under_maintenance_payments
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: Foster care or kinship guardianship assistance maintenance payments
+            are being made by a State or Tribe under title IV-E of the Act.
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'foster_care_maintenance_payments_made_by_state_or_tribe_under_title_iv_e
+
+      or kinship_guardianship_assistance_maintenance_payments_made_by_state_or_tribe_under_title_iv_e'


### PR DESCRIPTION
## Signed apply manifest (manually assembled)

Citation: `us/regulation/42/435/145/b`
Base commit: `38d5c8c516f9243cedf8e07a22f96dde9ac66fe3`
Base branch: `main`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/34261357382 (dispatched with `open_pr=false`)
Manifest: `axiom-encode/applied-rulespec/v5`, encoder 0.2.1766, `ed25519-domain-v1`, guard-generated passed in the run.

## Why this PR was opened by hand

Experiment for the encoding guide: an artifact-only protected run followed by manual PR assembly. Steps: download `targeted-reencode-34261357382-1`, extract `untracked.tar.gz` onto a branch from the run's `rulespec_ref`, verify the manifest's `applied_files` SHA-256s against the extracted files (both match), regenerate `.axiom/index/provisions_to_rules.json` with `tests/generate_reverse_index.py`, commit, push. No RuleSpec, test, or manifest bytes were edited.

## Encoding notes

- The section-level citation `us/regulation/42/435/145` failed the completeness gate twice on the basis paragraph (a) (runs 34088902535, 34232291106). Citing paragraph (b) makes it the source unit; the manifest records `requested_corpus_citation_path` `.../145/b` and `resolved_corpus_citation_path` `.../145`.
- Two drafts on gpt-5.6-terra: the first was rejected for not covering the (b) chapeau; the second added the chapeau excerpt as a proof atom and passed compile, CI gates, and reviewers.
- Review point: every version uses `effective_from: '0001-01-01'`.

Related: #1348 (legacy local-path experiment on the same section, not for merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)