### PR TITLE
Add signed encoding manifest for us/regulation/7/273/4

### DIFF
--- a/.axiom/encoding-manifests/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.json
+++ b/.axiom/encoding-manifests/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.json
@@ -1,0 +1,251 @@
+{
+  "applied_files": [
+    {
+      "path": "us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml",
+      "sha256": "11b02eb515650c32b139276574e1c1883d3e839b3316f15ce8769a35f0949be5"
+    },
+    {
+      "path": "us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml",
+      "sha256": "59637d789a37c0ed24e3acf75b05a58af7d10aec5b3d904ba53e85db17fb6ff1"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1973",
+    "version_commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3"
+  },
+  "axiom_encode_version": "0.2.1973",
+  "backend": "openai",
+  "citation": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+  "context_manifest_file": "/home/runner/work/_temp/generated/source-01/_eval_workspaces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-obbb-alien-eligibility-implementation-memo/workspace/context-manifest.json",
+  "context_manifest_sha256": "3c5e801d5f802134664d546d6981402751ed8286e12f962e34afd930284baab1",
+  "generated_at": "2026-09-11T12:50:49.846610+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/source-01/openai-gpt-5.6-terra/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/source-01",
+  "generated_output_sha256": "11b02eb515650c32b139276574e1c1883d3e839b3316f15ce8769a35f0949be5",
+  "generation_prompt_sha256": "bc15c6fadeec3c5824861eb7944e60d7f3d3214b32d04ba898e8e64dcf0703a6",
+  "model": "gpt-5.6-terra",
+  "run_id": "364c8757",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "QAl6klWYiksnrNiSpYD5Giq+dxapR0nIYwUVOzbv3wQ7sFRnhUieFYnB6/YybZfRp6LGj1sxFenitih6hXFNDA=="
+  },
+  "source_attestation": {
+    "component_rows": [
+      {
+        "body_sha256": "49dc2ccf52a26ed453f8ddad319c99fd59085bbc01958aba89393c14e1a355dc",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-1",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 2,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "2756e2a3-6d3e-55aa-bced-4c33681b61c5",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "46c90f029882a1efb8e7a90a306d72451ded411aa6a072c95691c4256c6bba13",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-2",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 3,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "609fc487-ed49-597e-ae7b-c4a4e9e6364e",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "f72ae7092f8a2a71b3e0b3698e7fbc8ad3697c58491f3ebaac875e3d976716f1",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-3",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 4,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "f2c56943-45e4-5976-97bd-d335f9018c8c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "b000f7c5b8a08e66012566703be6b03650c9d8e05332c8165764d1b6ef228ff8",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-4",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 5,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "5fa4d7a0-2eac-5adb-9d53-ff2b7f35a41b",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "5ca41d41d4366a9a0c9a5c9bdd4b18868f6679eb47f2092c1522b931f4570b02",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-5",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 6,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "ee93060e-13bb-51e3-9f98-1abf82539252",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "6a96cbdeceecb2eebd9789424067b7a5f2ae6410e50055c8fd012a047df02041",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-6",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 7,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "72962936-fbc3-50e7-8f7a-99ac80f231ef",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "71fcfb4bd3e6500fd707b2b365bd7e28c7073344c1113eb51b793258aada2640",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-7",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 8,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "423c63bf-bf79-51aa-b368-ee862ae59ed1",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "db7f57da8d7b771eecd6e9ec3c72fc00b40d568797250882ee40a064020e510e",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-8",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 9,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "3fce701d-8dc9-515f-a084-16270112a38d",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "8e717455a887dbd8ea9663980a52c2daa7e1abac02ca6acb39e329005d793390",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-9",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 10,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "bb8b1d8b-21de-5c0b-b094-1fb18cd04334",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "5173fe1feee684bec81c19cc4b82b6e5d8d45c37d396a662e99839ea6e35a7e7",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-10",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 11,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "6809d721-f1e6-5012-9d92-fc099a24ac9c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      },
+      {
+        "body_sha256": "94a74d114be850b9d8afc970aad80087efe9c8dac2fceb3ecd7461b761f70ca5",
+        "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo/page-11",
+        "document_class": "guidance",
+        "expression_date": "2025-10-31",
+        "jurisdiction": "us",
+        "line_number": 12,
+        "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+        "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+        "record_id": "a1b3b769-94a3-5650-b8ff-31e96c7baa5c",
+        "source_as_of": "2026-03-02",
+        "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+        "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+      }
+    ],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2025-10-31",
+    "generation_input_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c",
+    "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+    "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+    "requested_corpus_citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+    "resolved_corpus_citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+    "resolved_text_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c",
+    "row": {
+      "body_sha256": null,
+      "citation_path": "us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo",
+      "document_class": "guidance",
+      "expression_date": "2025-10-31",
+      "jurisdiction": "us",
+      "line_number": 1,
+      "provision_file": "data/corpus/provisions/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo.jsonl",
+      "provision_file_sha256": "6475df5a213466d7998301a4541fb93aa5107c084dc6fc25ab695eac887c1a42",
+      "record_id": "1d2b4574-ad56-513b-b993-033a6d4df27e",
+      "source_as_of": "2026-03-02",
+      "source_path": "sources/us/guidance/2026-08-07-snap-obbb-alien-eligibility-implementation-memo/official-documents/snap-obbb-alien-eligibility-implementation-memo.pdf",
+      "version": "2026-08-07-snap-obbb-alien-eligibility-implementation-memo"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-03-02",
+    "source_sha256": "0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/source-01/traces/openai-gpt-5.6-terra/us-guidance-usda-fns-snap-obbb-alien-eligibility-implementation-memo.json",
+  "trace_sha256": "c2e049215243f9c6770d7980bf26e5759a0d007554267f80f601181b953d51ac",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1973"
+    },
+    "axiom_rules_engine": {
+      "commit": "f6b0d15246a7db1403836628576f11e0d334348c",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "4a431acb19c10a5fe224b641e532efc9956ac12c01c938f67190a71069f08a96",
+      "pre_apply_file_count": 2711,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "full_checkout",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/.axiom/encoding-manifests/us/regulations/7-cfr/273/4.json
+++ b/.axiom/encoding-manifests/us/regulations/7-cfr/273/4.json
@@ -1,0 +1,96 @@
+{
+  "applied_files": [
+    {
+      "path": "us/regulations/7-cfr/273/4.yaml",
+      "sha256": "bc6e66655864e8b1c9176caf87424ef3418b996d31df2bc8707361dbee573a4c"
+    },
+    {
+      "path": "us/regulations/7-cfr/273/4.test.yaml",
+      "sha256": "41b58eec9dcb9f2324fe4ddc55842c84d8b5786632591d48ef69c763ae3fa34b"
+    }
+  ],
+  "axiom_encode_git": {
+    "commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3",
+    "dirty_tracked": false,
+    "identity_source": "trusted-runtime-attestation",
+    "root": "/opt/axiom-verification/python/runtime-attestation.json",
+    "version": "0.2.1973",
+    "version_commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3"
+  },
+  "axiom_encode_version": "0.2.1973",
+  "backend": "openai",
+  "citation": "us/regulation/7/273/4",
+  "context_manifest_file": "/home/runner/work/_temp/generated/target/_eval_workspaces/openai-gpt-5.6-terra/us-regulation-7-273-4/workspace/context-manifest.json",
+  "context_manifest_sha256": "24e839dfe447977176cdbe1fa90c8030a74ec4ddb3bb21510092a0a395cb2784",
+  "generated_at": "2026-09-11T13:01:06.804943+00:00",
+  "generated_output_file": "/home/runner/work/_temp/generated/target/openai-gpt-5.6-terra/regulations/7-cfr/273/4.yaml",
+  "generated_output_root": "/home/runner/work/_temp/generated/target",
+  "generated_output_sha256": "bc6e66655864e8b1c9176caf87424ef3418b996d31df2bc8707361dbee573a4c",
+  "generation_prompt_sha256": "1e6f4b2f2980910dd04ac8beea909fb4e59e08ab785bfda212c42993437c0d51",
+  "model": "gpt-5.6-terra",
+  "run_id": "cb114cb7",
+  "runner": "openai-gpt-5.6-terra",
+  "schema_version": "axiom-encode/applied-rulespec/v5",
+  "signature": {
+    "algorithm": "ed25519-domain-v1",
+    "key_id": "sha256:24a78725a23b1c83cfc38bdc22f75401d8008e7a8477796b55179d1fc79c4d9a",
+    "value": "Qe34yC90oIAN+COEKgoyLqDwaWF5H7g5H1q9FVBWqIAQLKOUR2SkmybCvo5zSgb9M7kVdWxAnjrZLWFBn8E3BQ=="
+  },
+  "source_attestation": {
+    "component_rows": [],
+    "corpus_release": "us-rulespec-2026-08-08-obbb-alien-snap",
+    "corpus_release_content_sha256": "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc",
+    "corpus_release_selector_sha256": "1b88863f0e6f09c3383e0572666da892d49125f34bda5088bd90a6706d8b37fd",
+    "corpus_source": "local",
+    "expression_date": "2026-04-29",
+    "generation_input_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+    "provision_file": "data/corpus/provisions/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained.jsonl",
+    "provision_file_sha256": "de25d2b32f261e92405a553f65dfc90b47b032a4d1a80b1b585857b7fd342d1e",
+    "requested_corpus_citation_path": "us/regulation/7/273/4",
+    "resolved_corpus_citation_path": "us/regulation/7/273/4",
+    "resolved_text_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+    "row": {
+      "body_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3",
+      "citation_path": "us/regulation/7/273/4",
+      "document_class": "regulation",
+      "expression_date": "2026-04-29",
+      "jurisdiction": "us",
+      "line_number": 9,
+      "provision_file": "data/corpus/provisions/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained.jsonl",
+      "provision_file_sha256": "de25d2b32f261e92405a553f65dfc90b47b032a4d1a80b1b585857b7fd342d1e",
+      "record_id": "3c7f0bf5-cc4e-5a8b-b1fd-2ee868a41be8",
+      "source_as_of": "2026-04-29",
+      "source_path": "sources/us/regulation/2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained/official-documents/release-scope-us-regulation-2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained",
+      "version": "2026-05-10-snap-7-cfr-273-r2026-07-15-self-contained"
+    },
+    "rulespec_root": "rulespec-us/us",
+    "source_as_of": "2026-04-29",
+    "source_sha256": "846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3"
+  },
+  "tool": "axiom-encode encode --apply",
+  "trace_file": "/home/runner/work/_temp/generated/target/traces/openai-gpt-5.6-terra/us-regulation-7-273-4.json",
+  "trace_sha256": "8b90af5c2872af144f3cbbee59d71efe9ed682f739be825e69de778c27f40831",
+  "validation_execution": {
+    "axiom_encode": {
+      "commit": "b041b6b5a0e39f2c05c93669f354f8a54e9a84c3",
+      "identity_source": "trusted-runtime-attestation",
+      "repository": "github.com/TheAxiomFoundation/axiom-encode",
+      "version": "0.2.1973"
+    },
+    "axiom_rules_engine": {
+      "commit": "f6b0d15246a7db1403836628576f11e0d334348c",
+      "repository": "github.com/TheAxiomFoundation/axiom-rules-engine"
+    },
+    "policy_pre_apply": {
+      "pre_apply_content_sha256": "c67c3da0a1192f5dc152094185b4895ca4d34bbd82a1b2b014db68acda5327c2",
+      "pre_apply_file_count": 2713,
+      "rulespec_root": "rulespec-us/us",
+      "toolchain_contract_sha256": "073522172cd8fd0214fb769bfefc29fcd1df41fbe67201f7a71c503be20aed87",
+      "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+    },
+    "rulespec_dependencies": [],
+    "rulespec_scope": "active_jurisdiction_and_country_ancestors",
+    "schema": "axiom-encode/apply-validation-execution/v2"
+  },
+  "validation_waiver_set_sha256": "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+}

--- a/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml
+++ b/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.test.yaml
@@ -1,0 +1,789 @@
+- name: lpr_waiting_period_boundary
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_exemption_principal_output_blocking_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: not_holds
+- name: lpr_under_age_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_work_quarters_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_blind_or_disabled_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_older_lawful_resident_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_military_connection_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_amerasian_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_american_indian_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_hmong_or_highland_laotian_exemption_principal_output_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: obbb_recertification_overissuance_claim_not_imposed
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_not_required_to_report_change_in_immigration_status
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_change
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#household_not_subject_to_obbb_recertification_overissuance_claim
+    : holds
+- name: obbb_recertification_overissuance_claim_requires_nonreportable_change
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.household_is_not_required_to_report_change_in_immigration_status
+    : false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.alien_loses_snap_eligibility_at_recertification_due_to_obbb_change
+    : true
+  output:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#household_not_subject_to_obbb_recertification_overissuance_claim
+    : not_holds
+- name: variance_exclusion_required_implementation_control
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.quality_control_review_is_within_section_10108_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_agency_does_not_implement_new_provision_in_accordance_with_7_cfr_275_12_d_2_vii_d
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#quality_control_variance_exclusion_applies: holds
+- name: variance_exclusion_required_implementation_blocking_pair
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.quality_control_review_is_within_section_10108_variance_exclusion_period
+    : true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_agency_does_not_implement_new_provision_in_accordance_with_7_cfr_275_12_d_2_vii_d
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#quality_control_variance_exclusion_applies: not_holds
+- name: quality_control_variance_exclusion_blocked_outside_exclusion_period
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.quality_control_review_is_within_section_10108_variance_exclusion_period
+    : false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.state_agency_does_not_implement_new_provision_in_accordance_with_7_cfr_275_12_d_2_vii_d
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#quality_control_variance_exclusion_applies: not_holds
+- name: lpr_exemption_all_conditions_absent_control
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+- name: lpr_exemption_under_age_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_work_quarters_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_blind_or_disabled_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_older_lawful_resident_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_military_connection_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_amerasian_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_american_indian_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: lpr_exemption_hmong_or_highland_laotian_condition_pair
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+- name: trafficking_victim_lpr_path_enabled
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_victim_of_severe_trafficking_or_certain_family_member
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#trafficking_victim_lpr_path_applies: holds
+- name: trafficking_victim_lpr_path_blocked_without_lpr_status
+  period: 2025-08
+  input:
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_victim_of_severe_trafficking_or_certain_family_member
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#trafficking_victim_lpr_path_applies: not_holds
+- name: exempt_lpr_blocked_without_other_snap_requirements
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: not_holds
+- name: conditional_entrant_lpr_path_enabled
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_conditional_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#conditional_entrant_lpr_path_applies: holds
+- name: conditional_entrant_lpr_path_blocked_without_lpr_status
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_conditional_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#conditional_entrant_lpr_path_applies: not_holds
+- name: battered_alien_lpr_path_enabled
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_battered_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#battered_alien_lpr_path_applies: holds
+- name: battered_alien_lpr_path_blocked_without_lpr_status
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_battered_alien: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#battered_alien_lpr_path_applies: not_holds
+- name: non_citizen_us_national_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: cuban_or_haitian_entrant_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: cofa_citizen_is_eligible_immediately
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_is_eligible_after_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_without_exemption_is_ineligible_before_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: not_holds
+- name: lpr_under_18_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_with_40_work_quarters_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: blind_or_disabled_lpr_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: elderly_lawfully_residing_lpr_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: lpr_with_military_connection_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: amerasian_lpr_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: american_indian_lpr_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds
+- name: hmong_or_highland_laotian_lpr_is_eligible_without_waiting_period
+  period: 2025-08
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: true
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+  output:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_satisfied: not_holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#lpr_waiting_period_exemption_applies: holds
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility: holds

--- a/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml
+++ b/us/policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo.yaml
@@ -1,0 +1,467 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+    source_sha256: 0be8e3e6891999b0f1e4a6dca6dc459063797d22a7b8f9fd5a8294213b7d655c
+  summary: Section 10108 of the OBBB limits SNAP eligibility to U.S. citizens, U.S.
+    nationals, lawful permanent residents, Cuban and Haitian entrants, and COFA citizens.
+    The memorandum states that Section 10108 was effective upon enactment on July
+    4, 2025.
+rules:
+- name: cuban_haitian_entrant_definition_note_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Footnote 1, page 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 1 Cuban and Haitian entrants as defined in section 501(e)
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '1'
+- name: prwora_waiting_period_reference_note_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Footnote 3, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 3 See 8 USC 1612.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '3'
+- name: overissuance_claim_reference_note_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Footnote 4, page 3
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 4 Pursuant to USDA regulations at 7 CFR 273.12(a)(1)
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '4'
+- name: immigration_nationality_act_reference_note_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Footnote 6, page 8
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 6 Immigration and Nationality Act.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '6'
+- name: lpr_section_249_reference_note_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: Footnote 7, page 8
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 7 Status acquired after any type of entry into the U.S. prior to
+            January 1, 1972
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '7'
+- name: title_8_usc_reference_marker
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 1
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 2 Aliens who were qualified aliens as defined by section 431 of
+            the Personal Responsibility and Work Opportunity Reconciliation Act (PRWORA)
+            (8 USC 1641) and aliens included in section 402(a) of PRWORA (8 USC 1612(a))
+            in addition to groups listed in section 6(f) of the FNA were eligible
+            for SNAP.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '8'
+- name: trafficking_victim_lpr_path_applies
+  kind: derived
+  entity: Family
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Victims of Severe Trafficking and Certain Family Members Eligible
+            immediately Not eligible unless an LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_victim_of_severe_trafficking_or_certain_family_member
+
+      and person_is_lawful_permanent_resident'
+- name: household_not_subject_to_obbb_recertification_overissuance_claim
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: Footnote 4, page 3
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Since households are not required to report a change in immigration
+            status, aliens who lose SNAP eligibility at recertification due to the
+            OBBB SNAP eligibility changes, are not subject to a claim for over issuance
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'household_is_not_required_to_report_change_in_immigration_status
+
+      and alien_loses_snap_eligibility_at_recertification_due_to_obbb_change'
+- name: quality_control_variance_exclusion_applies
+  kind: derived
+  entity: StateAgency
+  dtype: Judgment
+  period: Month
+  source: Quality Control and Technical Assistance, pages 3-4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: The 120-day variance exclusion period will not apply if the State
+            agency does not implement the new provision in accordance with 7 CFR 275.12(d)(2)(vii)(D).
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: until the exclusionary period end date on November 1, 2025
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'quality_control_review_is_within_section_10108_variance_exclusion_period
+
+      and not state_agency_does_not_implement_new_provision_in_accordance_with_7_cfr_275_12_d_2_vii_d'
+- name: lpr_child_age_threshold
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Are under 18 years old
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '18'
+- name: lpr_qualifying_work_quarters_threshold
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Have 40 qualifying work quarters
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '40'
+- name: older_lawful_resident_age_threshold
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Were lawfully residing in the U.S. and 65 or older on August 22,
+            1996
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '65'
+- name: conditional_entrant_lpr_path_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Conditional Entrants Eligible immediately Not eligible unless an
+            LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_conditional_entrant
+
+      and person_is_lawful_permanent_resident'
+- name: battered_alien_lpr_path_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: Attachment 1, page 7
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Battered Aliens Eligible immediately Not eligible unless an LPR.
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'person_is_battered_alien
+
+      and person_is_lawful_permanent_resident'
+- name: quality_control_variance_exclusion_days
+  kind: parameter
+  dtype: Count
+  period: Month
+  source: Quality Control and Technical Assistance, page 4
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: A 120-day variance exclusion is permitted
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '120'
+- name: lpr_waiting_period_years
+  kind: parameter
+  dtype: Integer
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Eligible after a 5-year waiting period
+  versions:
+  - effective_from: '2025-07-04'
+    formula: '5'
+- name: lpr_waiting_period_satisfied
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: Eligible after a 5-year waiting period
+  versions:
+  - effective_from: '2025-07-04'
+    formula: years_since_lpr_status >= lpr_waiting_period_years
+- name: lpr_waiting_period_exemption_applies
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility, page 2
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: LPRs may still be eligible for SNAP without a waiting period if
+            they meet one or more
+  versions:
+  - effective_from: '2025-07-04'
+    formula: 'lpr_is_under_age_18
+
+      or lpr_has_40_qualifying_work_quarters
+
+      or lpr_is_blind_or_disabled
+
+      or lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+
+      or lpr_has_us_military_connection
+
+      or lpr_is_admitted_as_amerasian_immigrant
+
+      or lpr_is_american_indian_born_abroad
+
+      or lpr_is_hmong_or_highland_laotian_tribal_member'
+- name: alien_snap_eligibility
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: SNAP Alien Eligibility; Attachment 1, pages 1-8
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: 'SNAP Alien Eligibility Section 10108 of the OBBB amends section
+            6(f) of the Food and Nutrition Act of 2008 (FNA), limiting eligibility
+            for SNAP to the following groups: U.S. citizens, U.S. nationals, lawful
+            permanent residents (LPRs), Cuban and Haitian entrants1, and Compact of
+            Free Association (COFA) citizens.'
+      - path: versions[0].formula
+        kind: effective_period
+        source:
+          corpus_citation_path: us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo
+          excerpt: effective upon enactment, July 4, 2025
+  versions:
+  - effective_from: '2025-07-04'
+    formula: "person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements\n\
+      and (\n  person_is_us_citizen\n  or person_is_non_citizen_us_national\n  or\
+      \ person_is_cuban_or_haitian_entrant\n  or person_is_cofa_citizen\n  or (\n\
+      \    person_is_lawful_permanent_resident\n    and (\n      lpr_waiting_period_satisfied\n\
+      \      or lpr_waiting_period_exemption_applies\n    )\n  )\n)"
+inputs:
+- name: household_is_not_required_to_report_change_in_immigration_status
+  entity: Household
+  dtype: Boolean
+  period: Month
+- name: state_agency_does_not_implement_new_provision_in_accordance_with_7_cfr_275_12_d_2_vii_d
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: person_is_conditional_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_battered_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_victim_of_severe_trafficking_or_certain_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: quality_control_review_is_within_section_10108_variance_exclusion_period
+  entity: StateAgency
+  dtype: Boolean
+  period: Month
+- name: alien_loses_snap_eligibility_at_recertification_due_to_obbb_change
+  entity: Household
+  dtype: Boolean
+  period: Month
+- name: person_is_us_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_non_citizen_us_national
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_lawful_permanent_resident
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_cuban_or_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_is_cofa_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: years_since_lpr_status
+  entity: Person
+  dtype: Integer
+  period: Month
+- name: lpr_is_under_age_18
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_has_40_qualifying_work_quarters
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_blind_or_disabled
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_has_us_military_connection
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_admitted_as_amerasian_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_american_indian_born_abroad
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: lpr_is_hmong_or_highland_laotian_tribal_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+  entity: Person
+  dtype: Boolean
+  period: Month

--- a/us/regulations/7-cfr/273/4.test.yaml
+++ b/us/regulations/7-cfr/273/4.test.yaml
@@ -1,78 +1,186 @@
-- name: us_citizen_member_is_status_eligible
+- name: qualifying_lawful_permanent_resident_is_status_eligible
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
-    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: true
   output:
-    us:regulations/7-cfr/273/4#snap_member_citizen_or_national_status_eligible: holds
     us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
-- name: trafficking_victim_alien_status_is_eligible_when_documented
+- name: cuban_haitian_entrant_is_status_eligible
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
-    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: true
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: true
   output:
-    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
     us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
-- name: refugee_qualified_alien_is_immediately_eligible
+- name: compact_of_free_association_resident_is_status_eligible
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-    us:regulations/7-cfr/273/4#input.member_is_refugee: true
-    us:regulations/7-cfr/273/4#input.member_is_asylee: false
-    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 0
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: false
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: true
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: true
   output:
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_immediately_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
-- name: qualified_alien_after_five_year_wait_is_eligible
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: holds
+- name: missing_alien_documentation_blocks_qualifying_lpr
   period: 2026-01
   input:
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
-    us:regulations/7-cfr/273/4#input.member_is_refugee: false
-    us:regulations/7-cfr/273/4#input.member_is_asylee: false
-    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
-    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
-    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
-    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
-    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
-    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
-    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
-    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: true
-    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: true
-    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
-  output:
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_after_wait_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_qualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: holds
-- name: missing_alien_documentation_bars_alien_status
-  period: 2026-01
-  input:
-    us:regulations/7-cfr/273/4#input.member_is_us_citizen: false
-    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
-    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
-    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
-    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
     us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: true
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: true
   output:
-    us:regulations/7-cfr/273/4#snap_member_special_nonqualified_alien_status_eligible: holds
-    us:regulations/7-cfr/273/4#snap_member_alien_status_eligible: not_holds
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: not_holds
+- name: lack_of_us_residence_blocks_qualifying_lpr
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: true
+  output:
+    us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: not_holds
+- name: other_snap_conditions_block_qualifying_lpr
+  period: 2026-01
+  input:
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_us_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_non_citizen_us_national: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_lawful_permanent_resident: true
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cuban_or_haitian_entrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_is_cofa_citizen: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.years_since_lpr_status: 5
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_under_age_18: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_40_qualifying_work_quarters: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_blind_or_disabled: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_was_lawfully_residing_in_us_and_age_65_or_older_on_august_22_1996
+    : false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_has_us_military_connection: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_admitted_as_amerasian_immigrant: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_american_indian_born_abroad: false
+    us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.lpr_is_hmong_or_highland_laotian_tribal_member: false
+    ? us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#input.person_meets_other_snap_financial_and_nonfinancial_eligibility_requirements
+    : true
+    us:statutes/7/2015/f#input.person_is_member_of_household_otherwise_eligible_to_participate_under_this_section: true
+    us:statutes/7/2015/f#input.person_is_resident_of_united_states: true
+    us:statutes/7/2015/f#input.person_is_citizen_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_national_of_united_states: false
+    us:statutes/7/2015/f#input.person_is_alien_lawfully_admitted_for_permanent_residence_as_immigrant: true
+    us:statutes/7/2015/f#input.person_has_been_granted_status_of_cuban_and_haitian_entrant: false
+    us:statutes/7/2015/f#input.person_lawfully_resides_in_united_states_in_accordance_with_compact_of_free_association: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+    us:regulations/7-cfr/273/4#input.member_satisfies_other_snap_participation_conditions: false
+  output:
     us:regulations/7-cfr/273/4#snap_member_citizenship_or_alien_status_eligible: not_holds

--- a/us/regulations/7-cfr/273/4.yaml
+++ b/us/regulations/7-cfr/273/4.yaml
@@ -1,102 +1,164 @@
 format: rulespec/v1
 module:
-  deferred_outputs:
-    - output: us:regulations/7-cfr/273/4/c#sponsored_alien_household_income_and_resource_deeming
-      blocked_by:
-        - us:regulations/7-cfr/273/4#sponsored_alien_sponsor_deeming_context
-      reason: >-
-        Paragraph (c) governs sponsor income and resource deeming for households
-        containing sponsored alien members. This module encodes citizenship and
-        alien-status eligibility predicates; sponsored-alien household budgeting
-        and sponsor deeming are deferred until income and resource eligibility
-        composition is encoded.
-  summary: |-
-    7 CFR 273.4 makes a person eligible for SNAP only if the person is a U.S.
-    citizen, U.S. non-citizen national, an enumerated eligible noncitizen, or
-    a qualified alien satisfying the applicable immediate-eligibility or
-    five-year-status criteria. A person who cannot or will not document alien
-    status is classified as ineligible.
+  proof_validation:
+    required: true
   source_verification:
     corpus_citation_path: us/regulation/7/273/4
+    source_sha256: 846140bd0e210be0f69a81dc1006c3914c81b0dd7faebedcdd978be7526601b3
+  summary: '“No person is eligible to participate in the Program unless that person”
+
+    meets the applicable citizenship or alien-status requirements. A person
+
+    unable or unwilling to provide alien-status documentation must be
+
+    classified as an ineligible alien. Paragraph (b) imposes State-agency
+
+    reporting duties, and paragraph (c) governs sponsored-alien income and
+
+    resource deeming.'
+  deferred_outputs:
+  - output: us:regulations/7-cfr/273/4/b#illegal_alien_reporting_duty
+    reason: Paragraph (b) imposes a State-agency procedural reporting and classification
+      duty rather than a person-level eligibility computation; the certification,
+      USCIS-notification, and case-processing workflow is outside this module's executable
+      eligibility surface.
+  - output: us:regulations/7-cfr/273/4/c#sponsored_alien_household_income_and_resource_deeming
+    reason: Paragraph (c) requires household income and resource composition, sponsor
+      and spouse financial records, sponsor-affidavit relationships, gross-income
+      eligibility limits, and State-agency indigence workflow not available in the
+      current executable context.
+  - output: us:regulations/7-cfr/273/4/c#deferred_c
+    reason: Generated module encodes the supported rules from this source, but this
+      source subparagraph depends on policy surfaces or entities that are not available
+      in the current RuleSpec context. It is deferred instead of being modeled as
+      a caller-supplied input or an unsupported local entity.
+imports:
+- us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility
+- us:statutes/7/2015/f#individual_ineligible_for_snap_participation_due_to_residence_or_status
+inputs:
+- name: alien_status_documentation_missing_or_unwilling
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_satisfies_other_snap_participation_conditions
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_us_citizen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_us_noncitizen_national
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_legacy_eligible_alien_status
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_hmong_or_highland_laotian_qualifying_person_or_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_trafficking_victim_or_qualifying_family_member
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_battered_qualified_alien
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_qualified_alien_with_forty_qualifying_quarters
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_refugee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_asylee
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_deportation_or_removal_withheld
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_cuban_or_haitian_entrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_amerasian_immigrant
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_has_eligible_military_connection
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_receives_blindness_or_disability_benefits
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_under_age_eighteen
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: member_is_qualified_alien_subject_to_five_year_wait
+  entity: Person
+  dtype: Boolean
+  period: Month
+- name: qualified_alien_five_year_status_period_met
+  entity: Person
+  dtype: Boolean
+  period: Month
 rules:
-  - name: snap_member_citizen_or_national_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(1)-(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: member_is_us_citizen or member_is_us_noncitizen_national
-  - name: snap_member_special_nonqualified_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(3)-(5)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member
-          or member_is_hmong_or_highland_laotian_qualifying_person_or_family_member
-          or member_is_trafficking_victim_or_qualifying_family_member
-  - name: snap_member_qualified_alien_immediately_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)(ii)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          member_is_qualified_alien_with_forty_qualifying_quarters
-          or member_is_refugee
-          or member_is_asylee
-          or member_has_deportation_or_removal_withheld
-          or member_is_cuban_or_haitian_entrant
-          or member_is_amerasian_immigrant
-          or member_has_eligible_military_connection
-          or member_receives_blindness_or_disability_benefits
-          or member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22
-          or member_is_under_age_eighteen
-  - name: snap_member_qualified_alien_after_wait_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)(iii)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: member_is_qualified_alien_subject_to_five_year_wait and qualified_alien_five_year_status_period_met
-  - name: snap_member_qualified_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a)(6)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: snap_member_qualified_alien_immediately_eligible or snap_member_qualified_alien_after_wait_eligible
-  - name: snap_member_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: |-
-          (
-              snap_member_special_nonqualified_alien_status_eligible
-              or snap_member_qualified_alien_status_eligible
-          )
-          and not alien_status_documentation_missing_or_unwilling
-  - name: snap_member_citizenship_or_alien_status_eligible
-    kind: derived
-    entity: Person
-    dtype: Judgment
-    period: Month
-    source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
-    versions:
-      - effective_from: '2025-10-01'
-        formula: snap_member_citizen_or_national_status_eligible or snap_member_alien_status_eligible
+- name: snap_member_citizenship_or_alien_status_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 7 CFR 273.4(a), 7 CFR 273.4(b)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: No person is eligible to participate in the Program unless that
+            person is
+      - path: versions[0].formula
+        kind: condition
+        source:
+          corpus_citation_path: us/regulation/7/273/4
+          excerpt: must classify that person as an ineligible alien
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:policies/usda/fns/snap-obbb-alien-eligibility-implementation-memo#alien_snap_eligibility
+          output: alien_snap_eligibility
+          hash: sha256:11b02eb515650c32b139276574e1c1883d3e839b3316f15ce8769a35f0949be5
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/7/2015/f#individual_ineligible_for_snap_participation_due_to_residence_or_status
+          output: individual_ineligible_for_snap_participation_due_to_residence_or_status
+          hash: sha256:a2d4205551c6e79f7e7ed62e4fdd349faaf265811d69bc04686674555195b5aa
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'member_satisfies_other_snap_participation_conditions
+
+      and alien_snap_eligibility
+
+      and not alien_status_documentation_missing_or_unwilling
+
+      and not individual_ineligible_for_snap_participation_due_to_residence_or_status'


### PR DESCRIPTION
## Signed apply manifest

Citation: `us/regulation/7/273/4`
Independent canonical refresh bundle: `[]`
Atomic source bundle: `["us/guidance/usda/fns/snap-obbb-alien-eligibility-implementation-memo"]`
Existing signed imports: `["us/statutes/7/2015/f.yaml"]`
Direct dependent: `n/a`
Second direct dependent: `n/a`
Exact legacy dependent: `n/a`
Second exact legacy dependent: `n/a`
Retained successor legacy paths: `[]`
Repair candidate run: `34590446762`
Base commit: `38d5c8c516f9243cedf8e07a22f96dde9ac66fe3`
Base branch: `main`
Queue item: `ad-hoc/ad-hoc`
Queue generation SHA-256: `n/a`
Queue manifest SHA-256: `n/a`
Axiom Encode run: https://github.com/TheAxiomFoundation/axiom-encode/actions/runs/34598822979

This draft PR was produced by the protected country-general signed-apply workflow. Review all RuleSpec and manifest changes before marking it ready.