### PR TITLE
Add signed encoding manifest for us/guidance/usda/fns/snap-fy2026-cola/page-1

### DIFF
--- a/.axiom/encoding-manifests/us/policies/usda/snap/fy-2026-cola/maximum-allotments.json
+++ b/.axiom/encoding-manifests/us/policies/usda/snap/fy-2026-cola/maximum-allotments.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml",
+      "sha256": "b19511f4898d688d2286b91f9b9504e18f2faceb99127ebb90d0df6f09cda386"
+    },
+    {
+      "path": "us/policies/usda/snap/fy-2026-cola/maximum-allotments.test.yaml",
+      "sha256": "037cb74a3d8a72a7197acdbccf94c4c147fb23f8ed836163e09fa914f3f1234e"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1971",
+    "version_commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5"
+  },
+  "axiom_encode_version": "0.2.1971",
+  "backend": "openai",
+  "citation": "us/guidance/usda/fns/snap-fy2026-cola/page-1",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-fy2026-cola-page-1/workspace/context-manifest.json",
+  "context_manifest_sha256": "1935151c3a7029f57bf592d17b224a146018cc2ec23d5ab94183f18da7dd0173",
+  "generated_at": "2026-09-10T20:02:34.392111+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "b19511f4898d688d2286b91f9b9504e18f2faceb99127ebb90d0df6f09cda386",
+  "generation_prompt_sha256": "f97831bf6e7d5e6059ed601dd539c8ec3bad5445bfc858de570fcbbd6731127b",
+  "model": "gpt-5.6-terra",
+  "run_id": "96c841d1",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "KfTscmxhmRkapXCDSCC9kgvY8ZertaoM2iMOMRPypVemoOjBOMiOyqzfudenqhT0iVjFaO7IDuSHDKE+B5kxDQ=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2025-10-01",
+    "generation_input_sha256": "806907224a37eecb7fb5fa3f8279fcd7bd29de7bd3fc9c3111953d2cb6701566",
+    "provision_file": "data/corpus/provisions/us/guidance/2026-05-01-snap-fy2026-cola-r2026-07-15-self-contained.jsonl",
+    "provision_file_sha256": "83eb59832a53d979e0927327f49f99ccd95551335818af505077047033e1ebf3",
+    "requested_corpus_citation_path": "us/guidance/usda/fns/snap-fy2026-cola/page-1",
+    "resolved_corpus_citation_path": "us/guidance/usda/fns/snap-fy2026-cola/page-1",
+    "resolved_text_sha256": "806907224a37eecb7fb5fa3f8279fcd7bd29de7bd3fc9c3111953d2cb6701566",
+    "row": {
+      "body_sha256": "806907224a37eecb7fb5fa3f8279fcd7bd29de7bd3fc9c3111953d2cb6701566",
+      "citation_path": "us/guidance/usda/fns/snap-fy2026-cola/page-1",
+      "document_class": "guidance",
+      "expression_date": "2025-10-01",
+      "jurisdiction": "us",
+      "line_number": 2,
+      "provision_file": "data/corpus/provisions/us/guidance/2026-05-01-snap-fy2026-cola-r2026-07-15-self-contained.jsonl",
+      "provision_file_sha256": "83eb59832a53d979e0927327f49f99ccd95551335818af505077047033e1ebf3",
+      "record_id": "2416046b-5e45-5c74-9d7f-f3084034ed5f",
+      "source_as_of": "2025-08-14",
+      "source_path": "sources/us/guidance/2026-05-01-snap-fy2026-cola-r2026-07-15-self-contained/official-documents/release-scope-us-guidance-2026-05-01-snap-fy2026-cola-r2026-07-15-self-contained",
+      "version": "2026-05-01-snap-fy2026-cola-r2026-07-15-self-contained"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2025-08-14",
+    "source_sha256": "806907224a37eecb7fb5fa3f8279fcd7bd29de7bd3fc9c3111953d2cb6701566"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-fy2026-cola-page-1.json",
+  "trace_sha256": "a6db0d30d2a744f9d3e25d8f19e6a27ef571be489c29645091e8d55c960eefd7",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1971"
+    },
+    "axiom_rules_engine": {
+      "commit": "f6b0d15246a7db1403836628576f11e0d334348c",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "4a431acb19c10a5fe224b641e532efc9956ac12c01c938f67190a71069f08a96",
+      "pre_apply_file_count": 2711,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/.axiom/encoding-manifests/us/statutes/7/2017/a.json
+++ b/.axiom/encoding-manifests/us/statutes/7/2017/a.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/statutes/7/2017/a.yaml",
+      "sha256": "9f63d4e7340f0327d58b3d8f24f695c4385e5e00ff105b40f5cfb84d72f0b9c1"
+    },
+    {
+      "path": "us/statutes/7/2017/a.test.yaml",
+      "sha256": "9a1d992dfe556eb48aaeae72a15e00e6378c438a19198ec0fb737d3fc37dacae"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1971",
+    "version_commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5"
+  },
+  "axiom_encode_version": "0.2.1971",
+  "backend": "openai",
+  "citation": "us/statute/7/2017/a",
+  "context_manifest_file": "/home/runner/work/_temp/generated/dependent/_eval_workspaces/openai-gpt-5.6-terra/us-statute-7-2017-a/workspace/context-manifest.json",
+  "context_manifest_sha256": "30beb730106f6d0d1ee296ce47e4e50eebb9c2c52983d4a3b8845cb64e61e21c",
+  "generated_at": "2026-09-10T20:06:38.135376+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/dependent/openai-gpt-5.6-terra/statutes/7/2017/a.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/dependent",
+  "generated_output_sha256": "9f63d4e7340f0327d58b3d8f24f695c4385e5e00ff105b40f5cfb84d72f0b9c1",
+  "generation_prompt_sha256": "b87e2171cd72791e25972b35b532575a9a46aaf9cd95b4327e63607e44685c4d",
+  "model": "gpt-5.6-terra",
+  "run_id": "3136a9ca",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "Q2KyqQvrA2TEhCrBeNJFtrOgcGqk/bEX4J3SEhkVAtYMsYxyWxtD78pAAOaGkDBP6UNklx4nDAnpgkK2pUHVDA=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-06-26",
+    "generation_input_sha256": "ed24d68ecd7c238100ca0e268bf0a38ee9da84da17394c0b9b7673ccfe3da036",
+    "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+    "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+    "requested_corpus_citation_path": "us/statute/7/2017/a",
+    "resolved_corpus_citation_path": "us/statute/7/2017/a",
+    "resolved_text_sha256": "ed24d68ecd7c238100ca0e268bf0a38ee9da84da17394c0b9b7673ccfe3da036",
+    "row": {
+      "body_sha256": "ed24d68ecd7c238100ca0e268bf0a38ee9da84da17394c0b9b7673ccfe3da036",
+      "citation_path": "us/statute/7/2017/a",
+      "document_class": "statute",
+      "expression_date": "2026-06-26",
+      "jurisdiction": "us",
+      "line_number": 311,
+      "provision_file": "data/corpus/provisions/us/statute/2026-07-22-rulespec-title-7-consolidated.jsonl",
+      "provision_file_sha256": "88a56c9032cca614208f3d1f324b15417e3bbee3c26ff3ff3c1ad67d64b38213",
+      "record_id": "42be9eb3-2fa1-5d01-a78d-947f61115ec2",
+      "source_as_of": "2026-06-26",
+      "source_path": "sources/us/statute/2026-07-22-rulespec-title-7-consolidated/2026-07-21-snap-chapter-51-title-7-title-7/uslm/usc7.xml",
+      "version": "2026-07-22-rulespec-title-7-consolidated"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-06-26",
+    "source_sha256": "ed24d68ecd7c238100ca0e268bf0a38ee9da84da17394c0b9b7673ccfe3da036"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/dependent/traces/openai-gpt-5.6-terra/us-statute-7-2017-a.json",
+  "trace_sha256": "29036327f6a71b012cedbaab42e97c8c3334749b3fc6823666034323482ffd33",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "983fb39bad007ffbe77ba1dd4ec8683790f55cf5",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1971"
+    },
+    "axiom_rules_engine": {
+      "commit": "f6b0d15246a7db1403836628576f11e0d334348c",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "240c7f38a9164c0acd4deaaeb285072b3ae3f13353d37d007fce96aa01076418",
+      "pre_apply_file_count": 2711,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/us/policies/usda/snap/fy-2026-cola/maximum-allotments.test.yaml
+++ b/us/policies/usda/snap/fy-2026-cola/maximum-allotments.test.yaml
@@ -1,34 +1,21 @@
-- name: snap_maximum_allotment_for_one_person_household
+- name: one_person_household_maximum_allotment
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
   output:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table: 298
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost: 298
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 298
-- name: snap_maximum_allotment_for_eight_person_household
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost: 298
+- name: eight_person_household_maximum_allotment
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 8
   output:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table: 1789
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_urban_table: 2314
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_rural_1_table: 2950
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_rural_2_table: 3591
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_guam_table: 2637
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_hawaii_table: 3040
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_virgin_islands_table: 2300
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 1789
-- name: snap_maximum_allotment_adds_each_additional_person
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost: 298
+- name: additional_household_member_maximum_allotment
   period: 2026-01
   input:
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 9
   output:
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_additional_member: 218
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_urban_additional_member: 282
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_rural_1_additional_member: 360
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_alaska_rural_2_additional_member: 438
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_guam_additional_member: 322
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_hawaii_additional_member: 371
-    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_virgin_islands_additional_member: 281
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 2007
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost: 298

--- a/us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml
+++ b/us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml
@@ -2,477 +2,387 @@ format: rulespec/v1
 module:
   proof_validation:
     required: true
-  summary: |-
-    USDA SNAP FY 2026 cost-of-living adjustments set maximum monthly
-    allotments for the 48 states and the District of Columbia effective
-    October 1, 2025 through September 30, 2026. The maximum allotments are
-    298, 546, 785, 994, 1183, 1421, 1571, and 1789 for household sizes 1
-    through 8, plus 218 for each additional person. The same table sets
-    Alaska Urban amounts of 385, 707, 1015, 1285, 1529, 1838, 2031, and
-    2314, plus 282; Alaska Rural 1 amounts of 491, 901, 1295, 1639, 1950,
-    2344, 2590, and 2950, plus 360; Alaska Rural 2 amounts of 598, 1097,
-    1576, 1995, 2374, 2853, 3152, and 3591, plus 438; Guam amounts of
-    439, 806, 1157, 1465, 1743, 2095, 2315, and 2637, plus 322; Hawaii
-    amounts of 506, 929, 1334, 1689, 2010, 2415, 2668, and 3040, plus
-    371; and Virgin Islands amounts of 383, 703, 1009, 1278, 1521, 1827,
-    2019, and 2300, plus 281.
   source_verification:
     corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-    values:
-      snap_maximum_allotment_table:
-        1: 298
-        2: 546
-        3: 785
-        4: 994
-        5: 1183
-        6: 1421
-        7: 1571
-        8: 1789
-      snap_maximum_allotment_additional_member: 218
-      snap_maximum_allotment_alaska_urban_table:
-        1: 385
-        2: 707
-        3: 1015
-        4: 1285
-        5: 1529
-        6: 1838
-        7: 2031
-        8: 2314
-      snap_maximum_allotment_alaska_urban_additional_member: 282
-      snap_maximum_allotment_alaska_rural_1_table:
-        1: 491
-        2: 901
-        3: 1295
-        4: 1639
-        5: 1950
-        6: 2344
-        7: 2590
-        8: 2950
-      snap_maximum_allotment_alaska_rural_1_additional_member: 360
-      snap_maximum_allotment_alaska_rural_2_table:
-        1: 598
-        2: 1097
-        3: 1576
-        4: 1995
-        5: 2374
-        6: 2853
-        7: 3152
-        8: 3591
-      snap_maximum_allotment_alaska_rural_2_additional_member: 438
-      snap_maximum_allotment_guam_table:
-        1: 439
-        2: 806
-        3: 1157
-        4: 1465
-        5: 1743
-        6: 2095
-        7: 2315
-        8: 2637
-      snap_maximum_allotment_guam_additional_member: 322
-      snap_maximum_allotment_hawaii_table:
-        1: 506
-        2: 929
-        3: 1334
-        4: 1689
-        5: 2010
-        6: 2415
-        7: 2668
-        8: 3040
-      snap_maximum_allotment_hawaii_additional_member: 371
-      snap_maximum_allotment_virgin_islands_table:
-        1: 383
-        2: 703
-        3: 1009
-        4: 1278
-        5: 1521
-        6: 1827
-        7: 2019
-        8: 2300
-      snap_maximum_allotment_virgin_islands_additional_member: 281
-  source_claims:
-    - claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
+    source_sha256: 806907224a37eecb7fb5fa3f8279fcd7bd29de7bd3fc9c3111953d2cb6701566
+  summary: '“Maximum Monthly Allotment” table for FY 2026, effective October 1,
+
+    2025, through September 30, 2026, supplies monthly amounts for household
+
+    sizes 1 through 8 and “Each Additional Member.”'
+inputs:
+- name: household_size
+  entity: Household
+  dtype: Integer
+  period: Month
 rules:
-  - name: snap_maximum_allotment_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: 48_states_dc
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 298
-          2: 546
-          3: 785
-          4: 994
-          5: 1183
-          6: 1421
-          7: 1571
-          8: 1789
-  - name: snap_maximum_allotment_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '218'
-  - name: snap_maximum_allotment
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          snap_maximum_allotment_table[max(min(household_size, 8), 1)]
-          + (max(household_size - 8, 0) * snap_maximum_allotment_additional_member)
-  - name: snap_one_person_thrifty_food_plan_cost
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_table
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: snap_maximum_allotment_table[1]
-  - name: snap_maximum_allotment_alaska_urban_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_urban_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: alaska_urban
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 385
-          2: 707
-          3: 1015
-          4: 1285
-          5: 1529
-          6: 1838
-          7: 2031
-          8: 2314
-  - name: snap_maximum_allotment_alaska_urban_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_urban_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '282'
-  - name: snap_maximum_allotment_alaska_rural_1_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_rural_1_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: alaska_rural_1
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 491
-          2: 901
-          3: 1295
-          4: 1639
-          5: 1950
-          6: 2344
-          7: 2590
-          8: 2950
-  - name: snap_maximum_allotment_alaska_rural_1_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_rural_1_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '360'
-  - name: snap_maximum_allotment_alaska_rural_2_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_rural_2_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: alaska_rural_2
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 598
-          2: 1097
-          3: 1576
-          4: 1995
-          5: 2374
-          6: 2853
-          7: 3152
-          8: 3591
-  - name: snap_maximum_allotment_alaska_rural_2_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_alaska_rural_2_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '438'
-  - name: snap_maximum_allotment_guam_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_guam_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: guam
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 439
-          2: 806
-          3: 1157
-          4: 1465
-          5: 1743
-          6: 2095
-          7: 2315
-          8: 2637
-  - name: snap_maximum_allotment_guam_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_guam_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '322'
-  - name: snap_maximum_allotment_hawaii_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_hawaii_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: hawaii
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 506
-          2: 929
-          3: 1334
-          4: 1689
-          5: 2010
-          6: 2415
-          7: 2668
-          8: 3040
-  - name: snap_maximum_allotment_hawaii_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_hawaii_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '371'
-  - name: snap_maximum_allotment_virgin_islands_table
-    kind: parameter
-    dtype: Money
-    unit: USD
-    indexed_by: household_size
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].values
-            kind: parameter_table
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_virgin_islands_table
-              table:
-                header: Maximum Monthly Allotment
-                row_key: household_size
-                column_key: virgin_islands
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        values:
-          1: 383
-          2: 703
-          3: 1009
-          4: 1278
-          5: 1521
-          6: 1827
-          7: 2019
-          8: 2300
-  - name: snap_maximum_allotment_virgin_islands_additional_member
-    kind: parameter
-    dtype: Money
-    unit: USD
-    source: USDA SNAP FY 2026 maximum allotments and deductions
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: amount
-            source:
-              corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
-              value_key: snap_maximum_allotment_virgin_islands_additional_member
-            claim:
-              id: claims:us/guidance/usda/fns/snap-fy2026-cola/page-1#sets-maximum-allotments
-    versions:
-      - effective_from: '2025-10-01'
-        formula: '281'
+- name: snap_fiscal_year
+  kind: parameter
+  dtype: Integer
+  source: SNAP Fiscal Year 2026 Maximum Allotments and Deductions
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          excerpt: Supplemental Nutrition Assistance Program (SNAP) Fiscal Year (FY)
+            2026 Maximum Allotments and Deductions The following tables provide the
+            monthly maximum allotment and allowable deductions for FY 2026 (effective
+            October 1, 2025, through September 30, 2026).
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '2026'
+- name: states_and_district_of_columbia_count
+  kind: parameter
+  dtype: Integer
+  source: SNAP FY 2026 Maximum Allotments Table 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          excerpt: 48 States & District of Columbia
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '48'
+- name: snap_maximum_allotment_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, 48 States & District of Columbia
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: 48 States & District of Columbia
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 298
+      2: 546
+      3: 785
+      4: 994
+      5: 1183
+      6: 1421
+      7: 1571
+      8: 1789
+- name: snap_maximum_allotment_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, 48 States & District of Columbia
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '218'
+- name: snap_maximum_allotment
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'snap_maximum_allotment_table[max(min(household_size, 8), 1)]
+
+      + (max(household_size - 8, 0) * snap_maximum_allotment_additional_member)'
+- name: snap_one_person_thrifty_food_plan_cost
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: snap_maximum_allotment_table[1]
+- name: snap_maximum_allotment_alaska_urban_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Urban)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Alaska (Urban)
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 385
+      2: 707
+      3: 1015
+      4: 1285
+      5: 1529
+      6: 1838
+      7: 2031
+      8: 2314
+- name: snap_maximum_allotment_alaska_urban_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Urban)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '282'
+- name: snap_maximum_allotment_alaska_rural_1_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Rural 1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Alaska (Rural 1)
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 491
+      2: 901
+      3: 1295
+      4: 1639
+      5: 1950
+      6: 2344
+      7: 2590
+      8: 2950
+- name: snap_maximum_allotment_alaska_rural_1_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Rural 1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '360'
+- name: snap_maximum_allotment_alaska_rural_2_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Rural 2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Alaska (Rural 2)
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 598
+      2: 1097
+      3: 1576
+      4: 1995
+      5: 2374
+      6: 2853
+      7: 3152
+      8: 3591
+- name: snap_maximum_allotment_alaska_rural_2_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Alaska (Rural 2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '438'
+- name: snap_maximum_allotment_guam_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Guam
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Guam
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 439
+      2: 806
+      3: 1157
+      4: 1465
+      5: 1743
+      6: 2095
+      7: 2315
+      8: 2637
+- name: snap_maximum_allotment_guam_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Guam
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '322'
+- name: snap_maximum_allotment_hawaii_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Hawaii
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Hawaii
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 506
+      2: 929
+      3: 1334
+      4: 1689
+      5: 2010
+      6: 2415
+      7: 2668
+      8: 3040
+- name: snap_maximum_allotment_hawaii_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Hawaii
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '371'
+- name: snap_maximum_allotment_virgin_islands_table
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: SNAP FY 2026 Maximum Allotments Table 1, Virgin Islands
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].values
+        kind: parameter_table
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+          table:
+            header: Maximum Monthly Allotment
+            row_key: Household Size
+            column_key: Virgin Islands
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 383
+      2: 703
+      3: 1009
+      4: 1278
+      5: 1521
+      6: 1827
+      7: 2019
+      8: 2300
+- name: snap_maximum_allotment_virgin_islands_additional_member
+  kind: parameter
+  dtype: Money
+  unit: USD
+  source: SNAP FY 2026 Maximum Allotments Table 1, Virgin Islands
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: amount
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '281'

--- a/us/statutes/7/2017/a.test.yaml
+++ b/us/statutes/7/2017/a.test.yaml
@@ -1,27 +1,48 @@
-- name: one_person_eligible_household_receives_thrifty_food_plan_less_thirty_percent_income
+- name: one_person_household_rounds_unrounded_allotment_down_at_one_hundred_point_four_nine
   period: 2026-01
   input:
     us:statutes/7/2017/a#input.household_size: 1
     us:statutes/7/2017/a#input.snap_eligible: true
     us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
-    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 1000
-    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 209
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 658.3666666666667
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
     us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
     us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
     us:statutes/7/2014/e/6/A#input.medical_deduction: 0
-    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 204.5
-    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
   output:
-    us:statutes/7/2017/a#snap_household_food_contribution_rate: 0.3
-    us:statutes/7/2017/a#snap_minimum_allotment_rate: 0.08
-    us:statutes/7/2017/a#snap_minimum_allotment_household_size_limit: 2
-    us:statutes/7/2017/a#snap_net_income_for_allotment: 386.5
-    us:statutes/7/2017/a#snap_household_food_contribution: 115.95
-    us:statutes/7/2017/a#snap_allotment_before_minimum: 182
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 658.3666666666667
+    us:statutes/7/2017/a#snap_household_food_contribution: 197.51
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 100.49
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 100
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment_unrounded: 23.84
     us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
-    us:statutes/7/2017/a#snap_regular_month_allotment: 182
-- name: two_person_eligible_household_receives_minimum_allotment_when_income_reduction_exceeds_plan_cost
+    us:statutes/7/2017/a#snap_regular_month_allotment: 100
+- name: one_person_household_rounds_unrounded_allotment_down_at_one_hundred_point_fifty
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 1
+    us:statutes/7/2017/a#input.snap_eligible: true
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 658.3333333333334
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 658.3333333333334
+    us:statutes/7/2017/a#snap_household_food_contribution: 197.5
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 100.5
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 100
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment_unrounded: 23.84
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
+    us:statutes/7/2017/a#snap_regular_month_allotment: 100
+- name: two_person_household_receives_rounded_minimum_at_twenty_three_point_eighty_four
   period: 2026-01
   input:
     us:statutes/7/2017/a#input.household_size: 2
@@ -38,10 +59,34 @@
   output:
     us:statutes/7/2017/a#snap_net_income_for_allotment: 3000
     us:statutes/7/2017/a#snap_household_food_contribution: 900
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 0
     us:statutes/7/2017/a#snap_allotment_before_minimum: 0
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment_unrounded: 23.84
     us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
     us:statutes/7/2017/a#snap_regular_month_allotment: 24
-- name: three_person_household_has_no_minimum_allotment_under_proviso
+- name: uncertified_three_person_household_has_no_minimum_or_issued_allotment
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 3
+    us:statutes/7/2017/a#input.snap_eligible: false
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 3
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 3000
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 3000
+    us:statutes/7/2017/a#snap_household_food_contribution: 900
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 0
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 0
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment_unrounded: 0
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 0
+    us:statutes/7/2017/a#snap_regular_month_allotment: 0
+- name: three_person_household_has_no_minimum_allotment
   period: 2026-01
   input:
     us:statutes/7/2017/a#input.household_size: 3
@@ -56,7 +101,11 @@
     us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
   output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 3000
+    us:statutes/7/2017/a#snap_household_food_contribution: 900
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 0
     us:statutes/7/2017/a#snap_allotment_before_minimum: 0
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment_unrounded: 0
     us:statutes/7/2017/a#snap_minimum_monthly_allotment: 0
     us:statutes/7/2017/a#snap_regular_month_allotment: 0
 - name: household_not_certified_eligible_receives_no_regular_month_allotment
@@ -75,3 +124,85 @@
     us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
   output:
     us:statutes/7/2017/a#snap_regular_month_allotment: 0
+- name: one_person_household_rounds_unrounded_allotment_up_at_one_hundred_point_fifty
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 1
+    us:statutes/7/2017/a#input.snap_eligible: true
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 658.3333333333334
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 658.3333333333334
+    us:statutes/7/2017/a#snap_household_food_contribution: 197.5
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 100.5
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 100
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
+    us:statutes/7/2017/a#snap_regular_month_allotment: 100
+- name: two_person_eligible_household_receives_rounded_minimum_allotment
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 2
+    us:statutes/7/2017/a#input.snap_eligible: true
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 2
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 3000
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 3000
+    us:statutes/7/2017/a#snap_household_food_contribution: 900
+    us:statutes/7/2017/a#snap_allotment_before_minimum_unrounded: 0
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 0
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
+    us:statutes/7/2017/a#snap_regular_month_allotment: 24
+- name: one_person_eligible_household_receives_thrifty_food_plan_less_thirty_percent_income
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 1
+    us:statutes/7/2017/a#input.snap_eligible: true
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 1000
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 209
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 204.5
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 386.5
+    us:statutes/7/2017/a#snap_household_food_contribution: 115.95
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 182
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 24
+    us:statutes/7/2017/a#snap_regular_month_allotment: 182
+- name: three_person_household_rounds_allotment_down_from_seven_hundred_eighty_three_point_five
+  period: 2026-01
+  input:
+    us:statutes/7/2017/a#input.household_size: 3
+    us:statutes/7/2017/a#input.snap_eligible: true
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 3
+    us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 5
+    us:statutes/7/2014/e/6/A#input.snap_standard_deduction: 0
+    us:statutes/7/2014/e/6/A#input.dependent_care_deduction: 0
+    us:statutes/7/2014/e/6/A#input.child_support_deduction: 0
+    us:statutes/7/2014/e/6/A#input.medical_deduction: 0
+    us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction: 0
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 0
+    us:statutes/7/2014/e/2#input.work_supplementation_earned_income: 0
+  output:
+    us:statutes/7/2017/a#snap_net_income_for_allotment: 5
+    us:statutes/7/2017/a#snap_household_food_contribution: 1.5
+    us:statutes/7/2017/a#snap_allotment_before_minimum: 783
+    us:statutes/7/2017/a#snap_minimum_monthly_allotment: 0
+    us:statutes/7/2017/a#snap_regular_month_allotment: 783

--- a/us/statutes/7/2017/a.yaml
+++ b/us/statutes/7/2017/a.yaml
@@ -3,176 +3,248 @@ module:
   proof_validation:
     required: true
   source_verification:
-    corpus_citation_path: us/statute/7/2017
-  summary: |-
-    (a) Calculation The value of the allotment which State agencies shall be authorized to issue to any households certified as eligible to participate in the supplemental nutrition assistance program shall be equal to the cost to such households of the thrifty food plan reduced by an amount equal to 30 per centum of the household’s income, as determined in accordance with section 2014(d) and (e) of this title, rounded to the nearest lower whole dollar: Provided , That for households of one and two persons the minimum allotment shall be 8 percent of the cost of the thrifty food plan for a household containing 1 member, as determined by the Secretary under section 2012 of this title , rounded to the nearest whole dollar increment.
+    corpus_citation_path: us/statute/7/2017/a
+    source_sha256: ed24d68ecd7c238100ca0e268bf0a38ee9da84da17394c0b9b7673ccfe3da036
+  summary: The allotment equals the cost of the thrifty food plan reduced by 30 per
+    centum of household income, rounded to the nearest lower whole dollar; for households
+    of one and two persons, the minimum is 8 percent of the one-member thrifty food
+    plan cost, rounded to the nearest whole dollar.
 imports:
-  - us:statutes/7/2014/e/6/A
-  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+- us:statutes/7/2014/e/6/A#snap_net_income
+- us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
+- us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost
+inputs:
+- name: household_size
+  entity: Household
+  dtype: Count
+  period: Month
+- name: snap_eligible
+  entity: Household
+  dtype: Boolean
+  period: Month
 rules:
-  - name: snap_household_food_contribution_rate
-    kind: parameter
-    dtype: Rate
-    source: 7 USC 2017(a), "30 per centum"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/statute/7/2017
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          0.30
-
-  - name: snap_minimum_allotment_rate
-    kind: parameter
-    dtype: Rate
-    source: 7 USC 2017(a), "8 percent"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/statute/7/2017
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          0.08
-
-  - name: snap_minimum_allotment_household_size_limit
-    kind: parameter
-    dtype: Count
-    source: 7 USC 2017(a), "households of one and two persons"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: parameter
-            source:
-              corpus_citation_path: us/statute/7/2017
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          2
-
-  - name: snap_net_income_for_allotment
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 USC 2017(a), "income, as determined in accordance with section 2014(d) and (e)"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/7/2017
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:statutes/7/2014/e/6/A#snap_net_income
-              output: snap_net_income
-              hash: sha256:f53ed05c6283dbf02f63c634a96f60d6ce9955f00e2f9ce44f7c5a3a9796c675
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          max(0, snap_net_income)
-
-  - name: snap_household_food_contribution
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 USC 2017(a), "an amount equal to 30 per centum of the household's income"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/7/2017
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          snap_net_income_for_allotment * snap_household_food_contribution_rate
-
-  - name: snap_allotment_before_minimum
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 USC 2017(a), "cost ... of the thrifty food plan reduced ... rounded to the nearest lower whole dollar"
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/7/2017
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
-              output: snap_maximum_allotment
-              hash: sha256:2e4708b8df906b506f07d091fe93dbcc6aefe603a31500502ecc270d436e9f2e
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          floor(max(0, snap_maximum_allotment - snap_household_food_contribution))
-
-  - name: snap_minimum_monthly_allotment
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 USC 2017(a), proviso for households of one and two persons
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/7/2017
-          - path: versions[0].formula
-            kind: import
-            import:
-              target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost
-              output: snap_one_person_thrifty_food_plan_cost
-              hash: sha256:2e4708b8df906b506f07d091fe93dbcc6aefe603a31500502ecc270d436e9f2e
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          if household_size <= snap_minimum_allotment_household_size_limit:
-              floor((snap_one_person_thrifty_food_plan_cost * snap_minimum_allotment_rate) + 0.5)
-          else:
-              0
-
-  - name: snap_regular_month_allotment
-    kind: derived
-    entity: Household
-    dtype: Money
-    period: Month
-    unit: USD
-    source: 7 USC 2017(a), allotment authorized for households certified as eligible
-    metadata:
-      proof:
-        atoms:
-          - path: versions[0].formula
-            kind: formula
-            source:
-              corpus_citation_path: us/statute/7/2017
-    versions:
-      - effective_from: '2008-10-01'
-        formula: |-
-          if snap_eligible:
-              max(snap_allotment_before_minimum, snap_minimum_monthly_allotment)
-          else:
-              0
+- name: snap_household_food_contribution
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: shall be equal to the cost to such households of the thrifty food
+            plan reduced by an amount equal to 30 per centum of the household’s income,
+            as determined in accordance with section 2014(d) and (e) of this title,
+            rounded to the nearest lower whole dollar
+  versions:
+  - effective_from: '2008-10-01'
+    formula: snap_net_income_for_allotment * snap_household_food_contribution_rate
+- name: snap_household_food_contribution_rate
+  kind: parameter
+  dtype: Rate
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: 30 per centum of the household’s income
+  versions:
+  - effective_from: '2008-10-01'
+    formula: '0.30'
+- name: snap_minimum_allotment_rate
+  kind: parameter
+  dtype: Rate
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: 8 percent of the cost
+  versions:
+  - effective_from: '2008-10-01'
+    formula: '0.08'
+- name: snap_one_member_thrifty_food_plan_household_size
+  kind: parameter
+  dtype: Count
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: household containing 1 member
+  versions:
+  - effective_from: '2008-10-01'
+    formula: '1'
+- name: snap_minimum_allotment_household_size_limit
+  kind: parameter
+  dtype: Count
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: households of one and two persons
+  versions:
+  - effective_from: '2008-10-01'
+    formula: '2'
+- name: snap_net_income_for_allotment
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: income, as determined in accordance with section 2014(d) and (e)
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/7/2014/e/6/A#snap_net_income
+          output: snap_net_income
+          hash: sha256:f53ed05c6283dbf02f63c634a96f60d6ce9955f00e2f9ce44f7c5a3a9796c675
+  versions:
+  - effective_from: '2008-10-01'
+    formula: max(0, snap_net_income)
+- name: snap_allotment_before_minimum_unrounded
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: shall be equal to the cost to such households of the thrifty food
+            plan reduced by an amount equal to 30 per centum of the household’s income
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment
+          output: snap_maximum_allotment
+          hash: sha256:b19511f4898d688d2286b91f9b9504e18f2faceb99127ebb90d0df6f09cda386
+  versions:
+  - effective_from: '2008-10-01'
+    formula: max(0, snap_maximum_allotment - snap_household_food_contribution)
+- name: snap_allotment_before_minimum
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: rounded to the nearest lower whole dollar
+  versions:
+  - effective_from: '2008-10-01'
+    formula: floor(snap_allotment_before_minimum_unrounded)
+- name: snap_minimum_monthly_allotment_unrounded
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: for households of one and two persons the minimum allotment shall
+            be 8 percent of the cost of the thrifty food plan for a household containing
+            1 member
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_one_person_thrifty_food_plan_cost
+          output: snap_one_person_thrifty_food_plan_cost
+          hash: sha256:b19511f4898d688d2286b91f9b9504e18f2faceb99127ebb90d0df6f09cda386
+  versions:
+  - effective_from: '2008-10-01'
+    formula: "if household_size >= snap_one_member_thrifty_food_plan_household_size\
+      \ and household_size <= snap_minimum_allotment_household_size_limit:\n  snap_one_person_thrifty_food_plan_cost\
+      \ * snap_minimum_allotment_rate\nelse: 0"
+- name: snap_minimum_monthly_allotment
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: rounded to the nearest whole dollar increment
+  versions:
+  - effective_from: '2008-10-01'
+    formula: floor(snap_minimum_monthly_allotment_unrounded + (1 / snap_minimum_allotment_household_size_limit))
+- name: snap_regular_month_allotment
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 7 USC 2017(a)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: allotment which State agencies shall be authorized to issue to
+            any households certified as eligible
+      - path: versions[0].formula
+        kind: ordering
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: rounded to the nearest lower whole dollar
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/statute/7/2017/a
+          excerpt: for households of one and two persons the minimum allotment shall
+            be 8 percent
+  versions:
+  - effective_from: '2008-10-01'
+    formula: "if snap_eligible:\n  max(snap_allotment_before_minimum, snap_minimum_monthly_allotment)\n\
+      else: 0"


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/guidance/usda/fns/snap-fy2026-cola/page-1`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `[]`
Existing signed imports: `[]`
Direct dependent: `us/statute/7/2017/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `34412969609`
Base commit: `38d5c8c516f9243cedf8e07a22f96dde9ac66fe3`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/34522456096

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.