### PR TITLE
Approve residual validation fingerprints for encoder 0.2.1973

### DIFF
--- a/.axiom/toolchain.toml
+++ b/.axiom/toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 axiom_corpus_release = "us-rulespec-2026-08-08-obbb-alien-snap"
 axiom_corpus_release_content_sha256 = "0d69a0cdbe024fc2276f3c261c00402bb0a47488ac5f482cc20bd3404980adbc"
-validation_waiver_set_sha256 = "bb18d2ce1876a7e69ade24d07bd59a023185267a8ce68c7e8624fe2f22ced4fb"
+validation_waiver_set_sha256 = "814feeabed52aa7062e718c6b4cc71f30cf95360669869d79ba8c106932885db"

--- a/known-validation-gaps.yaml
+++ b/known-validation-gaps.yaml
@@ -9729,6 +9729,12 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@MaxGhenis"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
       expires: "2026-10-08"
+  "us-nj/policies/income_tax/pilot_liability_pipeline.yaml":
+    pending:
+      fingerprint: "sha256:2e4472489f7659c8248fc26ece06419d8ba71f0da589d196a0d14eb58bee41a3"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
   "us-nm/policies/income_tax/pilot_liability_pipeline.yaml":
     active:
       fingerprint: "sha256:77d0f8860b544f7c967923b53cde4c7f09dc4b10319974d8f39fac0e40282b4e"
@@ -11684,3 +11690,51 @@ validate_failures:  # https://github.com/TheAxiomFoundation/rulespec-us/issues/3
       owner: "@PavelMakarchuk"
       issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/1248"
       expires: "2026-12-06"
+  "us-ks/policies/dcf/keesm/keesm7400/cash-proration-rounding.yaml":
+    pending:
+      fingerprint: "sha256:bef9b9c146895087e16f81940ffa2701e2b169b9ad50f2c30164344d39020172"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-300-sources-of-income/page-20.yaml":
+    pending:
+      fingerprint: "sha256:27f376b16056860288b5146f41eab7ac2f6d4c2f5df9aa7da26bf62012cb3bb8"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-810-administrative-error-ae-claims/page-12.yaml":
+    pending:
+      fingerprint: "sha256:e9f957e33e03a4d88b5c0f81b687d4c8542362898a844d67358273d025bb8d5c"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-nc/policies/dhhs/fns/fns-820-intentional-program-violation-ipv-claims/page-6.yaml":
+    pending:
+      fingerprint: "sha256:ccd0c585524de48ea01233ee1f4837a69b95e95629354aca4ee13cddebadd3b4"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us-tx/policies/hhs/texas-works-handbook/a-1340-income-limits/block-16.yaml":
+    pending:
+      fingerprint: "sha256:79d6778169bdf9987b1c2bc1914f82da31ce64c4efc22da5907fa1c568f02cf7"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/119.yaml":
+    pending:
+      fingerprint: "sha256:e2eb8f745b436135713f9a90f89f5fa230e8570d1ba94a6edd650576af9c62f6"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/regulations/42-cfr/435/150.yaml":
+    pending:
+      fingerprint: "sha256:ae99bfcb778dd564dd9c5955e89ec500b7db2e6e9b73572e1966b10b1b4c9964"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"
+  "us/statutes/26/212.yaml":
+    pending:
+      fingerprint: "sha256:eb967018f2bef6c2f146b5d66d9c6430f0a6e7b7b2f728283bfae0f05dc1e5a5"
+      owner: "@MaxGhenis"
+      issue: "https://github.com/TheAxiomFoundation/rulespec-us/issues/782"
+      expires: "2026-10-08"


### PR DESCRIPTION
## Summary

- records the nine deterministic encoder 0.2.1973 validation fingerprints missed by the earlier existing-waiver transition census
- adds them as **pending only** across KS (1), NC (3), NJ (1), TX (1), and federal (3)
- updates the toolchain-bound waiver-set digest
- does not activate or skip any new failure on this PR; activation remains a separate protected-base transition in #1356

The exact set comes from every failed validation shard in #1356 run 34708072130. All nine failures are proof-source excerpt mismatches; their companion suites pass (93 cases total).

## Checks

- `python -m pytest -q tests/test_repository_layout.py` (9 passed)
- deterministic local fingerprinting of all nine modules under the public release verification key
- exact base/head transition check: 9 pending additions, 0 modified existing entries, 0 removals
- waiver YAML structure and `.axiom/toolchain.toml` digest verified
- `git diff --check`

## Cycle

Independent review pending; actionable findings will be fixed and focused checks rerun before merge.