### PR TITLE
Experiment 10g: unsigned contributor draft of 42 CFR 435.145(b) (expected to fail the manifest guard)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -36215,6 +36215,15 @@
         ]
       }
     ],
+    "us/regulation/42/435/145/b": [
+      {
+        "module": "us/regulations/42-cfr/435/145/b.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us/regulation/42/435/150": [
       {
         "module": "us/regulations/42-cfr/435/150.yaml",

--- a/us/regulations/42-cfr/435/145/b.test.yaml
+++ b/us/regulations/42-cfr/435/145/b.test.yaml
@@ -1,0 +1,40 @@
+- name: adoption_assistance_agreement_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_under_title_iv_e: true
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e: false
+  output:
+    us:regulations/42-cfr/435/145/b#adoption_assistance_eligibility_path: holds
+    us:regulations/42-cfr/435/145/b#title_iv_e_maintenance_payment_eligibility_path: not_holds
+    us:regulations/42-cfr/435/145/b#eligible_for_medicaid: holds
+- name: foster_care_maintenance_payment_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_under_title_iv_e: true
+    us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e: false
+  output:
+    us:regulations/42-cfr/435/145/b#adoption_assistance_eligibility_path: not_holds
+    us:regulations/42-cfr/435/145/b#title_iv_e_maintenance_payment_eligibility_path: holds
+    us:regulations/42-cfr/435/145/b#eligible_for_medicaid: holds
+- name: kinship_guardianship_maintenance_payment_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e: true
+  output:
+    us:regulations/42-cfr/435/145/b#adoption_assistance_eligibility_path: not_holds
+    us:regulations/42-cfr/435/145/b#title_iv_e_maintenance_payment_eligibility_path: holds
+    us:regulations/42-cfr/435/145/b#eligible_for_medicaid: holds
+- name: no_title_iv_e_eligibility_path
+  period: 2026-06
+  input:
+    us:regulations/42-cfr/435/145/b#input.adoption_assistance_agreement_in_effect_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.foster_care_maintenance_payments_made_under_title_iv_e: false
+    us:regulations/42-cfr/435/145/b#input.kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e: false
+  output:
+    us:regulations/42-cfr/435/145/b#adoption_assistance_eligibility_path: not_holds
+    us:regulations/42-cfr/435/145/b#title_iv_e_maintenance_payment_eligibility_path: not_holds
+    us:regulations/42-cfr/435/145/b#eligible_for_medicaid: not_holds

--- a/us/regulations/42-cfr/435/145/b.yaml
+++ b/us/regulations/42-cfr/435/145/b.yaml
@@ -1,0 +1,80 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/145/b
+  summary: Eligibility. The agency must provide Medicaid to individuals for whom an
+    adoption assistance agreement is in effect under title IV-E, or foster care or
+    kinship guardianship assistance maintenance payments are being made under title
+    IV-E.
+inputs:
+- name: adoption_assistance_agreement_in_effect_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: foster_care_maintenance_payments_made_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e
+  entity: Person
+  dtype: Boolean
+  period: Month
+rules:
+- name: adoption_assistance_eligibility_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: An adoption assistance agreement is in effect
+  versions:
+  - effective_from: '0001-01-01'
+    formula: adoption_assistance_agreement_in_effect_under_title_iv_e
+- name: title_iv_e_maintenance_payment_eligibility_path
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: Foster care or kinship guardianship assistance maintenance payments
+            are being made
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'foster_care_maintenance_payments_made_under_title_iv_e
+
+      or kinship_guardianship_assistance_maintenance_payments_made_under_title_iv_e'
+- name: eligible_for_medicaid
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.145(b)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/regulation/42/435/145/b
+          excerpt: The agency must provide Medicaid to individuals for whom—
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'adoption_assistance_eligibility_path
+
+      or title_iv_e_maintenance_payment_eligibility_path'


### PR DESCRIPTION
## What this is

An experiment, not a merge candidate. It tests what CI says to a RuleSpec draft that a contributor generated locally with the **current encoder (0.2.1764, the version this repo pins)** on a **personal Codex subscription**, using the verification-only supervisor documented in `axiom-encode/docs/trusted-signing-supervisor.md` ("ChatGPT subscription generation").

- Citation: `us/regulation/42/435/145/b`
- Generated 2026-09-10 in 71 s, two attempts; the second passed compile, CI and the complete-source-unit gate (`status=standalone_validated`).
- Committed **without** an apply manifest, because signing is impossible outside the org's runtime: a `--allow-local-dev` signer is refused by the supervisor ("external apply signer challenge response is invalid").
- Includes a regenerated `.axiom/index/provisions_to_rules.json` so the reverse-index check is not the reason for failure.

## Expected result

`Reject manual RuleSpec changes` fails with "changed without a matching .axiom/encoding-manifests manifest". Running that exact step locally under the provisioned runtime already produced that message; this PR checks the real CI verdict and records it.

## Why it matters

The stated contributor policy is to encode on a personal key, with the org-key `targeted-signed-reencode` workflow as a backup. Today a personal-key draft can be generated and gate-passed locally but cannot be signed or landed; the workflow has no intake for an outside draft. This PR is the evidence for that gap. Will be closed after CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)