### PR TITLE
Approve encoder 0.2.1973 validation fingerprints

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
 axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
-validation_waiver_set_sha256 = "dded4ff64d7064d854fef2c2988278b495d4a38af5ceada1d1964612bf2d3453"
+validation_waiver_set_sha256 = "bb18d2ce1876a7e69ade24d07bd59a023185267a8ce68c7e8624fe2f22ced4fb"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -1388,6 +1388,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:f7c0dbbc1efc774dc4d8580d04cd55383ab947772e1fc98cf20aff00d246086e"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ny/regulations/18-nycrr/385/3.yaml":
     active:
       fingerprint: "sha256:b751274e37fd7ba55ddb9fab93e41e23743893f2d09a91738ed780e2d2e1c724"
@@ -2252,15 +2257,30 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:002670540f878989340e9bc8ca748e236d397dc7b74bd3fa4f4fc712d2a1a0a6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-22.yaml":
     active:
       fingerprint: "sha256:e07ea599c08ff108181a502ec5c29843445e4731512b992ead4be7a459d45536"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:a0426cb3ae5be118065e5a7cae8740b1bfceffcaa36af3e05d6c7f8a15d088bc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-23.yaml":
     active:
       fingerprint: "sha256:840bcbb9f5fae93869f1337c7a25224ddfc5aa11997c0d8d62e143a2804c4ccc"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:b945e06453572a6a7cd56979a7a35df5fcd36c3877013c09ae022f4079444357"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2528,6 +2548,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:d31ddd96ba33a01254033606704890ef6334797f5cddd54d0157da95e87c3cc9"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nc/policies/dhhs/fns/fns-815-inadvertent-household-error-ihe-claims/page-3.yaml":
     active:
       fingerprint: "sha256:874550359cb45dfeca692f9dee535b8fdb09d90bd1f7302cc00034a22a9b8aac"
@@ -2561,6 +2586,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-25.yaml":
     active:
       fingerprint: "sha256:2771fc3dc86de455bb8421a565e007efec2f764e1bbbd5fc0de1744e5876e954"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:6f6909aabfb3b2e12eab7b9a355bd9a0f3a05282c9adb75b0e209f9cd7ae385e"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -2831,6 +2861,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-sc/policies/dss/snap-policy-manual/page-314.yaml":
     active:
       fingerprint: "sha256:8627243507046dfbdf2e2e48a0c4e0a465d0117d2e971a787e7e556c78059757"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:fc77e1795e70b8b4b6649b3ea1c33476d3151e879d6c83ccec8ed23ce40048f3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3494,6 +3529,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:1fc70255e849df0a1e0e492dd29801af659f804fe22db8df5e2657b717768a5b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-fl/policies/dcf/ess-program-policy-manual/1400-technical-requirements-fs-tca/page-9.yaml":
     active:
       fingerprint: "sha256:f10e257306c897d6ff3dcf844c91a06c04bbe874b9c4dc58ef354f5fb82c83db"
@@ -3563,6 +3603,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-fl/policies/dcf/ess-program-policy-manual/1600-assets-fs-tca/page-8.yaml":
     active:
       fingerprint: "sha256:b3cd4b767cf8783bd362333b2ba7dfd8878bbee370859660086e1daf546b02bf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:cdd0a1317e78e07b991e999b3b2a826b9079fb0fac8ff5a497416a7b627a7af3"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -3662,6 +3707,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:ab8818ddadeede78a363551b8c77c35eccbe24c70a0ad8e165af69e1be42a2f5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-ga/policies/decal/caps/appendix-d-family-fee-chart.yaml":
     active:
       fingerprint: "sha256:f55fa99fa39201372ac02a8555e23ccbef7304f7746df01e6f585a761a8f016a"
@@ -3755,6 +3805,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-la/policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml":
     active:
       fingerprint: "sha256:a0baa03196157ee7dd3f5d26c7fe88711386c8c7bea84675c866409895862dcf"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:bec1b4797caa7174b239b759883a0ad73b4c903cc49a945f0cdce3b756a1d87f"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -4964,6 +5019,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:86ad7273aa5721ad44ebee5324930832f4d1fdf8de9b2e89397c662f9d2ca1de"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-il/statutes/320/30/3.yaml":
     active:
       fingerprint: "sha256:ac03671ea216d2c17a2bc28337aba766a74ee90b85b39cc7fcd1392b83262615"
@@ -5093,6 +5153,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ma/policies/cms/massachusetts-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:d65d0163ef040c8467c2f4edca28a3edc6c00e57c1bb8f5481fd528ffdd421ae"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:5a8dce43eef9047d4e56da937c86ae72a450500bb263257a3cfe36f8588d2ef0"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5348,6 +5413,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:66100c87bb9cf4801afd6d4e91611f757ff7f5fba1f3445d2e42de49e36e156b"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-mn/statutes/290/06.yaml":
     active:
       fingerprint: "sha256:db548af4187d1c17e22deefb91b9eccb23aa06797dba029960aa5bb6b03f53cf"
@@ -5369,6 +5439,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-mo/policies/cms/missouri-chip-eligibility.yaml":
     active:
       fingerprint: "sha256:690f93f790fa831a63a2ca04cc3ee5989f55113aa98a9961ab310ad34d6edde6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:2c7e604e557daa2de827a549f70383b637cbbd59ecf3925382a6fc991cbf26c9"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -5657,6 +5732,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-ny/statutes/TAX/616.yaml":
     active:
       fingerprint: "sha256:c066d57865ec6764a3cad7750896e1041613b1f19a7f44ad7eef6d48c8d5bf8c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:98b079d98ab0bcba6feeb6fa05102aea0f3e14c0132541646ec31fb4c23e3acd"
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
@@ -9644,6 +9724,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+    pending:
+      fingerprint: "sha256:25c9338729b0fb7ad52398776bcbf1e36a7353e462d4ac295b5ee772c9f7923c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nm/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:77d0f8860b544f7c967923b53cde4c7f09dc4b10319974d8f39fac0e40282b4e"
@@ -10751,6 +10836,11 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
   "us-az/policies/des/faa6/utility-allowance-current-amount.yaml":
     active:
       fingerprint: "sha256:6f97f3fb30de4316b6bfa12b7c253eef30ea489a76c9af99b5b3e637b07b9851"
+      owner: "@PavelMakarchuk"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
+      expires: "2026-12-06"
+    pending:
+      fingerprint: "sha256:af57d36163997fb19cafbf15d5b1ac4cdc5461a1a8feff145b06090336a6bbbf"
       owner: "@PavelMakarchuk"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
       expires: "2026-12-06"


### PR DESCRIPTION
Stages the 18 deterministic validation-failure fingerprints produced by encoder 0.2.1973 / rules engine f6b0d152 during PR #1356. This is the protected pending-approval half of the repository waiver protocol; it does not activate or broaden any waiver. Existing owners, issues, and expiries are preserved byte-for-byte, and `.axiom/toolchain.toml` pins the exact resulting ledger digest.\n\nChecks: 47 repository tests passed in 316.06s; exact ledger digest and all 18 active/pending metadata pairs independently verified; `git diff --check` clean.\n\nCycle: independent review pending.